### PR TITLE
docs: issue #125 辞書サイズ上限とALLOTオーバーフロー仕様をblueprint.mdに明記

### DIFF
--- a/blueprint.md
+++ b/blueprint.md
@@ -117,6 +117,17 @@ enum ReturnFrame {
 * `ALLOT N` — DP を N セル分進めて領域を確保する。確保した領域の先頭アドレスを返す。
 * `HERE` — 現在のDPの値（次の書き込み先アドレス）をスタックに積む。
 
+> Issue #125「ヒープポインタDPのオーバーフロー対策が未定義」に基づく設計方針
+
+**辞書の最大サイズ: `MAX_DICTIONARY_CELLS = 1_048_576`（1Mセル ≒ 8MB）**
+
+これはコア言語の仕様として規定する定数であり、`STRING_MAX_LENGTH` と同じスタイルでコア定数モジュールに定義する。
+
+* `ALLOT`・`APPEND`・`LITERAL` 等、DP を進めるすべての操作で DP 上限チェックを行う。
+  - チェック方法: `let new_dp = dp + n; if new_dp > MAX_DICTIONARY_CELLS { return Err(TbxError::DictionaryOverflow { requested: new_dp, limit: MAX_DICTIONARY_CELLS }); }`
+  - 超過時は `TbxError::DictionaryOverflow { requested: usize, limit: usize }` を返す（既存の `TbxError::StringTooLong { len }` と同じスタイル）。
+* `ALLOT N` の引数 N が負値の場合は `TbxError::InvalidAllotCount` を返す。DP を後退させる操作は仕様として禁止する。
+
 #### 永続化
 
 * 辞書の永続化はメモリのダンプ（スナップショット保存）とリストア（ロード）によって行う。


### PR DESCRIPTION
## 概要

issue #125「ヒープポインタDPのオーバーフロー対策が未定義」で決定した仕様を `blueprint.md` の「ヒープ」節に追記する。

## 変更内容

- `MAX_DICTIONARY_CELLS = 1_048_576`（1Mセル ≒ 8MB）を辞書サイズの上限定数として明記
- `ALLOT`・`APPEND`・`LITERAL` 等のDP進め操作すべてに上限チェックを課す仕様を追記
- 超過時のエラー型 `TbxError::DictionaryOverflow { requested: usize, limit: usize }` を規定（既存の `StringTooLong` と同じスタイル）
- `ALLOT N` で N が負値の場合は `TbxError::InvalidAllotCount` を返し、DP後退を仕様として禁止することを明記

Closes #125
