### PR TITLE
fix: Xt newtype を導入し headers インデックスを型で保護する

### DIFF
--- a/src/cell.rs
+++ b/src/cell.rs
@@ -1,3 +1,17 @@
+/// Execution token: a type-safe index into `VM::headers` (the word header table).
+///
+/// Distinct from an index into `VM::dictionary` (the flat code/data array).
+/// `lookup()` returns `Option<Xt>`; `register()` returns `Xt`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Xt(pub usize);
+
+impl Xt {
+    /// Returns the raw index into `VM::headers`.
+    pub fn index(self) -> usize {
+        self.0
+    }
+}
+
 /// Cell is the fundamental value type of the TBX VM.
 /// It represents all values that can exist on the stack or in the dictionary.
 #[derive(Debug, Clone, PartialEq)]
@@ -8,8 +22,8 @@ pub enum Cell {
     Float(f64),
     /// Memory address (result of address-of operator &)
     Addr(usize),
-    /// Execution token — index into the dictionary
-    Xt(usize),
+    /// Execution token — type-safe index into `VM::headers` (word header array), not into `dictionary`
+    Xt(Xt),
     /// Boolean value for logical/comparison operations
     Bool(bool),
     /// Empty / null value

--- a/src/dict.rs
+++ b/src/dict.rs
@@ -1,4 +1,4 @@
-use crate::cell::Cell;
+use crate::cell::{Cell, Xt};
 
 /// Function pointer type for native Rust primitives.
 pub type PrimFn = fn(&mut crate::vm::VM);
@@ -47,7 +47,7 @@ pub struct WordEntry {
     ///
     /// **Do not set this field directly.** It is automatically managed by
     /// `VM::register()`, which overwrites any value set here.
-    pub(crate) prev: Option<usize>,
+    pub(crate) prev: Option<Xt>,
 }
 
 impl WordEntry {

--- a/src/dict.rs
+++ b/src/dict.rs
@@ -1,41 +1,90 @@
 use crate::cell::Cell;
 
-/// A single entry in the TBX dictionary.
-/// Represents one word — either a primitive (backed by a Rust function)
-/// or a compiled word (a sequence of Xts).
-#[derive(Debug)]
-pub struct WordEntry {
-    /// The name of the word as it appears in source code
-    pub name: String,
-    /// Attribute flags (e.g. IMMEDIATE)
-    pub flags: u8,
-    /// The compiled body of the word as a sequence of Cells
-    pub code: Vec<Cell>,
-    /// If true, this word is implemented in Rust (not in TBX bytecode)
-    pub is_primitive: bool,
+/// Function pointer type for native Rust primitives.
+pub type PrimFn = fn(&mut crate::vm::VM);
+
+/// How a dictionary entry is executed or accessed.
+#[derive(Clone)]
+pub enum EntryKind {
+    /// Compiled TBX word — usize is the start offset into `dictionary: Vec<Cell>`
+    Word(usize),
+    /// Native Rust primitive — holds a function pointer
+    Primitive(PrimFn),
+    /// Global variable — usize is the index of the storage cell in `dictionary`
+    Variable(usize),
+    /// Constant — value stored directly in this entry
+    Constant(Cell),
+}
+
+impl std::fmt::Debug for EntryKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EntryKind::Word(offset) => write!(f, "Word({offset})"),
+            EntryKind::Primitive(ptr) => write!(f, "Primitive({ptr:p})"),
+            EntryKind::Variable(idx) => write!(f, "Variable({idx})"),
+            EntryKind::Constant(cell) => write!(f, "Constant({cell:?})"),
+        }
+    }
 }
 
 /// Flag bit: word executes immediately even in compile mode
 pub const FLAG_IMMEDIATE: u8 = 0b0000_0001;
 
+/// A single entry in the TBX word header table.
+///
+/// The header table (`VM::headers`) and the flat code array (`VM::dictionary`)
+/// are kept separate. Each `WordEntry` stores how to execute or access the word
+/// via `EntryKind`, and links to the previous entry for dictionary search.
+#[derive(Debug, Clone)]
+pub struct WordEntry {
+    /// The name of the word as it appears in source code
+    pub name: String,
+    /// Attribute flags (e.g. IMMEDIATE)
+    pub flags: u8,
+    /// How this entry is executed or accessed
+    pub kind: EntryKind,
+    /// Index of the previous entry in `VM::headers` (linked list for search)
+    pub prev: Option<usize>,
+}
+
 impl WordEntry {
-    /// Create a new primitive word entry (no compiled body).
-    pub fn new_primitive(name: &str) -> Self {
+    /// Create a new primitive word entry backed by a Rust function.
+    pub fn new_primitive(name: &str, f: PrimFn) -> Self {
         Self {
             name: name.to_string(),
             flags: 0,
-            code: Vec::new(),
-            is_primitive: true,
+            kind: EntryKind::Primitive(f),
+            prev: None,
         }
     }
 
-    /// Create a new compiled word entry with an empty body.
-    pub fn new_compiled(name: &str) -> Self {
+    /// Create a new compiled word entry with a given start offset in `dictionary`.
+    pub fn new_word(name: &str, offset: usize) -> Self {
         Self {
             name: name.to_string(),
             flags: 0,
-            code: Vec::new(),
-            is_primitive: false,
+            kind: EntryKind::Word(offset),
+            prev: None,
+        }
+    }
+
+    /// Create a new global variable entry with a given storage index in `dictionary`.
+    pub fn new_variable(name: &str, idx: usize) -> Self {
+        Self {
+            name: name.to_string(),
+            flags: 0,
+            kind: EntryKind::Variable(idx),
+            prev: None,
+        }
+    }
+
+    /// Create a new constant entry.
+    pub fn new_constant(name: &str, value: Cell) -> Self {
+        Self {
+            name: name.to_string(),
+            flags: 0,
+            kind: EntryKind::Constant(value),
+            prev: None,
         }
     }
 

--- a/src/dict.rs
+++ b/src/dict.rs
@@ -43,8 +43,11 @@ pub struct WordEntry {
     pub flags: u8,
     /// How this entry is executed or accessed
     pub kind: EntryKind,
-    /// Index of the previous entry in `VM::headers` (linked list for search)
-    pub prev: Option<usize>,
+    /// Index of the previous entry in `VM::headers` (linked list for search).
+    ///
+    /// **Do not set this field directly.** It is automatically managed by
+    /// `VM::register()`, which overwrites any value set here.
+    pub(crate) prev: Option<usize>,
 }
 
 impl WordEntry {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -3,18 +3,22 @@ use crate::cell::Cell;
 
 /// The TBX virtual machine.
 ///
-/// Holds all runtime state: dictionary, string pool, stacks, and registers.
+/// The dictionary is split into two layers:
+/// - `headers`: word name/flag/kind metadata, forming a linked list via `prev`
+/// - `dictionary`: flat `Vec<Cell>` array of compiled code; `pc` indexes into this
 #[derive(Debug)]
 pub struct VM {
-    /// The dictionary: all registered words (system primitives + user-defined)
-    pub dictionary: Vec<WordEntry>,
+    /// Word header table (linked list via `WordEntry::prev`)
+    pub headers: Vec<WordEntry>,
+    /// Flat code/data storage; `pc` is an index into this array
+    pub dictionary: Vec<Cell>,
     /// String pool: all string data packed as length-prefixed byte sequences
     pub string_pool: Vec<u8>,
     /// Data stack: operand stack for arithmetic and parameter passing
     pub data_stack: Vec<Cell>,
     /// Return stack: saves (pc, bp) pairs on word calls
     pub return_stack: Vec<(usize, usize)>,
-    /// Program counter: index of the currently executing word in the dictionary
+    /// Program counter: index into `dictionary` of the currently executing cell
     pub pc: usize,
     /// Base pointer: index into data_stack marking the current stack frame base
     pub bp: usize,
@@ -24,12 +28,15 @@ pub struct VM {
     pub dp_lib: usize,
     /// End of user dictionary
     pub dp_user: usize,
+    /// Index of the most recently registered entry in `headers` (head of linked list)
+    pub latest: Option<usize>,
 }
 
 impl VM {
-    /// Create a new VM with empty dictionary and stacks.
+    /// Create a new VM with empty header table, dictionary, and stacks.
     pub fn new() -> Self {
         Self {
+            headers: Vec::new(),
             dictionary: Vec::new(),
             string_pool: Vec::new(),
             data_stack: Vec::new(),
@@ -39,18 +46,32 @@ impl VM {
             dp_sys: 0,
             dp_lib: 0,
             dp_user: 0,
+            latest: None,
         }
     }
 
-    /// Look up a word by name, searching from newest to oldest entry.
-    /// Returns the dictionary index (Xt) if found.
+    /// Register a word entry in the header table, linking it into the search list.
+    /// Returns the index (Xt) of the newly added entry.
+    pub fn register(&mut self, mut entry: WordEntry) -> usize {
+        let idx = self.headers.len();
+        entry.prev = self.latest;
+        self.latest = Some(idx);
+        self.headers.push(entry);
+        idx
+    }
+
+    /// Look up a word by name, searching from newest to oldest entry via the linked list.
+    /// Returns the header index (Xt) if found.
     pub fn lookup(&self, name: &str) -> Option<usize> {
-        self.dictionary
-            .iter()
-            .enumerate()
-            .rev()
-            .find(|(_, entry)| entry.name == name)
-            .map(|(idx, _)| idx)
+        let mut current = self.latest;
+        while let Some(idx) = current {
+            let entry = &self.headers[idx];
+            if entry.name == name {
+                return Some(idx);
+            }
+            current = entry.prev;
+        }
+        None
     }
 
     /// Push a value onto the data stack.
@@ -73,13 +94,18 @@ impl Default for VM {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::dict::WordEntry;
+
+    fn noop(_vm: &mut VM) {}
 
     #[test]
     fn test_vm_new() {
         let vm = VM::new();
+        assert!(vm.headers.is_empty());
         assert!(vm.dictionary.is_empty());
         assert!(vm.data_stack.is_empty());
         assert!(vm.return_stack.is_empty());
+        assert!(vm.latest.is_none());
     }
 
     #[test]
@@ -91,14 +117,35 @@ mod tests {
     }
 
     #[test]
-    fn test_lookup() {
+    fn test_register_and_lookup() {
         let mut vm = VM::new();
-        use crate::dict::WordEntry;
-        vm.dictionary.push(WordEntry::new_primitive("HALT"));
-        vm.dictionary.push(WordEntry::new_primitive("DROP"));
+        vm.register(WordEntry::new_primitive("HALT", noop));
+        vm.register(WordEntry::new_primitive("DROP", noop));
 
         assert_eq!(vm.lookup("HALT"), Some(0));
         assert_eq!(vm.lookup("DROP"), Some(1));
         assert_eq!(vm.lookup("MISSING"), None);
+    }
+
+    #[test]
+    fn test_lookup_shadows_older_entry() {
+        let mut vm = VM::new();
+        vm.register(WordEntry::new_word("FOO", 0));
+        vm.register(WordEntry::new_word("FOO", 10)); // shadows the first
+
+        // Lookup should find the newer (index 1) entry
+        assert_eq!(vm.lookup("FOO"), Some(1));
+    }
+
+    #[test]
+    fn test_lookup_linked_list_order() {
+        let mut vm = VM::new();
+        vm.register(WordEntry::new_primitive("A", noop));
+        vm.register(WordEntry::new_primitive("B", noop));
+        vm.register(WordEntry::new_primitive("C", noop));
+
+        assert_eq!(vm.lookup("A"), Some(0));
+        assert_eq!(vm.lookup("B"), Some(1));
+        assert_eq!(vm.lookup("C"), Some(2));
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -22,12 +22,18 @@ pub struct VM {
     pub pc: usize,
     /// Base pointer: index into data_stack marking the current stack frame base
     pub bp: usize,
-    /// End of system dictionary (primitives registered at startup)
+    /// End of system dictionary in `dictionary` (data layer boundary)
     pub dp_sys: usize,
-    /// End of standard library dictionary
+    /// End of standard library in `dictionary` (data layer boundary)
     pub dp_lib: usize,
-    /// End of user dictionary
+    /// End of user dictionary in `dictionary` (data layer boundary)
     pub dp_user: usize,
+    /// End of system entries in `headers` (header layer boundary, mirrors `dp_sys`)
+    pub hdr_sys: usize,
+    /// End of standard library entries in `headers` (header layer boundary, mirrors `dp_lib`)
+    pub hdr_lib: usize,
+    /// End of user entries in `headers` (header layer boundary, mirrors `dp_user`)
+    pub hdr_user: usize,
     /// Index of the most recently registered entry in `headers` (head of linked list)
     pub latest: Option<usize>,
 }
@@ -46,6 +52,9 @@ impl VM {
             dp_sys: 0,
             dp_lib: 0,
             dp_user: 0,
+            hdr_sys: 0,
+            hdr_lib: 0,
+            hdr_user: 0,
             latest: None,
         }
     }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1,5 +1,5 @@
 use crate::dict::WordEntry;
-use crate::cell::Cell;
+use crate::cell::{Cell, Xt};
 
 /// The TBX virtual machine.
 ///
@@ -35,7 +35,7 @@ pub struct VM {
     /// End of user entries in `headers` (header layer boundary, mirrors `dp_user`)
     pub hdr_user: usize,
     /// Index of the most recently registered entry in `headers` (head of linked list)
-    pub latest: Option<usize>,
+    pub latest: Option<Xt>,
 }
 
 impl VM {
@@ -60,23 +60,23 @@ impl VM {
     }
 
     /// Register a word entry in the header table, linking it into the search list.
-    /// Returns the index (Xt) of the newly added entry.
-    pub fn register(&mut self, mut entry: WordEntry) -> usize {
-        let idx = self.headers.len();
+    /// Returns the `Xt` (execution token) of the newly added entry.
+    pub fn register(&mut self, mut entry: WordEntry) -> Xt {
+        let xt = Xt(self.headers.len());
         entry.prev = self.latest;
-        self.latest = Some(idx);
+        self.latest = Some(xt);
         self.headers.push(entry);
-        idx
+        xt
     }
 
     /// Look up a word by name, searching from newest to oldest entry via the linked list.
-    /// Returns the header index (Xt) if found.
-    pub fn lookup(&self, name: &str) -> Option<usize> {
+    /// Returns the `Xt` (header index) if found.
+    pub fn lookup(&self, name: &str) -> Option<Xt> {
         let mut current = self.latest;
-        while let Some(idx) = current {
-            let entry = &self.headers[idx];
+        while let Some(xt) = current {
+            let entry = &self.headers[xt.index()];
             if entry.name == name {
-                return Some(idx);
+                return Some(xt);
             }
             current = entry.prev;
         }
@@ -131,8 +131,8 @@ mod tests {
         vm.register(WordEntry::new_primitive("HALT", noop));
         vm.register(WordEntry::new_primitive("DROP", noop));
 
-        assert_eq!(vm.lookup("HALT"), Some(0));
-        assert_eq!(vm.lookup("DROP"), Some(1));
+        assert_eq!(vm.lookup("HALT"), Some(Xt(0)));
+        assert_eq!(vm.lookup("DROP"), Some(Xt(1)));
         assert_eq!(vm.lookup("MISSING"), None);
     }
 
@@ -143,7 +143,7 @@ mod tests {
         vm.register(WordEntry::new_word("FOO", 10)); // shadows the first
 
         // Lookup should find the newer (index 1) entry
-        assert_eq!(vm.lookup("FOO"), Some(1));
+        assert_eq!(vm.lookup("FOO"), Some(Xt(1)));
     }
 
     #[test]
@@ -153,8 +153,8 @@ mod tests {
         vm.register(WordEntry::new_primitive("B", noop));
         vm.register(WordEntry::new_primitive("C", noop));
 
-        assert_eq!(vm.lookup("A"), Some(0));
-        assert_eq!(vm.lookup("B"), Some(1));
-        assert_eq!(vm.lookup("C"), Some(2));
+        assert_eq!(vm.lookup("A"), Some(Xt(0)));
+        assert_eq!(vm.lookup("B"), Some(Xt(1)));
+        assert_eq!(vm.lookup("C"), Some(Xt(2)));
     }
 }


### PR DESCRIPTION
## 概要

`Cell::Xt` が保持する `usize` が `VM::headers` へのインデックスであることを、docコメントだけでなく **型レベルで保証** する。

## 変更内容

### 新規: `Xt` newtype (`cell.rs`)

```rust
pub struct Xt(pub usize);
```

`VM::headers: Vec<WordEntry>` へのインデックスであることを型として表現し、`VM::dictionary: Vec<Cell>` へのインデックスと混同できなくなる。

### 変更箇所

| ファイル | 変更前 | 変更後 |
|---|---|---|
| `cell.rs` | `Cell::Xt(usize)` | `Cell::Xt(Xt)` |
| `dict.rs` | `WordEntry::prev: Option<usize>` | `Option<Xt>` |
| `vm.rs` | `VM::latest: Option<usize>` | `Option<Xt>` |
| `vm.rs` | `register() -> usize` | `register() -> Xt` |
| `vm.rs` | `lookup() -> Option<usize>` | `lookup() -> Option<Xt>` |

Closes #54
