### PR TITLE
chore: mainへの直接コミット禁止ルールをカスタムインストラクションに追加

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,9 @@
 # Copilot Instructions
+## Git ワークフロー
+
+- **mainブランチへの直接コミットは禁止**。変更は必ずブランチを切り、Pull Request経由でマージすること。
+- PRを作成する際は `create-pull-request` スキルの手順に従うこと。
+
 ## Natural language instructions
 - ユーザーとの対話や思考内容の発信はは日本語で出力してください。
 - コミットメッセージは日本語で記述して下さい。


### PR DESCRIPTION
## 概要

`.github/copilot-instructions.md` に Git ワークフローのルールを追加しました。

## 変更内容

- mainブランチへの直接コミットを禁止するルールを追加
- PR作成時は `create-pull-request` スキルに従うよう明記

## 背景

前回のセッションで誤ってmainに直接コミットしてしまったため、
カスタムインストラクションにルールを明文化して再発を防ぎます。
