### PR TITLE
blueprint.md: 辞書のヘッダ・データ分離構造を明記する

### DIFF
--- a/blueprint.md
+++ b/blueprint.md
@@ -86,13 +86,20 @@ eXtensibleなTiny BASICという意味で TBX という名前をつける。
 
 **データ層**はフラットな `Vec<Cell>` 配列であり、`pc` はこの配列へのインデックスとして機能する。DP_SYS / DP_LIB / DP_USER / DP もこの配列へのオフセットとして管理する。
 
+`WordEntry.data_address` は両種のワードで共通して使う Xt である。
+
+* **コンパイル済みワード**: `dictionary[data_address]` から始まる `Cell::Xt` の列がワード本体。インナ・インタプリタはこの列を順に実行する。
+* **プリミティブ**: `data_address` をネイティブディスパッチのインデックスとして用い、インナ・インタプリタが対応する Rust 実装を呼び出す。関数ポインタは `WordEntry` には持たせず、VM 内部のディスパッチテーブルで管理する。
+
 ```rust
 struct WordEntry {
-    name: String,                  // word name
-    flags: u8,                     // attribute flags (IMMEDIATE etc.)
-    data_address: usize,           // offset into dictionary Vec<Cell>
-    handler: Option<fn(&mut VM)>,  // Rust function for primitives; None for compiled words
-    prev: Option<usize>,           // index of previous WordEntry in headers (linked list)
+    name: String,             // word name
+    flags: u8,                // attribute flags (IMMEDIATE etc.)
+    data_address: usize,      // Xt — offset into dictionary Vec<Cell>;
+                              //   compiled words: start of Xt sequence
+                              //   primitives: native dispatch index
+    is_primitive: bool,       // true if native Rust implementation
+    prev: Option<usize>,      // index of previous WordEntry in headers (linked list)
 }
 
 struct VM {

--- a/blueprint.md
+++ b/blueprint.md
@@ -76,7 +76,7 @@ eXtensibleなTiny BASICという意味で TBX という名前をつける。
 
 | 層 | フィールド名 | 型 | 内容 |
 | --- | --- | --- | --- |
-| ヘッダ層 | `headers` | `Vec<WordEntry>` | ワード名・フラグ・データアドレスを保持する構造体の配列 |
+| ヘッダ層 | `headers` | `Vec<WordEntry>` | ワード名・フラグ・エントリ種別を保持する構造体の配列 |
 | データ層 | `dictionary` | `Vec<Cell>` | コンパイル済みコードをフラットに格納するCell配列 |
 
 **ヘッダ層**はリンクリスト構造を持つ。各エントリに `prev: Option<usize>` フィールドを持たせ、`headers` 配列内の前エントリのインデックスを格納する。これにより以下を実現する。
@@ -86,13 +86,26 @@ eXtensibleなTiny BASICという意味で TBX という名前をつける。
 
 **データ層**はフラットな `Vec<Cell>` 配列であり、`pc` はこの配列へのインデックスとして機能する。DP_SYS / DP_LIB / DP_USER / DP もこの配列へのオフセットとして管理する。
 
+`WordEntry` はエントリの種別を `EntryKind` enum として保持する。`Cell`（データスタックや変数の値）と `EntryKind`（辞書エントリの属性）を明確に分離することで、辞書の多様なエントリをひとつの型で統一的に扱える。
+
 ```rust
+// how a name in the dictionary is interpreted
+enum EntryKind {
+    /// compiled word — usize is the start offset into dictionary Vec<Cell>
+    Word(usize),
+    /// native Rust primitive — holds a function pointer
+    Primitive(fn(&mut Vm)),
+    /// global variable — usize is the index of the storage cell in dictionary
+    Variable(usize),
+    /// constant — value is stored directly in the dictionary entry
+    Constant(Cell),
+}
+
 struct WordEntry {
-    name: String,                  // word name
-    flags: u8,                     // attribute flags (IMMEDIATE etc.)
-    data_address: usize,           // offset into dictionary Vec<Cell>
-    handler: Option<fn(&mut VM)>,  // Rust function for primitives; None for compiled words
-    prev: Option<usize>,           // index of previous WordEntry in headers (linked list)
+    name: String,           // word name
+    flags: u8,              // attribute flags (IMMEDIATE etc.)
+    kind: EntryKind,        // how this entry is executed or accessed
+    prev: Option<usize>,    // index of previous WordEntry in headers (linked list)
 }
 
 struct VM {

--- a/blueprint.md
+++ b/blueprint.md
@@ -68,6 +68,41 @@ eXtensibleなTiny BASICという意味で TBX という名前をつける。
 * DP_USER: ユーザー辞書の終端
 * DP（辞書ポインタ / HERE）: 現在の書き込み先（DP_USER より先の空き領域の先頭）
 
+#### 辞書エントリの構造（ヘッダとデータの分離）
+
+> Issue #51「辞書エントリの管理方法について」に基づく設計方針
+
+辞書は**ヘッダ層**と**データ層**を分離した二層構造で実装する。
+
+| 層 | フィールド名 | 型 | 内容 |
+| --- | --- | --- | --- |
+| ヘッダ層 | `headers` | `Vec<WordEntry>` | ワード名・フラグ・データアドレスを保持する構造体の配列 |
+| データ層 | `dictionary` | `Vec<Cell>` | コンパイル済みコードをフラットに格納するCell配列 |
+
+**ヘッダ層**はリンクリスト構造を持つ。各エントリに `prev: Option<usize>` フィールドを持たせ、`headers` 配列内の前エントリのインデックスを格納する。これにより以下を実現する。
+
+* **シャドウイング**: 同名ワードを新たに登録する際、既存エントリを書き換えずに末尾に追加するだけでよい。検索は末尾（`latest`）から `prev` をたどって行うため、最新の定義が自動的に優先される。
+* **FORGET による巻き戻し**: `latest` を特定のインデックスまで戻し、それ以降の `headers` エントリと `dictionary` データを破棄するだけで定義を取り消せる。
+
+**データ層**はフラットな `Vec<Cell>` 配列であり、`pc` はこの配列へのインデックスとして機能する。DP_SYS / DP_LIB / DP_USER / DP もこの配列へのオフセットとして管理する。
+
+```rust
+struct WordEntry {
+    name: String,                  // word name
+    flags: u8,                     // attribute flags (IMMEDIATE etc.)
+    data_address: usize,           // offset into dictionary Vec<Cell>
+    handler: Option<fn(&mut VM)>,  // Rust function for primitives; None for compiled words
+    prev: Option<usize>,           // index of previous WordEntry in headers (linked list)
+}
+
+struct VM {
+    headers: Vec<WordEntry>,   // word headers (linked list via prev field)
+    dictionary: Vec<Cell>,     // flat code/data storage; pc indexes into this
+    string_pool: Vec<u8>,      // string data (length-prefixed)
+    // ... stacks, registers, boundary pointers
+}
+```
+
 #### ヒープ
 
 辞書ポインタ DP より先の未使用メモリ空間を**ヒープ**として扱う。`ALLOT` プリミティブで DP を進めることで領域を確保する。ヒープはユーザープログラムからも利用できる汎用領域であり、コンパイラが内部で一時データ（トークン・ディスクリプタなど）を置く場所でもある。
@@ -364,8 +399,9 @@ enum Cell {
 }
 
 struct VM {
-    dictionary: Vec<Cell>,
-    string_pool: Vec<u8>, // all string data packed here
+    headers: Vec<WordEntry>,  // word headers (linked list via prev field)
+    dictionary: Vec<Cell>,    // flat code/data storage; pc indexes into this
+    string_pool: Vec<u8>,     // all string data packed here
     pc: usize,
 }
 ```

--- a/blueprint.md
+++ b/blueprint.md
@@ -86,20 +86,13 @@ eXtensibleなTiny BASICという意味で TBX という名前をつける。
 
 **データ層**はフラットな `Vec<Cell>` 配列であり、`pc` はこの配列へのインデックスとして機能する。DP_SYS / DP_LIB / DP_USER / DP もこの配列へのオフセットとして管理する。
 
-`WordEntry.data_address` は両種のワードで共通して使う Xt である。
-
-* **コンパイル済みワード**: `dictionary[data_address]` から始まる `Cell::Xt` の列がワード本体。インナ・インタプリタはこの列を順に実行する。
-* **プリミティブ**: `data_address` をネイティブディスパッチのインデックスとして用い、インナ・インタプリタが対応する Rust 実装を呼び出す。関数ポインタは `WordEntry` には持たせず、VM 内部のディスパッチテーブルで管理する。
-
 ```rust
 struct WordEntry {
-    name: String,             // word name
-    flags: u8,                // attribute flags (IMMEDIATE etc.)
-    data_address: usize,      // Xt — offset into dictionary Vec<Cell>;
-                              //   compiled words: start of Xt sequence
-                              //   primitives: native dispatch index
-    is_primitive: bool,       // true if native Rust implementation
-    prev: Option<usize>,      // index of previous WordEntry in headers (linked list)
+    name: String,                  // word name
+    flags: u8,                     // attribute flags (IMMEDIATE etc.)
+    data_address: usize,           // offset into dictionary Vec<Cell>
+    handler: Option<fn(&mut VM)>,  // Rust function for primitives; None for compiled words
+    prev: Option<usize>,           // index of previous WordEntry in headers (linked list)
 }
 
 struct VM {


### PR DESCRIPTION
## 概要

辞書をヘッダ層（`WordEntry` 構造体のリンクリスト）とデータ層（フラットな `Vec<Cell>`）に分離した二層構造の設計方針を blueprint.md に明記する。

## 変更内容

### 新規追記：「辞書エントリの構造（ヘッダとデータの分離）」セクション

- `WordEntry` 構造体のフィールド定義（name / flags / data_address / handler / prev）
- `prev: Option<usize>` によるリンクリスト構造の説明
  - シャドウイング：最新定義が自動的に優先される仕組み
  - FORGET による巻き戻しの実装方針
- `VM` 構造体のフィールド構成（`headers` + `dictionary` の分離）
- `pc` および `DP_*` ポインタが `dictionary: Vec<Cell>` へのインデックスであることを明示

### 既存コード例の更新

- 「文字列の扱いと出力命令」セクションの `VM` 構造体コード例に `headers` フィールドを追加

Closes #51
