### PR TITLE
implement-issue エージェントの clippy コマンドを CI に合わせる

### DIFF
--- a/.github/agents/implement-issue.agent.md
+++ b/.github/agents/implement-issue.agent.md
@@ -61,7 +61,7 @@ Rustのベストプラクティスに従いコードを実装する。
 ```bash
 cargo build
 cargo test
-cargo clippy -- -D warnings
+cargo clippy --all-targets -- -D warnings
 ```
 
 ビルドエラー・テスト失敗・clippy警告がある場合は修正してから次のステップに進む。


### PR DESCRIPTION
## 概要

`implement-issue` エージェントが実行する `cargo clippy` コマンドを CI と一致させる。

## 変更内容

```diff
- cargo clippy -- -D warnings
+ cargo clippy --all-targets -- -D warnings
```

## 背景

CI（`ci.yml`）は `cargo clippy --all-targets` を使用しているため、テスト・ベンチマーク等すべてのコードが lint 対象になる。一方、エージェントは `--all-targets` なしで実行していたため `#[cfg(test)]` 内のコードが対象外となり、ローカルでは検出されなかった clippy エラーが CI で発覚するケースがあった。（issue #161 フェーズ2 の `approx_constant` エラーが該当）
