### PR TITLE
T07: メモリ操作プリミティブ FETCH/STORE を実装

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -17,6 +17,7 @@ pub enum TbxError {
         expected: &'static str,
         got: &'static str,
     },
+    IndexOutOfBounds { index: usize, size: usize },
 }
 
 impl std::fmt::Display for TbxError {
@@ -32,6 +33,9 @@ impl std::fmt::Display for TbxError {
             TbxError::StackUnderflow => write!(f, "stack underflow"),
             TbxError::TypeError { expected, got } => {
                 write!(f, "type error: expected {}, got {}", expected, got)
+            }
+            TbxError::IndexOutOfBounds { index, size } => {
+                write!(f, "index out of bounds: index {}, size {}", index, size)
             }
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,6 +9,14 @@ pub enum TbxError {
     StringTooLong { len: usize },
     /// A pop was attempted on an empty data stack.
     StackUnderflow,
+    /// A value of the wrong type was provided.
+    ///
+    /// `expected` describes the type(s) the operation accepts;
+    /// `got` describes the type that was actually on the stack.
+    TypeError {
+        expected: &'static str,
+        got: &'static str,
+    },
 }
 
 impl std::fmt::Display for TbxError {
@@ -22,6 +30,9 @@ impl std::fmt::Display for TbxError {
                 )
             }
             TbxError::StackUnderflow => write!(f, "stack underflow"),
+            TbxError::TypeError { expected, got } => {
+                write!(f, "type error: expected {}, got {}", expected, got)
+            }
         }
     }
 }
@@ -49,5 +60,16 @@ mod tests {
     fn test_stack_underflow_debug() {
         let e = TbxError::StackUnderflow;
         assert!(format!("{:?}", e).contains("StackUnderflow"));
+    }
+
+    #[test]
+    fn test_type_error_display() {
+        let e = TbxError::TypeError {
+            expected: "address",
+            got: "Int",
+        };
+        let msg = e.to_string();
+        assert!(msg.contains("address"));
+        assert!(msg.contains("Int"));
     }
 }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1,3 +1,4 @@
+use crate::cell::Cell;
 use crate::dict::WordEntry;
 use crate::error::TbxError;
 use crate::vm::VM;
@@ -25,11 +26,54 @@ pub fn swap_prim(vm: &mut VM) -> Result<(), TbxError> {
     Ok(())
 }
 
+/// FETCH — fetch a value from an address and push it onto the stack.
+pub fn fetch_prim(vm: &mut VM) -> Result<(), TbxError> {
+    let addr = vm.pop()?;
+    match addr {
+        Cell::DictAddr(a) => {
+            let value = vm.dictionary[a].clone();
+            vm.push(value);
+            Ok(())
+        }
+        Cell::StackAddr(a) => {
+            // TODO: vm.bp との加算をvmにカプセル化したい。その中で範囲チェックも行う。
+            let value = vm.data_stack[vm.bp + a].clone();
+            vm.push(value);
+            Ok(())        }
+        _ => Err(TbxError::TypeError {
+            expected: "address",
+            got: "non-address",
+        })
+    }
+}
+
+/// STORE — pop a value and an address, and store the value at the address.
+pub fn store_prim(vm: &mut VM) -> Result<(), TbxError> {
+    let addr = vm.pop()?;
+    let value = vm.pop()?;
+    match addr {
+        Cell::DictAddr(a) => {
+            vm.dictionary[a] = value;
+            Ok(())
+        }
+        Cell::StackAddr(a) => {
+            vm.data_stack[vm.bp + a] = value;
+            Ok(())
+        }
+        _ => Err(TbxError::TypeError {
+            expected: "address",
+            got: "non-address",
+        })
+    }
+}
+
 /// Register all stack primitives (DROP, DUP, SWAP) into the VM's dictionary.
 pub fn register_all(vm: &mut VM) {
     vm.register(WordEntry::new_primitive("DROP", drop_prim));
     vm.register(WordEntry::new_primitive("DUP", dup_prim));
     vm.register(WordEntry::new_primitive("SWAP", swap_prim));
+    vm.register(WordEntry::new_primitive("FETCH", fetch_prim));
+    vm.register(WordEntry::new_primitive("STORE", store_prim));
 }
 
 #[cfg(test)]
@@ -122,5 +166,86 @@ mod tests {
             panic!("DROP is not a Primitive");
         }
         assert_eq!(vm.pop(), Err(TbxError::StackUnderflow));
+    }
+
+    #[test]
+    fn test_fetch_dict_addr() {
+        let mut vm = VM::new();
+        vm.dictionary.push(Cell::Int(123)); // dict[0] = 123
+        vm.push(Cell::DictAddr(0));
+        fetch_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Int(123)));
+    }
+
+    #[test]
+    fn test_fetch_stack_addr() {
+        // This test also verifies that fetch_prim correctly adds vm.bp to the address.
+        let mut vm = VM::new();
+        vm.push(Cell::Int(10));   // data_stack[0] = 10
+        vm.push(Cell::Int(20));   // data_stack[1] = 20
+        vm.bp = 1;                // base pointer at index 1
+        vm.push(Cell::StackAddr(0)); // address of data_stack[bp + 0] = data_stack[1] = 20
+        fetch_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Int(20)));
+    }
+
+    #[test]
+    fn test_fetch_type_error() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(42)); // Not an address
+        assert_eq!(
+            fetch_prim(&mut vm),
+            Err(TbxError::TypeError {
+                expected: "address",
+                got: "non-address"
+            })
+        );
+    }
+
+    #[test]
+    fn test_fetch_underflow() {
+        let mut vm = VM::new();
+        assert_eq!(fetch_prim(&mut vm), Err(TbxError::StackUnderflow));
+    }
+    
+    #[test]
+    fn test_store_dict_addr() {
+        let mut vm = VM::new();
+        vm.dictionary.push(Cell::Int(0)); // dict[0] = 0
+        vm.push(Cell::Int(123)); // value to store
+        vm.push(Cell::DictAddr(0)); // address to store at
+        store_prim(&mut vm).unwrap();
+        assert_eq!(vm.dictionary[0], Cell::Int(123));
+    }
+
+    #[test]
+    fn test_store_stack_addr() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(0)); // data_stack[0] = 0
+        vm.bp = 0;
+        vm.push(Cell::Int(123)); // value to store
+        vm.push(Cell::StackAddr(0)); // address to store at
+        store_prim(&mut vm).unwrap();
+        assert_eq!(vm.data_stack[0], Cell::Int(123));
+    }
+
+    #[test]
+    fn test_store_type_error() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(123)); // value to store
+        vm.push(Cell::Int(0)); // Not an address
+        assert_eq!(
+            store_prim(&mut vm),
+            Err(TbxError::TypeError {
+                expected: "address",
+                got: "non-address"
+            })
+        );
+    }
+
+    #[test]
+    fn test_store_underflow() {
+        let mut vm = VM::new();
+        assert_eq!(store_prim(&mut vm), Err(TbxError::StackUnderflow));
     }
 }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -31,15 +31,23 @@ pub fn fetch_prim(vm: &mut VM) -> Result<(), TbxError> {
     let addr = vm.pop()?;
     match addr {
         Cell::DictAddr(a) => {
-            let value = vm.dictionary[a].clone();
+            let size = vm.dictionary.len();
+            let value = vm.dictionary.get(a)
+                .ok_or(TbxError::IndexOutOfBounds { index: a, size })?
+                .clone();
             vm.push(value);
             Ok(())
         }
         Cell::StackAddr(a) => {
             // TODO: vm.bp との加算をvmにカプセル化したい。その中で範囲チェックも行う。
-            let value = vm.data_stack[vm.bp + a].clone();
+            let idx = vm.bp + a;
+            let size = vm.data_stack.len();
+            let value = vm.data_stack.get(idx)
+                .ok_or(TbxError::IndexOutOfBounds { index: idx, size })?
+                .clone();
             vm.push(value);
-            Ok(())        }
+            Ok(())
+        }
         _ => Err(TbxError::TypeError {
             expected: "address",
             got: "non-address",
@@ -53,11 +61,16 @@ pub fn store_prim(vm: &mut VM) -> Result<(), TbxError> {
     let value = vm.pop()?;
     match addr {
         Cell::DictAddr(a) => {
-            vm.dictionary[a] = value;
+            let size = vm.dictionary.len();
+            *vm.dictionary.get_mut(a)
+                .ok_or(TbxError::IndexOutOfBounds { index: a, size })? = value;
             Ok(())
         }
         Cell::StackAddr(a) => {
-            vm.data_stack[vm.bp + a] = value;
+            let idx = vm.bp + a;
+            let size = vm.data_stack.len();
+            *vm.data_stack.get_mut(idx)
+                .ok_or(TbxError::IndexOutOfBounds { index: idx, size })? = value;
             Ok(())
         }
         _ => Err(TbxError::TypeError {
@@ -67,7 +80,7 @@ pub fn store_prim(vm: &mut VM) -> Result<(), TbxError> {
     }
 }
 
-/// Register all stack primitives (DROP, DUP, SWAP) into the VM's dictionary.
+/// Register all stack primitives into the VM's dictionary.
 pub fn register_all(vm: &mut VM) {
     vm.register(WordEntry::new_primitive("DROP", drop_prim));
     vm.register(WordEntry::new_primitive("DUP", dup_prim));
@@ -246,6 +259,13 @@ mod tests {
     #[test]
     fn test_store_underflow() {
         let mut vm = VM::new();
+        assert_eq!(store_prim(&mut vm), Err(TbxError::StackUnderflow));
+    }
+
+    #[test]
+    fn test_store_underflow_one_value() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(123)); // value to store
         assert_eq!(store_prim(&mut vm), Err(TbxError::StackUnderflow));
     }
 }


### PR DESCRIPTION
## 概要

辞書メモリ（アドレス空間）への読み書きプリミティブ FETCH / STORE を実装する。

## 変更内容

- `TbxError::TypeError { expected, got }` バリアントを追加（汎用的な型エラー）
- `fetch_prim`: `DictAddr` / `StackAddr` から値を読み出してスタックに積む
- `store_prim`: スタックから値とアドレスを取り出し、指定アドレスに書き込む
- `register_all` に FETCH / STORE を登録
- テスト8件追加（正常系・TypeError・StackUnderflow）

Closes #34
