### PR TITLE
算術演算プリミティブ（ADD, SUB, MUL, DIV, MOD）を実装

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -18,6 +18,7 @@ pub enum TbxError {
         got: &'static str,
     },
     IndexOutOfBounds { index: usize, size: usize },
+    DivisionByZero,
 }
 
 impl std::fmt::Display for TbxError {
@@ -37,6 +38,7 @@ impl std::fmt::Display for TbxError {
             TbxError::IndexOutOfBounds { index, size } => {
                 write!(f, "index out of bounds: index {}, size {}", index, size)
             }
+            TbxError::DivisionByZero => write!(f, "division by zero"),
         }
     }
 }
@@ -75,5 +77,11 @@ mod tests {
         let msg = e.to_string();
         assert!(msg.contains("address"));
         assert!(msg.contains("Int"));
+    }
+
+    #[test]
+    fn test_division_by_zero_display() {
+        let e = TbxError::DivisionByZero;
+        assert!(e.to_string().contains("division by zero"));
     }
 }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -128,6 +128,98 @@ pub fn exit_prim(vm: &mut VM) -> Result<(), TbxError> {
     Ok(())
 }
 
+pub fn add_prim(vm: &mut VM) -> Result<(), TbxError> {
+    let b = vm.pop()?;
+    let a = vm.pop()?;
+    match (a, b) {
+        (Cell::Int(x), Cell::Int(y)) => vm.push(Cell::Int(x + y)),
+        (Cell::Float(x), Cell::Float(y)) => vm.push(Cell::Float(x + y)),
+        (Cell::Int(x), Cell::Float(y)) => vm.push(Cell::Float(x as f64 + y)),
+        (Cell::Float(x), Cell::Int(y)) => vm.push(Cell::Float(x + y as f64)),
+        _ => {
+            return Err(TbxError::TypeError {
+                expected: "number",
+                got: "non-number",
+            })
+        }
+    }
+    Ok(())
+}
+
+pub fn sub_prim(vm: &mut VM) -> Result<(), TbxError> {
+    let b = vm.pop()?;
+    let a = vm.pop()?;
+    match (a, b) {
+        (Cell::Int(x), Cell::Int(y)) => vm.push(Cell::Int(x - y)),
+        (Cell::Float(x), Cell::Float(y)) => vm.push(Cell::Float(x - y)),
+        (Cell::Int(x), Cell::Float(y)) => vm.push(Cell::Float(x as f64 - y)),
+        (Cell::Float(x), Cell::Int(y)) => vm.push(Cell::Float(x - y as f64)),
+        _ => {
+            return Err(TbxError::TypeError {
+                expected: "number",
+                got: "non-number",
+            })
+        }
+    }
+    Ok(())
+}
+
+pub fn mul_prim(vm: &mut VM) -> Result<(), TbxError> {
+    let b = vm.pop()?;
+    let a = vm.pop()?;
+    match (a, b) {
+        (Cell::Int(x), Cell::Int(y)) => vm.push(Cell::Int(x * y)),
+        (Cell::Float(x), Cell::Float(y)) => vm.push(Cell::Float(x * y)),
+        (Cell::Int(x), Cell::Float(y)) => vm.push(Cell::Float(x as f64 * y)),
+        (Cell::Float(x), Cell::Int(y)) => vm.push(Cell::Float(x * y as f64)),
+        _ => {
+            return Err(TbxError::TypeError {
+                expected: "number",
+                got: "non-number",
+            })
+        }
+    }
+    Ok(())
+}
+
+pub fn div_prim(vm: &mut VM) -> Result<(), TbxError> {
+    let b = vm.pop()?;
+    let a = vm.pop()?;
+    match (a, b) {
+        (Cell::Int(_), Cell::Int(0)) => return Err(TbxError::DivisionByZero),
+        (Cell::Int(x), Cell::Int(y)) => vm.push(Cell::Int(x / y)),
+        (Cell::Float(_), Cell::Float(y)) if y == 0.0 => return Err(TbxError::DivisionByZero),
+        (Cell::Float(x), Cell::Float(y)) => vm.push(Cell::Float(x / y)),
+        (Cell::Int(_), Cell::Float(y)) if y == 0.0 => return Err(TbxError::DivisionByZero),
+        (Cell::Int(x), Cell::Float(y)) => vm.push(Cell::Float(x as f64 / y)),
+        (Cell::Float(_), Cell::Int(0)) => return Err(TbxError::DivisionByZero),
+        (Cell::Float(x), Cell::Int(y)) => vm.push(Cell::Float(x / y as f64)),
+        _ => {
+            return Err(TbxError::TypeError {
+                expected: "number",
+                got: "non-number",
+            })
+        }
+    }
+    Ok(())
+}
+
+pub fn mod_prim(vm: &mut VM) -> Result<(), TbxError> {
+    let b = vm.pop()?;
+    let a = vm.pop()?;
+    match (a, b) {
+        (Cell::Int(_), Cell::Int(0)) => return Err(TbxError::DivisionByZero),
+        (Cell::Int(x), Cell::Int(y)) => vm.push(Cell::Int(x % y)),
+        _ => {
+            return Err(TbxError::TypeError {
+                expected: "Int",
+                got: "non-Int",
+            })
+        }
+    }
+    Ok(())
+}
+
 /// Register all stack primitives into the VM's dictionary.
 pub fn register_all(vm: &mut VM) {
     vm.register(WordEntry::new_primitive("DROP", drop_prim));
@@ -137,6 +229,11 @@ pub fn register_all(vm: &mut VM) {
     vm.register(WordEntry::new_primitive("STORE", store_prim));
     vm.register(WordEntry::new_primitive("CALL", call_prim));
     vm.register(WordEntry::new_primitive("EXIT", exit_prim));
+    vm.register(WordEntry::new_primitive("ADD", add_prim));
+    vm.register(WordEntry::new_primitive("SUB", sub_prim));
+    vm.register(WordEntry::new_primitive("MUL", mul_prim));
+    vm.register(WordEntry::new_primitive("DIV", div_prim));
+    vm.register(WordEntry::new_primitive("MOD", mod_prim));
 }
 
 #[cfg(test)]
@@ -380,5 +477,257 @@ mod tests {
         assert_eq!(vm.pc, 0);
         assert_eq!(vm.bp, original_bp);
         assert_eq!(vm.return_stack.len(), original_rs_len);
+    }
+
+    #[test]
+    fn test_add_int() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(2));
+        vm.push(Cell::Int(3));
+        add_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Int(5)));
+    }
+
+    #[test]
+    fn test_add_float() {
+        let mut vm = VM::new();
+        vm.push(Cell::Float(2.5));
+        vm.push(Cell::Float(3.5));
+        add_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Float(6.0)));
+    }
+
+    #[test]
+    fn test_add_int_float() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(2));
+        vm.push(Cell::Float(3.5));
+        add_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Float(5.5)));
+    }
+
+    #[test]
+    fn test_add_float_int() {
+        let mut vm = VM::new();
+        vm.push(Cell::Float(2.5));
+        vm.push(Cell::Int(3));
+        add_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Float(5.5)));
+    }
+
+    #[test]
+    fn test_add_type_error() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(2));
+        vm.push(Cell::Bool(true)); // Not a number
+        assert_eq!(add_prim(&mut vm), Err(TbxError::TypeError {
+            expected: "number",
+            got: "non-number"
+        }));
+    }
+
+    // --- sub_prim ---
+
+    #[test]
+    fn test_sub_int() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(10));
+        vm.push(Cell::Int(3));
+        sub_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Int(7)));
+    }
+
+    #[test]
+    fn test_sub_float() {
+        let mut vm = VM::new();
+        vm.push(Cell::Float(5.5));
+        vm.push(Cell::Float(2.0));
+        sub_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Float(3.5)));
+    }
+
+    #[test]
+    fn test_sub_int_float() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(5));
+        vm.push(Cell::Float(1.5));
+        sub_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Float(3.5)));
+    }
+
+    #[test]
+    fn test_sub_type_error() {
+        let mut vm = VM::new();
+        vm.push(Cell::Bool(false));
+        vm.push(Cell::Int(1));
+        assert!(matches!(sub_prim(&mut vm), Err(TbxError::TypeError { .. })));
+    }
+
+    // --- mul_prim ---
+
+    #[test]
+    fn test_mul_int() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(4));
+        vm.push(Cell::Int(5));
+        mul_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Int(20)));
+    }
+
+    #[test]
+    fn test_mul_float() {
+        let mut vm = VM::new();
+        vm.push(Cell::Float(2.5));
+        vm.push(Cell::Float(4.0));
+        mul_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Float(10.0)));
+    }
+
+    #[test]
+    fn test_mul_float_int() {
+        let mut vm = VM::new();
+        vm.push(Cell::Float(2.5));
+        vm.push(Cell::Int(4));
+        mul_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Float(10.0)));
+    }
+
+    #[test]
+    fn test_mul_type_error() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(1));
+        vm.push(Cell::Bool(true));
+        assert!(matches!(mul_prim(&mut vm), Err(TbxError::TypeError { .. })));
+    }
+
+    // --- div_prim ---
+
+    #[test]
+    fn test_div_int() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(10));
+        vm.push(Cell::Int(3));
+        div_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Int(3))); // truncation toward zero
+    }
+
+    #[test]
+    fn test_div_int_negative() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(-7));
+        vm.push(Cell::Int(2));
+        div_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Int(-3))); // truncation toward zero
+    }
+
+    #[test]
+    fn test_div_float() {
+        let mut vm = VM::new();
+        vm.push(Cell::Float(7.0));
+        vm.push(Cell::Float(2.0));
+        div_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Float(3.5)));
+    }
+
+    #[test]
+    fn test_div_int_float() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(7));
+        vm.push(Cell::Float(2.0));
+        div_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Float(3.5)));
+    }
+
+    #[test]
+    fn test_div_float_int() {
+        let mut vm = VM::new();
+        vm.push(Cell::Float(7.0));
+        vm.push(Cell::Int(2));
+        div_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Float(3.5)));
+    }
+
+    #[test]
+    fn test_div_by_zero_int() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(5));
+        vm.push(Cell::Int(0));
+        assert_eq!(div_prim(&mut vm), Err(TbxError::DivisionByZero));
+    }
+
+    #[test]
+    fn test_div_by_zero_float() {
+        let mut vm = VM::new();
+        vm.push(Cell::Float(5.0));
+        vm.push(Cell::Float(0.0));
+        assert_eq!(div_prim(&mut vm), Err(TbxError::DivisionByZero));
+    }
+
+    #[test]
+    fn test_div_by_zero_int_float() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(5));
+        vm.push(Cell::Float(0.0));
+        assert_eq!(div_prim(&mut vm), Err(TbxError::DivisionByZero));
+    }
+
+    #[test]
+    fn test_div_by_zero_float_int() {
+        let mut vm = VM::new();
+        vm.push(Cell::Float(5.0));
+        vm.push(Cell::Int(0));
+        assert_eq!(div_prim(&mut vm), Err(TbxError::DivisionByZero));
+    }
+
+    #[test]
+    fn test_div_type_error() {
+        let mut vm = VM::new();
+        vm.push(Cell::Bool(true));
+        vm.push(Cell::Int(1));
+        assert!(matches!(div_prim(&mut vm), Err(TbxError::TypeError { .. })));
+    }
+
+    // --- mod_prim ---
+
+    #[test]
+    fn test_mod_int() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(7));
+        vm.push(Cell::Int(3));
+        mod_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Int(1)));
+    }
+
+    #[test]
+    fn test_mod_negative() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(-7));
+        vm.push(Cell::Int(2));
+        mod_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Int(-1))); // truncation toward zero
+    }
+
+    #[test]
+    fn test_mod_by_zero() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(5));
+        vm.push(Cell::Int(0));
+        assert_eq!(mod_prim(&mut vm), Err(TbxError::DivisionByZero));
+    }
+
+    #[test]
+    fn test_mod_float_rejected() {
+        let mut vm = VM::new();
+        vm.push(Cell::Float(7.0));
+        vm.push(Cell::Float(3.0));
+        assert!(matches!(mod_prim(&mut vm), Err(TbxError::TypeError { .. })));
+    }
+
+    #[test]
+    fn test_mod_int_float_rejected() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(7));
+        vm.push(Cell::Float(3.0));
+        assert!(matches!(mod_prim(&mut vm), Err(TbxError::TypeError { .. })));
     }
 }


### PR DESCRIPTION
## 概要

算術演算プリミティブ（ADD, SUB, MUL, DIV, MOD）をシステム辞書に登録する。

## 変更内容

### error.rs
- `TbxError::DivisionByZero` バリアントを追加
- `Display` impl に対応するアームを追加

### primitives.rs
- `add_prim` — 加算（Int/Float混合対応、暗黙の型昇格）
- `sub_prim` — 減算（同上）
- `mul_prim` — 乗算（同上）
- `div_prim` — 除算（ゼロ除算チェック付き、truncation toward zero）
- `mod_prim` — 剰余（Int専用、Float入力はTypeError）
- `register_all` に5プリミティブを追加
- 各プリミティブのテストを追加（正常系・型昇格・ゼロ除算・TypeError）

## 設計判断

- **型昇格**: Int op Float → Float（暗黙の型昇格）
- **整数除算**: truncation toward zero（Rust/C互換）
- **MOD**: Int専用（ミニマル方針）
- **ゼロ除算**: Int(0) と Float(0.0) の両方でチェック

Closes #36
