### PR TITLE
issue #42/#43: init_vm() 追加と PUTDEC 実行テスト追加

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,15 @@ pub mod dict;
 pub mod error;
 pub mod primitives;
 pub mod vm;
+
+/// Create a VM with all system primitives registered and sealed.
+///
+/// This is the standard way to obtain a ready-to-use VM. It calls
+/// [`primitives::register_all`] to populate the system dictionary and
+/// [`vm::VM::seal_sys`] to record the system boundary.
+pub fn init_vm() -> vm::VM {
+    let mut v = vm::VM::new();
+    primitives::register_all(&mut v);
+    v.seal_sys();
+    v
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
 fn main() {
+    let _vm = tbx::init_vm();
     println!("TBX - Tiny BASIC eXtensible");
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1523,8 +1523,8 @@ mod tests {
     #[test]
     fn test_run_putdec_outputs_number() {
         // Verify that a program of [LIT 42 PUTDEC EXIT] writes "42" to the output buffer.
-        let mut vm = VM::new();
-        crate::primitives::register_all(&mut vm);
+        // Uses init_vm() to also validate the full initialization (register_all + seal_sys).
+        let mut vm = crate::init_vm();
 
         let lit_xt = vm.lookup("LIT").unwrap();
         let putdec_xt = vm.lookup("PUTDEC").unwrap();

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1517,4 +1517,28 @@ mod tests {
             Err(crate::error::TbxError::StackUnderflow)
         ));
     }
+
+    // --- integration tests ---
+
+    #[test]
+    fn test_run_putdec_outputs_number() {
+        // Verify that a program of [LIT 42 PUTDEC EXIT] writes "42" to the output buffer.
+        let mut vm = VM::new();
+        crate::primitives::register_all(&mut vm);
+
+        let lit_xt = vm.lookup("LIT").unwrap();
+        let putdec_xt = vm.lookup("PUTDEC").unwrap();
+        let exit_xt = vm.lookup("EXIT").unwrap();
+
+        let start = vm.dp;
+        vm.dict_write(Cell::Xt(lit_xt)).unwrap();
+        vm.dict_write(Cell::Int(42)).unwrap();
+        vm.dict_write(Cell::Xt(putdec_xt)).unwrap();
+        vm.dict_write(Cell::Xt(exit_xt)).unwrap();
+
+        vm.run(start).unwrap();
+
+        assert_eq!(vm.take_output(), "42");
+        assert_eq!(vm.pop(), Err(crate::error::TbxError::StackUnderflow));
+    }
 }


### PR DESCRIPTION
## 概要

issue #42（全プリミティブ登録）と issue #43（単体テスト）に対応します。

## 変更内容

### issue #42: システム辞書への全プリミティブ登録

- `lib.rs` に `pub fn init_vm() -> VM` を追加
  - `VM::new()` + `register_all()` + `seal_sys()` を呼び出し、すぐに使える状態のVMを返す
  - `vm.rs` から `primitives.rs` を参照すると循環依存が発生するため、両モジュールを橋渡しする関数を `lib.rs` に配置
- `main.rs` を `tbx::init_vm()` を使用するよう更新

### issue #43: 単体テスト追加

- `vm.rs` に `test_run_putdec_outputs_number` テストを追加
  - `[LIT 42, PUTDEC, EXIT]` のプログラムを構築して実行
  - `output_buffer` に `"42"` が出力されることを確認

Closes #42
Closes #43
