### PR TITLE
issue #161 フェーズ2: 型付き pop メソッドを追加し primitives に適用

### DIFF
--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -75,63 +75,48 @@ pub fn store_prim(vm: &mut VM) -> Result<(), TbxError> {
 }
 
 pub fn add_prim(vm: &mut VM) -> Result<(), TbxError> {
-    let b = vm.pop()?;
-    let a = vm.pop()?;
+    let b = vm.pop_number()?;
+    let a = vm.pop_number()?;
     match (a, b) {
         (Cell::Int(x), Cell::Int(y)) => vm.push(Cell::Int(x + y)),
         (Cell::Float(x), Cell::Float(y)) => vm.push(Cell::Float(x + y)),
         (Cell::Int(x), Cell::Float(y)) => vm.push(Cell::Float(x as f64 + y)),
         (Cell::Float(x), Cell::Int(y)) => vm.push(Cell::Float(x + y as f64)),
-        _ => {
-            return Err(TbxError::TypeError {
-                expected: "number",
-                got: "non-number",
-            })
-        }
+        _ => unreachable!("pop_number guarantees Int or Float"),
     }
     Ok(())
 }
 
 pub fn sub_prim(vm: &mut VM) -> Result<(), TbxError> {
-    let b = vm.pop()?;
-    let a = vm.pop()?;
+    let b = vm.pop_number()?;
+    let a = vm.pop_number()?;
     match (a, b) {
         (Cell::Int(x), Cell::Int(y)) => vm.push(Cell::Int(x - y)),
         (Cell::Float(x), Cell::Float(y)) => vm.push(Cell::Float(x - y)),
         (Cell::Int(x), Cell::Float(y)) => vm.push(Cell::Float(x as f64 - y)),
         (Cell::Float(x), Cell::Int(y)) => vm.push(Cell::Float(x - y as f64)),
-        _ => {
-            return Err(TbxError::TypeError {
-                expected: "number",
-                got: "non-number",
-            })
-        }
+        _ => unreachable!("pop_number guarantees Int or Float"),
     }
     Ok(())
 }
 
 pub fn mul_prim(vm: &mut VM) -> Result<(), TbxError> {
-    let b = vm.pop()?;
-    let a = vm.pop()?;
+    let b = vm.pop_number()?;
+    let a = vm.pop_number()?;
     match (a, b) {
         (Cell::Int(x), Cell::Int(y)) => vm.push(Cell::Int(x * y)),
         (Cell::Float(x), Cell::Float(y)) => vm.push(Cell::Float(x * y)),
         (Cell::Int(x), Cell::Float(y)) => vm.push(Cell::Float(x as f64 * y)),
         (Cell::Float(x), Cell::Int(y)) => vm.push(Cell::Float(x * y as f64)),
-        _ => {
-            return Err(TbxError::TypeError {
-                expected: "number",
-                got: "non-number",
-            })
-        }
+        _ => unreachable!("pop_number guarantees Int or Float"),
     }
     Ok(())
 }
 
 #[allow(clippy::redundant_guards)] // Float(0.0) pattern also matches -0.0; use guard for clarity
 pub fn div_prim(vm: &mut VM) -> Result<(), TbxError> {
-    let b = vm.pop()?;
-    let a = vm.pop()?;
+    let b = vm.pop_number()?;
+    let a = vm.pop_number()?;
     match (a, b) {
         (Cell::Int(_), Cell::Int(0)) => return Err(TbxError::DivisionByZero),
         (Cell::Int(x), Cell::Int(y)) => vm.push(Cell::Int(x / y)),
@@ -141,29 +126,18 @@ pub fn div_prim(vm: &mut VM) -> Result<(), TbxError> {
         (Cell::Int(x), Cell::Float(y)) => vm.push(Cell::Float(x as f64 / y)),
         (Cell::Float(_), Cell::Int(0)) => return Err(TbxError::DivisionByZero),
         (Cell::Float(x), Cell::Int(y)) => vm.push(Cell::Float(x / y as f64)),
-        _ => {
-            return Err(TbxError::TypeError {
-                expected: "number",
-                got: "non-number",
-            })
-        }
+        _ => unreachable!("pop_number guarantees Int or Float"),
     }
     Ok(())
 }
 
 pub fn mod_prim(vm: &mut VM) -> Result<(), TbxError> {
-    let b = vm.pop()?;
-    let a = vm.pop()?;
-    match (a, b) {
-        (Cell::Int(_), Cell::Int(0)) => return Err(TbxError::DivisionByZero),
-        (Cell::Int(x), Cell::Int(y)) => vm.push(Cell::Int(x % y)),
-        _ => {
-            return Err(TbxError::TypeError {
-                expected: "Int",
-                got: "non-Int",
-            })
-        }
+    let b = vm.pop_int()?;
+    let a = vm.pop_int()?;
+    if b == 0 {
+        return Err(TbxError::DivisionByZero);
     }
+    vm.push(Cell::Int(a % b));
     Ok(())
 }
 
@@ -197,19 +171,14 @@ pub fn neq_prim(vm: &mut VM) -> Result<(), TbxError> {
 
 /// LT — less than. Pushes Bool(true) if a < b (numeric only, with Int/Float promotion).
 pub fn lt_prim(vm: &mut VM) -> Result<(), TbxError> {
-    let b = vm.pop()?;
-    let a = vm.pop()?;
+    let b = vm.pop_number()?;
+    let a = vm.pop_number()?;
     let result = match (&a, &b) {
         (Cell::Int(x), Cell::Int(y)) => x < y,
         (Cell::Float(x), Cell::Float(y)) => x < y,
         (Cell::Int(x), Cell::Float(y)) => (*x as f64) < *y,
         (Cell::Float(x), Cell::Int(y)) => *x < (*y as f64),
-        _ => {
-            return Err(TbxError::TypeError {
-                expected: "number",
-                got: "non-number",
-            })
-        }
+        _ => unreachable!("pop_number guarantees Int or Float"),
     };
     vm.push(Cell::Bool(result));
     Ok(())
@@ -217,19 +186,14 @@ pub fn lt_prim(vm: &mut VM) -> Result<(), TbxError> {
 
 /// GT — greater than. Pushes Bool(true) if a > b (numeric only, with Int/Float promotion).
 pub fn gt_prim(vm: &mut VM) -> Result<(), TbxError> {
-    let b = vm.pop()?;
-    let a = vm.pop()?;
+    let b = vm.pop_number()?;
+    let a = vm.pop_number()?;
     let result = match (&a, &b) {
         (Cell::Int(x), Cell::Int(y)) => x > y,
         (Cell::Float(x), Cell::Float(y)) => x > y,
         (Cell::Int(x), Cell::Float(y)) => (*x as f64) > *y,
         (Cell::Float(x), Cell::Int(y)) => *x > (*y as f64),
-        _ => {
-            return Err(TbxError::TypeError {
-                expected: "number",
-                got: "non-number",
-            })
-        }
+        _ => unreachable!("pop_number guarantees Int or Float"),
     };
     vm.push(Cell::Bool(result));
     Ok(())
@@ -237,19 +201,14 @@ pub fn gt_prim(vm: &mut VM) -> Result<(), TbxError> {
 
 /// LE — less than or equal. Pushes Bool(true) if a <= b (numeric only, with Int/Float promotion).
 pub fn le_prim(vm: &mut VM) -> Result<(), TbxError> {
-    let b = vm.pop()?;
-    let a = vm.pop()?;
+    let b = vm.pop_number()?;
+    let a = vm.pop_number()?;
     let result = match (&a, &b) {
         (Cell::Int(x), Cell::Int(y)) => x <= y,
         (Cell::Float(x), Cell::Float(y)) => x <= y,
         (Cell::Int(x), Cell::Float(y)) => (*x as f64) <= *y,
         (Cell::Float(x), Cell::Int(y)) => *x <= (*y as f64),
-        _ => {
-            return Err(TbxError::TypeError {
-                expected: "number",
-                got: "non-number",
-            })
-        }
+        _ => unreachable!("pop_number guarantees Int or Float"),
     };
     vm.push(Cell::Bool(result));
     Ok(())
@@ -257,19 +216,14 @@ pub fn le_prim(vm: &mut VM) -> Result<(), TbxError> {
 
 /// GE — greater than or equal. Pushes Bool(true) if a >= b (numeric only, with Int/Float promotion).
 pub fn ge_prim(vm: &mut VM) -> Result<(), TbxError> {
-    let b = vm.pop()?;
-    let a = vm.pop()?;
+    let b = vm.pop_number()?;
+    let a = vm.pop_number()?;
     let result = match (&a, &b) {
         (Cell::Int(x), Cell::Int(y)) => x >= y,
         (Cell::Float(x), Cell::Float(y)) => x >= y,
         (Cell::Int(x), Cell::Float(y)) => (*x as f64) >= *y,
         (Cell::Float(x), Cell::Int(y)) => *x >= (*y as f64),
-        _ => {
-            return Err(TbxError::TypeError {
-                expected: "number",
-                got: "non-number",
-            })
-        }
+        _ => unreachable!("pop_number guarantees Int or Float"),
     };
     vm.push(Cell::Bool(result));
     Ok(())
@@ -295,75 +249,43 @@ pub fn or_prim(vm: &mut VM) -> Result<(), TbxError> {
 /// Escape sequences (\n, \t, \\) in the stored string are output literally
 /// as they were already expanded at compile time (during intern).
 pub fn putstr_prim(vm: &mut VM) -> Result<(), TbxError> {
-    let cell = vm.pop()?;
-    match cell {
-        Cell::StringDesc(idx) => {
-            let s = vm.resolve_string(idx)?;
-            vm.write_output(&s);
-            Ok(())
-        }
-        _ => Err(TbxError::TypeError {
-            expected: "StringDesc",
-            got: cell.type_name(),
-        }),
-    }
+    let idx = vm.pop_string_desc()?;
+    let s = vm.resolve_string(idx)?;
+    vm.write_output(&s);
+    Ok(())
 }
 
 /// PUTCHR — output the integer value on the stack as a single ASCII character (no newline).
 pub fn putchr_prim(vm: &mut VM) -> Result<(), TbxError> {
-    let cell = vm.pop()?;
-    match cell {
-        Cell::Int(code) => {
-            if !(0..=127).contains(&code) {
-                return Err(TbxError::TypeError {
-                    expected: "ASCII code (0-127)",
-                    got: "out of range",
-                });
-            }
-            let ch = code as u8 as char;
-            vm.write_output(&ch.to_string());
-            Ok(())
-        }
-        _ => Err(TbxError::TypeError {
-            expected: "Int",
-            got: cell.type_name(),
-        }),
+    let code = vm.pop_int()?;
+    if !(0..=127).contains(&code) {
+        return Err(TbxError::TypeError {
+            expected: "ASCII code (0-127)",
+            got: "out of range",
+        });
     }
+    let ch = code as u8 as char;
+    vm.write_output(&ch.to_string());
+    Ok(())
 }
 
 /// PUTDEC — output the integer value on the stack as a signed decimal number (no newline).
 pub fn putdec_prim(vm: &mut VM) -> Result<(), TbxError> {
-    let cell = vm.pop()?;
-    match cell {
-        Cell::Int(n) => {
-            vm.write_output(&n.to_string());
-            Ok(())
-        }
-        _ => Err(TbxError::TypeError {
-            expected: "Int",
-            got: cell.type_name(),
-        }),
-    }
+    let n = vm.pop_int()?;
+    vm.write_output(&n.to_string());
+    Ok(())
 }
 
 /// PUTHEX — output the integer value on the stack as $-prefixed uppercase hex (no newline).
 /// Negative values are output as two's complement 64-bit representation.
 pub fn puthex_prim(vm: &mut VM) -> Result<(), TbxError> {
-    let cell = vm.pop()?;
-    match cell {
-        Cell::Int(n) => {
-            if n < 0 {
-                vm.write_output(&format!("${:X}", n as u64));
-            } else {
-                vm.write_output(&format!("${:X}", n));
-            }
-            Ok(())
-        }
-        _ => Err(TbxError::TypeError {
-            expected: "Int",
-            got: cell.type_name(),
-        }),
+    let n = vm.pop_int()?;
+    if n < 0 {
+        vm.write_output(&format!("${:X}", n as u64));
+    } else {
+        vm.write_output(&format!("${:X}", n));
     }
+    Ok(())
 }
 
 /// APPEND — pop a Cell and write it to dictionary[dp], advancing dp by 1.
@@ -374,16 +296,7 @@ pub fn append_prim(vm: &mut VM) -> Result<(), TbxError> {
 
 /// ALLOT — pop N from the stack, advance dp by N cells, and push the start address.
 pub fn allot_prim(vm: &mut VM) -> Result<(), TbxError> {
-    let cell = vm.pop()?;
-    let n = match cell {
-        Cell::Int(n) => n,
-        _ => {
-            return Err(TbxError::TypeError {
-                expected: "Int",
-                got: cell.type_name(),
-            })
-        }
-    };
+    let n = vm.pop_int()?;
     if n < 0 {
         return Err(TbxError::InvalidAllotCount);
     }
@@ -720,13 +633,13 @@ mod tests {
         let mut vm = VM::new();
         vm.push(Cell::Int(2));
         vm.push(Cell::Bool(true)); // Not a number
-        assert_eq!(
+        assert!(matches!(
             add_prim(&mut vm),
             Err(TbxError::TypeError {
                 expected: "number",
-                got: "non-number"
+                ..
             })
-        );
+        ));
     }
 
     // --- sub_prim ---

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -125,7 +125,89 @@ impl VM {
         self.data_stack.pop().ok_or(TbxError::StackUnderflow)
     }
 
-    /// Read a cell from the dictionary at the given index, with bounds checking.
+    /// Pop an `Int` value from the data stack.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(TbxError::StackUnderflow)` if the stack is empty.
+    /// Returns `Err(TbxError::TypeError)` if the top value is not `Cell::Int`.
+    pub fn pop_int(&mut self) -> Result<i64, TbxError> {
+        match self.pop()? {
+            Cell::Int(n) => Ok(n),
+            other => Err(TbxError::TypeError {
+                expected: "Int",
+                got: other.type_name(),
+            }),
+        }
+    }
+
+    /// Pop a `Bool` value from the data stack.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(TbxError::StackUnderflow)` if the stack is empty.
+    /// Returns `Err(TbxError::TypeError)` if the top value is not `Cell::Bool`.
+    pub fn pop_bool(&mut self) -> Result<bool, TbxError> {
+        match self.pop()? {
+            Cell::Bool(b) => Ok(b),
+            other => Err(TbxError::TypeError {
+                expected: "Bool",
+                got: other.type_name(),
+            }),
+        }
+    }
+
+    /// Pop a `StringDesc` value from the data stack, returning its pool index.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(TbxError::StackUnderflow)` if the stack is empty.
+    /// Returns `Err(TbxError::TypeError)` if the top value is not `Cell::StringDesc`.
+    pub fn pop_string_desc(&mut self) -> Result<usize, TbxError> {
+        match self.pop()? {
+            Cell::StringDesc(idx) => Ok(idx),
+            other => Err(TbxError::TypeError {
+                expected: "StringDesc",
+                got: other.type_name(),
+            }),
+        }
+    }
+
+    /// Pop an `Xt` value from the data stack.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(TbxError::StackUnderflow)` if the stack is empty.
+    /// Returns `Err(TbxError::TypeError)` if the top value is not `Cell::Xt`.
+    pub fn pop_xt(&mut self) -> Result<Xt, TbxError> {
+        match self.pop()? {
+            Cell::Xt(xt) => Ok(xt),
+            other => Err(TbxError::TypeError {
+                expected: "Xt",
+                got: other.type_name(),
+            }),
+        }
+    }
+
+    /// Pop a numeric value (`Int` or `Float`) from the data stack.
+    ///
+    /// Returns the cell as-is if it is `Cell::Int` or `Cell::Float`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(TbxError::StackUnderflow)` if the stack is empty.
+    /// Returns `Err(TbxError::TypeError)` if the top value is neither `Int` nor `Float`.
+    pub fn pop_number(&mut self) -> Result<Cell, TbxError> {
+        let cell = self.pop()?;
+        match &cell {
+            Cell::Int(_) | Cell::Float(_) => Ok(cell),
+            other => Err(TbxError::TypeError {
+                expected: "number",
+                got: other.type_name(),
+            }),
+        }
+    }
+
     ///
     /// # Errors
     ///
@@ -1287,5 +1369,125 @@ mod tests {
             "expected IndexOutOfBounds on overflow, got {:?}",
             result
         );
+    }
+
+    // --- pop_int tests ---
+
+    #[test]
+    fn test_pop_int_ok() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(42));
+        assert_eq!(vm.pop_int(), Ok(42));
+    }
+
+    #[test]
+    fn test_pop_int_underflow() {
+        let mut vm = VM::new();
+        assert!(matches!(
+            vm.pop_int(),
+            Err(crate::error::TbxError::StackUnderflow)
+        ));
+    }
+
+    #[test]
+    fn test_pop_int_type_error() {
+        let mut vm = VM::new();
+        vm.push(Cell::Bool(true));
+        assert!(matches!(
+            vm.pop_int(),
+            Err(crate::error::TbxError::TypeError { .. })
+        ));
+    }
+
+    // --- pop_bool tests ---
+
+    #[test]
+    fn test_pop_bool_ok() {
+        let mut vm = VM::new();
+        vm.push(Cell::Bool(true));
+        assert_eq!(vm.pop_bool(), Ok(true));
+    }
+
+    #[test]
+    fn test_pop_bool_type_error() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(1));
+        assert!(matches!(
+            vm.pop_bool(),
+            Err(crate::error::TbxError::TypeError { .. })
+        ));
+    }
+
+    // --- pop_string_desc tests ---
+
+    #[test]
+    fn test_pop_string_desc_ok() {
+        let mut vm = VM::new();
+        vm.push(Cell::StringDesc(7));
+        assert_eq!(vm.pop_string_desc(), Ok(7));
+    }
+
+    #[test]
+    fn test_pop_string_desc_type_error() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(0));
+        assert!(matches!(
+            vm.pop_string_desc(),
+            Err(crate::error::TbxError::TypeError { .. })
+        ));
+    }
+
+    // --- pop_xt tests ---
+
+    #[test]
+    fn test_pop_xt_ok() {
+        let mut vm = VM::new();
+        vm.push(Cell::Xt(Xt(3)));
+        assert_eq!(vm.pop_xt(), Ok(Xt(3)));
+    }
+
+    #[test]
+    fn test_pop_xt_type_error() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(3));
+        assert!(matches!(
+            vm.pop_xt(),
+            Err(crate::error::TbxError::TypeError { .. })
+        ));
+    }
+
+    // --- pop_number tests ---
+
+    #[test]
+    fn test_pop_number_int() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(10));
+        assert_eq!(vm.pop_number(), Ok(Cell::Int(10)));
+    }
+
+    #[test]
+    fn test_pop_number_float() {
+        let mut vm = VM::new();
+        vm.push(Cell::Float(3.14));
+        assert_eq!(vm.pop_number(), Ok(Cell::Float(3.14)));
+    }
+
+    #[test]
+    fn test_pop_number_type_error() {
+        let mut vm = VM::new();
+        vm.push(Cell::Bool(false));
+        assert!(matches!(
+            vm.pop_number(),
+            Err(crate::error::TbxError::TypeError { .. })
+        ));
+    }
+
+    #[test]
+    fn test_pop_number_underflow() {
+        let mut vm = VM::new();
+        assert!(matches!(
+            vm.pop_number(),
+            Err(crate::error::TbxError::StackUnderflow)
+        ));
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -208,6 +208,7 @@ impl VM {
         }
     }
 
+    /// Read a cell from the dictionary at the given index, with bounds checking.
     ///
     /// # Errors
     ///
@@ -1418,6 +1419,15 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn test_pop_bool_underflow() {
+        let mut vm = VM::new();
+        assert!(matches!(
+            vm.pop_bool(),
+            Err(crate::error::TbxError::StackUnderflow)
+        ));
+    }
+
     // --- pop_string_desc tests ---
 
     #[test]
@@ -1434,6 +1444,15 @@ mod tests {
         assert!(matches!(
             vm.pop_string_desc(),
             Err(crate::error::TbxError::TypeError { .. })
+        ));
+    }
+
+    #[test]
+    fn test_pop_string_desc_underflow() {
+        let mut vm = VM::new();
+        assert!(matches!(
+            vm.pop_string_desc(),
+            Err(crate::error::TbxError::StackUnderflow)
         ));
     }
 
@@ -1456,6 +1475,14 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn test_pop_xt_underflow() {
+        let mut vm = VM::new();
+        assert!(matches!(
+            vm.pop_xt(),
+            Err(crate::error::TbxError::StackUnderflow)
+        ));
+    }
     // --- pop_number tests ---
 
     #[test]

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1495,8 +1495,8 @@ mod tests {
     #[test]
     fn test_pop_number_float() {
         let mut vm = VM::new();
-        vm.push(Cell::Float(3.14));
-        assert_eq!(vm.pop_number(), Ok(Cell::Float(3.14)));
+        vm.push(Cell::Float(2.5));
+        assert_eq!(vm.pop_number(), Ok(Cell::Float(2.5)));
     }
 
     #[test]


### PR DESCRIPTION
## 概要

issue #161 フェーズ2 — `vm.pop()` + 型チェックのボイラープレートを型付き pop メソッドに置き換えた。

## 追加メソッド（vm.rs）

| メソッド | 戻り値 | 説明 |
|---------|--------|------|
| `pop_int()` | `Result<i64, TbxError>` | `Cell::Int` 以外は `TypeError` |
| `pop_bool()` | `Result<bool, TbxError>` | `Cell::Bool` 以外は `TypeError` |
| `pop_string_desc()` | `Result<usize, TbxError>` | `Cell::StringDesc` 以外は `TypeError` |
| `pop_xt()` | `Result<Xt, TbxError>` | `Cell::Xt` 以外は `TypeError` |
| `pop_number()` | `Result<Cell, TbxError>` | `Int`/`Float` は通過、それ以外は `TypeError` |

各メソッドにユニットテストを追加済み（11件）。

## 適用箇所（primitives.rs）

- **`pop_int()`**: `putchr_prim`, `putdec_prim`, `puthex_prim`, `allot_prim`, `mod_prim`（5箇所）
- **`pop_string_desc()`**: `putstr_prim`（1箇所）
- **`pop_number()`**: `add_prim`, `sub_prim`, `mul_prim`, `div_prim`, `lt_prim`, `gt_prim`, `le_prim`, `ge_prim`（8箇所）

`pop_number()` 適用箇所では `_ => TypeError` アームが `_ => unreachable!()` に変わり、「型検証はメソッド側で完結している」という意図が明確になった。

## テスト

全217件のテストがパスしていることを確認済み。

Closes #161
