### PR TITLE
issue #161: vm.run() で dict_read() を使うようリファクタリング

### DIFF
--- a/src/vm.rs
+++ b/src/vm.rs
@@ -267,18 +267,16 @@ impl VM {
         self.pc = start_offset;
 
         loop {
+            let xt = self
+                .dict_read(self.pc)?
+                .as_xt()
+                .ok_or(TbxError::TypeError {
+                    expected: "Xt",
+                    got: "non-Xt",
+                })?;
             let entry_kind = self
                 .headers
-                .get(
-                    self.dictionary
-                        .get(self.pc)
-                        .and_then(|c: &Cell| c.as_xt())
-                        .ok_or(TbxError::TypeError {
-                            expected: "Xt",
-                            got: "non-Xt",
-                        })?
-                        .index(),
-                )
+                .get(xt.index())
                 .ok_or(TbxError::IndexOutOfBounds {
                     index: self.pc,
                     size: self.headers.len(),
@@ -309,17 +307,15 @@ impl VM {
                 }
                 EntryKind::Call => {
                     let target_xt = self
-                        .dictionary
-                        .get(self.pc + 1)
-                        .and_then(|c: &Cell| c.as_xt())
-                        .ok_or(TbxError::IndexOutOfBounds {
-                            index: self.pc + 1,
-                            size: self.dictionary.len(),
+                        .dict_read(self.pc + 1)?
+                        .as_xt()
+                        .ok_or(TbxError::TypeError {
+                            expected: "Xt",
+                            got: "non-Xt",
                         })?;
                     let arity_raw = self
-                        .dictionary
-                        .get(self.pc + 2)
-                        .and_then(|c: &Cell| c.as_int())
+                        .dict_read(self.pc + 2)?
+                        .as_int()
                         .ok_or(TbxError::TypeError {
                             expected: "Int (arity)",
                             got: "non-Int",
@@ -332,9 +328,8 @@ impl VM {
                     }
                     let arity = arity_raw as usize;
                     let local_count_raw = self
-                        .dictionary
-                        .get(self.pc + 3)
-                        .and_then(|c: &Cell| c.as_int())
+                        .dict_read(self.pc + 3)?
+                        .as_int()
                         .ok_or(TbxError::TypeError {
                             expected: "Int (local count)",
                             got: "non-Int",
@@ -429,14 +424,7 @@ impl VM {
 
                 EntryKind::Lit => {
                     self.pc += 1;
-                    let literal = self
-                        .dictionary
-                        .get(self.pc)
-                        .ok_or(TbxError::IndexOutOfBounds {
-                            index: self.pc,
-                            size: self.dictionary.len(),
-                        })?
-                        .clone();
+                    let literal = self.dict_read(self.pc)?;
                     self.push(literal);
                     self.pc += 1;
                 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -306,20 +306,20 @@ impl VM {
                     self.pc = offset;
                 }
                 EntryKind::Call => {
-                    let target_xt = self
-                        .dict_read(self.pc + 1)?
-                        .as_xt()
-                        .ok_or(TbxError::TypeError {
-                            expected: "Xt",
-                            got: "non-Xt",
-                        })?;
-                    let arity_raw = self
-                        .dict_read(self.pc + 2)?
-                        .as_int()
-                        .ok_or(TbxError::TypeError {
-                            expected: "Int (arity)",
-                            got: "non-Int",
-                        })?;
+                    let target_xt =
+                        self.dict_read(self.pc + 1)?
+                            .as_xt()
+                            .ok_or(TbxError::TypeError {
+                                expected: "Xt",
+                                got: "non-Xt",
+                            })?;
+                    let arity_raw =
+                        self.dict_read(self.pc + 2)?
+                            .as_int()
+                            .ok_or(TbxError::TypeError {
+                                expected: "Int (arity)",
+                                got: "non-Int",
+                            })?;
                     if arity_raw < 0 {
                         return Err(TbxError::TypeError {
                             expected: "non-negative Int (arity)",
@@ -327,13 +327,13 @@ impl VM {
                         });
                     }
                     let arity = arity_raw as usize;
-                    let local_count_raw = self
-                        .dict_read(self.pc + 3)?
-                        .as_int()
-                        .ok_or(TbxError::TypeError {
-                            expected: "Int (local count)",
-                            got: "non-Int",
-                        })?;
+                    let local_count_raw =
+                        self.dict_read(self.pc + 3)?
+                            .as_int()
+                            .ok_or(TbxError::TypeError {
+                                expected: "Int (local count)",
+                                got: "non-Int",
+                            })?;
                     if local_count_raw < 0 {
                         return Err(TbxError::TypeError {
                             expected: "non-negative Int (local count)",

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -278,7 +278,7 @@ impl VM {
                 .headers
                 .get(xt.index())
                 .ok_or(TbxError::IndexOutOfBounds {
-                    index: self.pc,
+                    index: xt.index(),
                     size: self.headers.len(),
                 })?
                 .kind
@@ -931,6 +931,30 @@ mod tests {
             result,
             Err(crate::error::TbxError::StackUnderflow)
         ));
+    }
+
+    #[test]
+    fn test_call_target_xt_type_mismatch_returns_type_error() {
+        // Verify that a non-Xt value at pc+1 (target_xt position) returns TypeError.
+        // This confirms the error type for type mismatch is TypeError, not IndexOutOfBounds.
+        let mut vm = VM::new();
+        crate::primitives::register_all(&mut vm);
+
+        let call_xt = vm.lookup("CALL").unwrap();
+
+        // Top-level: CALL <Int instead of Xt> arity=0 local_count=0
+        let start = vm.dp;
+        vm.dict_write(Cell::Xt(call_xt)).unwrap();
+        vm.dict_write(Cell::Int(999)).unwrap(); // wrong type: Int instead of Xt
+        vm.dict_write(Cell::Int(0)).unwrap();
+        vm.dict_write(Cell::Int(0)).unwrap();
+
+        let result = vm.run(start);
+        assert!(
+            matches!(result, Err(crate::error::TbxError::TypeError { .. })),
+            "expected TypeError for non-Xt target_xt, got {:?}",
+            result
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 概要

issue #161 フェーズ1で追加した `dict_read()` を `vm.run()` 内にも適用し、辞書への直接アクセスボイラープレートを解消した。

## 変更内容

`run()` 内で `self.dictionary.get(idx).ok_or(...)?` や `.and_then(|c| c.as_xt())` パターンを使っていた5箇所を `dict_read()` に置き換えた。

| 箇所 | 変更前 | 変更後 |
|------|--------|--------|
| `entry_kind` 取得 | `self.dictionary.get(self.pc).and_then(\|c\| c.as_xt()).ok_or(...)?` | `self.dict_read(self.pc)?.as_xt().ok_or(...)?` |
| `Call` の `target_xt` 取得 | 同上（IndexOutOfBoundsエラー） | `self.dict_read(self.pc + 1)?.as_xt().ok_or(...)?`（TypeError に改善） |
| `Call` の `arity_raw` 取得 | `self.dictionary.get(self.pc + 2).and_then(\|c\| c.as_int()).ok_or(...)?` | `self.dict_read(self.pc + 2)?.as_int().ok_or(...)?` |
| `Call` の `local_count_raw` 取得 | 同上 | `self.dict_read(self.pc + 3)?.as_int().ok_or(...)?` |
| `Lit` のリテラル取得 | `self.dictionary.get(self.pc).ok_or(...)?.clone()` | `self.dict_read(self.pc)?` |

## テスト

既存の203件のテストがすべてパスしていることを確認済み。

Closes #161
