### PR TITLE
fix: VM構造体にdpフィールドを追加する

### DIFF
--- a/src/vm.rs
+++ b/src/vm.rs
@@ -41,6 +41,9 @@ pub struct VM {
     /// Boundary index in `headers` at the start of the current user session.
     /// Mirrors `dp_user` for the header layer. Updated alongside `dp_user`.
     pub hdr_user: usize,
+    /// Dictionary pointer (HERE): index of the next free write position in `dictionary`.
+    /// Starts at 0 and advances as words are compiled or `ALLOT` is called.
+    pub dp: usize,
     /// Index of the most recently registered entry in `headers` (head of linked list)
     pub latest: Option<Xt>,
 }
@@ -62,6 +65,7 @@ impl VM {
             hdr_sys: 0,
             hdr_lib: 0,
             hdr_user: 0,
+            dp: 0,
             latest: None,
         }
     }
@@ -122,6 +126,7 @@ mod tests {
         assert!(vm.data_stack.is_empty());
         assert!(vm.return_stack.is_empty());
         assert!(vm.latest.is_none());
+        assert_eq!(vm.dp, 0);
     }
 
     #[test]


### PR DESCRIPTION
## 概要

`VM` 構造体に辞書ポインタ `dp`（HERE）フィールドが欠落していたため追加しました。

## 変更内容

- `src/vm.rs`: `VM` 構造体に `pub dp: usize` フィールドを追加
- `VM::new()` で `dp` を `0` で初期化
- `test_vm_new` に `dp` の初期値検証（`assert_eq!(vm.dp, 0)`）を追加

## 背景

blueprint.md「辞書の境界の管理」「ヒープ」セクションで定義されている4つのポインタ（`dp_sys` / `dp_lib` / `dp_user` / `dp`）のうち、`dp` のみ実装に存在していませんでした。`dp` は `ALLOT` / `HERE` プリミティブの実装に直接必要なフィールドです。

Closes #48
