### PR TITLE
T06: スタック操作プリミティブを実装する

### DIFF
--- a/src/dict.rs
+++ b/src/dict.rs
@@ -14,7 +14,8 @@ pub enum EntryKind {
     Variable(usize),
     /// Constant — value stored directly in this entry
     Constant(Cell),
-    /// Handled by the inner interpreter: push next cell as a literal value
+    /// Handled by the inner interpreter: push next cell as a literal value.
+    /// TODO: dispatched in the inner interpreter loop (to be implemented in a future task).
     Lit,
 }
 

--- a/src/dict.rs
+++ b/src/dict.rs
@@ -1,7 +1,7 @@
 use crate::cell::{Cell, Xt};
 
 /// Function pointer type for native Rust primitives.
-pub type PrimFn = fn(&mut crate::vm::VM);
+pub type PrimFn = fn(&mut crate::vm::VM) -> Result<(), crate::error::TbxError>;
 
 /// How a dictionary entry is executed or accessed.
 #[derive(Clone)]
@@ -14,6 +14,8 @@ pub enum EntryKind {
     Variable(usize),
     /// Constant — value stored directly in this entry
     Constant(Cell),
+    /// Handled by the inner interpreter: push next cell as a literal value
+    Lit,
 }
 
 impl std::fmt::Debug for EntryKind {
@@ -23,6 +25,7 @@ impl std::fmt::Debug for EntryKind {
             EntryKind::Primitive(ptr) => write!(f, "Primitive({ptr:p})"),
             EntryKind::Variable(idx) => write!(f, "Variable({idx})"),
             EntryKind::Constant(cell) => write!(f, "Constant({cell:?})"),
+            EntryKind::Lit => write!(f, "Lit"),
         }
     }
 }
@@ -103,7 +106,9 @@ mod tests {
     use crate::cell::Cell;
 
     /// A dummy primitive function used to obtain a concrete `PrimFn` value in tests.
-    fn dummy_prim(_vm: &mut crate::vm::VM) {}
+    fn dummy_prim(_vm: &mut crate::vm::VM) -> Result<(), crate::error::TbxError> {
+        Ok(())
+    }
 
     // --- FLAG_IMMEDIATE constant ---
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,8 @@ pub enum TbxError {
     /// must be at most 65535 bytes when encoded as UTF-8. This limit applies at
     /// the lexer/parser level before the string reaches the pool.
     StringTooLong { len: usize },
+    /// A pop was attempted on an empty data stack.
+    StackUnderflow,
 }
 
 impl std::fmt::Display for TbxError {
@@ -19,6 +21,7 @@ impl std::fmt::Display for TbxError {
                     len
                 )
             }
+            TbxError::StackUnderflow => write!(f, "stack underflow"),
         }
     }
 }
@@ -34,5 +37,17 @@ mod tests {
         let e = TbxError::StringTooLong { len: 300 };
         assert!(e.to_string().contains("300"));
         assert!(e.to_string().contains("65535"));
+    }
+
+    #[test]
+    fn test_stack_underflow_display() {
+        let e = TbxError::StackUnderflow;
+        assert!(e.to_string().contains("stack underflow"));
+    }
+
+    #[test]
+    fn test_stack_underflow_debug() {
+        let e = TbxError::StackUnderflow;
+        assert!(format!("{:?}", e).contains("StackUnderflow"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod cell;
 pub mod dict;
 pub mod error;
+pub mod primitives;
 pub mod vm;

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1,3 +1,4 @@
+use crate::dict::WordEntry;
 use crate::error::TbxError;
 use crate::vm::VM;
 
@@ -22,6 +23,13 @@ pub fn swap_prim(vm: &mut VM) -> Result<(), TbxError> {
     vm.push(a);
     vm.push(b);
     Ok(())
+}
+
+/// Register all stack primitives (DROP, DUP, SWAP) into the VM's dictionary.
+pub fn register_all(vm: &mut VM) {
+    vm.register(WordEntry::new_primitive("DROP", drop_prim));
+    vm.register(WordEntry::new_primitive("DUP", dup_prim));
+    vm.register(WordEntry::new_primitive("SWAP", swap_prim));
 }
 
 #[cfg(test)]
@@ -89,5 +97,30 @@ mod tests {
         let mut vm = VM::new();
         vm.push(Cell::Int(1));
         assert_eq!(swap_prim(&mut vm), Err(TbxError::StackUnderflow));
+    }
+
+    // --- register_all ---
+
+    #[test]
+    fn test_register_all_registers_drop_dup_swap() {
+        let mut vm = VM::new();
+        register_all(&mut vm);
+        assert!(vm.lookup("DROP").is_some());
+        assert!(vm.lookup("DUP").is_some());
+        assert!(vm.lookup("SWAP").is_some());
+    }
+
+    #[test]
+    fn test_register_all_drop_is_callable() {
+        let mut vm = VM::new();
+        register_all(&mut vm);
+        let xt = vm.lookup("DROP").unwrap();
+        vm.push(Cell::Int(99));
+        if let crate::dict::EntryKind::Primitive(f) = vm.headers[xt.index()].kind {
+            f(&mut vm).unwrap();
+        } else {
+            panic!("DROP is not a Primitive");
+        }
+        assert_eq!(vm.pop(), Err(TbxError::StackUnderflow));
     }
 }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1,0 +1,93 @@
+use crate::error::TbxError;
+use crate::vm::VM;
+
+/// DROP — discard the top element of the data stack.
+pub fn drop_prim(vm: &mut VM) -> Result<(), TbxError> {
+    vm.pop()?;
+    Ok(())
+}
+
+/// DUP — duplicate the top element of the data stack.
+pub fn dup_prim(vm: &mut VM) -> Result<(), TbxError> {
+    let top = vm.pop()?;
+    vm.push(top.clone());
+    vm.push(top);
+    Ok(())
+}
+
+/// SWAP — exchange the top two elements of the data stack.
+pub fn swap_prim(vm: &mut VM) -> Result<(), TbxError> {
+    let a = vm.pop()?;
+    let b = vm.pop()?;
+    vm.push(a);
+    vm.push(b);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cell::Cell;
+
+    // --- drop_prim ---
+
+    #[test]
+    fn test_drop_removes_top() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(1));
+        vm.push(Cell::Int(2));
+        drop_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Int(1)));
+    }
+
+    #[test]
+    fn test_drop_underflow() {
+        let mut vm = VM::new();
+        assert_eq!(drop_prim(&mut vm), Err(TbxError::StackUnderflow));
+    }
+
+    // --- dup_prim ---
+
+    #[test]
+    fn test_dup_duplicates_top() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(42));
+        dup_prim(&mut vm).unwrap();
+        // Both copies must be on the stack; the original is below.
+        assert_eq!(vm.pop(), Ok(Cell::Int(42)));
+        assert_eq!(vm.pop(), Ok(Cell::Int(42)));
+        assert_eq!(vm.pop(), Err(TbxError::StackUnderflow));
+    }
+
+    #[test]
+    fn test_dup_underflow() {
+        let mut vm = VM::new();
+        assert_eq!(dup_prim(&mut vm), Err(TbxError::StackUnderflow));
+    }
+
+    // --- swap_prim ---
+
+    #[test]
+    fn test_swap_exchanges_top_two() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(1));
+        vm.push(Cell::Int(2));
+        swap_prim(&mut vm).unwrap();
+        // After swap: 1 is on top, 2 is below.
+        assert_eq!(vm.pop(), Ok(Cell::Int(1)));
+        assert_eq!(vm.pop(), Ok(Cell::Int(2)));
+    }
+
+    #[test]
+    fn test_swap_underflow_empty() {
+        let mut vm = VM::new();
+        assert_eq!(swap_prim(&mut vm), Err(TbxError::StackUnderflow));
+    }
+
+    #[test]
+    fn test_swap_underflow_one_element() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(1));
+        assert_eq!(swap_prim(&mut vm), Err(TbxError::StackUnderflow));
+    }
+}

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -108,8 +108,12 @@ impl VM {
     }
 
     /// Pop a value from the data stack.
-    pub fn pop(&mut self) -> Option<Cell> {
-        self.data_stack.pop()
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(TbxError::StackUnderflow)` if the data stack is empty.
+    pub fn pop(&mut self) -> Result<Cell, TbxError> {
+        self.data_stack.pop().ok_or(TbxError::StackUnderflow)
     }
 
     /// Seal the system dictionary boundary.
@@ -173,7 +177,9 @@ mod tests {
     use super::*;
     use crate::dict::WordEntry;
 
-    fn noop(_vm: &mut VM) {}
+    fn noop(_vm: &mut VM) -> Result<(), crate::error::TbxError> {
+        Ok(())
+    }
 
     #[test]
     fn test_vm_new() {
@@ -190,8 +196,8 @@ mod tests {
     fn test_push_pop() {
         let mut vm = VM::new();
         vm.push(Cell::Int(42));
-        assert_eq!(vm.pop(), Some(Cell::Int(42)));
-        assert_eq!(vm.pop(), None);
+        assert_eq!(vm.pop(), Ok(Cell::Int(42)));
+        assert_eq!(vm.pop(), Err(crate::error::TbxError::StackUnderflow));
     }
 
     #[test]


### PR DESCRIPTION
## 概要

issue #33「T06: スタック操作プリミティブ」の実装。

## 変更内容

### `src/error.rs`
- `TbxError` に `StackUnderflow` バリアントを追加
- `Display` 実装に `StackUnderflow` のアームを追加
- `StackUnderflow` の `Display` / `Debug` テストを追加

### `src/dict.rs`
- `PrimFn` 型を `fn(&mut VM) -> Result<(), TbxError>` に変更
- `EntryKind` に `Lit` バリアントを追加（インナインタプリタが次のセルをリテラルとして push するために使用）
- `Debug` 実装に `Lit` アームを追加
- テスト内 `dummy_prim` のシグネチャを新しい `PrimFn` 型に合わせて更新

### `src/vm.rs`
- `pop()` の返り値を `Option<Cell>` から `Result<Cell, TbxError>` に変更
- `test_push_pop` テストを `Result` 対応に更新
- テスト内 `noop` のシグネチャを新しい `PrimFn` 型に合わせて更新

### `src/primitives.rs`（新規）
- `drop_prim`: スタックトップを捨てる
- `dup_prim`: スタックトップを複製する
- `swap_prim`: スタックトップ2要素を入れ替える
- 各プリミティブの正常系・スタックアンダーフロー系テストを追加

### `src/lib.rs`
- `pub mod primitives;` を追加

## テスト結果

`cargo test` — 69 tests passed  
`cargo clippy -- -D warnings` — 警告なし

Closes #33
