### PR TITLE
出力プリミティブ（PUTSTR, PUTCHR, PUTDEC, PUTHEX）を追加

### DIFF
--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1370,7 +1370,7 @@ mod tests {
     #[test]
     fn test_putdec_type_error() {
         let mut vm = VM::new();
-        vm.push(Cell::Float(3.14));
+        vm.push(Cell::Float(3.5));
         assert!(matches!(
             putdec_prim(&mut vm),
             Err(TbxError::TypeError { .. })

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -345,6 +345,81 @@ pub fn or_prim(vm: &mut VM) -> Result<(), TbxError> {
     Ok(())
 }
 
+/// PUTSTR — output the string referenced by a StringDesc on the stack (no newline).
+/// Escape sequences (\n, \t, \\) in the stored string are output literally
+/// as they were already expanded at compile time (during intern).
+pub fn putstr_prim(vm: &mut VM) -> Result<(), TbxError> {
+    let cell = vm.pop()?;
+    match cell {
+        Cell::StringDesc(idx) => {
+            let s = vm.resolve_string(idx)?;
+            vm.write_output(&s);
+            Ok(())
+        }
+        _ => Err(TbxError::TypeError {
+            expected: "StringDesc",
+            got: cell.type_name(),
+        }),
+    }
+}
+
+/// PUTCHR — output the integer value on the stack as a single ASCII character (no newline).
+pub fn putchr_prim(vm: &mut VM) -> Result<(), TbxError> {
+    let cell = vm.pop()?;
+    match cell {
+        Cell::Int(code) => {
+            if !(0..=127).contains(&code) {
+                return Err(TbxError::TypeError {
+                    expected: "ASCII code (0-127)",
+                    got: "out of range",
+                });
+            }
+            let ch = code as u8 as char;
+            vm.write_output(&ch.to_string());
+            Ok(())
+        }
+        _ => Err(TbxError::TypeError {
+            expected: "Int",
+            got: cell.type_name(),
+        }),
+    }
+}
+
+/// PUTDEC — output the integer value on the stack as a signed decimal number (no newline).
+pub fn putdec_prim(vm: &mut VM) -> Result<(), TbxError> {
+    let cell = vm.pop()?;
+    match cell {
+        Cell::Int(n) => {
+            vm.write_output(&n.to_string());
+            Ok(())
+        }
+        _ => Err(TbxError::TypeError {
+            expected: "Int",
+            got: cell.type_name(),
+        }),
+    }
+}
+
+/// PUTHEX — output the integer value on the stack as $-prefixed uppercase hex (no newline).
+/// Negative values are output as two's complement 64-bit representation.
+pub fn puthex_prim(vm: &mut VM) -> Result<(), TbxError> {
+    let cell = vm.pop()?;
+    match cell {
+        Cell::Int(n) => {
+            if n < 0 {
+                vm.write_output(&format!("${:X}", n as u64));
+            } else {
+                vm.write_output(&format!("${:X}", n));
+            }
+            Ok(())
+        }
+        _ => Err(TbxError::TypeError {
+            expected: "Int",
+            got: cell.type_name(),
+        }),
+    }
+}
+
 /// Register all stack primitives into the VM's dictionary.
 pub fn register_all(vm: &mut VM) {
     vm.register(WordEntry::new_primitive("DROP", drop_prim));
@@ -367,6 +442,10 @@ pub fn register_all(vm: &mut VM) {
     vm.register(WordEntry::new_primitive("GE", ge_prim));
     vm.register(WordEntry::new_primitive("AND", and_prim));
     vm.register(WordEntry::new_primitive("OR", or_prim));
+    vm.register(WordEntry::new_primitive("PUTSTR", putstr_prim));
+    vm.register(WordEntry::new_primitive("PUTCHR", putchr_prim));
+    vm.register(WordEntry::new_primitive("PUTDEC", putdec_prim));
+    vm.register(WordEntry::new_primitive("PUTHEX", puthex_prim));
 }
 
 #[cfg(test)]
@@ -1173,5 +1252,164 @@ mod tests {
         vm.push(Cell::Int(5));
         or_prim(&mut vm).unwrap();
         assert_eq!(vm.pop(), Ok(Cell::Bool(true)));
+    }
+
+    // --- PUTSTR tests ---
+
+    #[test]
+    fn test_putstr_basic() {
+        let mut vm = VM::new();
+        let idx = vm.intern_string("hello").unwrap();
+        vm.push(Cell::StringDesc(idx));
+        putstr_prim(&mut vm).unwrap();
+        assert_eq!(vm.take_output(), "hello");
+    }
+
+    #[test]
+    fn test_putstr_empty() {
+        let mut vm = VM::new();
+        let idx = vm.intern_string("").unwrap();
+        vm.push(Cell::StringDesc(idx));
+        putstr_prim(&mut vm).unwrap();
+        assert_eq!(vm.take_output(), "");
+    }
+
+    #[test]
+    fn test_putstr_type_error() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(42));
+        assert!(matches!(
+            putstr_prim(&mut vm),
+            Err(TbxError::TypeError { .. })
+        ));
+    }
+
+    #[test]
+    fn test_putstr_underflow() {
+        let mut vm = VM::new();
+        assert!(matches!(
+            putstr_prim(&mut vm),
+            Err(TbxError::StackUnderflow)
+        ));
+    }
+
+    // --- PUTCHR tests ---
+
+    #[test]
+    fn test_putchr_basic() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(65)); // 'A'
+        putchr_prim(&mut vm).unwrap();
+        assert_eq!(vm.take_output(), "A");
+    }
+
+    #[test]
+    fn test_putchr_newline() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(10)); // '\n'
+        putchr_prim(&mut vm).unwrap();
+        assert_eq!(vm.take_output(), "\n");
+    }
+
+    #[test]
+    fn test_putchr_out_of_range() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(128));
+        assert!(matches!(
+            putchr_prim(&mut vm),
+            Err(TbxError::TypeError { .. })
+        ));
+    }
+
+    #[test]
+    fn test_putchr_negative() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(-1));
+        assert!(matches!(
+            putchr_prim(&mut vm),
+            Err(TbxError::TypeError { .. })
+        ));
+    }
+
+    #[test]
+    fn test_putchr_type_error() {
+        let mut vm = VM::new();
+        vm.push(Cell::Bool(true));
+        assert!(matches!(
+            putchr_prim(&mut vm),
+            Err(TbxError::TypeError { .. })
+        ));
+    }
+
+    // --- PUTDEC tests ---
+
+    #[test]
+    fn test_putdec_positive() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(42));
+        putdec_prim(&mut vm).unwrap();
+        assert_eq!(vm.take_output(), "42");
+    }
+
+    #[test]
+    fn test_putdec_negative() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(-7));
+        putdec_prim(&mut vm).unwrap();
+        assert_eq!(vm.take_output(), "-7");
+    }
+
+    #[test]
+    fn test_putdec_zero() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(0));
+        putdec_prim(&mut vm).unwrap();
+        assert_eq!(vm.take_output(), "0");
+    }
+
+    #[test]
+    fn test_putdec_type_error() {
+        let mut vm = VM::new();
+        vm.push(Cell::Float(3.14));
+        assert!(matches!(
+            putdec_prim(&mut vm),
+            Err(TbxError::TypeError { .. })
+        ));
+    }
+
+    // --- PUTHEX tests ---
+
+    #[test]
+    fn test_puthex_positive() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(255));
+        puthex_prim(&mut vm).unwrap();
+        assert_eq!(vm.take_output(), "$FF");
+    }
+
+    #[test]
+    fn test_puthex_zero() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(0));
+        puthex_prim(&mut vm).unwrap();
+        assert_eq!(vm.take_output(), "$0");
+    }
+
+    #[test]
+    fn test_puthex_negative() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(-1));
+        puthex_prim(&mut vm).unwrap();
+        assert_eq!(vm.take_output(), "$FFFFFFFFFFFFFFFF");
+    }
+
+    #[test]
+    fn test_puthex_type_error() {
+        let mut vm = VM::new();
+        vm.push(Cell::Bool(true));
+        assert!(matches!(
+            puthex_prim(&mut vm),
+            Err(TbxError::TypeError { .. })
+        ));
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -47,6 +47,9 @@ pub struct VM {
     pub dp: usize,
     /// Index of the most recently registered entry in `headers` (head of linked list)
     pub latest: Option<Xt>,
+    /// Output buffer: collects text from PUTSTR / PUTCHR / PUTDEC / PUTHEX.
+    /// Flushed to stdout at appropriate points (e.g. end of interpretation cycle).
+    pub output_buffer: String,
 }
 
 impl VM {
@@ -68,6 +71,7 @@ impl VM {
             hdr_user: 0,
             dp: 0,
             latest: None,
+            output_buffer: String::new(),
         }
     }
 
@@ -141,6 +145,42 @@ impl VM {
     pub fn seal_user(&mut self) {
         self.dp_user = self.dp;
         self.hdr_user = self.headers.len();
+    }
+
+    /// Append text to the output buffer.
+    pub fn write_output(&mut self, s: &str) {
+        self.output_buffer.push_str(s);
+    }
+
+    /// Take the current output buffer contents, leaving it empty.
+    pub fn take_output(&mut self) -> String {
+        std::mem::take(&mut self.output_buffer)
+    }
+
+    /// Resolve a StringDesc index to the string stored in the string pool.
+    ///
+    /// Returns `Err(TbxError::TypeError)` if the index is out of bounds or
+    /// the stored data is not valid UTF-8.
+    pub fn resolve_string(&self, idx: usize) -> Result<String, TbxError> {
+        if idx + 2 > self.string_pool.len() {
+            return Err(TbxError::TypeError {
+                expected: "valid string index",
+                got: "out of bounds",
+            });
+        }
+        let len = u16::from_le_bytes([self.string_pool[idx], self.string_pool[idx + 1]]) as usize;
+        let start = idx + 2;
+        let end = start + len;
+        if end > self.string_pool.len() {
+            return Err(TbxError::TypeError {
+                expected: "valid string data",
+                got: "truncated",
+            });
+        }
+        String::from_utf8(self.string_pool[start..end].to_vec()).map_err(|_| TbxError::TypeError {
+            expected: "valid UTF-8",
+            got: "invalid bytes",
+        })
     }
 
     /// Intern a string into the string pool using the length-prefix format.

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -163,18 +163,18 @@ impl VM {
     /// the stored data is not valid UTF-8.
     pub fn resolve_string(&self, idx: usize) -> Result<String, TbxError> {
         if idx + 2 > self.string_pool.len() {
-            return Err(TbxError::TypeError {
-                expected: "valid string index",
-                got: "out of bounds",
+            return Err(TbxError::IndexOutOfBounds {
+                index: idx,
+                size: self.string_pool.len(),
             });
         }
         let len = u16::from_le_bytes([self.string_pool[idx], self.string_pool[idx + 1]]) as usize;
         let start = idx + 2;
         let end = start + len;
         if end > self.string_pool.len() {
-            return Err(TbxError::TypeError {
-                expected: "valid string data",
-                got: "truncated",
+            return Err(TbxError::IndexOutOfBounds {
+                index: end,
+                size: self.string_pool.len(),
             });
         }
         String::from_utf8(self.string_pool[start..end].to_vec()).map_err(|_| TbxError::TypeError {


### PR DESCRIPTION
## 概要

出力プリミティブ（PUTSTR, PUTCHR, PUTDEC, PUTHEX）を追加する。

## 変更内容

### VM (`src/vm.rs`)
- `output_buffer: String` フィールドを追加
- `write_output(&str)`: 出力バッファにテキストを追記
- `take_output() -> String`: バッファ内容を取得して空にする
- `resolve_string(idx) -> Result<String>`: StringDescインデックスから文字列を解決

### プリミティブ (`src/primitives.rs`)
- **PUTSTR**: StringDescの文字列を出力バッファに書き込み
- **PUTCHR**: Int値をASCII文字として出力（0-127の範囲チェック付き）
- **PUTDEC**: Int値を符号付き10進数として出力
- **PUTHEX**: Int値を`$`接頭辞付き大文字16進数として出力（負値は2の補数64bit表現）
- `register_all`に4語を登録

### テスト
- 17件追加（PUTSTR: 4件、PUTCHR: 5件、PUTDEC: 4件、PUTHEX: 4件）

Closes #38
