### PR TITLE
fix: review-implementationエージェントにgh pr reviewのフォールバック手順を追記

### DIFF
--- a/.github/agents/review-implementation.agent.md
+++ b/.github/agents/review-implementation.agent.md
@@ -96,6 +96,13 @@ Critical / Warning の問題を以下の2段階で記録する。
 `gh pr review` コマンドでレビューコメントを投稿する（PRへの書き込みはMCPサーバーに対応ツールがないため `gh` CLIを使用する）。
 全コメントをまとめて `REQUEST_CHANGES`（Criticalあり）または `COMMENT`（Warningのみ）で提出する。
 
+> **注意**: `implement-issue` エージェントと同じユーザートークンで動作している場合、GitHubの制約により「PRの作成者は自分のPRをレビューできない」エラー（`GraphQL: Can't request changes on your own pull request`）が発生する。その場合は `gh pr comment` にフォールバックする。
+>
+> ```bash
+> # フォールバック: 通常コメントとして投稿
+> gh pr comment <PR番号> --body-file "$(git rev-parse --git-dir)/REVIEW_BODY.md"
+> ```
+
 コメントのフォーマット：
 
 ```


### PR DESCRIPTION
## 概要

`gh pr review` はPR作成者が自分のPRに対して実行するとGitHubにより拒否される。
`implement-issue` と `review-implementation` が同一ユーザートークンで動作する現構成では常にこのエラーが発生するため、フォールバック手順を追記する。

## 変更内容

`review-implementation.agent.md` のステップ5-1に注記を追加：
- エラーの発生条件（同一ユーザートークン）を説明
- `gh pr comment` へのフォールバックコマンドを明記

## エラーの詳細

```
GraphQL: Can't request changes on your own pull request (addPullRequestReview)
```

GitHub側の仕様として、PRの作成者は `REQUEST_CHANGES` / `COMMENT` いずれの `gh pr review` も実行できない。`gh pr comment` は制約なく使用できる。
