### PR TITLE
preToolUse hookで/tmpへの書き込みをブロックする

### DIFF
--- a/.github/hooks/security.json
+++ b/.github/hooks/security.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "hooks": {
+    "preToolUse": [
+      {
+        "type": "command",
+        "bash": ".github/scripts/block-tmp-writes.sh",
+        "cwd": ".",
+        "timeoutSec": 5
+      }
+    ]
+  }
+}

--- a/.github/scripts/block-tmp-writes.sh
+++ b/.github/scripts/block-tmp-writes.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# preToolUse hook: block any tool invocation that would write to /tmp or /private/tmp.
+#
+# Checked patterns:
+#   - bash tool: command string contains /tmp or /private/tmp
+#   - create/edit tools: file path starts with /tmp or /private/tmp
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+TOOL_NAME=$(echo "$INPUT" | jq -r '.toolName')
+TOOL_ARGS=$(echo "$INPUT" | jq -r '.toolArgs')
+
+TMP_PATTERN='(/tmp|/private/tmp)'
+
+deny() {
+  local reason="$1"
+  jq -n --arg r "$reason" \
+    '{"permissionDecision":"deny","permissionDecisionReason":$r}'
+  exit 0
+}
+
+case "$TOOL_NAME" in
+  bash)
+    COMMAND=$(echo "$TOOL_ARGS" | jq -r '.command // ""')
+    if echo "$COMMAND" | grep -qE "$TMP_PATTERN"; then
+      deny "/tmp へのアクセスはセキュリティポリシーにより禁止されています。一時ファイルは .git/ 配下を使用してください。"
+    fi
+    ;;
+  create|edit)
+    FILE_PATH=$(echo "$TOOL_ARGS" | jq -r '.path // ""')
+    if echo "$FILE_PATH" | grep -qE "^$TMP_PATTERN"; then
+      deny "/tmp へのファイル書き込みはセキュリティポリシーにより禁止されています。一時ファイルは .git/ 配下を使用してください。"
+    fi
+    ;;
+esac
+
+# Allow all other tool invocations
+exit 0


### PR DESCRIPTION
## 概要

エージェントが `/tmp` にファイルを書き込む問題を、Copilot CLI の公式 Hooks 機能を使ってフレームワークレベルで防止する。

## 背景

- `AGENTS.md` や `.agent.md` に禁止ルールを記載しても、エージェントがルールを無視して `/tmp` にコードを書き込み `rustc` でコンパイル・実行する事象が繰り返し発生した。
- GitHub 公式ドキュメントでは `preToolUse` フックを「危険なコマンドのブロックやセキュリティポリシーの強制」のために使用する仕組みとして明示している。

## 変更内容

- `.github/hooks/security.json` 新規作成
  - `preToolUse` フックで全ツール実行前に `block-tmp-writes.sh` を呼び出す設定
- `.github/scripts/block-tmp-writes.sh` 新規作成
  - `bash` ツール: コマンド文字列に `/tmp` または `/private/tmp` が含まれる場合 `deny`
  - `create`/`edit` ツール: ファイルパスが `/tmp` または `/private/tmp` で始まる場合 `deny`
  - その他はすべて許可

## 動作確認

スクリプト単体のテストで以下を確認済み：
- `/tmp` へのbash書き込みコマンド → deny（日本語メッセージ付き）
- 通常の `cargo test` など → allow（出力なし・exit 0）
- `/tmp` へのファイル作成 → deny
- プロジェクト内のファイル操作 → allow

## 参照

- [GitHub公式: About hooks](https://docs.github.com/en/copilot/concepts/agents/cloud-agent/about-hooks)
- [GitHub公式: Hooks configuration](https://docs.github.com/en/copilot/reference/hooks-configuration)
