### PR TITLE
feat: Cell::Marker と DROP_TO_MARKER を実装 (#151)

### DIFF
--- a/src/cell.rs
+++ b/src/cell.rs
@@ -46,6 +46,9 @@ pub enum Cell {
     /// Reserved for future array support
     Array,
     None,
+    /// Sentinel value placed on the data stack to mark a statement boundary.
+    /// Consumed by DROP_TO_MARKER to restore the stack after a statement call.
+    Marker,
 }
 
 impl std::fmt::Display for Cell {
@@ -74,6 +77,7 @@ impl std::fmt::Display for Cell {
             Cell::StringDesc(i) => write!(f, "str:{}", i),
             Cell::Array => write!(f, "<array>"),
             Cell::None => write!(f, "<none>"),
+            Cell::Marker => write!(f, "<marker>"),
         }
     }
 }
@@ -154,6 +158,7 @@ impl Cell {
             Cell::StringDesc(_) => "StringDesc",
             Cell::Array => "Array",
             Cell::None => "None",
+            Cell::Marker => "Marker",
         }
     }
 

--- a/src/dict.rs
+++ b/src/dict.rs
@@ -26,6 +26,9 @@ pub enum EntryKind {
     /// RETURN_VAL instruction: returns a value from the current word.
     /// Handled by the inner interpreter (not a PrimFn).
     ReturnVal,
+    /// DROP_TO_MARKER instruction: pops the data stack until a Cell::Marker is found (inclusive).
+    /// Handled by the inner interpreter (not a PrimFn).
+    DropToMarker,
 }
 
 impl std::fmt::Debug for EntryKind {
@@ -39,6 +42,7 @@ impl std::fmt::Debug for EntryKind {
             EntryKind::Call => write!(f, "Call"),
             EntryKind::Exit => write!(f, "Exit"),
             EntryKind::ReturnVal => write!(f, "ReturnVal"),
+            EntryKind::DropToMarker => write!(f, "DropToMarker"),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -115,4 +115,10 @@ mod tests {
         let e = TbxError::DivisionByZero;
         assert!(e.to_string().contains("division by zero"));
     }
+
+    #[test]
+    fn test_marker_not_found_display() {
+        let e = TbxError::MarkerNotFound;
+        assert!(e.to_string().contains("marker"));
+    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,6 +35,8 @@ pub enum TbxError {
     Halted,
     /// RETURN with a value was executed at the top level (outside any word definition).
     InvalidReturn,
+    /// DROP_TO_MARKER executed but no Cell::Marker was found on the data stack.
+    MarkerNotFound,
 }
 
 impl std::fmt::Display for TbxError {
@@ -65,6 +67,9 @@ impl std::fmt::Display for TbxError {
             TbxError::InvalidAllotCount => write!(f, "ALLOT count must be non-negative"),
             TbxError::Halted => write!(f, "execution halted"),
             TbxError::InvalidReturn => write!(f, "RETURN with value at top level is not allowed"),
+            TbxError::MarkerNotFound => {
+                write!(f, "DROP_TO_MARKER: no marker found on the data stack")
+            }
         }
     }
 }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -503,8 +503,8 @@ pub fn register_all(vm: &mut VM) {
         kind: EntryKind::DropToMarker,
         prev: None,
     });
-    // TODO(#164): LIT_MARKER is registered with flags=0, allowing user code to call it directly.
-    // Once a FLAG_SYSTEM mechanism is in place, protect this word from user access.
+    // TODO(#164): LIT_MARKER and DROP_TO_MARKER are registered with flags=0, allowing user code
+    // to call them directly. Once a FLAG_SYSTEM mechanism is in place, protect these words.
     vm.register(WordEntry::new_primitive("LIT_MARKER", lit_marker_prim));
     vm.register(WordEntry {
         name: "LIT".to_string(),

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -10,6 +10,12 @@ pub fn drop_prim(vm: &mut VM) -> Result<(), TbxError> {
     Ok(())
 }
 
+/// LIT_MARKER — push a Cell::Marker sentinel onto the data stack.
+pub fn lit_marker_prim(vm: &mut VM) -> Result<(), TbxError> {
+    vm.push(Cell::Marker);
+    Ok(())
+}
+
 /// DUP — duplicate the top element of the data stack.
 pub fn dup_prim(vm: &mut VM) -> Result<(), TbxError> {
     let top = vm.pop()?;
@@ -491,6 +497,13 @@ pub fn register_all(vm: &mut VM) {
         kind: EntryKind::ReturnVal,
         prev: None,
     });
+    vm.register(WordEntry {
+        name: "DROP_TO_MARKER".to_string(),
+        flags: 0,
+        kind: EntryKind::DropToMarker,
+        prev: None,
+    });
+    vm.register(WordEntry::new_primitive("LIT_MARKER", lit_marker_prim));
     vm.register(WordEntry {
         name: "LIT".to_string(),
         flags: 0,

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -503,6 +503,8 @@ pub fn register_all(vm: &mut VM) {
         kind: EntryKind::DropToMarker,
         prev: None,
     });
+    // TODO(#164): LIT_MARKER is registered with flags=0, allowing user code to call it directly.
+    // Once a FLAG_SYSTEM mechanism is in place, protect this word from user access.
     vm.register(WordEntry::new_primitive("LIT_MARKER", lit_marker_prim));
     vm.register(WordEntry {
         name: "LIT".to_string(),

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -335,9 +335,10 @@ impl VM {
                 }
                 EntryKind::DropToMarker => {
                     loop {
-                        match self.pop()? {
-                            Cell::Marker => break,
-                            _ => {} // discrard non-marker cells
+                        match self.data_stack.pop() {
+                            Some(Cell::Marker) => break,
+                            Some(_) => {} // discard non-marker cells
+                            None => return Err(TbxError::MarkerNotFound),
                         }
                     }
                     self.pc += 1;
@@ -904,8 +905,6 @@ mod tests {
         let exit_xt = vm.lookup("EXIT").unwrap();
         let drop_to_marker_xt = vm.lookup("DROP_TO_MARKER").unwrap();
 
-        let stmt_offset = 9; // STMT body starts at start+9 (will be adjusted below)
-                             // We place the word body relative to dp: dp+9
         let start = vm.dp;
         let stmt_xt = vm.register(crate::dict::WordEntry::new_word("STMT", start + 9));
 
@@ -920,7 +919,6 @@ mod tests {
         vm.dict_write(Cell::Xt(exit_xt)).unwrap(); // [start+8] top-level end
         vm.dict_write(Cell::Xt(exit_xt)).unwrap(); // [start+9] STMT body
 
-        let _ = stmt_offset; // suppress unused warning
         vm.run(start).unwrap();
 
         // Marker and arg should be gone; stack must be empty.
@@ -974,5 +972,31 @@ mod tests {
 
         // return value 99 must also be discarded by DROP_TO_MARKER.
         assert!(vm.data_stack.is_empty());
+    }
+
+    #[test]
+    fn test_drop_to_marker_without_marker_returns_error() {
+        // Verifies that DROP_TO_MARKER returns MarkerNotFound when no Marker is on the stack.
+        //
+        // Top-level layout:
+        //   [start+0] LIT
+        //   [start+1] Int(1)           <- non-marker value
+        //   [start+2] DROP_TO_MARKER   <- should fail: no Marker present
+        let mut vm = VM::new();
+        crate::primitives::register_all(&mut vm);
+
+        let lit_xt = vm.lookup("LIT").unwrap();
+        let drop_to_marker_xt = vm.lookup("DROP_TO_MARKER").unwrap();
+
+        let start = vm.dp;
+        vm.dict_write(Cell::Xt(lit_xt)).unwrap(); // [start+0]
+        vm.dict_write(Cell::Int(1)).unwrap(); // [start+1]
+        vm.dict_write(Cell::Xt(drop_to_marker_xt)).unwrap(); // [start+2]
+
+        let result = vm.run(start);
+        assert!(matches!(
+            result,
+            Err(crate::error::TbxError::MarkerNotFound)
+        ));
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -333,6 +333,16 @@ impl VM {
                         }
                     }
                 }
+                EntryKind::DropToMarker => {
+                    loop {
+                        match self.pop()? {
+                            Cell::Marker => break,
+                            _ => {} // discrard non-marker cells
+                        }
+                    }
+                    self.pc += 1;
+                }
+
                 EntryKind::Lit => {
                     self.pc += 1;
                     let literal = self
@@ -868,5 +878,101 @@ mod tests {
 
         let result = vm.run(start);
         assert!(matches!(result, Err(crate::error::TbxError::InvalidReturn)));
+    }
+
+    #[test]
+    fn test_drop_to_marker_after_void_statement() {
+        // Verifies that DROP_TO_MARKER clears Marker + args after a void return statement.
+        //
+        // Top-level layout:
+        //   [start+0] LIT_MARKER
+        //   [start+1] LIT
+        //   [start+2] Int(42)       <- argument
+        //   [start+3] CALL
+        //   [start+4] Xt(STMT)
+        //   [start+5] Int(1)        <- arity=1
+        //   [start+6] Int(0)        <- local_count=0
+        //   [start+7] DROP_TO_MARKER
+        //   [start+8] EXIT          <- top-level end
+        //   [start+9] EXIT          <- STMT body (void return)
+        let mut vm = VM::new();
+        crate::primitives::register_all(&mut vm);
+
+        let lit_marker_xt = vm.lookup("LIT_MARKER").unwrap();
+        let lit_xt = vm.lookup("LIT").unwrap();
+        let call_xt = vm.lookup("CALL").unwrap();
+        let exit_xt = vm.lookup("EXIT").unwrap();
+        let drop_to_marker_xt = vm.lookup("DROP_TO_MARKER").unwrap();
+
+        let stmt_offset = 9; // STMT body starts at start+9 (will be adjusted below)
+                             // We place the word body relative to dp: dp+9
+        let start = vm.dp;
+        let stmt_xt = vm.register(crate::dict::WordEntry::new_word("STMT", start + 9));
+
+        vm.dict_write(Cell::Xt(lit_marker_xt)).unwrap(); // [start+0]
+        vm.dict_write(Cell::Xt(lit_xt)).unwrap(); // [start+1]
+        vm.dict_write(Cell::Int(42)).unwrap(); // [start+2]
+        vm.dict_write(Cell::Xt(call_xt)).unwrap(); // [start+3]
+        vm.dict_write(Cell::Xt(stmt_xt)).unwrap(); // [start+4]
+        vm.dict_write(Cell::Int(1)).unwrap(); // [start+5] arity=1
+        vm.dict_write(Cell::Int(0)).unwrap(); // [start+6] local_count=0
+        vm.dict_write(Cell::Xt(drop_to_marker_xt)).unwrap(); // [start+7]
+        vm.dict_write(Cell::Xt(exit_xt)).unwrap(); // [start+8] top-level end
+        vm.dict_write(Cell::Xt(exit_xt)).unwrap(); // [start+9] STMT body
+
+        let _ = stmt_offset; // suppress unused warning
+        vm.run(start).unwrap();
+
+        // Marker and arg should be gone; stack must be empty.
+        assert!(vm.data_stack.is_empty());
+    }
+
+    #[test]
+    fn test_drop_to_marker_after_value_returning_statement() {
+        // Verifies that DROP_TO_MARKER discards the return value as well as Marker + args.
+        //
+        // Top-level layout:
+        //   [start+0]  LIT_MARKER
+        //   [start+1]  LIT
+        //   [start+2]  Int(42)       <- argument
+        //   [start+3]  CALL
+        //   [start+4]  Xt(STMT2)
+        //   [start+5]  Int(1)        <- arity=1
+        //   [start+6]  Int(0)        <- local_count=0
+        //   [start+7]  DROP_TO_MARKER
+        //   [start+8]  EXIT          <- top-level end
+        //   [start+9]  LIT           <- STMT2 body: push 99
+        //   [start+10] Int(99)
+        //   [start+11] RETURN_VAL    <- return with value 99
+        let mut vm = VM::new();
+        crate::primitives::register_all(&mut vm);
+
+        let lit_marker_xt = vm.lookup("LIT_MARKER").unwrap();
+        let lit_xt = vm.lookup("LIT").unwrap();
+        let call_xt = vm.lookup("CALL").unwrap();
+        let exit_xt = vm.lookup("EXIT").unwrap();
+        let drop_to_marker_xt = vm.lookup("DROP_TO_MARKER").unwrap();
+        let return_val_xt = vm.lookup("RETURN_VAL").unwrap();
+
+        let start = vm.dp;
+        let stmt2_xt = vm.register(crate::dict::WordEntry::new_word("STMT2", start + 9));
+
+        vm.dict_write(Cell::Xt(lit_marker_xt)).unwrap(); // [start+0]
+        vm.dict_write(Cell::Xt(lit_xt)).unwrap(); // [start+1]
+        vm.dict_write(Cell::Int(42)).unwrap(); // [start+2] arg
+        vm.dict_write(Cell::Xt(call_xt)).unwrap(); // [start+3]
+        vm.dict_write(Cell::Xt(stmt2_xt)).unwrap(); // [start+4]
+        vm.dict_write(Cell::Int(1)).unwrap(); // [start+5] arity=1
+        vm.dict_write(Cell::Int(0)).unwrap(); // [start+6] local_count=0
+        vm.dict_write(Cell::Xt(drop_to_marker_xt)).unwrap(); // [start+7]
+        vm.dict_write(Cell::Xt(exit_xt)).unwrap(); // [start+8] top-level end
+        vm.dict_write(Cell::Xt(lit_xt)).unwrap(); // [start+9]  STMT2: LIT 99
+        vm.dict_write(Cell::Int(99)).unwrap(); // [start+10]
+        vm.dict_write(Cell::Xt(return_val_xt)).unwrap(); // [start+11] RETURN_VAL
+
+        vm.run(start).unwrap();
+
+        // return value 99 must also be discarded by DROP_TO_MARKER.
+        assert!(vm.data_stack.is_empty());
     }
 }


### PR DESCRIPTION
## 概要

issue #151「ステートメントの実行後にスタックをクリアする仕様」の実装です。

## 変更内容

### マーカー方式の実装

ステートメント呼び出しの前後に sentinel を置き、CALL後にスタックを境界まで巻き戻す方式を実装しました。

コンパイル後の命令列：
```
LIT_MARKER             ← ステートメント境界のsentinel
... arg の式評価 ...
CALL(stmt, arity, 0)
DROP_TO_MARKER         ← Markerまでスタックを巻き戻す
```

### 追加したもの

- `Cell::Marker` — データスタック上のsentinelバリアント
- `EntryKind::DropToMarker` — インナインタプリタ用命令種別
- `LIT_MARKER` プリミティブ — Cell::Markerをスタックに積む
- `DROP_TO_MARKER` プリミティブ — Markerを見つけるまでpopし、Markerも除去する

## テスト

- void returnステートメント後のスタッククリアを確認
- 値返却ステートメント後の戻り値も含むスタッククリアを確認

Closes #151