### PR TITLE
fix: 式中でプリミティブ関数を呼び出せない不具合を修正 (#208)

### DIFF
--- a/src/vm.rs
+++ b/src/vm.rs
@@ -468,6 +468,19 @@ impl VM {
                             }
                             self.pc = offset;
                         }
+                        EntryKind::Primitive(f) => {
+                            // Arguments are already on the stack; the primitive reads them
+                            // directly. Primitives do not support local variables.
+                            if local_count != 0 {
+                                return Err(TbxError::TypeError {
+                                    expected: "local_count == 0 for Primitive",
+                                    got: "non-zero local_count",
+                                });
+                            }
+                            f(self)?;
+                            // Advance past CALL + target_xt + arity + local_count (4 cells).
+                            self.pc += 4;
+                        }
                         _ => {
                             return Err(TbxError::TypeError {
                                 expected: "Word",
@@ -1569,6 +1582,78 @@ mod tests {
                 }) if depth == MAX_DATA_STACK_DEPTH && limit == MAX_DATA_STACK_DEPTH
             ),
             "expected DataStackOverflow, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_call_primitive_dup() {
+        // Verify that a CALL instruction can invoke a Primitive word (DUP).
+        // Layout:
+        //   [0] Xt(CALL)   <- CALL instruction
+        //   [1] Xt(DUP)    <- target primitive
+        //   [2] Int(1)     <- arity = 1
+        //   [3] Int(0)     <- local_count = 0
+        //   [4] Xt(EXIT)   <- top-level exit
+        //
+        // DUP duplicates the top of stack. After CALL DUP, stack should be [5, 5].
+        let mut vm = VM::new();
+        crate::primitives::register_all(&mut vm);
+
+        let call_xt = vm.lookup("CALL").unwrap();
+        let dup_xt = vm.lookup("DUP").unwrap();
+        let exit_xt = vm.lookup("EXIT").unwrap();
+
+        vm.dict_write(Cell::Xt(call_xt)).unwrap(); // [0]
+        vm.dict_write(Cell::Xt(dup_xt)).unwrap(); // [1]
+        vm.dict_write(Cell::Int(1)).unwrap(); // [2] arity=1
+        vm.dict_write(Cell::Int(0)).unwrap(); // [3] local_count=0
+        vm.dict_write(Cell::Xt(exit_xt)).unwrap(); // [4]
+
+        vm.push(Cell::Int(5)).unwrap(); // argument
+        vm.run(0).unwrap();
+
+        // DUP should have duplicated 5 on the stack.
+        assert_eq!(vm.pop(), Ok(Cell::Int(5)));
+        assert_eq!(vm.pop(), Ok(Cell::Int(5)));
+        assert!(vm.data_stack.is_empty());
+    }
+
+    #[test]
+    fn test_call_primitive_nonzero_local_count_returns_error() {
+        // Verify that CALL targeting a Primitive with local_count != 0 returns TypeError.
+        // Primitives do not support local variables; local_count must be 0.
+        // Layout:
+        //   [0] Xt(CALL)   <- CALL instruction
+        //   [1] Xt(DUP)    <- target primitive
+        //   [2] Int(1)     <- arity = 1
+        //   [3] Int(1)     <- local_count = 1 (invalid for primitives)
+        //   [4] Xt(EXIT)   <- unreachable
+        let mut vm = VM::new();
+        crate::primitives::register_all(&mut vm);
+
+        let call_xt = vm.lookup("CALL").unwrap();
+        let dup_xt = vm.lookup("DUP").unwrap();
+        let exit_xt = vm.lookup("EXIT").unwrap();
+
+        vm.dict_write(Cell::Xt(call_xt)).unwrap(); // [0]
+        vm.dict_write(Cell::Xt(dup_xt)).unwrap(); // [1]
+        vm.dict_write(Cell::Int(1)).unwrap(); // [2] arity=1
+        vm.dict_write(Cell::Int(1)).unwrap(); // [3] local_count=1 (invalid)
+        vm.dict_write(Cell::Xt(exit_xt)).unwrap(); // [4]
+
+        vm.push(Cell::Int(5)).unwrap();
+        let result = vm.run(0);
+
+        assert!(
+            matches!(
+                result,
+                Err(crate::error::TbxError::TypeError {
+                    expected: "local_count == 0 for Primitive",
+                    got: "non-zero local_count",
+                })
+            ),
+            "expected TypeError for non-zero local_count, got {:?}",
             result
         );
     }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -477,6 +477,9 @@ impl VM {
                                     got: "non-zero local_count",
                                 });
                             }
+                            if self.data_stack.len() < arity {
+                                return Err(TbxError::StackUnderflow);
+                            }
                             f(self)?;
                             // Advance past CALL + target_xt + arity + local_count (4 cells).
                             self.pc += 4;
@@ -1656,5 +1659,69 @@ mod tests {
             "expected TypeError for non-zero local_count, got {:?}",
             result
         );
+    }
+
+    #[test]
+    fn test_call_primitive_arity_underflow_returns_error() {
+        // Verify that CALL targeting a Primitive with arity > stack depth returns StackUnderflow.
+        // Layout:
+        //   [0] Xt(CALL)   <- CALL instruction
+        //   [1] Xt(DUP)    <- target primitive
+        //   [2] Int(2)     <- arity = 2 (but stack has only 1 item)
+        //   [3] Int(0)     <- local_count = 0
+        //   [4] Xt(EXIT)   <- unreachable
+        let mut vm = VM::new();
+        crate::primitives::register_all(&mut vm);
+
+        let call_xt = vm.lookup("CALL").unwrap();
+        let dup_xt = vm.lookup("DUP").unwrap();
+        let exit_xt = vm.lookup("EXIT").unwrap();
+
+        vm.dict_write(Cell::Xt(call_xt)).unwrap(); // [0]
+        vm.dict_write(Cell::Xt(dup_xt)).unwrap(); // [1]
+        vm.dict_write(Cell::Int(2)).unwrap(); // [2] arity=2
+        vm.dict_write(Cell::Int(0)).unwrap(); // [3] local_count=0
+        vm.dict_write(Cell::Xt(exit_xt)).unwrap(); // [4]
+
+        vm.push(Cell::Int(5)).unwrap(); // only 1 item on stack, but arity=2
+        let result = vm.run(0);
+
+        assert!(
+            matches!(result, Err(crate::error::TbxError::StackUnderflow)),
+            "expected StackUnderflow, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_call_primitive_two_args() {
+        // Verify that a CALL instruction can invoke a two-argument Primitive (ADD).
+        // Layout:
+        //   [0] Xt(CALL)   <- CALL instruction
+        //   [1] Xt(+)      <- target primitive (pops 2, pushes 1)
+        //   [2] Int(2)     <- arity = 2
+        //   [3] Int(0)     <- local_count = 0
+        //   [4] Xt(EXIT)   <- top-level exit
+        //
+        // After CALL + with [3, 4] on stack, result should be [7].
+        let mut vm = VM::new();
+        crate::primitives::register_all(&mut vm);
+
+        let call_xt = vm.lookup("CALL").unwrap();
+        let add_xt = vm.lookup("ADD").unwrap();
+        let exit_xt = vm.lookup("EXIT").unwrap();
+
+        vm.dict_write(Cell::Xt(call_xt)).unwrap(); // [0]
+        vm.dict_write(Cell::Xt(add_xt)).unwrap(); // [1]
+        vm.dict_write(Cell::Int(2)).unwrap(); // [2] arity=2
+        vm.dict_write(Cell::Int(0)).unwrap(); // [3] local_count=0
+        vm.dict_write(Cell::Xt(exit_xt)).unwrap(); // [4]
+
+        vm.push(Cell::Int(3)).unwrap();
+        vm.push(Cell::Int(4)).unwrap();
+        vm.run(0).unwrap();
+
+        assert_eq!(vm.pop(), Ok(Cell::Int(7)));
+        assert!(vm.data_stack.is_empty());
     }
 }


### PR DESCRIPTION
## 概要

式中でプリミティブ関数を呼び出したとき `TypeError("Word", "non-Word")` が返る不具合を修正した。

## 根本原因

`src/vm.rs` の `EntryKind::Call` ハンドラ内の inner match が `EntryKind::Word` のみを処理しており、`EntryKind::Primitive` はワイルドカード `_` でエラーになっていた。

```rust
// Before
match ... kind.clone() {
    EntryKind::Word(offset) => { /* OK */ }
    _ => return Err(TypeError { expected: "Word", got: "non-Word" })  // ← Primitiveもここへ
}
```

`expr.rs` の `emit_call` はWord/Primitiveを区別せず同じ `[Xt(CALL), Xt(target), Int(arity), Int(0)]` を出力するため、プリミティブを式中で呼び出すとエラーになっていた。

## 変更内容

`src/vm.rs` の `EntryKind::Call` ハンドラ内に `EntryKind::Primitive(f)` アームを追加:

```rust
EntryKind::Primitive(f) => {
    // Arguments are already on the stack; the primitive reads them directly.
    // Primitives do not support local variables.
    if local_count != 0 {
        return Err(TbxError::TypeError {
            expected: "local_count == 0 for Primitive",
            got: "non-zero local_count",
        });
    }
    f(self)?;
    // Advance past CALL + target_xt + arity + local_count (4 cells).
    self.pc += 4;
}
```

## テスト追加

`src/vm.rs` の `#[cfg(test)]` ブロックに以下を追加:

- `test_call_primitive_dup`: DUP をCALL命令で呼び出す正常系テスト
- `test_call_primitive_nonzero_local_count_returns_error`: local_count != 0 の場合の異常系テスト

## CI確認

- `cargo build` ✅
- `cargo test` ✅ (341 tests passed)
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo fmt --check` ✅

Closes #208
