### PR TITLE
vm: 辞書・スタックアクセスをカプセル化するメソッドを追加（issue #161 フェーズ1）

### DIFF
--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -38,24 +38,12 @@ pub fn fetch_prim(vm: &mut VM) -> Result<(), TbxError> {
     let addr = vm.pop()?;
     match addr {
         Cell::DictAddr(a) => {
-            let size = vm.dictionary.len();
-            let value = vm
-                .dictionary
-                .get(a)
-                .ok_or(TbxError::IndexOutOfBounds { index: a, size })?
-                .clone();
+            let value = vm.dict_read(a)?;
             vm.push(value);
             Ok(())
         }
         Cell::StackAddr(a) => {
-            // TODO: vm.bp との加算をvmにカプセル化したい。その中で範囲チェックも行う。
-            let idx = vm.bp + a;
-            let size = vm.data_stack.len();
-            let value = vm
-                .data_stack
-                .get(idx)
-                .ok_or(TbxError::IndexOutOfBounds { index: idx, size })?
-                .clone();
+            let value = vm.local_read(a)?;
             vm.push(value);
             Ok(())
         }
@@ -72,18 +60,11 @@ pub fn store_prim(vm: &mut VM) -> Result<(), TbxError> {
     let value = vm.pop()?;
     match addr {
         Cell::DictAddr(a) => {
-            let size = vm.dictionary.len();
-            *vm.dictionary
-                .get_mut(a)
-                .ok_or(TbxError::IndexOutOfBounds { index: a, size })? = value;
+            vm.dict_write_at(a, value)?;
             Ok(())
         }
         Cell::StackAddr(a) => {
-            let idx = vm.bp + a;
-            let size = vm.data_stack.len();
-            *vm.data_stack
-                .get_mut(idx)
-                .ok_or(TbxError::IndexOutOfBounds { index: idx, size })? = value;
+            vm.local_write(a, value)?;
             Ok(())
         }
         _ => Err(TbxError::TypeError {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -125,6 +125,65 @@ impl VM {
         self.data_stack.pop().ok_or(TbxError::StackUnderflow)
     }
 
+    /// Read a cell from the dictionary at the given index, with bounds checking.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(TbxError::IndexOutOfBounds)` if `idx` is out of range.
+    pub fn dict_read(&self, idx: usize) -> Result<Cell, TbxError> {
+        let size = self.dictionary.len();
+        self.dictionary
+            .get(idx)
+            .cloned()
+            .ok_or(TbxError::IndexOutOfBounds { index: idx, size })
+    }
+
+    /// Write a cell to an arbitrary dictionary index, with bounds checking.
+    ///
+    /// Unlike `dict_write`, this does not advance `dp`; it overwrites an
+    /// existing slot identified by `idx`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(TbxError::IndexOutOfBounds)` if `idx` is out of range.
+    pub fn dict_write_at(&mut self, idx: usize, cell: Cell) -> Result<(), TbxError> {
+        let size = self.dictionary.len();
+        *self
+            .dictionary
+            .get_mut(idx)
+            .ok_or(TbxError::IndexOutOfBounds { index: idx, size })? = cell;
+        Ok(())
+    }
+
+    /// Read a local variable from the data stack at `bp + local_idx`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(TbxError::IndexOutOfBounds)` if `bp + local_idx` is out of range.
+    pub fn local_read(&self, local_idx: usize) -> Result<Cell, TbxError> {
+        let idx = self.bp + local_idx;
+        let size = self.data_stack.len();
+        self.data_stack
+            .get(idx)
+            .cloned()
+            .ok_or(TbxError::IndexOutOfBounds { index: idx, size })
+    }
+
+    /// Write a local variable to the data stack at `bp + local_idx`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(TbxError::IndexOutOfBounds)` if `bp + local_idx` is out of range.
+    pub fn local_write(&mut self, local_idx: usize, cell: Cell) -> Result<(), TbxError> {
+        let idx = self.bp + local_idx;
+        let size = self.data_stack.len();
+        *self
+            .data_stack
+            .get_mut(idx)
+            .ok_or(TbxError::IndexOutOfBounds { index: idx, size })? = cell;
+        Ok(())
+    }
+
     /// Write a cell to `dictionary[dp]` and advance dp by 1.
     ///
     /// Maintains the invariant `dp == dictionary.len()` by always using `push`.

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -161,10 +161,13 @@ impl VM {
     ///
     /// Returns `Err(TbxError::IndexOutOfBounds)` if `bp + local_idx` is out of range.
     pub fn local_read(&self, local_idx: usize) -> Result<Cell, TbxError> {
-        let idx = self.bp.checked_add(local_idx).ok_or(TbxError::IndexOutOfBounds {
-            index: usize::MAX,
-            size: self.data_stack.len(),
-        })?;
+        let idx = self
+            .bp
+            .checked_add(local_idx)
+            .ok_or(TbxError::IndexOutOfBounds {
+                index: usize::MAX,
+                size: self.data_stack.len(),
+            })?;
         let size = self.data_stack.len();
         self.data_stack
             .get(idx)
@@ -178,10 +181,13 @@ impl VM {
     ///
     /// Returns `Err(TbxError::IndexOutOfBounds)` if `bp + local_idx` is out of range.
     pub fn local_write(&mut self, local_idx: usize, cell: Cell) -> Result<(), TbxError> {
-        let idx = self.bp.checked_add(local_idx).ok_or(TbxError::IndexOutOfBounds {
-            index: usize::MAX,
-            size: self.data_stack.len(),
-        })?;
+        let idx = self
+            .bp
+            .checked_add(local_idx)
+            .ok_or(TbxError::IndexOutOfBounds {
+                index: usize::MAX,
+                size: self.data_stack.len(),
+            })?;
         let size = self.data_stack.len();
         *self
             .data_stack

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -161,7 +161,10 @@ impl VM {
     ///
     /// Returns `Err(TbxError::IndexOutOfBounds)` if `bp + local_idx` is out of range.
     pub fn local_read(&self, local_idx: usize) -> Result<Cell, TbxError> {
-        let idx = self.bp + local_idx;
+        let idx = self.bp.checked_add(local_idx).ok_or(TbxError::IndexOutOfBounds {
+            index: usize::MAX,
+            size: self.data_stack.len(),
+        })?;
         let size = self.data_stack.len();
         self.data_stack
             .get(idx)
@@ -175,7 +178,10 @@ impl VM {
     ///
     /// Returns `Err(TbxError::IndexOutOfBounds)` if `bp + local_idx` is out of range.
     pub fn local_write(&mut self, local_idx: usize, cell: Cell) -> Result<(), TbxError> {
-        let idx = self.bp + local_idx;
+        let idx = self.bp.checked_add(local_idx).ok_or(TbxError::IndexOutOfBounds {
+            index: usize::MAX,
+            size: self.data_stack.len(),
+        })?;
         let size = self.data_stack.len();
         *self
             .data_stack
@@ -1148,6 +1154,119 @@ mod tests {
                 Err(crate::error::TbxError::ReturnStackOverflow { .. })
             ),
             "expected ReturnStackOverflow, got {:?}",
+            result
+        );
+    }
+
+    // --- dict_read tests ---
+
+    #[test]
+    fn test_dict_read_ok() {
+        let mut vm = VM::new();
+        vm.dictionary.push(Cell::Int(99));
+        vm.dp = 1;
+        assert_eq!(vm.dict_read(0), Ok(Cell::Int(99)));
+    }
+
+    #[test]
+    fn test_dict_read_out_of_bounds() {
+        let vm = VM::new();
+        let result = vm.dict_read(0);
+        assert!(
+            matches!(result, Err(crate::error::TbxError::IndexOutOfBounds { .. })),
+            "expected IndexOutOfBounds, got {:?}",
+            result
+        );
+    }
+
+    // --- dict_write_at tests ---
+
+    #[test]
+    fn test_dict_write_at_ok() {
+        let mut vm = VM::new();
+        vm.dictionary.push(Cell::Int(0));
+        vm.dp = 1;
+        assert!(vm.dict_write_at(0, Cell::Int(42)).is_ok());
+        assert_eq!(vm.dictionary[0], Cell::Int(42));
+    }
+
+    #[test]
+    fn test_dict_write_at_out_of_bounds() {
+        let mut vm = VM::new();
+        let result = vm.dict_write_at(0, Cell::Int(42));
+        assert!(
+            matches!(result, Err(crate::error::TbxError::IndexOutOfBounds { .. })),
+            "expected IndexOutOfBounds, got {:?}",
+            result
+        );
+    }
+
+    // --- local_read tests ---
+
+    #[test]
+    fn test_local_read_ok() {
+        let mut vm = VM::new();
+        vm.data_stack.push(Cell::Int(10));
+        vm.data_stack.push(Cell::Int(20));
+        vm.bp = 1;
+        assert_eq!(vm.local_read(0), Ok(Cell::Int(20)));
+    }
+
+    #[test]
+    fn test_local_read_out_of_bounds() {
+        let mut vm = VM::new();
+        vm.bp = 0;
+        let result = vm.local_read(0);
+        assert!(
+            matches!(result, Err(crate::error::TbxError::IndexOutOfBounds { .. })),
+            "expected IndexOutOfBounds, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_local_read_overflow() {
+        let mut vm = VM::new();
+        vm.bp = usize::MAX;
+        let result = vm.local_read(1);
+        assert!(
+            matches!(result, Err(crate::error::TbxError::IndexOutOfBounds { .. })),
+            "expected IndexOutOfBounds on overflow, got {:?}",
+            result
+        );
+    }
+
+    // --- local_write tests ---
+
+    #[test]
+    fn test_local_write_ok() {
+        let mut vm = VM::new();
+        vm.data_stack.push(Cell::Int(0));
+        vm.bp = 0;
+        assert!(vm.local_write(0, Cell::Int(55)).is_ok());
+        assert_eq!(vm.data_stack[0], Cell::Int(55));
+    }
+
+    #[test]
+    fn test_local_write_out_of_bounds() {
+        let mut vm = VM::new();
+        vm.bp = 0;
+        let result = vm.local_write(0, Cell::Int(55));
+        assert!(
+            matches!(result, Err(crate::error::TbxError::IndexOutOfBounds { .. })),
+            "expected IndexOutOfBounds, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_local_write_overflow() {
+        let mut vm = VM::new();
+        vm.bp = usize::MAX;
+        let result = vm.local_write(1, Cell::Int(55));
+        assert!(
+            matches!(result, Err(crate::error::TbxError::IndexOutOfBounds { .. })),
+            "expected IndexOutOfBounds on overflow, got {:?}",
             result
         );
     }


### PR DESCRIPTION
## 概要

issue #161（フェーズ1）の実装。

辞書やスタックへのアクセスでボイラープレート化していた範囲チェック処理を、VM メソッドとしてカプセル化する。

## 変更内容

### `src/vm.rs`：4つのアクセサメソッドを追加

| メソッド | 説明 |
|---|---|
| `dict_read(idx)` | 辞書の指定位置から読む（範囲チェック込み） |
| `dict_write_at(idx, cell)` | 辞書の指定位置に書く（範囲チェック込み） |
| `local_read(local_idx)` | ローカル変数を読む（`bp + local_idx`、範囲チェック込み） |
| `local_write(local_idx, cell)` | ローカル変数に書く（`bp + local_idx`、範囲チェック込み） |

### `src/primitives.rs`：`fetch_prim` / `store_prim` をリファクタリング

- 辞書アクセスを `dict_read` / `dict_write_at` に置き換え
- `bp` 加算 + スタックアクセスを `local_read` / `local_write` に置き換え
- `// TODO: vm.bp との加算をvmにカプセル化したい` コメントを削除

## 確認事項

- `cargo build` ✅
- `cargo test`（193テスト）✅
- `cargo clippy -- -D warnings` ✅

Closes #161
