### PR TITLE
fix: VM::lookup()の境界チェック欠如によるパニックリスクを修正

### DIFF
--- a/src/cell.rs
+++ b/src/cell.rs
@@ -2,8 +2,12 @@
 ///
 /// Distinct from an index into `VM::dictionary` (the flat code/data array).
 /// `lookup()` returns `Option<Xt>`; `register()` returns `Xt`.
+///
+/// The inner index is intentionally `pub(crate)` to prevent external callers
+/// from constructing arbitrary `Xt` values. Valid `Xt` tokens are obtained
+/// only through `VM::register()` or `VM::lookup()`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Xt(pub usize);
+pub struct Xt(pub(crate) usize);
 
 impl Xt {
     /// Returns the raw index into `VM::headers`.

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -83,9 +83,16 @@ impl VM {
 
     /// Look up a word by name, searching from newest to oldest entry via the linked list.
     /// Returns the `Xt` (header index) if found.
+    ///
+    /// Returns `None` if the word is not found or if an out-of-bounds index is
+    /// encountered in the linked list (defensive guard against corrupted state).
     pub fn lookup(&self, name: &str) -> Option<Xt> {
         let mut current = self.latest;
         while let Some(xt) = current {
+            if xt.index() >= self.headers.len() {
+                // Defensive: index is out of bounds; the linked list is corrupted.
+                break;
+            }
             let entry = &self.headers[xt.index()];
             if entry.name == name {
                 return Some(xt);
@@ -344,5 +351,16 @@ mod tests {
         let idx = vm.intern_string("あ").unwrap();
         assert_eq!(u16::from_le_bytes([vm.string_pool[idx], vm.string_pool[idx + 1]]), 3);
         assert_eq!(&vm.string_pool[idx + 2..idx + 5], "あ".as_bytes());
+    }
+
+    #[test]
+    fn test_lookup_out_of_bounds_latest_returns_none() {
+        // Simulate corrupted state: vm.latest points to an index beyond headers.len().
+        // lookup() must return None instead of panicking.
+        let mut vm = VM::new();
+        // Directly set latest to an out-of-bounds Xt (index 99, but headers is empty)
+        vm.latest = Some(Xt(99));
+        // Should return None, not panic
+        assert_eq!(vm.lookup("FOO"), None);
     }
 }


### PR DESCRIPTION
## 概要

`VM::lookup()` の境界チェック欠如によるパニックリスクを修正する（issue #63）。

## 変更内容

### 案A: `Xt` 内部フィールドの可視性変更

`pub struct Xt(pub usize)` → `pub struct Xt(pub(crate) usize)`

- 外部ライブラリ利用者が `Xt(9999)` のような任意インデックスの `Xt` を構築できなくなる
- クレート内部（`vm.rs` の `register()` 等）は引き続きそのまま利用可能
- `VM::register()` の戻り値または `VM::lookup()` の結果としてのみ `Xt` を取得できる

### 案B: `VM::lookup()` への境界チェック追加

リンクリストの走査中に `xt.index() >= self.headers.len()` を検出した場合、
パニックではなく `None` を返す防御的ガードを追加。

### テスト追加

`vm.latest` に範囲外インデックスを持つ `Xt` がセットされた場合に `lookup()` が
パニックせず `None` を返すことを確認するテストを追加。

## 動作確認

```
cargo build   ✅
cargo test    ✅ (37 tests passed)
cargo clippy  ✅ (warnings なし)
```

Closes #63
