### PR TITLE
fix: MAX_RETURN_STACK_DEPTH と TbxError::ReturnStackOverflow を実装

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,3 +1,7 @@
 /// Maximum number of cells in the dictionary (data layer).
 /// Approximately 8 MB when each cell is 8 bytes.
 pub const MAX_DICTIONARY_CELLS: usize = 1_048_576;
+
+/// Maximum depth of the return stack.
+/// Exceeding this limit raises `TbxError::ReturnStackOverflow`.
+pub const MAX_RETURN_STACK_DEPTH: usize = 4_096;

--- a/src/error.rs
+++ b/src/error.rs
@@ -37,6 +37,11 @@ pub enum TbxError {
     InvalidReturn,
     /// DROP_TO_MARKER executed but no Cell::Marker was found on the data stack.
     MarkerNotFound,
+    /// The return stack depth exceeded the maximum allowed limit.
+    ReturnStackOverflow {
+        depth: usize,
+        limit: usize,
+    },
 }
 
 impl std::fmt::Display for TbxError {
@@ -69,6 +74,13 @@ impl std::fmt::Display for TbxError {
             TbxError::InvalidReturn => write!(f, "RETURN with value at top level is not allowed"),
             TbxError::MarkerNotFound => {
                 write!(f, "DROP_TO_MARKER: no marker found on the data stack")
+            }
+            TbxError::ReturnStackOverflow { depth, limit } => {
+                write!(
+                    f,
+                    "return stack overflow: depth {} exceeds limit {}",
+                    depth, limit
+                )
             }
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -78,7 +78,7 @@ impl std::fmt::Display for TbxError {
             TbxError::ReturnStackOverflow { depth, limit } => {
                 write!(
                     f,
-                    "return stack overflow: depth {} exceeds limit {}",
+                    "return stack overflow: depth {} reached or exceeded limit {}",
                     depth, limit
                 )
             }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1,5 +1,5 @@
 use crate::cell::{Cell, ReturnFrame, Xt};
-use crate::constants::MAX_DICTIONARY_CELLS;
+use crate::constants::{MAX_DICTIONARY_CELLS, MAX_RETURN_STACK_DEPTH};
 use crate::dict::WordEntry;
 use crate::error::TbxError;
 
@@ -223,6 +223,12 @@ impl VM {
                 EntryKind::Word(offset) => {
                     let return_pc = self.pc + 1;
                     let saved_bp = self.bp;
+                    if self.return_stack.len() >= MAX_RETURN_STACK_DEPTH {
+                        return Err(TbxError::ReturnStackOverflow {
+                            depth: self.return_stack.len(),
+                            limit: MAX_RETURN_STACK_DEPTH,
+                        });
+                    }
                     self.return_stack.push(ReturnFrame::Call {
                         return_pc,
                         saved_bp,
@@ -284,6 +290,12 @@ impl VM {
                             let saved_bp = self.bp;
                             if self.data_stack.len() < arity {
                                 return Err(TbxError::StackUnderflow);
+                            }
+                            if self.return_stack.len() >= MAX_RETURN_STACK_DEPTH {
+                                return Err(TbxError::ReturnStackOverflow {
+                                    depth: self.return_stack.len(),
+                                    limit: MAX_RETURN_STACK_DEPTH,
+                                });
                             }
                             self.return_stack.push(ReturnFrame::Call {
                                 return_pc,
@@ -998,5 +1010,86 @@ mod tests {
             result,
             Err(crate::error::TbxError::MarkerNotFound)
         ));
+    }
+
+    #[test]
+    fn test_word_call_return_stack_overflow() {
+        // Verify that calling a word via EntryKind::Word when the return stack is at
+        // MAX_RETURN_STACK_DEPTH returns ReturnStackOverflow.
+        use crate::constants::MAX_RETURN_STACK_DEPTH;
+
+        let mut vm = VM::new();
+        crate::primitives::register_all(&mut vm);
+
+        let exit_xt = vm.lookup("EXIT").unwrap();
+
+        // Build a simple word body: EXIT
+        let word_offset = vm.dp;
+        vm.dict_write(Cell::Xt(exit_xt)).unwrap();
+        let word_xt = vm.register(crate::dict::WordEntry::new_word("MY_WORD", word_offset));
+
+        // Pre-fill the return stack to its limit with dummy frames
+        for _ in 0..MAX_RETURN_STACK_DEPTH {
+            vm.return_stack.push(ReturnFrame::Call {
+                return_pc: 0,
+                saved_bp: 0,
+            });
+        }
+
+        // Emit top-level: Xt(MY_WORD)
+        let start = vm.dp;
+        vm.dict_write(Cell::Xt(word_xt)).unwrap();
+
+        let result = vm.run(start);
+        assert!(
+            matches!(
+                result,
+                Err(crate::error::TbxError::ReturnStackOverflow { .. })
+            ),
+            "expected ReturnStackOverflow, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_call_instruction_return_stack_overflow() {
+        // Verify that the CALL instruction (EntryKind::Call) also enforces the return stack limit.
+        use crate::constants::MAX_RETURN_STACK_DEPTH;
+
+        let mut vm = VM::new();
+        crate::primitives::register_all(&mut vm);
+
+        let call_xt = vm.lookup("CALL").unwrap();
+        let exit_xt = vm.lookup("EXIT").unwrap();
+
+        // Build word body: EXIT
+        let word_offset = vm.dp;
+        vm.dict_write(Cell::Xt(exit_xt)).unwrap();
+        let word_xt = vm.register(crate::dict::WordEntry::new_word("CALLEE", word_offset));
+
+        // Pre-fill the return stack to its limit
+        for _ in 0..MAX_RETURN_STACK_DEPTH {
+            vm.return_stack.push(ReturnFrame::Call {
+                return_pc: 0,
+                saved_bp: 0,
+            });
+        }
+
+        // Emit top-level: CALL CALLEE arity=0 local_count=0
+        let start = vm.dp;
+        vm.dict_write(Cell::Xt(call_xt)).unwrap();
+        vm.dict_write(Cell::Xt(word_xt)).unwrap();
+        vm.dict_write(Cell::Int(0)).unwrap(); // arity=0
+        vm.dict_write(Cell::Int(0)).unwrap(); // local_count=0
+
+        let result = vm.run(start);
+        assert!(
+            matches!(
+                result,
+                Err(crate::error::TbxError::ReturnStackOverflow { .. })
+            ),
+            "expected ReturnStackOverflow, got {:?}",
+            result
+        );
     }
 }


### PR DESCRIPTION
## 概要

blueprint.md「スタック深度の上限値」セクションに記載されているリターンスタック上限の仕様を実装する。
再帰が深くなった場合に `return_stack` が無制限に増加するのを防ぎ、明示的なエラーを返す。

## 変更内容

### `src/constants.rs`
- `MAX_RETURN_STACK_DEPTH: usize = 4_096` を追加

### `src/error.rs`
- `TbxError::ReturnStackOverflow { depth: usize, limit: usize }` バリアントを追加
- `Display` 実装でメッセージを表示: `return stack overflow: depth N exceeds limit M`

### `src/vm.rs`
- `use crate::constants::MAX_RETURN_STACK_DEPTH` をインポートに追加
- `EntryKind::Word` ハンドラ: `return_stack.push()` 前に深度チェックを追加
- `EntryKind::Call` → `EntryKind::Word` 内ハンドラ: 同様に深度チェックを追加
- `#[cfg(test)]` に `test_word_call_return_stack_overflow` と `test_call_instruction_return_stack_overflow` の2テストを追加

## 確認

- `cargo build` : ✅
- `cargo test` : ✅ (193 tests passed)
- `cargo clippy -- -D warnings` : ✅

Closes #159
