### PR TITLE
main.rs: ファイル実行モードとstdinモードを実装 (#188)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,90 @@
-fn main() {
-    let _vm = tbx::init_vm();
-    println!("TBX - Tiny BASIC eXtensible");
+use std::io::{self, BufRead, Write};
+use tbx::error::TbxError;
+use tbx::interpreter::{Interpreter, InterpreterError};
+
+fn print_error(err: &InterpreterError) {
+    eprintln!("Error: {err}");
+    eprintln!("  {}", err.source_line);
+}
+
+fn run_file(path: &str) -> std::process::ExitCode {
+    let src = match std::fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("Error: cannot read '{}': {}", path, e);
+            return std::process::ExitCode::FAILURE;
+        }
+    };
+
+    let mut interp = Interpreter::new();
+
+    for line in src.lines() {
+        match interp.exec_line(line) {
+            Ok(()) => {
+                let out = interp.take_output();
+                print!("{out}");
+                let _ = io::stdout().flush();
+            }
+            Err(err) if matches!(err.kind, TbxError::Halted) => {
+                let out = interp.take_output();
+                print!("{out}");
+                let _ = io::stdout().flush();
+                return std::process::ExitCode::SUCCESS;
+            }
+            Err(err) => {
+                print_error(&err);
+                return std::process::ExitCode::FAILURE;
+            }
+        }
+    }
+
+    std::process::ExitCode::SUCCESS
+}
+
+fn run_stdin() -> std::process::ExitCode {
+    let mut interp = Interpreter::new();
+    let stdin = io::stdin();
+
+    for line_result in stdin.lock().lines() {
+        let line = match line_result {
+            Ok(l) => l,
+            Err(e) => {
+                eprintln!("Error: reading stdin: {}", e);
+                return std::process::ExitCode::FAILURE;
+            }
+        };
+
+        match interp.exec_line(&line) {
+            Ok(()) => {
+                let out = interp.take_output();
+                print!("{out}");
+                let _ = io::stdout().flush();
+            }
+            Err(err) if matches!(err.kind, TbxError::Halted) => {
+                let out = interp.take_output();
+                print!("{out}");
+                let _ = io::stdout().flush();
+                return std::process::ExitCode::SUCCESS;
+            }
+            Err(err) => {
+                print_error(&err);
+                return std::process::ExitCode::FAILURE;
+            }
+        }
+    }
+
+    std::process::ExitCode::SUCCESS
+}
+
+fn main() -> std::process::ExitCode {
+    let args: Vec<String> = std::env::args().collect();
+
+    match args.as_slice() {
+        [_] => run_stdin(),
+        [_, path] => run_file(path),
+        _ => {
+            eprintln!("Usage: tbx [source_file]");
+            std::process::ExitCode::FAILURE
+        }
+    }
 }


### PR DESCRIPTION
## 概要

`src/main.rs` にファイル実行モードとstdinモードを実装しました。

## 変更内容

- **ファイルモード** (`tbx <source_file>`):
  - `std::fs::read_to_string` でファイルを読み込み、`.lines()` でループ
  - 各行を `exec_line()` で実行し、`take_output()` で出力をフラッシュ
  - `TbxError::Halted` は正常終了（exit code 0）として扱う
  - `InterpreterError` は stderr に行番号・ソース行付きで出力し exit code 1

- **stdinモード** (`tbx` 引数なし):
  - `stdin().lock().lines()` で1行ずつ読み込み、同様に処理
  - EOF または `HALT` で正常終了

- **エラーフォーマット**:
  ```
  Error: line 3:5: undefined symbol: 'FOO'
    FOO 1 + 2
  ```

## 動作確認

```bash
cargo build
cargo test        # 335 tests passed
cargo clippy --all-targets -- -D warnings
cargo fmt --check
```

Closes #188
