### PR TITLE
docs: FizzBuzzサンプルのBIFジャンプ先ラベルを修正

### DIFF
--- a/blueprint.md
+++ b/blueprint.md
@@ -145,11 +145,11 @@ DEF FIZZBUZZ
           PRINT "FizzBuzz"
           GOTO 99
   10
-        BIF I % 3 = 0, 2               ; REM 不成立の場合は20にジャンプ
+        BIF I % 3 = 0, 20              ; REM 不成立の場合は20にジャンプ
           PRINT "Fizz"
           GOTO 99
   20
-        BIF I % 5 = 0, 3               ; REM 不成立の場合は30にジャンプ
+        BIF I % 5 = 0, 30              ; REM 不成立の場合は30にジャンプ
           PRINT "Buzz"
           GOTO 99
   30


### PR DESCRIPTION
## 概要

FizzBuzzサンプルコード内のBIF文のジャンプ先ラベルが誤っていたため修正しました。

## 変更内容

| 修正前 | 修正後 |
|---|---|
| `BIF I % 3 = 0, 2` | `BIF I % 3 = 0, 20` |
| `BIF I % 5 = 0, 3` | `BIF I % 5 = 0, 30` |

定義済みラベルは `10`, `20`, `30`, `99` であり、ジャンプ先が `2`, `3` になっていたのは単純な誤記です。

Closes #9
