### PR TITLE
DEF仮引数・VAR宣言のコンパイルを実装 (#205)

### DIFF
--- a/src/dict.rs
+++ b/src/dict.rs
@@ -66,6 +66,10 @@ pub struct WordEntry {
     pub flags: u8,
     /// How this entry is executed or accessed
     pub kind: EntryKind,
+    /// Number of VAR-declared local variables in this word's body.
+    /// Set to 0 at registration time and patched to the final count when END is compiled.
+    /// Used by callers to emit the correct `local_count` operand in CALL instructions.
+    pub local_count: usize,
     /// Index of the previous entry in `VM::headers` (linked list for search).
     ///
     /// **Do not set this field directly.** It is automatically managed by
@@ -80,6 +84,7 @@ impl WordEntry {
             name: name.to_string(),
             flags: 0,
             kind: EntryKind::Primitive(f),
+            local_count: 0,
             prev: None,
         }
     }
@@ -90,6 +95,7 @@ impl WordEntry {
             name: name.to_string(),
             flags: 0,
             kind: EntryKind::Word(offset),
+            local_count: 0,
             prev: None,
         }
     }
@@ -100,6 +106,7 @@ impl WordEntry {
             name: name.to_string(),
             flags: 0,
             kind: EntryKind::Variable(idx),
+            local_count: 0,
             prev: None,
         }
     }
@@ -110,6 +117,7 @@ impl WordEntry {
             name: name.to_string(),
             flags: 0,
             kind: EntryKind::Constant(value),
+            local_count: 0,
             prev: None,
         }
     }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -4,6 +4,8 @@
 //! flat RPN instruction sequence (`Vec<Cell>`) that can be appended to the VM
 //! dictionary or executed directly.
 
+use std::collections::HashMap;
+
 use crate::cell::{Cell, Xt};
 use crate::dict::EntryKind;
 use crate::error::TbxError;
@@ -42,12 +44,28 @@ enum OpItem {
 /// The caller receives the instruction sequence and decides how to use it.
 pub struct ExprCompiler<'a> {
     vm: &'a mut VM,
+    /// Optional local variable table passed in during compile mode.
+    /// Local variables shadow same-named globals: this table is checked first.
+    local_table: Option<&'a HashMap<String, usize>>,
 }
 
 impl<'a> ExprCompiler<'a> {
-    /// Create an `ExprCompiler` backed by the given VM.
+    /// Create an `ExprCompiler` backed by the given VM (no local variable table).
     pub fn new(vm: &'a mut VM) -> Self {
-        Self { vm }
+        Self {
+            vm,
+            local_table: None,
+        }
+    }
+
+    /// Create an `ExprCompiler` with an optional local variable table.
+    ///
+    /// When `local_table` is `Some`, local variables shadow same-named globals.
+    pub fn with_local_table_opt(
+        vm: &'a mut VM,
+        local_table: Option<&'a HashMap<String, usize>>,
+    ) -> Self {
+        Self { vm, local_table }
     }
 
     /// Parse `tokens` and return the corresponding RPN instruction sequence.
@@ -95,6 +113,16 @@ impl<'a> ExprCompiler<'a> {
                 // Identifiers (variables, constants, function calls)
                 // -------------------------------------------------------
                 Token::Ident(name) => {
+                    // Check local variable table first — locals shadow globals.
+                    if let Some(idx) = self.local_table.and_then(|lt| lt.get(&name)).copied() {
+                        // Peek ahead: a local variable cannot be called like a function.
+                        // Just emit a local variable read: LIT StackAddr(idx) FETCH.
+                        emit_local_read(&mut output, idx, self.vm)?;
+                        prev_was_operand = true;
+                        i += 1;
+                        continue;
+                    }
+
                     let xt = self
                         .vm
                         .lookup(&name)
@@ -157,27 +185,37 @@ impl<'a> ExprCompiler<'a> {
                         prev_was_operand = false;
                     } else {
                         // Unary address-of operator: eagerly consume the next identifier
-                        // and emit LIT DictAddr(addr) WITHOUT a FETCH instruction.
+                        // and emit LIT addr WITHOUT a FETCH instruction.
                         i += 1;
                         let next_tok = tokens.get(i).map(|st| st.token.clone());
                         match next_tok {
                             Some(Token::Ident(name)) => {
-                                let xt = self.vm.lookup(&name).ok_or_else(|| {
-                                    TbxError::UndefinedSymbol { name: name.clone() }
-                                })?;
-                                let kind = self.vm.headers[xt.index()].kind.clone();
-                                match kind {
-                                    EntryKind::Variable(addr) => {
-                                        // Emit address only — no FETCH.
-                                        let xt_lit = require_xt(self.vm, "LIT")?;
-                                        output.push(Cell::Xt(xt_lit));
-                                        output.push(Cell::DictAddr(addr));
-                                    }
-                                    _ => {
-                                        return Err(TbxError::TypeError {
-                                            expected: "variable identifier after unary &",
-                                            got: "non-variable",
-                                        });
+                                // Check local table first — locals shadow globals.
+                                if let Some(idx) =
+                                    self.local_table.and_then(|lt| lt.get(&name)).copied()
+                                {
+                                    // Emit StackAddr — no FETCH.
+                                    let xt_lit = require_xt(self.vm, "LIT")?;
+                                    output.push(Cell::Xt(xt_lit));
+                                    output.push(Cell::StackAddr(idx));
+                                } else {
+                                    let xt = self.vm.lookup(&name).ok_or_else(|| {
+                                        TbxError::UndefinedSymbol { name: name.clone() }
+                                    })?;
+                                    let kind = self.vm.headers[xt.index()].kind.clone();
+                                    match kind {
+                                        EntryKind::Variable(addr) => {
+                                            // Emit address only — no FETCH.
+                                            let xt_lit = require_xt(self.vm, "LIT")?;
+                                            output.push(Cell::Xt(xt_lit));
+                                            output.push(Cell::DictAddr(addr));
+                                        }
+                                        _ => {
+                                            return Err(TbxError::TypeError {
+                                                expected: "variable identifier after unary &",
+                                                got: "non-variable",
+                                            });
+                                        }
                                     }
                                 }
                             }
@@ -354,9 +392,19 @@ fn emit_var_read(output: &mut Vec<Cell>, addr: usize, vm: &VM) -> Result<(), Tbx
     Ok(())
 }
 
+/// Emit the local-variable-read sequence: `Xt(LIT)`, `StackAddr(idx)`, `Xt(FETCH)`.
+fn emit_local_read(output: &mut Vec<Cell>, idx: usize, vm: &VM) -> Result<(), TbxError> {
+    let lit_xt = require_xt(vm, "LIT")?;
+    let fetch_xt = require_xt(vm, "FETCH")?;
+    output.push(Cell::Xt(lit_xt));
+    output.push(Cell::StackAddr(idx));
+    output.push(Cell::Xt(fetch_xt));
+    Ok(())
+}
+
 /// Emit the function-call sequence based on the `EntryKind` of `xt`.
 ///
-/// - `EntryKind::Word`: emits `Xt(CALL)`, `Xt(xt)`, `Int(arity)`, `Int(0)`
+/// - `EntryKind::Word`: emits `Xt(CALL)`, `Xt(xt)`, `Int(arity)`, `Int(local_count)`
 /// - `EntryKind::Primitive` / `Variable` / `Constant`: emits `Xt(xt)` directly
 /// - Any internal kind (Lit, Call, Exit, ReturnVal, DropToMarker): returns `InvalidExpression`
 fn emit_call_by_kind(
@@ -369,10 +417,11 @@ fn emit_call_by_kind(
     match kind {
         EntryKind::Word(_) => {
             let call_xt = require_xt(vm, "CALL")?;
+            let local_count = vm.headers[xt.index()].local_count;
             output.push(Cell::Xt(call_xt));
             output.push(Cell::Xt(xt));
             output.push(Cell::Int(arity as i64));
-            output.push(Cell::Int(0));
+            output.push(Cell::Int(local_count as i64));
         }
         EntryKind::Primitive(_) | EntryKind::Variable(_) | EntryKind::Constant(_) => {
             output.push(Cell::Xt(xt));
@@ -1130,6 +1179,7 @@ mod tests {
             name: "INTERNAL".to_string(),
             flags: 0,
             kind: EntryKind::Lit,
+            local_count: 0,
             prev: None,
         });
 

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1,5 +1,7 @@
 //! Outer interpreter: tokenizes source text and executes statements via the inner interpreter.
 
+use std::collections::HashMap;
+
 use crate::cell::{Cell, Xt};
 use crate::dict::FLAG_SYSTEM;
 use crate::error::TbxError;
@@ -17,6 +19,17 @@ struct CompileState {
     /// Header count at the start of DEF (for rollback on error).
     hdr_len_at_def: usize,
     saved_latest: Option<crate::cell::Xt>,
+    /// Local variable table: maps variable name to StackAddr index.
+    /// Parameters are assigned indices 0..arity, VAR locals start at arity.
+    local_table: HashMap<String, usize>,
+    /// Number of formal parameters parsed from DEF WORD(X, Y, ...).
+    arity: usize,
+    /// Number of VAR-declared local variables encountered so far.
+    local_count: usize,
+    /// Dictionary offsets of the `local_count` placeholder (Int(0)) in CALL instructions
+    /// that refer to the currently-compiled word (self-recursive calls).
+    /// Patched to the final `local_count` when END is compiled.
+    call_patch_list: Vec<usize>,
 }
 
 /// Error produced by the outer interpreter, including source location information.
@@ -163,6 +176,16 @@ impl Interpreter {
             return self.handle_end(line, stmt_pos_line, stmt_pos_col);
         }
 
+        // Handle VAR in compile mode: register a local variable (no code emitted).
+        if stmt_name.eq_ignore_ascii_case("VAR") && self.compile_state.is_some() {
+            return self.handle_var(&tokens[idx..], line, stmt_pos_line, stmt_pos_col);
+        }
+
+        // Handle VAR at top level: declare a global variable (allocates a dictionary slot).
+        if stmt_name.eq_ignore_ascii_case("VAR") && self.compile_state.is_none() {
+            return self.handle_global_var(&tokens[idx..], line, stmt_pos_line, stmt_pos_col);
+        }
+
         // If we are in compile mode, write this statement to the dictionary instead of executing it.
         if self.compile_state.is_some() {
             let result = self.write_stmt_to_dict(
@@ -269,6 +292,43 @@ impl Interpreter {
             }
         };
 
+        // Parse optional formal parameter list: DEF WORD(X, Y, ...)
+        let mut local_table: HashMap<String, usize> = HashMap::new();
+        let mut arity: usize = 0;
+        let rest = &arg_tokens[1..];
+        if rest
+            .first()
+            .map(|st| matches!(st.token, Token::LParen))
+            .unwrap_or(false)
+        {
+            let mut idx = 1; // skip '('
+            while idx < rest.len() {
+                match &rest[idx].token {
+                    Token::RParen => {
+                        break;
+                    }
+                    Token::Ident(param) => {
+                        local_table.insert(param.clone(), arity);
+                        arity += 1;
+                        idx += 1;
+                        // Skip optional comma.
+                        if rest
+                            .get(idx)
+                            .map(|st| matches!(st.token, Token::Comma))
+                            .unwrap_or(false)
+                        {
+                            idx += 1;
+                        }
+                    }
+                    _ => {
+                        return Err(make_err(TbxError::InvalidExpression {
+                            reason: "expected identifier or ')' in parameter list",
+                        }))
+                    }
+                }
+            }
+        }
+
         // Snapshot for rollback.
         let dp_at_def = self.vm.dp;
         let hdr_len_at_def = self.vm.headers.len();
@@ -284,6 +344,10 @@ impl Interpreter {
             dp_at_def,
             hdr_len_at_def,
             saved_latest,
+            local_table,
+            arity,
+            local_count: 0,
+            call_patch_list: Vec::new(),
         });
 
         Ok(())
@@ -301,11 +365,30 @@ impl Interpreter {
         let exit_xt = self.lookup_required("EXIT", line, col, source_line)?;
         self.vm.dict_write(Cell::Xt(exit_xt)).map_err(&make_err)?;
 
+        // Take the compile state to get local_count and patch list.
+        let state = self
+            .compile_state
+            .take()
+            .expect("compile_state must be Some in handle_end");
+
+        // Patch all self-recursive CALL instructions with the confirmed local_count.
+        for &pos in &state.call_patch_list {
+            self.vm
+                .dict_write_at(pos, Cell::Int(state.local_count as i64))
+                .map_err(&make_err)?;
+        }
+
+        // Update the word header with the confirmed local_count.
+        // The word was registered as the last entry at hdr_len_at_def.
+        let word_hdr_idx = state.hdr_len_at_def;
+        if word_hdr_idx < self.vm.headers.len() {
+            self.vm.headers[word_hdr_idx].local_count = state.local_count;
+        }
+
         // Seal user-defined space.
         self.vm.seal_user();
 
         self.vm.is_compiling = false;
-        self.compile_state = None;
 
         Ok(())
     }
@@ -320,9 +403,86 @@ impl Interpreter {
         }
     }
 
+    /// Register a local variable declared with `VAR name` during compile mode.
+    ///
+    /// Adds `name` to the local variable table and increments `local_count`.
+    /// No code is emitted to the dictionary.
+    fn handle_var(
+        &mut self,
+        arg_tokens: &[SpannedToken],
+        source_line: &str,
+        line: usize,
+        col: usize,
+    ) -> Result<(), InterpreterError> {
+        let make_err = |e: TbxError| InterpreterError::new(line, col, source_line, e);
+
+        let name = match arg_tokens.first() {
+            Some(st) => match &st.token {
+                Token::Ident(n) => n.clone(),
+                _ => {
+                    return Err(make_err(TbxError::InvalidExpression {
+                        reason: "expected variable name after VAR",
+                    }))
+                }
+            },
+            None => {
+                return Err(make_err(TbxError::InvalidExpression {
+                    reason: "expected variable name after VAR",
+                }))
+            }
+        };
+
+        let state = self
+            .compile_state
+            .as_mut()
+            .expect("handle_var called outside compile mode");
+        let idx = state.arity + state.local_count;
+        state.local_table.insert(name, idx);
+        state.local_count += 1;
+
+        Ok(())
+    }
+
+    /// Declare a global variable at the top level.
+    ///
+    /// Allocates one cell in the dictionary as storage and registers a
+    /// `Variable` header entry. The initial value is `Cell::None`.
+    fn handle_global_var(
+        &mut self,
+        arg_tokens: &[SpannedToken],
+        source_line: &str,
+        line: usize,
+        col: usize,
+    ) -> Result<(), InterpreterError> {
+        let make_err = |e: TbxError| InterpreterError::new(line, col, source_line, e);
+
+        let name = match arg_tokens.first() {
+            Some(st) => match &st.token {
+                Token::Ident(n) => n.clone(),
+                _ => {
+                    return Err(make_err(TbxError::InvalidExpression {
+                        reason: "expected variable name after VAR",
+                    }))
+                }
+            },
+            None => {
+                return Err(make_err(TbxError::InvalidExpression {
+                    reason: "expected variable name after VAR",
+                }))
+            }
+        };
+
+        let storage_idx = self.vm.dp;
+        self.vm.dict_write(Cell::None).map_err(&make_err)?;
+        let entry = crate::dict::WordEntry::new_variable(&name, storage_idx);
+        self.vm.register(entry);
+
+        Ok(())
+    }
+
     /// Write a single statement and its arguments to the dictionary.
     ///
-    /// Emits: `LIT_MARKER [arg_cells] (CALL stmt arity 0 | stmt) DROP_TO_MARKER`
+    /// Emits: `LIT_MARKER [arg_cells] (CALL stmt arity local_count | stmt) DROP_TO_MARKER`
     ///
     /// This is used both during interpretation (followed by `EXIT` + run) and during
     /// compilation (within a DEF body; `EXIT` is written by `handle_end`).
@@ -348,8 +508,11 @@ impl Interpreter {
         }
 
         // Compile the argument expression to a cell sequence.
+        // Local variables in the current compile scope shadow globals (local_table checked first).
         let arg_cells = {
-            let mut compiler = ExprCompiler::new(&mut self.vm);
+            let local_table_opt: Option<&HashMap<String, usize>> =
+                self.compile_state.as_ref().map(|s| &s.local_table);
+            let mut compiler = ExprCompiler::with_local_table_opt(&mut self.vm, local_table_opt);
             compiler.compile_expr(arg_tokens).map_err(&make_err)?
         };
 
@@ -373,7 +536,7 @@ impl Interpreter {
         // Build code sequence:
         //   Xt(LIT_MARKER)
         //   [arg_cells]
-        //   For compiled words: Xt(CALL), Xt(stmt), Int(arity), Int(0)
+        //   For compiled words: Xt(CALL), Xt(stmt), Int(arity), Int(local_count)
         //   For primitives:     Xt(stmt)  (dispatched directly by the inner interpreter)
         //   Xt(DROP_TO_MARKER)
         self.vm
@@ -383,12 +546,35 @@ impl Interpreter {
             self.vm.dict_write(cell).map_err(&make_err)?;
         }
         if stmt_is_word {
+            // Determine local_count for the CALL instruction.
+            // For self-recursive calls (word currently being compiled), local_count is not yet
+            // known — write 0 as placeholder and add the position to the patch list.
+            // For all other calls, use the callee's confirmed local_count from the header.
+            let callee_name = self.vm.headers[stmt_xt.index()].name.clone();
+            let is_self_recursive = self
+                .compile_state
+                .as_ref()
+                .map(|s| s.word_name == callee_name)
+                .unwrap_or(false);
+
             self.vm.dict_write(Cell::Xt(call_xt)).map_err(&make_err)?;
             self.vm.dict_write(Cell::Xt(stmt_xt)).map_err(&make_err)?;
             self.vm
                 .dict_write(Cell::Int(arity as i64))
                 .map_err(&make_err)?;
-            self.vm.dict_write(Cell::Int(0)).map_err(&make_err)?;
+
+            if is_self_recursive {
+                let patch_pos = self.vm.dp;
+                self.vm.dict_write(Cell::Int(0)).map_err(&make_err)?;
+                if let Some(state) = &mut self.compile_state {
+                    state.call_patch_list.push(patch_pos);
+                }
+            } else {
+                let callee_local_count = self.vm.headers[stmt_xt.index()].local_count;
+                self.vm
+                    .dict_write(Cell::Int(callee_local_count as i64))
+                    .map_err(&make_err)?;
+            }
         } else {
             self.vm.dict_write(Cell::Xt(stmt_xt)).map_err(&make_err)?;
         }
@@ -649,5 +835,76 @@ GREET";
         interp.exec_line("PUTDEC ADD(1, 2)").unwrap();
         let out = interp.take_output();
         assert_eq!(out, "3", "expected '3', got: {:?}", out);
+    }
+
+    // --- issue #205: DEF formal parameters and VAR locals ---
+
+    #[test]
+    fn test_def_with_param_double() {
+        // DEF DOUBLE(X) multiplies its argument by 2.
+        let mut interp = Interpreter::new();
+        let src = "\
+DEF DOUBLE(X)
+  PUTDEC X * 2
+  PUTSTR \"\\n\"
+END
+DOUBLE 21";
+        interp.exec_source(src).unwrap();
+        let out = interp.take_output();
+        assert_eq!(out, "42\n", "expected '42\\n', got: {:?}", out);
+    }
+
+    #[test]
+    fn test_def_with_var_counter() {
+        // DEF COUNTER declares a local VAR and assigns it.
+        let mut interp = Interpreter::new();
+        let src = "\
+DEF COUNTER
+  VAR I
+  LET &I, 1
+  PUTDEC I
+  PUTSTR \"\\n\"
+END
+COUNTER";
+        interp.exec_source(src).unwrap();
+        let out = interp.take_output();
+        assert_eq!(out, "1\n", "expected '1\\n', got: {:?}", out);
+    }
+
+    #[test]
+    fn test_def_param_multiple_calls() {
+        // Calling a parameterized word multiple times must work correctly.
+        let mut interp = Interpreter::new();
+        let src = "\
+DEF DOUBLE(X)
+  PUTDEC X * 2
+  PUTSTR \"\\n\"
+END
+DOUBLE 3
+DOUBLE 10";
+        interp.exec_source(src).unwrap();
+        let out = interp.take_output();
+        assert_eq!(out, "6\n20\n", "expected '6\\n20\\n', got: {:?}", out);
+    }
+
+    #[test]
+    fn test_def_param_local_shadows_global() {
+        // A formal parameter should shadow a global variable of the same name.
+        let mut interp = Interpreter::new();
+        let src = "\
+VAR X
+LET &X, 99
+DEF SHADOW(X)
+  PUTDEC X
+  PUTSTR \"\\n\"
+END
+SHADOW 42";
+        interp.exec_source(src).unwrap();
+        let out = interp.take_output();
+        assert_eq!(
+            out, "42\n",
+            "expected '42\\n' (local shadows global), got: {:?}",
+            out
+        );
     }
 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -476,6 +476,8 @@ impl Interpreter {
         self.vm.dict_write(Cell::None).map_err(&make_err)?;
         let entry = crate::dict::WordEntry::new_variable(&name, storage_idx);
         self.vm.register(entry);
+        // Seal so that FORGET does not roll back the storage cell.
+        self.vm.seal_user();
 
         Ok(())
     }
@@ -550,11 +552,11 @@ impl Interpreter {
             // For self-recursive calls (word currently being compiled), local_count is not yet
             // known — write 0 as placeholder and add the position to the patch list.
             // For all other calls, use the callee's confirmed local_count from the header.
-            let callee_name = self.vm.headers[stmt_xt.index()].name.clone();
+            // Compare by header index (not name) to handle shadowed/redefined words correctly.
             let is_self_recursive = self
                 .compile_state
                 .as_ref()
-                .map(|s| s.word_name == callee_name)
+                .map(|s| stmt_xt.index() == s.hdr_len_at_def)
                 .unwrap_or(false);
 
             self.vm.dict_write(Cell::Xt(call_xt)).map_err(&make_err)?;
@@ -906,5 +908,41 @@ SHADOW 42";
             "expected '42\\n' (local shadows global), got: {:?}",
             out
         );
+    }
+
+    #[test]
+    fn test_def_param_and_var_combined() {
+        // A word with both a formal parameter and a local VAR should work correctly.
+        let mut interp = Interpreter::new();
+        let src = "\
+DEF ADDONE(X)
+  VAR R
+  LET &R, X + 1
+  PUTDEC R
+  PUTSTR \"\\n\"
+END
+ADDONE 10";
+        interp.exec_source(src).unwrap();
+        let out = interp.take_output();
+        assert_eq!(out, "11\n", "expected '11\\n', got: {:?}", out);
+    }
+
+    #[test]
+    fn test_def_var_isolated_across_calls() {
+        // Each call to a word with VAR locals must get its own independent slot.
+        // Calling ADDONE twice should produce independent results.
+        let mut interp = Interpreter::new();
+        let src = "\
+DEF ADDONE(X)
+  VAR R
+  LET &R, X + 1
+  PUTDEC R
+  PUTSTR \"\\n\"
+END
+ADDONE 5
+ADDONE 20";
+        interp.exec_source(src).unwrap();
+        let out = interp.take_output();
+        assert_eq!(out, "6\n21\n", "expected '6\\n21\\n', got: {:?}", out);
     }
 }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -54,10 +54,36 @@ pub fn fetch_prim(vm: &mut VM) -> Result<(), TbxError> {
     }
 }
 
-/// STORE — pop a value and an address, and store the value at the address.
+/// STORE — pop addr (top) then value (below), and store value at addr.
+///
+/// Stack convention: `[..., value, addr]` → STORE → `[...]`
 pub fn store_prim(vm: &mut VM) -> Result<(), TbxError> {
     let addr = vm.pop()?;
     let value = vm.pop()?;
+    match addr {
+        Cell::DictAddr(a) => {
+            vm.dict_write_at(a, value)?;
+            Ok(())
+        }
+        Cell::StackAddr(a) => {
+            vm.local_write(a, value)?;
+            Ok(())
+        }
+        _ => Err(TbxError::TypeError {
+            expected: "address",
+            got: "non-address",
+        }),
+    }
+}
+
+/// LET — pop value (top) then addr (below), and store value at addr.
+///
+/// Designed for the `LET &var, value` statement pattern where `&var` is
+/// pushed before `value` (left-to-right argument evaluation via comma).
+/// Stack convention: `[..., addr, value]` → LET → `[...]`
+pub fn let_prim(vm: &mut VM) -> Result<(), TbxError> {
+    let value = vm.pop()?;
+    let addr = vm.pop()?;
     match addr {
         Cell::DictAddr(a) => {
             vm.dict_write_at(a, value)?;
@@ -405,6 +431,7 @@ pub fn register_all(vm: &mut VM) {
     vm.register(WordEntry::new_primitive("SWAP", swap_prim));
     vm.register(WordEntry::new_primitive("FETCH", fetch_prim));
     vm.register(WordEntry::new_primitive("STORE", store_prim));
+    vm.register(WordEntry::new_primitive("LET", let_prim));
     vm.register(WordEntry::new_primitive("ADD", add_prim));
     vm.register(WordEntry::new_primitive("SUB", sub_prim));
     vm.register(WordEntry::new_primitive("MUL", mul_prim));
@@ -434,24 +461,28 @@ pub fn register_all(vm: &mut VM) {
         name: "CALL".to_string(),
         flags: FLAG_SYSTEM,
         kind: EntryKind::Call,
+        local_count: 0,
         prev: None,
     });
     vm.register(WordEntry {
         name: "EXIT".to_string(),
         flags: FLAG_SYSTEM,
         kind: EntryKind::Exit,
+        local_count: 0,
         prev: None,
     });
     vm.register(WordEntry {
         name: "RETURN_VAL".to_string(),
         flags: FLAG_SYSTEM,
         kind: EntryKind::ReturnVal,
+        local_count: 0,
         prev: None,
     });
     vm.register(WordEntry {
         name: "DROP_TO_MARKER".to_string(),
         flags: FLAG_SYSTEM,
         kind: EntryKind::DropToMarker,
+        local_count: 0,
         prev: None,
     });
     let mut lit_marker_entry = WordEntry::new_primitive("LIT_MARKER", lit_marker_prim);
@@ -461,6 +492,7 @@ pub fn register_all(vm: &mut VM) {
         name: "LIT".to_string(),
         flags: FLAG_SYSTEM,
         kind: EntryKind::Lit,
+        local_count: 0,
         prev: None,
     });
     let mut literal_entry = WordEntry::new_primitive("LITERAL", literal_prim);

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1589,6 +1589,7 @@ mod tests {
                 name: "TARGET".to_string(),
                 flags: 0,
                 kind,
+                local_count: 0,
                 prev: None,
             });
             vm.dict_write(Cell::Xt(call_xt)).unwrap();


### PR DESCRIPTION
## 概要

issue #205 「DEF仮引数・VAR宣言のコンパイル」の実装。
DEF/END コンパイラ基盤（#204）を拡張し、仮引数と VAR ローカル変数を使えるようにする。

## 変更内容

### src/dict.rs
- `WordEntry` に `pub local_count: usize` フィールドを追加（CALL 命令サイトで参照）

### src/interpreter.rs
- `CompileState` に `local_table / arity / local_count / call_patch_list` を追加
- `handle_def`: `DEF WORD(X, Y)` の仮引数リストをパースし `local_table` に登録
- `handle_var`: compile mode での `VAR I` をローカルテーブルに登録（コード生成なし）
- `handle_global_var` (新規): トップレベルの `VAR X` をグローバル変数として辞書に確保
- `write_stmt_to_dict`: ExprCompiler にローカルテーブルを渡す。自己再帰 CALL は END でパッチ
- `handle_end`: 自己再帰 CALL の local_count をパッチバックし、ヘッダを更新

### src/expr.rs
- `ExprCompiler` に `local_table` フィールドを追加
- `Token::Ident` / `Token::Ampersand` でローカルをグローバルより優先して解決

### src/primitives.rs
- `LET` プリミティブを追加: `[..., addr, value]` → value を addr に格納

## テスト

4つの統合テストを追加:
- `test_def_with_param_double` — `DEF DOUBLE(X); PUTDEC X * 2; END` の基本動作
- `test_def_with_var_counter` — `VAR I; LET &I, 1; PUTDEC I` のローカル変数
- `test_def_param_multiple_calls` — 同一ワードの複数回呼び出し
- `test_def_param_local_shadows_global` — グローバル変数と同名のローカルが優先されること

Closes #205
