### PR TITLE
div_primのFloat(0.0)パターンをガード式に戻しclippy警告を抑制

### DIFF
--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -182,15 +182,16 @@ pub fn mul_prim(vm: &mut VM) -> Result<(), TbxError> {
     Ok(())
 }
 
+#[allow(clippy::redundant_guards)] // Float(0.0) pattern also matches -0.0; use guard for clarity
 pub fn div_prim(vm: &mut VM) -> Result<(), TbxError> {
     let b = vm.pop()?;
     let a = vm.pop()?;
     match (a, b) {
         (Cell::Int(_), Cell::Int(0)) => return Err(TbxError::DivisionByZero),
         (Cell::Int(x), Cell::Int(y)) => vm.push(Cell::Int(x / y)),
-        (Cell::Float(_), Cell::Float(0.0)) => return Err(TbxError::DivisionByZero),
+        (Cell::Float(_), Cell::Float(y)) if y == 0.0 => return Err(TbxError::DivisionByZero),
         (Cell::Float(x), Cell::Float(y)) => vm.push(Cell::Float(x / y)),
-        (Cell::Int(_), Cell::Float(0.0)) => return Err(TbxError::DivisionByZero),
+        (Cell::Int(_), Cell::Float(y)) if y == 0.0 => return Err(TbxError::DivisionByZero),
         (Cell::Int(x), Cell::Float(y)) => vm.push(Cell::Float(x as f64 / y)),
         (Cell::Float(_), Cell::Int(0)) => return Err(TbxError::DivisionByZero),
         (Cell::Float(x), Cell::Int(y)) => vm.push(Cell::Float(x / y as f64)),


### PR DESCRIPTION
## 概要

`div_prim` の `Float(0.0)` パターンマッチをガード式 (`if y == 0.0`) に戻し、`clippy::redundant_guards` 警告を `#[allow]` で抑制する。

## 背景

- #36 で `Float(0.0)` をパターンに直接書くと `-0.0` にもマッチしてしまうため、ガード式に変更した経緯がある
- CI導入時に `cargo clippy` が `redundant_guards` 警告を出したため `Float(0.0)` パターンに戻していたが、元の意図を尊重しガード式に戻す

## 変更内容

- `div_prim` の `Float(0.0)` パターンを `Float(y) if y == 0.0` ガード式に変更
- `#[allow(clippy::redundant_guards)]` を `div_prim` に付与し、理由をコメントで記載

Ref #36
