### PR TITLE
issue #193: BAND/BOR ビット演算プリミティブを追加し & / | のマッピングを修正

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -151,7 +151,7 @@ impl<'a> ExprCompiler<'a> {
                         // Binary bitwise-AND (precedence 6, left-associative).
                         pop_ops_while(&mut op_stack, &mut output, self.vm, 6, true)?;
                         op_stack.push(OpItem::BinOp {
-                            prim: "AND",
+                            prim: "BAND",
                             prec: 6,
                         });
                         prev_was_operand = false;
@@ -452,7 +452,7 @@ fn binary_op_info(op: &str) -> Option<(&'static str, u8, bool)> {
         ">=" => Some(("GE", 4, true)),
         "=" => Some(("EQ", 5, true)),
         "<>" => Some(("NEQ", 5, true)),
-        "|" => Some(("OR", 7, true)),
+        "|" => Some(("BOR", 7, true)),
         "&&" => Some(("AND", 8, true)),
         "||" => Some(("OR", 9, true)),
         _ => None,

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -851,4 +851,52 @@ mod tests {
             "expected InvalidExpression for unknown operator, got: {err:?}"
         );
     }
+
+    // ------------------------------------------------------------------
+    // Binary & / | compile to BAND / BOR
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_binary_band_compiles() {
+        // `1 & 3` should compile to: LIT 1 LIT 3 BAND
+        let mut vm = make_vm();
+        let tokens = lex("1 & 3");
+        let result = ExprCompiler::new(&mut vm).compile_expr(&tokens).unwrap();
+
+        let lit_xt = vm.lookup("LIT").unwrap();
+        let band_xt = vm.lookup("BAND").unwrap();
+
+        assert_eq!(
+            result,
+            vec![
+                Cell::Xt(lit_xt),
+                Cell::Int(1),
+                Cell::Xt(lit_xt),
+                Cell::Int(3),
+                Cell::Xt(band_xt),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_binary_bor_compiles() {
+        // `1 | 2` should compile to: LIT 1 LIT 2 BOR
+        let mut vm = make_vm();
+        let tokens = lex("1 | 2");
+        let result = ExprCompiler::new(&mut vm).compile_expr(&tokens).unwrap();
+
+        let lit_xt = vm.lookup("LIT").unwrap();
+        let bor_xt = vm.lookup("BOR").unwrap();
+
+        assert_eq!(
+            result,
+            vec![
+                Cell::Xt(lit_xt),
+                Cell::Int(1),
+                Cell::Xt(lit_xt),
+                Cell::Int(2),
+                Cell::Xt(bor_xt),
+            ]
+        );
+    }
 }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1316,6 +1316,24 @@ mod tests {
     }
 
     #[test]
+    fn test_band_type_error_top() {
+        // b (stack top) is non-Int; first pop should fail with TypeError.
+        let mut vm = VM::new();
+        vm.push(Cell::Int(1)).unwrap();
+        vm.push(Cell::Bool(true)).unwrap();
+        assert!(matches!(
+            band_prim(&mut vm),
+            Err(TbxError::TypeError { .. })
+        ));
+    }
+
+    #[test]
+    fn test_band_underflow() {
+        let mut vm = VM::new();
+        assert_eq!(band_prim(&mut vm), Err(TbxError::StackUnderflow));
+    }
+
+    #[test]
     fn test_bor_basic() {
         let mut vm = VM::new();
         vm.push(Cell::Int(1)).unwrap();
@@ -1339,6 +1357,21 @@ mod tests {
         vm.push(Cell::Bool(false)).unwrap();
         vm.push(Cell::Int(1)).unwrap();
         assert!(matches!(bor_prim(&mut vm), Err(TbxError::TypeError { .. })));
+    }
+
+    #[test]
+    fn test_bor_type_error_top() {
+        // b (stack top) is non-Int; first pop should fail with TypeError.
+        let mut vm = VM::new();
+        vm.push(Cell::Int(1)).unwrap();
+        vm.push(Cell::Bool(false)).unwrap();
+        assert!(matches!(bor_prim(&mut vm), Err(TbxError::TypeError { .. })));
+    }
+
+    #[test]
+    fn test_bor_underflow() {
+        let mut vm = VM::new();
+        assert_eq!(bor_prim(&mut vm), Err(TbxError::StackUnderflow));
     }
 
     // --- PUTSTR tests ---

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -258,6 +258,22 @@ pub fn or_prim(vm: &mut VM) -> Result<(), TbxError> {
     Ok(())
 }
 
+/// BAND — bitwise AND. Both operands must be Int.
+pub fn band_prim(vm: &mut VM) -> Result<(), TbxError> {
+    let b = vm.pop_int()?;
+    let a = vm.pop_int()?;
+    vm.push(Cell::Int(a & b))?;
+    Ok(())
+}
+
+/// BOR — bitwise OR. Both operands must be Int.
+pub fn bor_prim(vm: &mut VM) -> Result<(), TbxError> {
+    let b = vm.pop_int()?;
+    let a = vm.pop_int()?;
+    vm.push(Cell::Int(a | b))?;
+    Ok(())
+}
+
 /// PUTSTR — output the string referenced by a StringDesc on the stack (no newline).
 /// Escape sequences (\n, \t, \\) in the stored string are output literally
 /// as they were already expanded at compile time (during intern).
@@ -402,6 +418,8 @@ pub fn register_all(vm: &mut VM) {
     vm.register(WordEntry::new_primitive("GE", ge_prim));
     vm.register(WordEntry::new_primitive("AND", and_prim));
     vm.register(WordEntry::new_primitive("OR", or_prim));
+    vm.register(WordEntry::new_primitive("BAND", band_prim));
+    vm.register(WordEntry::new_primitive("BOR", bor_prim));
     vm.register(WordEntry::new_primitive("NEGATE", negate_prim));
     vm.register(WordEntry::new_primitive("PUTSTR", putstr_prim));
     vm.register(WordEntry::new_primitive("PUTCHR", putchr_prim));
@@ -1264,6 +1282,63 @@ mod tests {
         vm.push(Cell::Int(5)).unwrap();
         or_prim(&mut vm).unwrap();
         assert_eq!(vm.pop(), Ok(Cell::Bool(true)));
+    }
+
+    // --- BAND / BOR tests ---
+
+    #[test]
+    fn test_band_basic() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(1)).unwrap();
+        vm.push(Cell::Int(3)).unwrap();
+        band_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Int(1)));
+    }
+
+    #[test]
+    fn test_band_zero() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(0)).unwrap();
+        vm.push(Cell::Int(5)).unwrap();
+        band_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Int(0)));
+    }
+
+    #[test]
+    fn test_band_type_error() {
+        let mut vm = VM::new();
+        vm.push(Cell::Bool(true)).unwrap();
+        vm.push(Cell::Int(1)).unwrap();
+        assert!(matches!(
+            band_prim(&mut vm),
+            Err(TbxError::TypeError { .. })
+        ));
+    }
+
+    #[test]
+    fn test_bor_basic() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(1)).unwrap();
+        vm.push(Cell::Int(2)).unwrap();
+        bor_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Int(3)));
+    }
+
+    #[test]
+    fn test_bor_same() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(5)).unwrap();
+        vm.push(Cell::Int(5)).unwrap();
+        bor_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Int(5)));
+    }
+
+    #[test]
+    fn test_bor_type_error() {
+        let mut vm = VM::new();
+        vm.push(Cell::Bool(false)).unwrap();
+        vm.push(Cell::Int(1)).unwrap();
+        assert!(matches!(bor_prim(&mut vm), Err(TbxError::TypeError { .. })));
     }
 
     // --- PUTSTR tests ---


### PR DESCRIPTION
## 概要

`&`（二項）と `|` 演算子がビット演算ではなく論理 AND/OR にマップされていた問題を修正する。

## 変更内容

### `src/primitives.rs`
- `band_prim` を追加: `Int(a) & Int(b)` → `Int`（整数ビット積）
- `bor_prim` を追加: `Int(a) | Int(b)` → `Int`（整数ビット和）
- `register_primitives` に `BAND` / `BOR` を登録
- BAND / BOR のユニットテストを 6 件追加（basic, zero/same, type_error）

### `src/expr.rs`
- 二項 `&` のマッピングを `"AND"` → `"BAND"` に変更
- `|` のマッピングを `"OR"` → `"BOR"` に変更

### 変更しないもの
- `&&` → `"AND"`（論理 AND のまま維持）
- `||` → `"OR"`（論理 OR のまま維持）
- `&` 単項（アドレス参照）は変更なし

Closes #193
