### PR TITLE
T14: インナ・インタプリタ実装

### DIFF
--- a/src/cell.rs
+++ b/src/cell.rs
@@ -19,7 +19,8 @@ impl Xt {
 /// Return frame for the return stack, saving the program counter and base pointer
 #[derive(Debug, Clone)]
 pub enum ReturnFrame {
-    Call { pc: usize, bp: usize },
+    Call { return_pc: usize, saved_bp: usize },
+    TopLevel, // Sentinel value for the bottom of the return stack
 }
 
 /// Cell is the fundamental value type of the TBX VM.

--- a/src/dict.rs
+++ b/src/dict.rs
@@ -17,6 +17,12 @@ pub enum EntryKind {
     /// Handled by the inner interpreter: push next cell as a literal value.
     /// TODO: dispatched in the inner interpreter loop (to be implemented in a future task).
     Lit,
+    /// CALL instruction: reads next cell as Xt and enters the word body.
+    /// Handled by the inner interpreter (not a PrimFn).
+    Call,
+    /// EXIT instruction: returns from the current word.
+    /// Handled by the inner interpreter (not a PrimFn).
+    Exit,
 }
 
 impl std::fmt::Debug for EntryKind {
@@ -27,6 +33,8 @@ impl std::fmt::Debug for EntryKind {
             EntryKind::Variable(idx) => write!(f, "Variable({idx})"),
             EntryKind::Constant(cell) => write!(f, "Constant({cell:?})"),
             EntryKind::Lit => write!(f, "Lit"),
+            EntryKind::Call => write!(f, "Call"),
+            EntryKind::Exit => write!(f, "Exit"),
         }
     }
 }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1,4 +1,4 @@
-use crate::cell::{Cell, ReturnFrame};
+use crate::cell::Cell;
 use crate::constants::MAX_DICTIONARY_CELLS;
 use crate::dict::{EntryKind, WordEntry};
 use crate::error::TbxError;
@@ -85,48 +85,6 @@ pub fn store_prim(vm: &mut VM) -> Result<(), TbxError> {
             got: "non-address",
         }),
     }
-}
-
-/// CALL — call an execution token (Xt).
-pub fn call_prim(vm: &mut VM) -> Result<(), TbxError> {
-    let xt_cell = vm
-        .dictionary
-        .get(vm.pc + 1)
-        .ok_or(TbxError::IndexOutOfBounds {
-            index: vm.pc + 1,
-            size: vm.dictionary.len(),
-        })?;
-    if let Cell::Xt(x) = xt_cell {
-        let offset = match vm.headers[x.index()].kind {
-            EntryKind::Word(offset) => offset,
-            _ => {
-                return Err(TbxError::TypeError {
-                    expected: "callable (primitive or word)",
-                    got: "non-callable",
-                })
-            }
-        };
-        let pc = vm.pc + 2; // CALL命令の次の命令のアドレス)
-        let bp = vm.bp;
-        let return_frame = ReturnFrame::Call { pc, bp };
-        vm.return_stack.push(return_frame);
-        vm.bp = vm.data_stack.len();
-        vm.pc = offset;
-        Ok(())
-    } else {
-        Err(TbxError::TypeError {
-            expected: "Xt",
-            got: xt_cell.type_name(),
-        })
-    }
-}
-
-pub fn exit_prim(vm: &mut VM) -> Result<(), TbxError> {
-    let return_frame = vm.return_stack.pop().ok_or(TbxError::StackUnderflow)?;
-    let ReturnFrame::Call { pc, bp } = return_frame;
-    vm.pc = pc;
-    vm.bp = bp;
-    Ok(())
 }
 
 pub fn add_prim(vm: &mut VM) -> Result<(), TbxError> {
@@ -475,6 +433,17 @@ pub fn halt_prim(_vm: &mut VM) -> Result<(), TbxError> {
     Err(TbxError::Halted)
 }
 
+/// LITERAL — compile a literal value into the dictionary as LIT + value (2 cells).
+pub fn literal_prim(vm: &mut VM) -> Result<(), TbxError> {
+    let value = vm.pop()?;
+    let lit_xt = vm.lookup("LIT").ok_or(TbxError::TypeError {
+        expected: "LIT word to be registered",
+        got: "not found",
+    })?;
+    vm.dict_write(Cell::Xt(lit_xt))?;
+    vm.dict_write(value)?;
+    Ok(())
+}
 /// Register all stack primitives into the VM's dictionary.
 pub fn register_all(vm: &mut VM) {
     vm.register(WordEntry::new_primitive("DROP", drop_prim));
@@ -482,8 +451,6 @@ pub fn register_all(vm: &mut VM) {
     vm.register(WordEntry::new_primitive("SWAP", swap_prim));
     vm.register(WordEntry::new_primitive("FETCH", fetch_prim));
     vm.register(WordEntry::new_primitive("STORE", store_prim));
-    vm.register(WordEntry::new_primitive("CALL", call_prim));
-    vm.register(WordEntry::new_primitive("EXIT", exit_prim));
     vm.register(WordEntry::new_primitive("ADD", add_prim));
     vm.register(WordEntry::new_primitive("SUB", sub_prim));
     vm.register(WordEntry::new_primitive("MUL", mul_prim));
@@ -506,6 +473,27 @@ pub fn register_all(vm: &mut VM) {
     vm.register(WordEntry::new_primitive("HERE", here_prim));
     vm.register(WordEntry::new_primitive("STATE", state_prim));
     vm.register(WordEntry::new_primitive("HALT", halt_prim));
+    vm.register(WordEntry {
+        name: "CALL".to_string(),
+        flags: 0,
+        kind: EntryKind::Call,
+        prev: None,
+    });
+    vm.register(WordEntry {
+        name: "EXIT".to_string(),
+        flags: 0,
+        kind: EntryKind::Exit,
+        prev: None,
+    });
+    vm.register(WordEntry {
+        name: "LIT".to_string(),
+        flags: 0,
+        kind: EntryKind::Lit,
+        prev: None,
+    });
+    let mut literal_entry = WordEntry::new_primitive("LITERAL", literal_prim);
+    literal_entry.flags |= crate::dict::FLAG_IMMEDIATE;
+    vm.register(literal_entry);
 }
 
 #[cfg(test)]
@@ -687,69 +675,6 @@ mod tests {
         let mut vm = VM::new();
         vm.push(Cell::Int(123)); // value to store
         assert_eq!(store_prim(&mut vm), Err(TbxError::StackUnderflow));
-    }
-
-    #[test]
-    fn test_call_and_exit() {
-        let mut vm = VM::new();
-        register_all(&mut vm); // Ensure CALL and EXIT are registered
-        let dummy_xt = vm.register(WordEntry::new_word("TEST", 10));
-        vm.dictionary.push(Cell::None);
-        vm.dictionary.push(Cell::Xt(dummy_xt)); // code for TEST: CALL EXIT
-
-        vm.pc = 0;
-        call_prim(&mut vm).unwrap();
-        assert_eq!(vm.pc, 10); // After CALL, pc should be at TEST's code
-    }
-
-    #[test]
-    fn test_exit_restores_pc_bp() {
-        let mut vm = VM::new();
-        register_all(&mut vm); // Ensure CALL and EXIT are registered
-        vm.return_stack.push(ReturnFrame::Call { pc: 42, bp: 99 });
-        exit_prim(&mut vm).unwrap();
-        assert_eq!(vm.pc, 42);
-        assert_eq!(vm.bp, 99);
-    }
-
-    #[test]
-    fn test_exit_underflow() {
-        let mut vm = VM::new();
-        assert_eq!(exit_prim(&mut vm), Err(TbxError::StackUnderflow));
-    }
-
-    #[test]
-    fn test_call_type_error() {
-        let mut vm = VM::new();
-        register_all(&mut vm); // Ensure CALL and EXIT are registered
-        vm.dictionary.push(Cell::None);
-        vm.dictionary.push(Cell::Int(123)); // Not an Xt
-        vm.pc = 0;
-        assert_eq!(
-            call_prim(&mut vm),
-            Err(TbxError::TypeError {
-                expected: "Xt",
-                got: "Int"
-            })
-        );
-    }
-
-    #[test]
-    fn test_call_non_word_xt() {
-        let mut vm = VM::new();
-        register_all(&mut vm);
-        let drop_xt = vm.lookup("DROP").unwrap();
-        vm.dictionary.push(Cell::None);
-        vm.dictionary.push(Cell::Xt(drop_xt)); // Xt exists but points to a Primitive
-        vm.pc = 0;
-        let original_bp = vm.bp;
-        let original_rs_len = vm.return_stack.len();
-        assert!(call_prim(&mut vm).is_err());
-
-        // Verify that VM state remains unchanged after error
-        assert_eq!(vm.pc, 0);
-        assert_eq!(vm.bp, original_bp);
-        assert_eq!(vm.return_stack.len(), original_rs_len);
     }
 
     #[test]
@@ -1649,5 +1574,22 @@ mod tests {
         let _ = halt_prim(&mut vm);
         assert_eq!(vm.data_stack.len(), 1);
         assert_eq!(vm.pop().unwrap(), Cell::Int(42));
+    }
+
+    #[test]
+    fn test_literal_compiles_lit_and_value() {
+        // LITERAL should write [Xt(LIT), value] into the dictionary.
+        let mut vm = VM::new();
+        crate::primitives::register_all(&mut vm);
+
+        let lit_xt = vm.lookup("LIT").unwrap();
+        let dp_before = vm.dp;
+
+        vm.push(Cell::Int(123));
+        crate::primitives::literal_prim(&mut vm).unwrap();
+
+        assert_eq!(vm.dictionary[dp_before], Cell::Xt(lit_xt));
+        assert_eq!(vm.dictionary[dp_before + 1], Cell::Int(123));
+        assert_eq!(vm.dp, dp_before + 2);
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -183,6 +183,130 @@ impl VM {
         std::mem::take(&mut self.output_buffer)
     }
 
+    /// Run the inner interpreter starting from the given dictionary offset.
+    ///
+    /// Pushes a `ReturnFrame::TopLevel` sentinel before entering the loop.
+    /// Execution ends when EXIT pops the TopLevel frame (normal end) or
+    /// when a primitive returns `Err(TbxError::Halted)`.
+    pub fn run(&mut self, start_offset: usize) -> Result<(), TbxError> {
+        use crate::cell::ReturnFrame;
+        use crate::dict::EntryKind;
+
+        self.return_stack.push(ReturnFrame::TopLevel);
+        self.pc = start_offset;
+
+        loop {
+            let entry_kind = self
+                .headers
+                .get(
+                    self.dictionary
+                        .get(self.pc)
+                        .and_then(|c: &Cell| c.as_xt())
+                        .ok_or(TbxError::TypeError {
+                            expected: "Xt",
+                            got: "non-Xt",
+                        })?
+                        .index(),
+                )
+                .ok_or(TbxError::IndexOutOfBounds {
+                    index: self.pc,
+                    size: self.headers.len(),
+                })?
+                .kind
+                .clone();
+
+            match entry_kind {
+                EntryKind::Primitive(f) => {
+                    f(self)?;
+                    self.pc += 1;
+                }
+                EntryKind::Word(offset) => {
+                    let return_pc = self.pc + 1;
+                    let saved_bp = self.bp;
+                    self.return_stack.push(ReturnFrame::Call {
+                        return_pc,
+                        saved_bp,
+                    });
+                    self.bp = self.data_stack.len();
+                    self.pc = offset;
+                }
+                EntryKind::Call => {
+                    let target_xt = self
+                        .dictionary
+                        .get(self.pc + 1)
+                        .and_then(|c: &Cell| c.as_xt())
+                        .ok_or(TbxError::IndexOutOfBounds {
+                            index: self.pc + 1,
+                            size: self.dictionary.len(),
+                        })?;
+                    match self
+                        .headers
+                        .get(target_xt.index())
+                        .ok_or(TbxError::IndexOutOfBounds {
+                            index: target_xt.index(),
+                            size: self.headers.len(),
+                        })?
+                        .kind
+                        .clone()
+                    {
+                        EntryKind::Word(offset) => {
+                            let return_pc = self.pc + 2;
+                            let saved_bp = self.bp;
+                            self.return_stack.push(ReturnFrame::Call {
+                                return_pc,
+                                saved_bp,
+                            });
+                            self.bp = self.data_stack.len();
+                            self.pc = offset;
+                        }
+                        _ => {
+                            return Err(TbxError::TypeError {
+                                expected: "Word",
+                                got: "non-Word",
+                            })
+                        }
+                    }
+                }
+                EntryKind::Exit => {
+                    match self.return_stack.pop().ok_or(TbxError::StackUnderflow)? {
+                        ReturnFrame::Call {
+                            return_pc,
+                            saved_bp,
+                        } => {
+                            self.pc = return_pc;
+                            self.bp = saved_bp;
+                        }
+                        ReturnFrame::TopLevel => break,
+                    }
+                }
+                EntryKind::Lit => {
+                    self.pc += 1;
+                    let literal = self
+                        .dictionary
+                        .get(self.pc)
+                        .ok_or(TbxError::IndexOutOfBounds {
+                            index: self.pc,
+                            size: self.dictionary.len(),
+                        })?
+                        .clone();
+                    self.push(literal);
+                    self.pc += 1;
+                }
+                EntryKind::Variable(idx) => {
+                    self.push(Cell::DictAddr(idx));
+                    self.pc += 1;
+                }
+                EntryKind::Constant(ref c) => {
+                    let val = c.clone();
+                    self.push(val);
+                    self.pc += 1;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     /// Resolve a StringDesc index to the string stored in the string pool.
     ///
     /// Returns `Err(TbxError::TypeError)` if the index is out of bounds or
@@ -456,5 +580,74 @@ mod tests {
         vm.latest = Some(Xt(99));
         // Should return None, not panic
         assert_eq!(vm.lookup("FOO"), None);
+    }
+
+    #[test]
+    fn test_run_primitive_drop() {
+        // Verify that the inner interpreter can execute a primitive (DROP) via an Xt cell.
+        let mut vm = VM::new();
+        crate::primitives::register_all(&mut vm);
+
+        let drop_xt = vm.lookup("DROP").unwrap();
+        let exit_xt = vm.lookup("EXIT").unwrap();
+
+        // Program: [Xt(DROP), Xt(EXIT)]
+        vm.dict_write(Cell::Xt(drop_xt)).unwrap();
+        vm.dict_write(Cell::Xt(exit_xt)).unwrap();
+
+        vm.push(Cell::Int(99));
+        vm.run(0).unwrap();
+
+        // DROP should have removed the 99
+        assert_eq!(vm.pop(), Err(crate::error::TbxError::StackUnderflow));
+    }
+
+    #[test]
+    fn test_run_lit() {
+        // Verify that EntryKind::Lit pushes the next cell as a literal value.
+        let mut vm = VM::new();
+        crate::primitives::register_all(&mut vm);
+
+        let lit_xt = vm.lookup("LIT").unwrap();
+        let exit_xt = vm.lookup("EXIT").unwrap();
+
+        // Program: [Xt(LIT), Int(42), Xt(EXIT)]
+        vm.dict_write(Cell::Xt(lit_xt)).unwrap();
+        vm.dict_write(Cell::Int(42)).unwrap();
+        vm.dict_write(Cell::Xt(exit_xt)).unwrap();
+
+        vm.run(0).unwrap();
+
+        assert_eq!(vm.pop(), Ok(Cell::Int(42)));
+    }
+
+    #[test]
+    fn test_run_word_call() {
+        // Verify that EntryKind::Word dispatches correctly via the inner interpreter.
+        // Layout:
+        //   [0] Xt(MY_WORD)  <- top-level: call MY_WORD
+        //   [1] Xt(EXIT)     <- top-level exit
+        //   [2] Xt(DUP)      <- MY_WORD body: DUP
+        //   [3] Xt(EXIT)     <- MY_WORD body: EXIT
+        let mut vm = VM::new();
+        crate::primitives::register_all(&mut vm);
+
+        let dup_xt = vm.lookup("DUP").unwrap();
+        let exit_xt = vm.lookup("EXIT").unwrap();
+
+        // Register MY_WORD pointing to offset 2
+        let my_word_xt = vm.register(crate::dict::WordEntry::new_word("MY_WORD", 2));
+
+        vm.dict_write(Cell::Xt(my_word_xt)).unwrap(); // [0]
+        vm.dict_write(Cell::Xt(exit_xt)).unwrap(); // [1]
+        vm.dict_write(Cell::Xt(dup_xt)).unwrap(); // [2]
+        vm.dict_write(Cell::Xt(exit_xt)).unwrap(); // [3]
+
+        vm.push(Cell::Int(7));
+        vm.run(0).unwrap();
+
+        // DUP should have duplicated the 7
+        assert_eq!(vm.pop(), Ok(Cell::Int(7)));
+        assert_eq!(vm.pop(), Ok(Cell::Int(7)));
     }
 }


### PR DESCRIPTION
## 概要

issue #41「T14: インナ・インタプリタ実装」の実装。
仕様はissue #41のコメントとblueprint.mdに記録済みの決定事項に従い、ペアプログラミングで実装した。

## 変更内容

### cell.rs
- `ReturnFrame::TopLevel` バリアントを追加（番哨フレーム方式によるトップレベル終端管理）
- `ReturnFrame::Call` のフィールド名を `pc`/`bp` → `return_pc`/`saved_bp` に変更（blueprintの命名に合わせる）

### dict.rs
- `EntryKind::Call` を追加（CALL命令: dictionary[pc+1]のXtを読んでワード本体へジャンプ）
- `EntryKind::Exit` を追加（EXIT命令: リターンスタックをpopしてCallまたはTopLevelで分岐）

### primitives.rs
- `call_prim` / `exit_prim` を削除（PCの操作はインナインタプリタに集約する原則に従う）
- `register_all` に LIT / CALL / EXIT を追加登録（EntryKind特殊バリアントとして）
- `literal_prim` を実装・登録（IMMEDIATEフラグ付き）

### vm.rs
- `VM::run(start_offset: usize)` を実装（インナインタプリタのメインループ）
  - 全 EntryKind（Primitive / Word / Call / Exit / Lit / Variable / Constant）をディスパッチ
  - ReturnFrame::TopLevel で break して正常終了
- テスト追加: DROP経由のプリミティブ実行 / LIT / Wordのサブルーティン呼び出し

Closes #41
