### PR TITLE
T08: リターンスタック操作とEXITプリミティブ

### DIFF
--- a/src/cell.rs
+++ b/src/cell.rs
@@ -16,6 +16,12 @@ impl Xt {
     }
 }
 
+/// Return frame for the return stack, saving the program counter and base pointer
+#[derive(Debug, Clone)]
+pub enum ReturnFrame {
+    Call { pc: usize, bp: usize },
+ }
+
 /// Cell is the fundamental value type of the TBX VM.
 /// It represents all values that can exist on the stack or in the dictionary.
 #[derive(Debug, Clone)]
@@ -34,12 +40,11 @@ pub enum Cell {
     Xt(Xt),
     /// Boolean value for logical/comparison operations
     Bool(bool),
-    /// Empty / null value
-    None,
-    /// Reserved for future array support
-    Array,
     /// Index into the string pool (length-prefixed)
     StringDesc(usize),
+    /// Reserved for future array support
+    Array,
+    None,
 }
 
 impl std::fmt::Display for Cell {
@@ -65,9 +70,9 @@ impl std::fmt::Display for Cell {
             Cell::StackAddr(a) => write!(f, "stack:{}", a),
             Cell::Xt(x) => write!(f, "xt:{}", x.0),
             Cell::Bool(b) => write!(f, "{}", b),
-            Cell::None => write!(f, "<none>"),
-            Cell::Array => write!(f, "<array>"),
             Cell::StringDesc(i) => write!(f, "str:{}", i),
+            Cell::Array => write!(f, "<array>"),
+            Cell::None => write!(f, "<none>"),
         }
     }
 }
@@ -145,9 +150,9 @@ impl Cell {
             Cell::StackAddr(_) => "StackAddr",
             Cell::Xt(_) => "Xt",
             Cell::Bool(_) => "Bool",
-            Cell::None => "None",
-            Cell::Array => "Array",
             Cell::StringDesc(_) => "StringDesc",
+            Cell::Array => "Array",
+            Cell::None => "None",
         }
     }
 

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -88,33 +88,34 @@ pub fn store_prim(vm: &mut VM) -> Result<(), TbxError> {
 
 /// CALL — call an execution token (Xt).
 pub fn call_prim(vm: &mut VM) -> Result<(), TbxError> {
-    let xt = vm
+    let xt_cell = vm
         .dictionary
         .get(vm.pc + 1)
         .ok_or(TbxError::IndexOutOfBounds {
             index: vm.pc + 1,
             size: vm.dictionary.len(),
         })?;
-    if let Cell::Xt(x) = xt {
-        let pc = vm.pc + 2; // CALL instruction is 2 cells: opcode + xt
-        let bp = vm.bp;
-        let return_frame = ReturnFrame::Call { pc, bp };
-        vm.return_stack.push(return_frame);
-        vm.bp = vm.data_stack.len();
-        match vm.headers[x.index()].kind {
-            EntryKind::Word(offset) => vm.pc = offset,
+    if let Cell::Xt(x) = xt_cell {
+        let offset = match vm.headers[x.index()].kind {
+            EntryKind::Word(offset) => offset,
             _ => {
                 return Err(TbxError::TypeError {
                     expected: "callable (primitive or word)",
                     got: "non-callable",
                 })
             }
-        }
+        };
+        let pc = vm.pc + 2; // CALL命令の次の命令のアドレス)
+        let bp = vm.bp;
+        let return_frame = ReturnFrame::Call { pc, bp };
+        vm.return_stack.push(return_frame);
+        vm.bp = vm.data_stack.len();
+        vm.pc = offset;
         Ok(())
     } else {
         Err(TbxError::TypeError {
             expected: "Xt",
-            got: xt.type_name(),
+            got: xt_cell.type_name(),
         })
     }
 }
@@ -354,9 +355,12 @@ mod tests {
         vm.dictionary.push(Cell::None);
         vm.dictionary.push(Cell::Int(123)); // Not an Xt
         vm.pc = 0;
-        assert_eq!(call_prim(&mut vm), Err(TbxError::TypeError {
-            expected: "Xt",
-            got: "Int"
-        }));
+        assert_eq!(
+            call_prim(&mut vm),
+            Err(TbxError::TypeError {
+                expected: "Xt",
+                got: "Int"
+            })
+        );
     }
 }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -363,4 +363,22 @@ mod tests {
             })
         );
     }
+
+    #[test]
+    fn test_call_non_word_xt() {
+        let mut vm = VM::new();
+        register_all(&mut vm);
+        let drop_xt = vm.lookup("DROP").unwrap();
+        vm.dictionary.push(Cell::None);
+        vm.dictionary.push(Cell::Xt(drop_xt)); // Xt exists but points to a Primitive
+        vm.pc = 0;
+        let original_bp = vm.bp;
+        let original_rs_len = vm.return_stack.len();
+        assert!(call_prim(&mut vm).is_err());
+
+        // Verify that VM state remains unchanged after error
+        assert_eq!(vm.pc, 0);
+        assert_eq!(vm.bp, original_bp);
+        assert_eq!(vm.return_stack.len(), original_rs_len);
+    }
 }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1,5 +1,5 @@
-use crate::cell::Cell;
-use crate::dict::WordEntry;
+use crate::cell::{Cell, ReturnFrame};
+use crate::dict::{EntryKind, WordEntry};
 use crate::error::TbxError;
 use crate::vm::VM;
 
@@ -32,7 +32,9 @@ pub fn fetch_prim(vm: &mut VM) -> Result<(), TbxError> {
     match addr {
         Cell::DictAddr(a) => {
             let size = vm.dictionary.len();
-            let value = vm.dictionary.get(a)
+            let value = vm
+                .dictionary
+                .get(a)
                 .ok_or(TbxError::IndexOutOfBounds { index: a, size })?
                 .clone();
             vm.push(value);
@@ -42,7 +44,9 @@ pub fn fetch_prim(vm: &mut VM) -> Result<(), TbxError> {
             // TODO: vm.bp との加算をvmにカプセル化したい。その中で範囲チェックも行う。
             let idx = vm.bp + a;
             let size = vm.data_stack.len();
-            let value = vm.data_stack.get(idx)
+            let value = vm
+                .data_stack
+                .get(idx)
                 .ok_or(TbxError::IndexOutOfBounds { index: idx, size })?
                 .clone();
             vm.push(value);
@@ -51,7 +55,7 @@ pub fn fetch_prim(vm: &mut VM) -> Result<(), TbxError> {
         _ => Err(TbxError::TypeError {
             expected: "address",
             got: "non-address",
-        })
+        }),
     }
 }
 
@@ -62,22 +66,65 @@ pub fn store_prim(vm: &mut VM) -> Result<(), TbxError> {
     match addr {
         Cell::DictAddr(a) => {
             let size = vm.dictionary.len();
-            *vm.dictionary.get_mut(a)
+            *vm.dictionary
+                .get_mut(a)
                 .ok_or(TbxError::IndexOutOfBounds { index: a, size })? = value;
             Ok(())
         }
         Cell::StackAddr(a) => {
             let idx = vm.bp + a;
             let size = vm.data_stack.len();
-            *vm.data_stack.get_mut(idx)
+            *vm.data_stack
+                .get_mut(idx)
                 .ok_or(TbxError::IndexOutOfBounds { index: idx, size })? = value;
             Ok(())
         }
         _ => Err(TbxError::TypeError {
             expected: "address",
             got: "non-address",
+        }),
+    }
+}
+
+/// CALL — call an execution token (Xt).
+pub fn call_prim(vm: &mut VM) -> Result<(), TbxError> {
+    let xt = vm
+        .dictionary
+        .get(vm.pc + 1)
+        .ok_or(TbxError::IndexOutOfBounds {
+            index: vm.pc + 1,
+            size: vm.dictionary.len(),
+        })?;
+    if let Cell::Xt(x) = xt {
+        let pc = vm.pc + 2; // CALL instruction is 2 cells: opcode + xt
+        let bp = vm.bp;
+        let return_frame = ReturnFrame::Call { pc, bp };
+        vm.return_stack.push(return_frame);
+        vm.bp = vm.data_stack.len();
+        match vm.headers[x.index()].kind {
+            EntryKind::Word(offset) => vm.pc = offset,
+            _ => {
+                return Err(TbxError::TypeError {
+                    expected: "callable (primitive or word)",
+                    got: "non-callable",
+                })
+            }
+        }
+        Ok(())
+    } else {
+        Err(TbxError::TypeError {
+            expected: "Xt",
+            got: xt.type_name(),
         })
     }
+}
+
+pub fn exit_prim(vm: &mut VM) -> Result<(), TbxError> {
+    let return_frame = vm.return_stack.pop().ok_or(TbxError::StackUnderflow)?;
+    let ReturnFrame::Call { pc, bp } = return_frame;
+    vm.pc = pc;
+    vm.bp = bp;
+    Ok(())
 }
 
 /// Register all stack primitives into the VM's dictionary.
@@ -87,6 +134,8 @@ pub fn register_all(vm: &mut VM) {
     vm.register(WordEntry::new_primitive("SWAP", swap_prim));
     vm.register(WordEntry::new_primitive("FETCH", fetch_prim));
     vm.register(WordEntry::new_primitive("STORE", store_prim));
+    vm.register(WordEntry::new_primitive("CALL", call_prim));
+    vm.register(WordEntry::new_primitive("EXIT", exit_prim));
 }
 
 #[cfg(test)]
@@ -194,9 +243,9 @@ mod tests {
     fn test_fetch_stack_addr() {
         // This test also verifies that fetch_prim correctly adds vm.bp to the address.
         let mut vm = VM::new();
-        vm.push(Cell::Int(10));   // data_stack[0] = 10
-        vm.push(Cell::Int(20));   // data_stack[1] = 20
-        vm.bp = 1;                // base pointer at index 1
+        vm.push(Cell::Int(10)); // data_stack[0] = 10
+        vm.push(Cell::Int(20)); // data_stack[1] = 20
+        vm.bp = 1; // base pointer at index 1
         vm.push(Cell::StackAddr(0)); // address of data_stack[bp + 0] = data_stack[1] = 20
         fetch_prim(&mut vm).unwrap();
         assert_eq!(vm.pop(), Ok(Cell::Int(20)));
@@ -220,7 +269,7 @@ mod tests {
         let mut vm = VM::new();
         assert_eq!(fetch_prim(&mut vm), Err(TbxError::StackUnderflow));
     }
-    
+
     #[test]
     fn test_store_dict_addr() {
         let mut vm = VM::new();
@@ -267,5 +316,47 @@ mod tests {
         let mut vm = VM::new();
         vm.push(Cell::Int(123)); // value to store
         assert_eq!(store_prim(&mut vm), Err(TbxError::StackUnderflow));
+    }
+
+    #[test]
+    fn test_call_and_exit() {
+        let mut vm = VM::new();
+        register_all(&mut vm); // Ensure CALL and EXIT are registered
+        let dummy_xt = vm.register(WordEntry::new_word("TEST", 10));
+        vm.dictionary.push(Cell::None);
+        vm.dictionary.push(Cell::Xt(dummy_xt)); // code for TEST: CALL EXIT
+
+        vm.pc = 0;
+        call_prim(&mut vm).unwrap();
+        assert_eq!(vm.pc, 10); // After CALL, pc should be at TEST's code
+    }
+
+    #[test]
+    fn test_exit_restores_pc_bp() {
+        let mut vm = VM::new();
+        register_all(&mut vm); // Ensure CALL and EXIT are registered
+        vm.return_stack.push(ReturnFrame::Call { pc: 42, bp: 99 });
+        exit_prim(&mut vm).unwrap();
+        assert_eq!(vm.pc, 42);
+        assert_eq!(vm.bp, 99);
+    }
+
+    #[test]
+    fn test_exit_underflow() {
+        let mut vm = VM::new();
+        assert_eq!(exit_prim(&mut vm), Err(TbxError::StackUnderflow));
+    }
+
+    #[test]
+    fn test_call_type_error() {
+        let mut vm = VM::new();
+        register_all(&mut vm); // Ensure CALL and EXIT are registered
+        vm.dictionary.push(Cell::None);
+        vm.dictionary.push(Cell::Int(123)); // Not an Xt
+        vm.pc = 0;
+        assert_eq!(call_prim(&mut vm), Err(TbxError::TypeError {
+            expected: "Xt",
+            got: "Int"
+        }));
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1,5 +1,5 @@
 use crate::dict::WordEntry;
-use crate::cell::{Cell, Xt};
+use crate::cell::{Cell, ReturnFrame, Xt};
 use crate::error::TbxError;
 
 /// The TBX virtual machine.
@@ -18,7 +18,7 @@ pub struct VM {
     /// Data stack: operand stack for arithmetic and parameter passing
     pub data_stack: Vec<Cell>,
     /// Return stack: saves (pc, bp) pairs on word calls
-    pub return_stack: Vec<(usize, usize)>,
+    pub return_stack: Vec<ReturnFrame>,
     /// Program counter: index into `dictionary` of the currently executing cell
     pub pc: usize,
     /// Base pointer: index into data_stack marking the current stack frame base


### PR DESCRIPTION
## 概要

リターンスタック操作のプリミティブ（CALL / EXIT）をシステム辞書に登録する。

## 変更内容

- `ReturnFrame` enum を `cell.rs` に追加（`Call { pc, bp }` バリアント、将来の拡張に備えた enum 形式）
- VM の `return_stack` の型を `Vec<(usize, usize)>` から `Vec<ReturnFrame>` に変更
- `call_prim`: `dictionary[pc+1]` から呼び出し先 Xt を読み、リターンスタックに (pc+2, bp) を退避し、呼び出し先ワードの本体オフセットにジャンプ
- `exit_prim`: リターンスタックからフレームを pop して pc / bp を復元
- `register_all` に CALL / EXIT を追加
- テスト4件追加（CALL正常系、EXIT正常系、EXITスタックアンダーフロー、CALL型エラー）

## 仕様上の判断

- `>R` / `R>` は仕様決定に基づきスコープ外
- 実際に pc を操作してワードを実行できるようになるのは issue #41（インナインタプリタ）の実装後

Closes #35
