### PR TITLE
fix: Cell::Float の PartialEq を手動実装して NaN == NaN を true にする

### DIFF
--- a/src/cell.rs
+++ b/src/cell.rs
@@ -14,7 +14,7 @@ impl Xt {
 
 /// Cell is the fundamental value type of the TBX VM.
 /// It represents all values that can exist on the stack or in the dictionary.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub enum Cell {
     /// Signed 64-bit integer
     Int(i64),
@@ -32,4 +32,52 @@ pub enum Cell {
     Array,
     /// Index into the string pool (length-prefixed)
     StringDesc(usize),
+}
+
+impl PartialEq for Cell {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            // For floats, treat NaN as equal to NaN (value identity semantics).
+            // IEEE 754 defines NaN != NaN, but for TBX value equality we use
+            // structural equality so that NaN cells compare as equal.
+            (Cell::Float(a), Cell::Float(b)) => a.is_nan() && b.is_nan() || a == b,
+            (Cell::Int(a), Cell::Int(b)) => a == b,
+            (Cell::Addr(a), Cell::Addr(b)) => a == b,
+            (Cell::Xt(a), Cell::Xt(b)) => a == b,
+            (Cell::Bool(a), Cell::Bool(b)) => a == b,
+            (Cell::None, Cell::None) => true,
+            (Cell::Array, Cell::Array) => true,
+            (Cell::StringDesc(a), Cell::StringDesc(b)) => a == b,
+            _ => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_float_nan_equals_nan() {
+        // TBX uses value identity: NaN should equal NaN
+        assert_eq!(Cell::Float(f64::NAN), Cell::Float(f64::NAN));
+    }
+
+    #[test]
+    fn test_float_nan_not_equal_to_non_nan() {
+        assert_ne!(Cell::Float(f64::NAN), Cell::Float(1.0));
+        assert_ne!(Cell::Float(1.0), Cell::Float(f64::NAN));
+    }
+
+    #[test]
+    fn test_float_normal_equality() {
+        assert_eq!(Cell::Float(1.0), Cell::Float(1.0));
+        assert_ne!(Cell::Float(1.0), Cell::Float(2.0));
+    }
+
+    #[test]
+    fn test_variant_mismatch_not_equal() {
+        assert_ne!(Cell::Int(1), Cell::Float(1.0));
+        assert_ne!(Cell::Bool(true), Cell::Int(1));
+    }
 }

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -40,7 +40,7 @@ impl PartialEq for Cell {
             // For floats, treat NaN as equal to NaN (value identity semantics).
             // IEEE 754 defines NaN != NaN, but for TBX value equality we use
             // structural equality so that NaN cells compare as equal.
-            (Cell::Float(a), Cell::Float(b)) => a.is_nan() && b.is_nan() || a == b,
+            (Cell::Float(a), Cell::Float(b)) => (a.is_nan() && b.is_nan()) || (a == b),
             (Cell::Int(a), Cell::Int(b)) => a == b,
             (Cell::Addr(a), Cell::Addr(b)) => a == b,
             (Cell::Xt(a), Cell::Xt(b)) => a == b,


### PR DESCRIPTION
## 概要

`Cell::Float(f64)` の `PartialEq` を手動実装し、NaN 同士の比較で `true` を返すようにしました。

## 問題

`#[derive(PartialEq)]` では IEEE 754 の規則により `NaN == NaN` が `false` になります。

## 変更内容

- `#[derive(PartialEq)]` を `Cell` から削除し、`PartialEq` を手動実装
- `Cell::Float` 同士の比較: 両方 NaN なら `true`、それ以外は通常の `f64` 比較
- その他のバリアントはすべて従来どおりの等値比較
- テスト4件を追加（NaN == NaN、NaN != 通常値、通常 Float 比較、バリアント不一致）

## 設計方針

TBX では値の同一性（structural equality）を採用するため、NaN セル同士は等しいとみなします。

Closes #50
