### PR TITLE
T01: Rustプロジェクト初期化

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "tbx"
+version = "0.1.0"
+edition = "2021"
+description = "Tiny BASIC eXtensible - a bootstrappable BASIC interpreter"
+
+[lib]
+name = "tbx"
+path = "src/lib.rs"
+
+[[bin]]
+name = "tbx"
+path = "src/main.rs"

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -1,0 +1,21 @@
+/// Cell is the fundamental value type of the TBX VM.
+/// It represents all values that can exist on the stack or in the dictionary.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Cell {
+    /// Signed 64-bit integer
+    Int(i64),
+    /// 64-bit floating point
+    Float(f64),
+    /// Memory address (result of address-of operator &)
+    Addr(usize),
+    /// Execution token — index into the dictionary
+    Xt(usize),
+    /// Boolean value for logical/comparison operations
+    Bool(bool),
+    /// Empty / null value
+    None,
+    /// Reserved for future array support
+    Array,
+    /// Index into the string pool (length-prefixed)
+    StringDesc(usize),
+}

--- a/src/dict.rs
+++ b/src/dict.rs
@@ -1,0 +1,46 @@
+use crate::cell::Cell;
+
+/// A single entry in the TBX dictionary.
+/// Represents one word — either a primitive (backed by a Rust function)
+/// or a compiled word (a sequence of Xts).
+#[derive(Debug)]
+pub struct WordEntry {
+    /// The name of the word as it appears in source code
+    pub name: String,
+    /// Attribute flags (e.g. IMMEDIATE)
+    pub flags: u8,
+    /// The compiled body of the word as a sequence of Cells
+    pub code: Vec<Cell>,
+    /// If true, this word is implemented in Rust (not in TBX bytecode)
+    pub is_primitive: bool,
+}
+
+/// Flag bit: word executes immediately even in compile mode
+pub const FLAG_IMMEDIATE: u8 = 0b0000_0001;
+
+impl WordEntry {
+    /// Create a new primitive word entry (no compiled body).
+    pub fn new_primitive(name: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            flags: 0,
+            code: Vec::new(),
+            is_primitive: true,
+        }
+    }
+
+    /// Create a new compiled word entry with an empty body.
+    pub fn new_compiled(name: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            flags: 0,
+            code: Vec::new(),
+            is_primitive: false,
+        }
+    }
+
+    /// Returns true if the IMMEDIATE flag is set.
+    pub fn is_immediate(&self) -> bool {
+        self.flags & FLAG_IMMEDIATE != 0
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod cell;
+pub mod dict;
+pub mod vm;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("TBX - Tiny BASIC eXtensible");
+}

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1,0 +1,104 @@
+use crate::dict::WordEntry;
+use crate::cell::Cell;
+
+/// The TBX virtual machine.
+///
+/// Holds all runtime state: dictionary, string pool, stacks, and registers.
+#[derive(Debug)]
+pub struct VM {
+    /// The dictionary: all registered words (system primitives + user-defined)
+    pub dictionary: Vec<WordEntry>,
+    /// String pool: all string data packed as length-prefixed byte sequences
+    pub string_pool: Vec<u8>,
+    /// Data stack: operand stack for arithmetic and parameter passing
+    pub data_stack: Vec<Cell>,
+    /// Return stack: saves (pc, bp) pairs on word calls
+    pub return_stack: Vec<(usize, usize)>,
+    /// Program counter: index of the currently executing word in the dictionary
+    pub pc: usize,
+    /// Base pointer: index into data_stack marking the current stack frame base
+    pub bp: usize,
+    /// End of system dictionary (primitives registered at startup)
+    pub dp_sys: usize,
+    /// End of standard library dictionary
+    pub dp_lib: usize,
+    /// End of user dictionary
+    pub dp_user: usize,
+}
+
+impl VM {
+    /// Create a new VM with empty dictionary and stacks.
+    pub fn new() -> Self {
+        Self {
+            dictionary: Vec::new(),
+            string_pool: Vec::new(),
+            data_stack: Vec::new(),
+            return_stack: Vec::new(),
+            pc: 0,
+            bp: 0,
+            dp_sys: 0,
+            dp_lib: 0,
+            dp_user: 0,
+        }
+    }
+
+    /// Look up a word by name, searching from newest to oldest entry.
+    /// Returns the dictionary index (Xt) if found.
+    pub fn lookup(&self, name: &str) -> Option<usize> {
+        self.dictionary
+            .iter()
+            .enumerate()
+            .rev()
+            .find(|(_, entry)| entry.name == name)
+            .map(|(idx, _)| idx)
+    }
+
+    /// Push a value onto the data stack.
+    pub fn push(&mut self, cell: Cell) {
+        self.data_stack.push(cell);
+    }
+
+    /// Pop a value from the data stack.
+    pub fn pop(&mut self) -> Option<Cell> {
+        self.data_stack.pop()
+    }
+}
+
+impl Default for VM {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_vm_new() {
+        let vm = VM::new();
+        assert!(vm.dictionary.is_empty());
+        assert!(vm.data_stack.is_empty());
+        assert!(vm.return_stack.is_empty());
+    }
+
+    #[test]
+    fn test_push_pop() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(42));
+        assert_eq!(vm.pop(), Some(Cell::Int(42)));
+        assert_eq!(vm.pop(), None);
+    }
+
+    #[test]
+    fn test_lookup() {
+        let mut vm = VM::new();
+        use crate::dict::WordEntry;
+        vm.dictionary.push(WordEntry::new_primitive("HALT"));
+        vm.dictionary.push(WordEntry::new_primitive("DROP"));
+
+        assert_eq!(vm.lookup("HALT"), Some(0));
+        assert_eq!(vm.lookup("DROP"), Some(1));
+        assert_eq!(vm.lookup("MISSING"), None);
+    }
+}


### PR DESCRIPTION
## 概要

Rustプロジェクトの初期構成を作成する。
lib + bin のデュアル構成とし、`cargo test` によるユニットテストと `cargo run` による実行の両方に対応する。

## 変更内容

- `Cargo.toml` — パッケージ定義（lib + bin）
- `src/lib.rs` — モジュール宣言（cell, dict, vm）
- `src/main.rs` — エントリポイントのスケルトン
- `src/cell.rs` — `Cell` enum のスタブ（Int/Float/Addr/Xt/Bool/None/Array/StringDesc）
- `src/dict.rs` — `WordEntry` 構造体のスタブ（name/flags/code/is_primitive）
- `src/vm.rs` — `VM` 構造体のスタブ（push/pop/lookup + 基本テスト3件）

## 確認済み

- `cargo build` — OK
- `cargo test` — 3 passed
- `cargo clippy -- -D warnings` — 警告なし

Closes #28
