### PR TITLE
dict.rs: WordEntry・FLAG_IMMEDIATEのユニットテストを追加

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tbx"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.76"
 description = "Tiny BASIC eXtensible - a bootstrappable BASIC interpreter"
 
 [lib]

--- a/src/dict.rs
+++ b/src/dict.rs
@@ -96,3 +96,157 @@ impl WordEntry {
         self.flags & FLAG_IMMEDIATE != 0
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cell::Cell;
+
+    /// A dummy primitive function used to obtain a concrete `PrimFn` value in tests.
+    fn dummy_prim(_vm: &mut crate::vm::VM) {}
+
+    // --- FLAG_IMMEDIATE constant ---
+
+    #[test]
+    fn test_flag_immediate_value() {
+        // FLAG_IMMEDIATE must be exactly bit 0 (0b0000_0001).
+        assert_eq!(FLAG_IMMEDIATE, 0b0000_0001);
+    }
+
+    // --- new_primitive ---
+
+    #[test]
+    fn test_new_primitive_name() {
+        let entry = WordEntry::new_primitive("dup", dummy_prim);
+        assert_eq!(entry.name, "dup");
+    }
+
+    #[test]
+    fn test_new_primitive_flags_zero() {
+        let entry = WordEntry::new_primitive("dup", dummy_prim);
+        assert_eq!(entry.flags, 0);
+    }
+
+    #[test]
+    fn test_new_primitive_prev_none() {
+        let entry = WordEntry::new_primitive("dup", dummy_prim);
+        assert!(entry.prev.is_none());
+    }
+
+    #[test]
+    fn test_new_primitive_kind() {
+        let entry = WordEntry::new_primitive("dup", dummy_prim);
+        assert!(matches!(entry.kind, EntryKind::Primitive(_)));
+    }
+
+    // --- new_word ---
+
+    #[test]
+    fn test_new_word_name() {
+        let entry = WordEntry::new_word("square", 42);
+        assert_eq!(entry.name, "square");
+    }
+
+    #[test]
+    fn test_new_word_flags_zero() {
+        let entry = WordEntry::new_word("square", 42);
+        assert_eq!(entry.flags, 0);
+    }
+
+    #[test]
+    fn test_new_word_prev_none() {
+        let entry = WordEntry::new_word("square", 42);
+        assert!(entry.prev.is_none());
+    }
+
+    #[test]
+    fn test_new_word_kind_offset() {
+        let entry = WordEntry::new_word("square", 42);
+        assert!(matches!(entry.kind, EntryKind::Word(42)));
+    }
+
+    // --- new_variable ---
+
+    #[test]
+    fn test_new_variable_name() {
+        let entry = WordEntry::new_variable("counter", 10);
+        assert_eq!(entry.name, "counter");
+    }
+
+    #[test]
+    fn test_new_variable_flags_zero() {
+        let entry = WordEntry::new_variable("counter", 10);
+        assert_eq!(entry.flags, 0);
+    }
+
+    #[test]
+    fn test_new_variable_prev_none() {
+        let entry = WordEntry::new_variable("counter", 10);
+        assert!(entry.prev.is_none());
+    }
+
+    #[test]
+    fn test_new_variable_kind_idx() {
+        let entry = WordEntry::new_variable("counter", 10);
+        assert!(matches!(entry.kind, EntryKind::Variable(10)));
+    }
+
+    // --- new_constant ---
+
+    #[test]
+    fn test_new_constant_name() {
+        let entry = WordEntry::new_constant("MAX", Cell::Int(100));
+        assert_eq!(entry.name, "MAX");
+    }
+
+    #[test]
+    fn test_new_constant_flags_zero() {
+        let entry = WordEntry::new_constant("MAX", Cell::Int(100));
+        assert_eq!(entry.flags, 0);
+    }
+
+    #[test]
+    fn test_new_constant_prev_none() {
+        let entry = WordEntry::new_constant("MAX", Cell::Int(100));
+        assert!(entry.prev.is_none());
+    }
+
+    #[test]
+    fn test_new_constant_kind_value() {
+        let entry = WordEntry::new_constant("MAX", Cell::Int(100));
+        assert!(matches!(entry.kind, EntryKind::Constant(Cell::Int(100))));
+    }
+
+    // --- is_immediate ---
+
+    #[test]
+    fn test_is_immediate_false_by_default() {
+        // All constructors set flags = 0, so is_immediate() must return false.
+        let entry = WordEntry::new_primitive("dup", dummy_prim);
+        assert!(!entry.is_immediate());
+    }
+
+    #[test]
+    fn test_is_immediate_true_when_flag_set() {
+        let mut entry = WordEntry::new_primitive("if", dummy_prim);
+        entry.flags |= FLAG_IMMEDIATE;
+        assert!(entry.is_immediate());
+    }
+
+    #[test]
+    fn test_is_immediate_ignores_other_bits() {
+        // Setting bits other than FLAG_IMMEDIATE must not affect is_immediate().
+        let mut entry = WordEntry::new_primitive("dup", dummy_prim);
+        entry.flags = 0b1111_1110; // all bits except bit 0
+        assert!(!entry.is_immediate());
+    }
+
+    #[test]
+    fn test_is_immediate_true_with_other_bits_also_set() {
+        // is_immediate() should return true whenever FLAG_IMMEDIATE bit is set,
+        // regardless of other bits.
+        let mut entry = WordEntry::new_primitive("if", dummy_prim);
+        entry.flags = 0b1111_1111; // all bits including bit 0
+        assert!(entry.is_immediate());
+    }
+}

--- a/src/dict.rs
+++ b/src/dict.rs
@@ -136,7 +136,12 @@ mod tests {
     #[test]
     fn test_new_primitive_kind() {
         let entry = WordEntry::new_primitive("dup", dummy_prim);
-        assert!(matches!(entry.kind, EntryKind::Primitive(_)));
+        // Verify both the variant and that the stored function pointer is dummy_prim.
+        // Use fn_addr_eq to avoid the unpredictable_function_pointer_comparisons lint.
+        let EntryKind::Primitive(stored_fn) = entry.kind else {
+            panic!("expected EntryKind::Primitive");
+        };
+        assert!(std::ptr::fn_addr_eq(stored_fn, dummy_prim as PrimFn));
     }
 
     // --- new_word ---


### PR DESCRIPTION
## 概要

`src/dict.rs` に `#[cfg(test)]` モジュールを追加し、公開関数・定数のユニットテストを実装しました。

## 変更内容

- `FLAG_IMMEDIATE` の値が `0b0000_0001` であることを検証するテスト
- `WordEntry::new_primitive()` の name / flags / prev / kind を検証するテスト
- `WordEntry::new_word()` の name / flags / prev / kind(offset) を検証するテスト
- `WordEntry::new_variable()` の name / flags / prev / kind(idx) を検証するテスト
- `WordEntry::new_constant()` の name / flags / prev / kind(value) を検証するテスト
- `is_immediate()` が `FLAG_IMMEDIATE` ビットのみを正しく検査することを検証するテスト（他ビットへの影響なし）

## テスト結果

```
test dict::tests::test_flag_immediate_value ... ok
test dict::tests::test_is_immediate_false_by_default ... ok
test dict::tests::test_is_immediate_ignores_other_bits ... ok
test dict::tests::test_is_immediate_true_when_flag_set ... ok
test dict::tests::test_is_immediate_true_with_other_bits_also_set ... ok
test dict::tests::test_new_constant_flags_zero ... ok
test dict::tests::test_new_constant_kind_value ... ok
test dict::tests::test_new_constant_name ... ok
test dict::tests::test_new_constant_prev_none ... ok
test dict::tests::test_new_primitive_flags_zero ... ok
test dict::tests::test_new_primitive_kind ... ok
test dict::tests::test_new_primitive_name ... ok
test dict::tests::test_new_primitive_prev_none ... ok
test dict::tests::test_new_variable_flags_zero ... ok
test dict::tests::test_new_variable_kind_idx ... ok
test dict::tests::test_new_variable_name ... ok
test dict::tests::test_new_variable_prev_none ... ok
test dict::tests::test_new_word_flags_zero ... ok
test dict::tests::test_new_word_kind_offset ... ok
test dict::tests::test_new_word_name ... ok
test dict::tests::test_new_word_prev_none ... ok
```

Closes #64
