### PR TITLE
辞書操作プリミティブ APPEND, ALLOT, HERE を実装

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,0 +1,3 @@
+/// Maximum number of cells in the dictionary (data layer).
+/// Approximately 8 MB when each cell is 8 bytes.
+pub const MAX_DICTIONARY_CELLS: usize = 1_048_576;

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,6 +24,13 @@ pub enum TbxError {
         size: usize,
     },
     DivisionByZero,
+    /// The dictionary pointer exceeded the maximum allowed size.
+    DictionaryOverflow {
+        requested: usize,
+        limit: usize,
+    },
+    /// ALLOT was called with a negative count.
+    InvalidAllotCount,
 }
 
 impl std::fmt::Display for TbxError {
@@ -44,6 +51,14 @@ impl std::fmt::Display for TbxError {
                 write!(f, "index out of bounds: index {}, size {}", index, size)
             }
             TbxError::DivisionByZero => write!(f, "division by zero"),
+            TbxError::DictionaryOverflow { requested, limit } => {
+                write!(
+                    f,
+                    "dictionary overflow: requested {} cells (limit {})",
+                    requested, limit
+                )
+            }
+            TbxError::InvalidAllotCount => write!(f, "ALLOT count must be non-negative"),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod cell;
+pub mod constants;
 pub mod dict;
 pub mod error;
 pub mod primitives;

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1,4 +1,5 @@
 use crate::cell::{Cell, ReturnFrame};
+use crate::constants::MAX_DICTIONARY_CELLS;
 use crate::dict::{EntryKind, WordEntry};
 use crate::error::TbxError;
 use crate::vm::VM;
@@ -420,6 +421,49 @@ pub fn puthex_prim(vm: &mut VM) -> Result<(), TbxError> {
     }
 }
 
+/// APPEND — pop a Cell and write it to dictionary[dp], advancing dp by 1.
+pub fn append_prim(vm: &mut VM) -> Result<(), TbxError> {
+    let cell = vm.pop()?;
+    vm.dict_write(cell)
+}
+
+/// ALLOT — pop N from the stack, advance dp by N cells, and push the start address.
+pub fn allot_prim(vm: &mut VM) -> Result<(), TbxError> {
+    let cell = vm.pop()?;
+    let n = match cell {
+        Cell::Int(n) => n,
+        _ => {
+            return Err(TbxError::TypeError {
+                expected: "Int",
+                got: cell.type_name(),
+            })
+        }
+    };
+    if n < 0 {
+        return Err(TbxError::InvalidAllotCount);
+    }
+    let count = n as usize;
+    let new_dp = vm.dp + count;
+    if new_dp > MAX_DICTIONARY_CELLS {
+        return Err(TbxError::DictionaryOverflow {
+            requested: new_dp,
+            limit: MAX_DICTIONARY_CELLS,
+        });
+    }
+    let start = vm.dp;
+    for _ in 0..count {
+        vm.dict_write(Cell::None)?;
+    }
+    vm.push(Cell::DictAddr(start));
+    Ok(())
+}
+
+/// HERE — push the current dictionary pointer as a DictAddr.
+pub fn here_prim(vm: &mut VM) -> Result<(), TbxError> {
+    vm.push(Cell::DictAddr(vm.dp));
+    Ok(())
+}
+
 /// Register all stack primitives into the VM's dictionary.
 pub fn register_all(vm: &mut VM) {
     vm.register(WordEntry::new_primitive("DROP", drop_prim));
@@ -446,12 +490,16 @@ pub fn register_all(vm: &mut VM) {
     vm.register(WordEntry::new_primitive("PUTCHR", putchr_prim));
     vm.register(WordEntry::new_primitive("PUTDEC", putdec_prim));
     vm.register(WordEntry::new_primitive("PUTHEX", puthex_prim));
+    vm.register(WordEntry::new_primitive("APPEND", append_prim));
+    vm.register(WordEntry::new_primitive("ALLOT", allot_prim));
+    vm.register(WordEntry::new_primitive("HERE", here_prim));
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::cell::Cell;
+    use crate::constants::MAX_DICTIONARY_CELLS;
 
     // --- drop_prim ---
 
@@ -1410,6 +1458,136 @@ mod tests {
         assert!(matches!(
             puthex_prim(&mut vm),
             Err(TbxError::TypeError { .. })
+        ));
+    }
+
+    // --- append_prim ---
+
+    #[test]
+    fn test_append_writes_to_dictionary() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(42));
+        append_prim(&mut vm).unwrap();
+        assert_eq!(vm.dictionary.len(), 1);
+        assert_eq!(vm.dp, 1);
+        assert!(matches!(vm.dictionary[0], Cell::Int(42)));
+    }
+
+    #[test]
+    fn test_append_xt_value() {
+        let mut vm = VM::new();
+        vm.push(Cell::Xt(crate::cell::Xt(5)));
+        append_prim(&mut vm).unwrap();
+        assert_eq!(vm.dictionary.len(), 1);
+        assert!(matches!(vm.dictionary[0], Cell::Xt(_)));
+    }
+
+    #[test]
+    fn test_append_multiple() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(10));
+        append_prim(&mut vm).unwrap();
+        vm.push(Cell::Int(20));
+        append_prim(&mut vm).unwrap();
+        vm.push(Cell::Int(30));
+        append_prim(&mut vm).unwrap();
+        assert_eq!(vm.dp, 3);
+        assert!(matches!(vm.dictionary[0], Cell::Int(10)));
+        assert!(matches!(vm.dictionary[1], Cell::Int(20)));
+        assert!(matches!(vm.dictionary[2], Cell::Int(30)));
+    }
+
+    #[test]
+    fn test_append_empty_stack() {
+        let mut vm = VM::new();
+        assert!(matches!(
+            append_prim(&mut vm),
+            Err(TbxError::StackUnderflow)
+        ));
+    }
+
+    // --- allot_prim ---
+
+    #[test]
+    fn test_allot_reserves_cells() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(5));
+        allot_prim(&mut vm).unwrap();
+        assert_eq!(vm.dp, 5);
+        assert_eq!(vm.dictionary.len(), 5);
+        // Returns start address
+        assert_eq!(vm.pop().unwrap(), Cell::DictAddr(0));
+    }
+
+    #[test]
+    fn test_allot_after_append() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(100));
+        append_prim(&mut vm).unwrap();
+        vm.push(Cell::Int(3));
+        allot_prim(&mut vm).unwrap();
+        assert_eq!(vm.dp, 4);
+        assert_eq!(vm.pop().unwrap(), Cell::DictAddr(1));
+    }
+
+    #[test]
+    fn test_allot_zero() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(0));
+        allot_prim(&mut vm).unwrap();
+        assert_eq!(vm.dp, 0);
+        assert_eq!(vm.pop().unwrap(), Cell::DictAddr(0));
+    }
+
+    #[test]
+    fn test_allot_negative() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(-1));
+        assert!(matches!(
+            allot_prim(&mut vm),
+            Err(TbxError::InvalidAllotCount)
+        ));
+    }
+
+    #[test]
+    fn test_allot_type_error() {
+        let mut vm = VM::new();
+        vm.push(Cell::Bool(true));
+        assert!(matches!(
+            allot_prim(&mut vm),
+            Err(TbxError::TypeError { .. })
+        ));
+    }
+
+    // --- here_prim ---
+
+    #[test]
+    fn test_here_initial() {
+        let mut vm = VM::new();
+        here_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop().unwrap(), Cell::DictAddr(0));
+    }
+
+    #[test]
+    fn test_here_after_append() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(1));
+        append_prim(&mut vm).unwrap();
+        vm.push(Cell::Int(2));
+        append_prim(&mut vm).unwrap();
+        here_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop().unwrap(), Cell::DictAddr(2));
+    }
+
+    // --- dict_write overflow ---
+
+    #[test]
+    fn test_allot_overflow() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int((MAX_DICTIONARY_CELLS + 1) as i64));
+        assert!(matches!(
+            allot_prim(&mut vm),
+            Err(TbxError::DictionaryOverflow { .. })
         ));
     }
 }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1506,6 +1506,19 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn test_append_overflow() {
+        let mut vm = VM::new();
+        vm.dp = MAX_DICTIONARY_CELLS;
+        // Manually grow dictionary to match dp invariant
+        vm.dictionary.resize(MAX_DICTIONARY_CELLS, Cell::None);
+        vm.push(Cell::Int(1));
+        assert!(matches!(
+            append_prim(&mut vm),
+            Err(TbxError::DictionaryOverflow { .. })
+        ));
+    }
+
     // --- allot_prim ---
 
     #[test]

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1,4 +1,5 @@
 use crate::cell::{Cell, ReturnFrame, Xt};
+use crate::constants::MAX_DICTIONARY_CELLS;
 use crate::dict::WordEntry;
 use crate::error::TbxError;
 
@@ -118,6 +119,27 @@ impl VM {
     /// Returns `Err(TbxError::StackUnderflow)` if the data stack is empty.
     pub fn pop(&mut self) -> Result<Cell, TbxError> {
         self.data_stack.pop().ok_or(TbxError::StackUnderflow)
+    }
+
+    /// Write a cell to `dictionary[dp]` and advance dp by 1.
+    ///
+    /// Maintains the invariant `dp == dictionary.len()` by always using `push`.
+    /// Checks the dictionary size limit before writing.
+    pub fn dict_write(&mut self, cell: Cell) -> Result<(), TbxError> {
+        debug_assert_eq!(
+            self.dp,
+            self.dictionary.len(),
+            "dp must equal dictionary.len()"
+        );
+        if self.dp >= MAX_DICTIONARY_CELLS {
+            return Err(TbxError::DictionaryOverflow {
+                requested: self.dp + 1,
+                limit: MAX_DICTIONARY_CELLS,
+            });
+        }
+        self.dictionary.push(cell);
+        self.dp += 1;
+        Ok(())
     }
 
     /// Seal the system dictionary boundary.


### PR DESCRIPTION
## 概要

Issue #39（T12: 辞書操作プリミティブ）のうち、ソース入力に依存しない3つのプリミティブ（APPEND, ALLOT, HERE）を実装する。

## 変更内容

- `constants.rs` を新設し `MAX_DICTIONARY_CELLS = 1_048_576` を定義
- `error.rs` に `DictionaryOverflow` と `InvalidAllotCount` エラーバリアントを追加
- `vm.rs` に `dict_write()` ヘルパーメソッドを追加（`dp == dictionary.len()` 不変条件を `debug_assert` で検証）
- `primitives.rs` に以下のプリミティブを実装・`register_all` に登録:
  - `APPEND ( cell -- )` — スタックトップの Cell を辞書に書き込み dp を進める
  - `ALLOT ( n -- addr )` — dp を n セル分進め、先頭アドレスを返す
  - `HERE ( -- addr )` — 現在の dp を DictAddr として返す
- 各プリミティブのユニットテスト（正常系・異常系・境界条件）を追加

## 仕様上の決定事項

- **HEADER** はソース入力機構への依存があるため除外（→ Issue #144）
- **LITERAL** は LIT のインナインタプリタ対応と合わせて別対応（→ Issue #41 にコメント済み）
- dictionary 書き込みは常に `push` を使用し、`dp == dictionary.len()` を不変条件とする（A2方式）

Closes #39
