### PR TITLE
feat: ADD/SUB/MUL/DIV/MOD に整数オーバーフロー検出を追加 (#111)

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -47,6 +47,8 @@ pub enum TbxError {
         depth: usize,
         limit: usize,
     },
+    /// An integer arithmetic operation produced a result outside the `i64` range.
+    IntegerOverflow,
 }
 
 impl std::fmt::Display for TbxError {
@@ -94,6 +96,7 @@ impl std::fmt::Display for TbxError {
                     depth, limit
                 )
             }
+            TbxError::IntegerOverflow => write!(f, "integer overflow"),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -148,4 +148,10 @@ mod tests {
         let e = TbxError::MarkerNotFound;
         assert!(e.to_string().contains("marker"));
     }
+
+    #[test]
+    fn test_integer_overflow_display() {
+        let e = TbxError::IntegerOverflow;
+        assert!(e.to_string().contains("integer overflow"));
+    }
 }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -78,7 +78,10 @@ pub fn add_prim(vm: &mut VM) -> Result<(), TbxError> {
     let b = vm.pop_number()?;
     let a = vm.pop_number()?;
     match (a, b) {
-        (Cell::Int(x), Cell::Int(y)) => vm.push(Cell::Int(x + y))?,
+        (Cell::Int(x), Cell::Int(y)) => {
+            let result = x.checked_add(y).ok_or(TbxError::IntegerOverflow)?;
+            vm.push(Cell::Int(result))?;
+        }
         (Cell::Float(x), Cell::Float(y)) => vm.push(Cell::Float(x + y))?,
         (Cell::Int(x), Cell::Float(y)) => vm.push(Cell::Float(x as f64 + y))?,
         (Cell::Float(x), Cell::Int(y)) => vm.push(Cell::Float(x + y as f64))?,
@@ -91,7 +94,10 @@ pub fn sub_prim(vm: &mut VM) -> Result<(), TbxError> {
     let b = vm.pop_number()?;
     let a = vm.pop_number()?;
     match (a, b) {
-        (Cell::Int(x), Cell::Int(y)) => vm.push(Cell::Int(x - y))?,
+        (Cell::Int(x), Cell::Int(y)) => {
+            let result = x.checked_sub(y).ok_or(TbxError::IntegerOverflow)?;
+            vm.push(Cell::Int(result))?;
+        }
         (Cell::Float(x), Cell::Float(y)) => vm.push(Cell::Float(x - y))?,
         (Cell::Int(x), Cell::Float(y)) => vm.push(Cell::Float(x as f64 - y))?,
         (Cell::Float(x), Cell::Int(y)) => vm.push(Cell::Float(x - y as f64))?,
@@ -104,7 +110,10 @@ pub fn mul_prim(vm: &mut VM) -> Result<(), TbxError> {
     let b = vm.pop_number()?;
     let a = vm.pop_number()?;
     match (a, b) {
-        (Cell::Int(x), Cell::Int(y)) => vm.push(Cell::Int(x * y))?,
+        (Cell::Int(x), Cell::Int(y)) => {
+            let result = x.checked_mul(y).ok_or(TbxError::IntegerOverflow)?;
+            vm.push(Cell::Int(result))?;
+        }
         (Cell::Float(x), Cell::Float(y)) => vm.push(Cell::Float(x * y))?,
         (Cell::Int(x), Cell::Float(y)) => vm.push(Cell::Float(x as f64 * y))?,
         (Cell::Float(x), Cell::Int(y)) => vm.push(Cell::Float(x * y as f64))?,
@@ -119,7 +128,10 @@ pub fn div_prim(vm: &mut VM) -> Result<(), TbxError> {
     let a = vm.pop_number()?;
     match (a, b) {
         (Cell::Int(_), Cell::Int(0)) => return Err(TbxError::DivisionByZero),
-        (Cell::Int(x), Cell::Int(y)) => vm.push(Cell::Int(x / y))?,
+        (Cell::Int(x), Cell::Int(y)) => {
+            let result = x.checked_div(y).ok_or(TbxError::IntegerOverflow)?;
+            vm.push(Cell::Int(result))?;
+        }
         (Cell::Float(_), Cell::Float(y)) if y == 0.0 => return Err(TbxError::DivisionByZero),
         (Cell::Float(x), Cell::Float(y)) => vm.push(Cell::Float(x / y))?,
         (Cell::Int(_), Cell::Float(y)) if y == 0.0 => return Err(TbxError::DivisionByZero),
@@ -137,7 +149,8 @@ pub fn mod_prim(vm: &mut VM) -> Result<(), TbxError> {
     if b == 0 {
         return Err(TbxError::DivisionByZero);
     }
-    vm.push(Cell::Int(a % b))?;
+    let result = a.checked_rem(b).ok_or(TbxError::IntegerOverflow)?;
+    vm.push(Cell::Int(result))?;
     Ok(())
 }
 
@@ -648,6 +661,14 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn test_add_overflow() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(i64::MAX)).unwrap();
+        vm.push(Cell::Int(1)).unwrap();
+        assert_eq!(add_prim(&mut vm), Err(TbxError::IntegerOverflow));
+    }
+
     // --- sub_prim ---
 
     #[test]
@@ -685,6 +706,14 @@ mod tests {
         assert!(matches!(sub_prim(&mut vm), Err(TbxError::TypeError { .. })));
     }
 
+    #[test]
+    fn test_sub_overflow() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(i64::MIN)).unwrap();
+        vm.push(Cell::Int(1)).unwrap();
+        assert_eq!(sub_prim(&mut vm), Err(TbxError::IntegerOverflow));
+    }
+
     // --- mul_prim ---
 
     #[test]
@@ -720,6 +749,14 @@ mod tests {
         vm.push(Cell::Int(1)).unwrap();
         vm.push(Cell::Bool(true)).unwrap();
         assert!(matches!(mul_prim(&mut vm), Err(TbxError::TypeError { .. })));
+    }
+
+    #[test]
+    fn test_mul_overflow() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(i64::MAX)).unwrap();
+        vm.push(Cell::Int(2)).unwrap();
+        assert_eq!(mul_prim(&mut vm), Err(TbxError::IntegerOverflow));
     }
 
     // --- div_prim ---
@@ -809,6 +846,15 @@ mod tests {
         assert!(matches!(div_prim(&mut vm), Err(TbxError::TypeError { .. })));
     }
 
+    #[test]
+    fn test_div_overflow() {
+        // i64::MIN / -1 overflows because the result (i64::MAX + 1) is out of range.
+        let mut vm = VM::new();
+        vm.push(Cell::Int(i64::MIN)).unwrap();
+        vm.push(Cell::Int(-1)).unwrap();
+        assert_eq!(div_prim(&mut vm), Err(TbxError::IntegerOverflow));
+    }
+
     // --- mod_prim ---
 
     #[test]
@@ -851,6 +897,15 @@ mod tests {
         vm.push(Cell::Int(7)).unwrap();
         vm.push(Cell::Float(3.0)).unwrap();
         assert!(matches!(mod_prim(&mut vm), Err(TbxError::TypeError { .. })));
+    }
+
+    #[test]
+    fn test_mod_overflow() {
+        // i64::MIN % -1 overflows for the same reason as i64::MIN / -1.
+        let mut vm = VM::new();
+        vm.push(Cell::Int(i64::MIN)).unwrap();
+        vm.push(Cell::Int(-1)).unwrap();
+        assert_eq!(mod_prim(&mut vm), Err(TbxError::IntegerOverflow));
     }
 
     // --- EQ / NEQ tests ---

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -669,6 +669,14 @@ mod tests {
         assert_eq!(add_prim(&mut vm), Err(TbxError::IntegerOverflow));
     }
 
+    #[test]
+    fn test_add_overflow_negative() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(i64::MIN)).unwrap();
+        vm.push(Cell::Int(-1)).unwrap();
+        assert_eq!(add_prim(&mut vm), Err(TbxError::IntegerOverflow));
+    }
+
     // --- sub_prim ---
 
     #[test]
@@ -714,6 +722,14 @@ mod tests {
         assert_eq!(sub_prim(&mut vm), Err(TbxError::IntegerOverflow));
     }
 
+    #[test]
+    fn test_sub_overflow_positive() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(i64::MAX)).unwrap();
+        vm.push(Cell::Int(-1)).unwrap();
+        assert_eq!(sub_prim(&mut vm), Err(TbxError::IntegerOverflow));
+    }
+
     // --- mul_prim ---
 
     #[test]
@@ -755,6 +771,14 @@ mod tests {
     fn test_mul_overflow() {
         let mut vm = VM::new();
         vm.push(Cell::Int(i64::MAX)).unwrap();
+        vm.push(Cell::Int(2)).unwrap();
+        assert_eq!(mul_prim(&mut vm), Err(TbxError::IntegerOverflow));
+    }
+
+    #[test]
+    fn test_mul_overflow_negative() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(i64::MIN)).unwrap();
         vm.push(Cell::Int(2)).unwrap();
         assert_eq!(mul_prim(&mut vm), Err(TbxError::IntegerOverflow));
     }


### PR DESCRIPTION
## 概要

issue #111 で報告された算術演算プリミティブの整数オーバーフロー未処理を修正する。

## 変更内容

- `src/error.rs`: `TbxError::IntegerOverflow` バリアントと Display 実装を追加
- `src/primitives.rs`:
  - `add_prim`: `checked_add` を使用。`None` → `IntegerOverflow`
  - `sub_prim`: `checked_sub` を使用
  - `mul_prim`: `checked_mul` を使用
  - `div_prim`: `checked_div` を使用（`i64::MIN / -1` のオーバーフローを検出）
  - `mod_prim`: `checked_rem` を使用（`i64::MIN % -1` のオーバーフローを検出）

## テスト

各演算のオーバーフロー異常系テストを5件追加。全227テスト通過。

Closes #111