### PR TITLE
状態管理プリミティブ STATE, HALT を実装

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -31,6 +31,8 @@ pub enum TbxError {
     },
     /// ALLOT was called with a negative count.
     InvalidAllotCount,
+    /// HALT was executed, requesting the VM to stop.
+    Halted,
 }
 
 impl std::fmt::Display for TbxError {
@@ -59,6 +61,7 @@ impl std::fmt::Display for TbxError {
                 )
             }
             TbxError::InvalidAllotCount => write!(f, "ALLOT count must be non-negative"),
+            TbxError::Halted => write!(f, "execution halted"),
         }
     }
 }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -464,6 +464,17 @@ pub fn here_prim(vm: &mut VM) -> Result<(), TbxError> {
     Ok(())
 }
 
+/// STATE — push the current compile mode flag as an Int (0 = execute, 1 = compile).
+pub fn state_prim(vm: &mut VM) -> Result<(), TbxError> {
+    vm.push(Cell::Int(if vm.is_compiling { 1 } else { 0 }));
+    Ok(())
+}
+
+/// HALT — stop VM execution by returning a Halted error.
+pub fn halt_prim(_vm: &mut VM) -> Result<(), TbxError> {
+    Err(TbxError::Halted)
+}
+
 /// Register all stack primitives into the VM's dictionary.
 pub fn register_all(vm: &mut VM) {
     vm.register(WordEntry::new_primitive("DROP", drop_prim));
@@ -493,6 +504,8 @@ pub fn register_all(vm: &mut VM) {
     vm.register(WordEntry::new_primitive("APPEND", append_prim));
     vm.register(WordEntry::new_primitive("ALLOT", allot_prim));
     vm.register(WordEntry::new_primitive("HERE", here_prim));
+    vm.register(WordEntry::new_primitive("STATE", state_prim));
+    vm.register(WordEntry::new_primitive("HALT", halt_prim));
 }
 
 #[cfg(test)]
@@ -1602,5 +1615,39 @@ mod tests {
             allot_prim(&mut vm),
             Err(TbxError::DictionaryOverflow { .. })
         ));
+    }
+
+    // --- state_prim ---
+
+    #[test]
+    fn test_state_execute_mode() {
+        let mut vm = VM::new();
+        state_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop().unwrap(), Cell::Int(0));
+    }
+
+    #[test]
+    fn test_state_compile_mode() {
+        let mut vm = VM::new();
+        vm.is_compiling = true;
+        state_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop().unwrap(), Cell::Int(1));
+    }
+
+    // --- halt_prim ---
+
+    #[test]
+    fn test_halt_returns_halted() {
+        let mut vm = VM::new();
+        assert!(matches!(halt_prim(&mut vm), Err(TbxError::Halted)));
+    }
+
+    #[test]
+    fn test_halt_leaves_stack_unchanged() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(42));
+        let _ = halt_prim(&mut vm);
+        assert_eq!(vm.data_stack.len(), 1);
+        assert_eq!(vm.pop().unwrap(), Cell::Int(42));
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -51,6 +51,9 @@ pub struct VM {
     /// Output buffer: collects text from PUTSTR / PUTCHR / PUTDEC / PUTHEX.
     /// Flushed to stdout at appropriate points (e.g. end of interpretation cycle).
     pub output_buffer: String,
+    /// Compile mode flag: false = execution mode (STATE=0), true = compile mode (STATE=1).
+    /// Toggled by DEF (enter compile mode) and END (return to execution mode).
+    pub is_compiling: bool,
 }
 
 impl VM {
@@ -73,6 +76,7 @@ impl VM {
             dp: 0,
             latest: None,
             output_buffer: String::new(),
+            is_compiling: false,
         }
     }
 


### PR DESCRIPTION
## 概要

Issue #40（T13: 状態管理・HALTプリミティブ）のうち、STATE と HALT を実装する。

## 変更内容

- `vm.rs`: `is_compiling: bool` フィールドを VM 構造体に追加（実行モード=false / コンパイルモード=true）
- `error.rs`: `TbxError::Halted` バリアントを追加（HALT 実行時の正常停止通知）
- `primitives.rs`:
  - `STATE ( -- n )` — 現在のモードを Int として push（0=実行, 1=コンパイル）
  - `HALT ( -- )` — `TbxError::Halted` を返して VM 実行を停止
  - 両プリミティブを `register_all` に登録
- 各プリミティブのユニットテストを追加

## スコープ外

- **IMMEDIATE** はソース入力機構（トークン読み取り）に依存するため Issue #147 として分離済み

Closes #40
