### PR TITLE
T05: 辞書境界シールメソッドと文字列プールinternメソッドの実装

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,37 @@
+/// Top-level error type for the TBX VM.
+#[derive(Debug, Clone, PartialEq)]
+pub enum TbxError {
+    /// A string was too long to store in the string pool.
+    ///
+    /// The pool uses a single byte for the length prefix, so strings must be
+    /// at most 255 bytes when encoded as UTF-8.
+    StringTooLong { len: usize },
+}
+
+impl std::fmt::Display for TbxError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TbxError::StringTooLong { len } => {
+                write!(
+                    f,
+                    "string too long for string pool: {} bytes (max 255)",
+                    len
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for TbxError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_string_too_long_display() {
+        let e = TbxError::StringTooLong { len: 300 };
+        assert!(e.to_string().contains("300"));
+        assert!(e.to_string().contains("255"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod cell;
 pub mod dict;
+pub mod error;
 pub mod vm;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1,5 +1,6 @@
 use crate::dict::WordEntry;
 use crate::cell::{Cell, Xt};
+use crate::error::TbxError;
 
 /// The TBX virtual machine.
 ///
@@ -138,18 +139,22 @@ impl VM {
     ///
     /// # Panics
     ///
-    /// Panics if `s` is 256 bytes or longer (length must fit in a `u8`).
-    pub fn intern_string(&mut self, s: &str) -> usize {
+    /// Append a string to the string pool using length-prefix format.
+    ///
+    /// Stores one byte for the UTF-8 byte length followed by the raw bytes.
+    /// Returns the index of the length byte in `string_pool`.
+    ///
+    /// Returns `Err(TbxError::StringTooLong)` if `s` is 256 bytes or longer,
+    /// since the length prefix is a single `u8` (max value 255).
+    pub fn intern_string(&mut self, s: &str) -> Result<usize, TbxError> {
         let bytes = s.as_bytes();
-        assert!(
-            bytes.len() < 256,
-            "string too long for string pool: {} bytes (max 255)",
-            bytes.len()
-        );
+        if bytes.len() > 255 {
+            return Err(TbxError::StringTooLong { len: bytes.len() });
+        }
         let idx = self.string_pool.len();
         self.string_pool.push(bytes.len() as u8);
         self.string_pool.extend_from_slice(bytes);
-        idx
+        Ok(idx)
     }
 }
 
@@ -284,7 +289,7 @@ mod tests {
     #[test]
     fn test_intern_string_basic() {
         let mut vm = VM::new();
-        let idx = vm.intern_string("hello");
+        let idx = vm.intern_string("hello").unwrap();
         assert_eq!(idx, 0);
         assert_eq!(vm.string_pool[0], 5); // length byte
         assert_eq!(&vm.string_pool[1..6], b"hello");
@@ -293,8 +298,8 @@ mod tests {
     #[test]
     fn test_intern_string_multiple() {
         let mut vm = VM::new();
-        let idx1 = vm.intern_string("hi");
-        let idx2 = vm.intern_string("world");
+        let idx1 = vm.intern_string("hi").unwrap();
+        let idx2 = vm.intern_string("world").unwrap();
         // "hi" occupies bytes 0..=2 (1 length + 2 data)
         assert_eq!(idx1, 0);
         assert_eq!(idx2, 3); // 1 (len) + 2 (data) = 3
@@ -307,17 +312,26 @@ mod tests {
     #[test]
     fn test_intern_string_empty() {
         let mut vm = VM::new();
-        let idx = vm.intern_string("");
+        let idx = vm.intern_string("").unwrap();
         assert_eq!(idx, 0);
         assert_eq!(vm.string_pool[0], 0); // zero-length string
         assert_eq!(vm.string_pool.len(), 1);
     }
 
     #[test]
-    #[should_panic(expected = "string too long")]
     fn test_intern_string_too_long() {
         let mut vm = VM::new();
         let long_str = "x".repeat(256);
-        vm.intern_string(&long_str);
+        let result = vm.intern_string(&long_str);
+        assert!(matches!(result, Err(crate::error::TbxError::StringTooLong { len: 256 })));
+    }
+
+    #[test]
+    fn test_intern_string_max_length() {
+        let mut vm = VM::new();
+        let max_str = "x".repeat(255);
+        let result = vm.intern_string(&max_str);
+        assert!(result.is_ok());
+        assert_eq!(vm.string_pool[0], 255);
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -134,15 +134,10 @@ impl VM {
 
     /// Intern a string into the string pool using the length-prefix format.
     ///
-    /// Appends the string as: one byte for the length followed by the UTF-8
-    /// bytes of the string. Returns the index of the length byte in `string_pool`.
+    /// Appends the string as: one byte for the UTF-8 byte length followed by
+    /// the raw bytes. Returns the index of the length byte in `string_pool`.
     ///
-    /// # Panics
-    ///
-    /// Append a string to the string pool using length-prefix format.
-    ///
-    /// Stores one byte for the UTF-8 byte length followed by the raw bytes.
-    /// Returns the index of the length byte in `string_pool`.
+    /// # Errors
     ///
     /// Returns `Err(TbxError::StringTooLong)` if `s` is 256 bytes or longer,
     /// since the length prefix is a single `u8` (max value 255).
@@ -227,8 +222,8 @@ mod tests {
     fn test_seal_sys() {
         let mut vm = VM::new();
         vm.dp = 10;
-        vm.headers.push(WordEntry::new_primitive("A", noop));
-        vm.headers.push(WordEntry::new_primitive("B", noop));
+        vm.register(WordEntry::new_primitive("A", noop));
+        vm.register(WordEntry::new_primitive("B", noop));
         vm.seal_sys();
         assert_eq!(vm.dp_sys, 10);
         assert_eq!(vm.hdr_sys, 2);
@@ -241,7 +236,7 @@ mod tests {
     fn test_seal_lib() {
         let mut vm = VM::new();
         vm.dp = 20;
-        vm.headers.push(WordEntry::new_primitive("X", noop));
+        vm.register(WordEntry::new_primitive("X", noop));
         vm.seal_lib();
         assert_eq!(vm.dp_lib, 20);
         assert_eq!(vm.hdr_lib, 1);
@@ -253,7 +248,7 @@ mod tests {
     fn test_seal_user() {
         let mut vm = VM::new();
         vm.dp = 42;
-        vm.headers.push(WordEntry::new_primitive("Y", noop));
+        vm.register(WordEntry::new_primitive("Y", noop));
         vm.seal_user();
         assert_eq!(vm.dp_user, 42);
         assert_eq!(vm.hdr_user, 1);
@@ -267,15 +262,15 @@ mod tests {
         let mut vm = VM::new();
 
         vm.dp = 5;
-        vm.headers.push(WordEntry::new_primitive("SYS1", noop));
+        vm.register(WordEntry::new_primitive("SYS1", noop));
         vm.seal_sys();
 
         vm.dp = 15;
-        vm.headers.push(WordEntry::new_primitive("LIB1", noop));
+        vm.register(WordEntry::new_primitive("LIB1", noop));
         vm.seal_lib();
 
         vm.dp = 30;
-        vm.headers.push(WordEntry::new_primitive("USR1", noop));
+        vm.register(WordEntry::new_primitive("USR1", noop));
         vm.seal_user();
 
         assert_eq!(vm.dp_sys, 5);
@@ -333,5 +328,16 @@ mod tests {
         let result = vm.intern_string(&max_str);
         assert!(result.is_ok());
         assert_eq!(vm.string_pool[0], 255);
+        assert_eq!(vm.string_pool.len(), 256); // 1 length byte + 255 data bytes
+        assert_eq!(&vm.string_pool[1..], max_str.as_bytes());
+    }
+
+    #[test]
+    fn test_intern_string_multibyte_utf8() {
+        let mut vm = VM::new();
+        // "あ" is 3 bytes in UTF-8; the length prefix must record byte length, not char count
+        let idx = vm.intern_string("あ").unwrap();
+        assert_eq!(vm.string_pool[idx], 3);
+        assert_eq!(&vm.string_pool[idx + 1..idx + 4], "あ".as_bytes());
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -103,6 +103,54 @@ impl VM {
     pub fn pop(&mut self) -> Option<Cell> {
         self.data_stack.pop()
     }
+
+    /// Seal the system dictionary boundary.
+    ///
+    /// Records the current `dp` and `headers.len()` as the end of the system
+    /// dictionary layer. Call this once all system primitives have been registered.
+    pub fn seal_sys(&mut self) {
+        self.dp_sys = self.dp;
+        self.hdr_sys = self.headers.len();
+    }
+
+    /// Seal the standard library dictionary boundary.
+    ///
+    /// Records the current `dp` and `headers.len()` as the end of the standard
+    /// library layer. Call this once the standard library has been loaded.
+    pub fn seal_lib(&mut self) {
+        self.dp_lib = self.dp;
+        self.hdr_lib = self.headers.len();
+    }
+
+    /// Seal the user dictionary boundary.
+    ///
+    /// Records the current `dp` and `headers.len()` as the end of the user
+    /// dictionary layer. Call this before accepting user code in a new session.
+    pub fn seal_user(&mut self) {
+        self.dp_user = self.dp;
+        self.hdr_user = self.headers.len();
+    }
+
+    /// Intern a string into the string pool using the length-prefix format.
+    ///
+    /// Appends the string as: one byte for the length followed by the UTF-8
+    /// bytes of the string. Returns the index of the length byte in `string_pool`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `s` is 256 bytes or longer (length must fit in a `u8`).
+    pub fn intern_string(&mut self, s: &str) -> usize {
+        let bytes = s.as_bytes();
+        assert!(
+            bytes.len() < 256,
+            "string too long for string pool: {} bytes (max 255)",
+            bytes.len()
+        );
+        let idx = self.string_pool.len();
+        self.string_pool.push(bytes.len() as u8);
+        self.string_pool.extend_from_slice(bytes);
+        idx
+    }
 }
 
 impl Default for VM {
@@ -168,5 +216,108 @@ mod tests {
         assert_eq!(vm.lookup("A"), Some(Xt(0)));
         assert_eq!(vm.lookup("B"), Some(Xt(1)));
         assert_eq!(vm.lookup("C"), Some(Xt(2)));
+    }
+
+    #[test]
+    fn test_seal_sys() {
+        let mut vm = VM::new();
+        vm.dp = 10;
+        vm.headers.push(WordEntry::new_primitive("A", noop));
+        vm.headers.push(WordEntry::new_primitive("B", noop));
+        vm.seal_sys();
+        assert_eq!(vm.dp_sys, 10);
+        assert_eq!(vm.hdr_sys, 2);
+        // lib and user remain untouched
+        assert_eq!(vm.dp_lib, 0);
+        assert_eq!(vm.dp_user, 0);
+    }
+
+    #[test]
+    fn test_seal_lib() {
+        let mut vm = VM::new();
+        vm.dp = 20;
+        vm.headers.push(WordEntry::new_primitive("X", noop));
+        vm.seal_lib();
+        assert_eq!(vm.dp_lib, 20);
+        assert_eq!(vm.hdr_lib, 1);
+        assert_eq!(vm.dp_sys, 0);
+        assert_eq!(vm.dp_user, 0);
+    }
+
+    #[test]
+    fn test_seal_user() {
+        let mut vm = VM::new();
+        vm.dp = 42;
+        vm.headers.push(WordEntry::new_primitive("Y", noop));
+        vm.seal_user();
+        assert_eq!(vm.dp_user, 42);
+        assert_eq!(vm.hdr_user, 1);
+        assert_eq!(vm.dp_sys, 0);
+        assert_eq!(vm.dp_lib, 0);
+    }
+
+    #[test]
+    fn test_seal_progression() {
+        // Simulate registering system -> lib -> user words and sealing each layer.
+        let mut vm = VM::new();
+
+        vm.dp = 5;
+        vm.headers.push(WordEntry::new_primitive("SYS1", noop));
+        vm.seal_sys();
+
+        vm.dp = 15;
+        vm.headers.push(WordEntry::new_primitive("LIB1", noop));
+        vm.seal_lib();
+
+        vm.dp = 30;
+        vm.headers.push(WordEntry::new_primitive("USR1", noop));
+        vm.seal_user();
+
+        assert_eq!(vm.dp_sys, 5);
+        assert_eq!(vm.hdr_sys, 1);
+        assert_eq!(vm.dp_lib, 15);
+        assert_eq!(vm.hdr_lib, 2);
+        assert_eq!(vm.dp_user, 30);
+        assert_eq!(vm.hdr_user, 3);
+    }
+
+    #[test]
+    fn test_intern_string_basic() {
+        let mut vm = VM::new();
+        let idx = vm.intern_string("hello");
+        assert_eq!(idx, 0);
+        assert_eq!(vm.string_pool[0], 5); // length byte
+        assert_eq!(&vm.string_pool[1..6], b"hello");
+    }
+
+    #[test]
+    fn test_intern_string_multiple() {
+        let mut vm = VM::new();
+        let idx1 = vm.intern_string("hi");
+        let idx2 = vm.intern_string("world");
+        // "hi" occupies bytes 0..=2 (1 length + 2 data)
+        assert_eq!(idx1, 0);
+        assert_eq!(idx2, 3); // 1 (len) + 2 (data) = 3
+        assert_eq!(vm.string_pool[idx1], 2);
+        assert_eq!(&vm.string_pool[idx1 + 1..idx1 + 3], b"hi");
+        assert_eq!(vm.string_pool[idx2], 5);
+        assert_eq!(&vm.string_pool[idx2 + 1..idx2 + 6], b"world");
+    }
+
+    #[test]
+    fn test_intern_string_empty() {
+        let mut vm = VM::new();
+        let idx = vm.intern_string("");
+        assert_eq!(idx, 0);
+        assert_eq!(vm.string_pool[0], 0); // zero-length string
+        assert_eq!(vm.string_pool.len(), 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "string too long")]
+    fn test_intern_string_too_long() {
+        let mut vm = VM::new();
+        let long_str = "x".repeat(256);
+        vm.intern_string(&long_str);
     }
 }


### PR DESCRIPTION
## 概要

issue #32「T05: 辞書管理機能」の未実装タスクを実装します。

## 変更内容

### `src/vm.rs` に追加したメソッド

#### 辞書境界ポインタの管理

| メソッド | 動作 |
|---|---|
| `seal_sys()` | `dp_sys = dp`、`hdr_sys = headers.len()` に確定させる |
| `seal_lib()` | `dp_lib = dp`、`hdr_lib = headers.len()` に確定させる |
| `seal_user()` | `dp_user = dp`、`hdr_user = headers.len()` に確定させる |

各メソッドは対応する層の初期化完了時に一度だけ呼び出し、境界を記録します。

#### 文字列プールへの追加

- `intern_string(s: &str) -> usize` — 長さプレフィックス方式（1バイト長 + UTF-8バイト列）で `string_pool` に格納し、先頭インデックスを返す
- 256バイト以上の文字列は `panic!` する（長さが `u8` に収まらないため）

### テスト

`#[cfg(test)]` モジュールに以下のテストを追加:

- `test_seal_sys` / `test_seal_lib` / `test_seal_user` — 各シールメソッドの境界確定を検証
- `test_seal_progression` — sys → lib → user の順で段階的にシールする流れを検証
- `test_intern_string_basic` / `test_intern_string_multiple` / `test_intern_string_empty` — 文字列プールへの格納と読み出しを検証
- `test_intern_string_too_long` — 256バイト以上でパニックすることを検証

Closes #32
