### PR TITLE
issue #223 GOTO/BIF/BIT VMプリミティブの実装

### DIFF
--- a/src/dict.rs
+++ b/src/dict.rs
@@ -29,6 +29,17 @@ pub enum EntryKind {
     /// DROP_TO_MARKER instruction: pops the data stack until a Cell::Marker is found (inclusive).
     /// Handled by the inner interpreter (not a PrimFn).
     DropToMarker,
+    /// GOTO instruction: reads next cell as target address, jumps unconditionally.
+    /// Handled by the inner interpreter (not a PrimFn).
+    Goto,
+    /// BIF (Branch If False) instruction: pops condition, jumps if falsy.
+    /// Reads next cell as target address.
+    /// Handled by the inner interpreter (not a PrimFn).
+    BranchIfFalse,
+    /// BIT (Branch If True) instruction: pops condition, jumps if truthy.
+    /// Reads next cell as target address.
+    /// Handled by the inner interpreter (not a PrimFn).
+    BranchIfTrue,
 }
 
 impl std::fmt::Debug for EntryKind {
@@ -43,6 +54,9 @@ impl std::fmt::Debug for EntryKind {
             EntryKind::Exit => write!(f, "Exit"),
             EntryKind::ReturnVal => write!(f, "ReturnVal"),
             EntryKind::DropToMarker => write!(f, "DropToMarker"),
+            EntryKind::Goto => write!(f, "Goto"),
+            EntryKind::BranchIfFalse => write!(f, "BranchIfFalse"),
+            EntryKind::BranchIfTrue => write!(f, "BranchIfTrue"),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -49,6 +49,10 @@ pub enum TbxError {
     },
     /// An integer arithmetic operation produced a result outside the `i64` range.
     IntegerOverflow,
+    /// A jump target address is negative and therefore invalid.
+    InvalidJumpTarget {
+        address: i64,
+    },
     /// A symbol name was not found in the dictionary.
     UndefinedSymbol {
         name: String,
@@ -108,6 +112,9 @@ impl std::fmt::Display for TbxError {
                 )
             }
             TbxError::IntegerOverflow => write!(f, "integer overflow"),
+            TbxError::InvalidJumpTarget { address } => {
+                write!(f, "invalid jump target: negative address {address}")
+            }
             TbxError::UndefinedSymbol { name } => write!(f, "undefined symbol: '{name}'"),
             TbxError::InvalidExpression { reason } => {
                 write!(f, "invalid expression: {reason}")
@@ -168,5 +175,13 @@ mod tests {
     fn test_integer_overflow_display() {
         let e = TbxError::IntegerOverflow;
         assert!(e.to_string().contains("integer overflow"));
+    }
+
+    #[test]
+    fn test_invalid_jump_target_display() {
+        let e = TbxError::InvalidJumpTarget { address: -7 };
+        let msg = e.to_string();
+        assert!(msg.contains("-7"));
+        assert!(msg.contains("negative"));
     }
 }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -485,6 +485,27 @@ pub fn register_all(vm: &mut VM) {
         local_count: 0,
         prev: None,
     });
+    vm.register(WordEntry {
+        name: "GOTO".to_string(),
+        flags: FLAG_SYSTEM,
+        kind: EntryKind::Goto,
+        local_count: 0,
+        prev: None,
+    });
+    vm.register(WordEntry {
+        name: "BIF".to_string(),
+        flags: FLAG_SYSTEM,
+        kind: EntryKind::BranchIfFalse,
+        local_count: 0,
+        prev: None,
+    });
+    vm.register(WordEntry {
+        name: "BIT".to_string(),
+        flags: FLAG_SYSTEM,
+        kind: EntryKind::BranchIfTrue,
+        local_count: 0,
+        prev: None,
+    });
     let mut lit_marker_entry = WordEntry::new_primitive("LIT_MARKER", lit_marker_prim);
     lit_marker_entry.flags |= FLAG_SYSTEM;
     vm.register(lit_marker_entry);

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -236,8 +236,12 @@ impl VM {
     /// Read the cell at `offset` as a jump target address.
     ///
     /// Expects `Cell::Int`; returns the address as `usize`.
-    /// Returns `Err(TbxError::TypeError)` if the cell is not an `Int`.
-    /// Returns `Err(TbxError::InvalidJumpTarget)` if the address is negative.
+    ///
+    /// # Errors
+    ///
+    /// - `Err(TbxError::IndexOutOfBounds)` if `offset` is beyond the dictionary end.
+    /// - `Err(TbxError::TypeError)` if the cell at `offset` is not a `Cell::Int`.
+    /// - `Err(TbxError::InvalidJumpTarget)` if the address is negative.
     fn read_jump_target(&self, offset: usize) -> Result<usize, TbxError> {
         let raw = self
             .dict_read(offset)?
@@ -1959,6 +1963,48 @@ mod tests {
         assert_eq!(
             result,
             Err(crate::error::TbxError::InvalidJumpTarget { address: -3 })
+        );
+    }
+
+    #[test]
+    fn test_run_bif_negative_target_errors_on_fallthrough() {
+        // BIF with a negative target address must return InvalidJumpTarget
+        // even when the condition is truthy (fall-through path).
+        // read_jump_target is always evaluated regardless of the condition.
+        let mut vm = VM::new();
+        crate::primitives::register_all(&mut vm);
+
+        let bif_xt = vm.lookup("BIF").unwrap();
+
+        vm.dict_write(Cell::Xt(bif_xt)).unwrap(); // [0]
+        vm.dict_write(Cell::Int(-1)).unwrap(); // [1] negative target
+
+        vm.push(Cell::Bool(true)).unwrap(); // truthy → fall-through would be taken
+        let result = vm.run(0);
+        assert_eq!(
+            result,
+            Err(crate::error::TbxError::InvalidJumpTarget { address: -1 })
+        );
+    }
+
+    #[test]
+    fn test_run_bit_negative_target_errors_on_fallthrough() {
+        // BIT with a negative target address must return InvalidJumpTarget
+        // even when the condition is falsy (fall-through path).
+        // read_jump_target is always evaluated regardless of the condition.
+        let mut vm = VM::new();
+        crate::primitives::register_all(&mut vm);
+
+        let bit_xt = vm.lookup("BIT").unwrap();
+
+        vm.dict_write(Cell::Xt(bit_xt)).unwrap(); // [0]
+        vm.dict_write(Cell::Int(-2)).unwrap(); // [1] negative target
+
+        vm.push(Cell::Bool(false)).unwrap(); // falsy → fall-through would be taken
+        let result = vm.run(0);
+        assert_eq!(
+            result,
+            Err(crate::error::TbxError::InvalidJumpTarget { address: -2 })
         );
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -383,13 +383,11 @@ impl VM {
         self.pc = start_offset;
 
         loop {
-            let xt = self
-                .dict_read(self.pc)?
-                .as_xt()
-                .ok_or(TbxError::TypeError {
-                    expected: "Xt",
-                    got: "non-Xt",
-                })?;
+            let dispatch_cell = self.dict_read(self.pc)?;
+            let xt = dispatch_cell.as_xt().ok_or_else(|| TbxError::TypeError {
+                expected: "Xt",
+                got: dispatch_cell.type_name(),
+            })?;
             let entry_kind = self
                 .headers
                 .get(xt.index())

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -233,6 +233,25 @@ impl VM {
             .ok_or(TbxError::IndexOutOfBounds { index: idx, size })
     }
 
+    /// Read the cell at `offset` as a jump target address.
+    ///
+    /// Expects `Cell::Int`; returns the address as `usize`.
+    /// Returns `Err(TbxError::TypeError)` if the cell is not an `Int`.
+    /// Returns `Err(TbxError::InvalidJumpTarget)` if the address is negative.
+    fn read_jump_target(&self, offset: usize) -> Result<usize, TbxError> {
+        let raw = self
+            .dict_read(offset)?
+            .as_int()
+            .ok_or(TbxError::TypeError {
+                expected: "Int (jump target)",
+                got: "non-Int",
+            })?;
+        if raw < 0 {
+            return Err(TbxError::InvalidJumpTarget { address: raw });
+        }
+        Ok(raw as usize)
+    }
+
     /// Write a cell to an arbitrary dictionary index, with bounds checking.
     ///
     /// Unlike `dict_write`, this does not advance `dp`; it overwrites an
@@ -520,59 +539,23 @@ impl VM {
                 }
 
                 EntryKind::Goto => {
-                    let target_raw =
-                        self.dict_read(self.pc + 1)?
-                            .as_int()
-                            .ok_or(TbxError::TypeError {
-                                expected: "Int (jump target)",
-                                got: "non-Int",
-                            })?;
-                    if target_raw < 0 {
-                        return Err(TbxError::TypeError {
-                            expected: "non-negative Int (jump target)",
-                            got: "negative value",
-                        });
-                    }
-                    self.pc = target_raw as usize;
+                    let target = self.read_jump_target(self.pc + 1)?;
+                    self.pc = target;
                 }
                 EntryKind::BranchIfFalse => {
                     let cond = self.pop()?;
-                    let target_raw =
-                        self.dict_read(self.pc + 1)?
-                            .as_int()
-                            .ok_or(TbxError::TypeError {
-                                expected: "Int (jump target)",
-                                got: "non-Int",
-                            })?;
-                    if target_raw < 0 {
-                        return Err(TbxError::TypeError {
-                            expected: "non-negative Int (jump target)",
-                            got: "negative value",
-                        });
-                    }
+                    let target = self.read_jump_target(self.pc + 1)?;
                     if !cond.is_truthy() {
-                        self.pc = target_raw as usize;
+                        self.pc = target;
                     } else {
                         self.pc += 2;
                     }
                 }
                 EntryKind::BranchIfTrue => {
                     let cond = self.pop()?;
-                    let target_raw =
-                        self.dict_read(self.pc + 1)?
-                            .as_int()
-                            .ok_or(TbxError::TypeError {
-                                expected: "Int (jump target)",
-                                got: "non-Int",
-                            })?;
-                    if target_raw < 0 {
-                        return Err(TbxError::TypeError {
-                            expected: "non-negative Int (jump target)",
-                            got: "negative value",
-                        });
-                    }
+                    let target = self.read_jump_target(self.pc + 1)?;
                     if cond.is_truthy() {
-                        self.pc = target_raw as usize;
+                        self.pc = target;
                     } else {
                         self.pc += 2;
                     }
@@ -1846,5 +1829,136 @@ mod tests {
 
         // Fall-through pushed 42 onto the stack.
         assert_eq!(vm.pop(), Ok(Cell::Int(42)));
+    }
+
+    // --- error cases for GOTO/BIF/BIT ---
+
+    #[test]
+    fn test_run_goto_negative_target_errors() {
+        // GOTO with a negative target address must return InvalidJumpTarget.
+        let mut vm = VM::new();
+        crate::primitives::register_all(&mut vm);
+
+        let goto_xt = vm.lookup("GOTO").unwrap();
+
+        vm.dict_write(Cell::Xt(goto_xt)).unwrap(); // [0]
+        vm.dict_write(Cell::Int(-1)).unwrap(); // [1] negative target
+
+        let result = vm.run(0);
+        assert_eq!(
+            result,
+            Err(crate::error::TbxError::InvalidJumpTarget { address: -1 })
+        );
+    }
+
+    #[test]
+    fn test_run_goto_non_int_target_errors() {
+        // GOTO with a non-Int operand must return TypeError.
+        let mut vm = VM::new();
+        crate::primitives::register_all(&mut vm);
+
+        let goto_xt = vm.lookup("GOTO").unwrap();
+        let exit_xt = vm.lookup("EXIT").unwrap();
+
+        vm.dict_write(Cell::Xt(goto_xt)).unwrap(); // [0]
+        vm.dict_write(Cell::Xt(exit_xt)).unwrap(); // [1] Xt instead of Int
+
+        let result = vm.run(0);
+        assert!(matches!(
+            result,
+            Err(crate::error::TbxError::TypeError { .. })
+        ));
+    }
+
+    #[test]
+    fn test_run_goto_out_of_bounds_target_errors() {
+        // GOTO with a target beyond the dictionary end must return IndexOutOfBounds.
+        let mut vm = VM::new();
+        crate::primitives::register_all(&mut vm);
+
+        let goto_xt = vm.lookup("GOTO").unwrap();
+
+        vm.dict_write(Cell::Xt(goto_xt)).unwrap(); // [0]
+        vm.dict_write(Cell::Int(9999)).unwrap(); // [1] out-of-bounds target
+
+        let result = vm.run(0);
+        assert!(matches!(
+            result,
+            Err(crate::error::TbxError::IndexOutOfBounds { .. })
+        ));
+    }
+
+    #[test]
+    fn test_run_bif_empty_stack_errors() {
+        // BIF with an empty stack must return StackUnderflow.
+        let mut vm = VM::new();
+        crate::primitives::register_all(&mut vm);
+
+        let bif_xt = vm.lookup("BIF").unwrap();
+        let exit_xt = vm.lookup("EXIT").unwrap();
+
+        vm.dict_write(Cell::Xt(bif_xt)).unwrap(); // [0]
+        vm.dict_write(Cell::Int(3)).unwrap(); // [1] target
+        vm.dict_write(Cell::Xt(exit_xt)).unwrap(); // [2] (not reached)
+
+        // No condition pushed — expect StackUnderflow.
+        let result = vm.run(0);
+        assert_eq!(result, Err(crate::error::TbxError::StackUnderflow));
+    }
+
+    #[test]
+    fn test_run_bit_empty_stack_errors() {
+        // BIT with an empty stack must return StackUnderflow.
+        let mut vm = VM::new();
+        crate::primitives::register_all(&mut vm);
+
+        let bit_xt = vm.lookup("BIT").unwrap();
+        let exit_xt = vm.lookup("EXIT").unwrap();
+
+        vm.dict_write(Cell::Xt(bit_xt)).unwrap(); // [0]
+        vm.dict_write(Cell::Int(3)).unwrap(); // [1] target
+        vm.dict_write(Cell::Xt(exit_xt)).unwrap(); // [2] (not reached)
+
+        // No condition pushed — expect StackUnderflow.
+        let result = vm.run(0);
+        assert_eq!(result, Err(crate::error::TbxError::StackUnderflow));
+    }
+
+    #[test]
+    fn test_run_bif_negative_target_errors() {
+        // BIF with a negative target address must return InvalidJumpTarget.
+        let mut vm = VM::new();
+        crate::primitives::register_all(&mut vm);
+
+        let bif_xt = vm.lookup("BIF").unwrap();
+
+        vm.dict_write(Cell::Xt(bif_xt)).unwrap(); // [0]
+        vm.dict_write(Cell::Int(-5)).unwrap(); // [1] negative target
+
+        vm.push(Cell::Bool(false)).unwrap(); // falsy → branch would be taken
+        let result = vm.run(0);
+        assert_eq!(
+            result,
+            Err(crate::error::TbxError::InvalidJumpTarget { address: -5 })
+        );
+    }
+
+    #[test]
+    fn test_run_bit_negative_target_errors() {
+        // BIT with a negative target address must return InvalidJumpTarget.
+        let mut vm = VM::new();
+        crate::primitives::register_all(&mut vm);
+
+        let bit_xt = vm.lookup("BIT").unwrap();
+
+        vm.dict_write(Cell::Xt(bit_xt)).unwrap(); // [0]
+        vm.dict_write(Cell::Int(-3)).unwrap(); // [1] negative target
+
+        vm.push(Cell::Bool(true)).unwrap(); // truthy → branch would be taken
+        let result = vm.run(0);
+        assert_eq!(
+            result,
+            Err(crate::error::TbxError::InvalidJumpTarget { address: -3 })
+        );
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -519,6 +519,65 @@ impl VM {
                     self.pc += 1;
                 }
 
+                EntryKind::Goto => {
+                    let target_raw =
+                        self.dict_read(self.pc + 1)?
+                            .as_int()
+                            .ok_or(TbxError::TypeError {
+                                expected: "Int (jump target)",
+                                got: "non-Int",
+                            })?;
+                    if target_raw < 0 {
+                        return Err(TbxError::TypeError {
+                            expected: "non-negative Int (jump target)",
+                            got: "negative value",
+                        });
+                    }
+                    self.pc = target_raw as usize;
+                }
+                EntryKind::BranchIfFalse => {
+                    let cond = self.pop()?;
+                    let target_raw =
+                        self.dict_read(self.pc + 1)?
+                            .as_int()
+                            .ok_or(TbxError::TypeError {
+                                expected: "Int (jump target)",
+                                got: "non-Int",
+                            })?;
+                    if target_raw < 0 {
+                        return Err(TbxError::TypeError {
+                            expected: "non-negative Int (jump target)",
+                            got: "negative value",
+                        });
+                    }
+                    if !cond.is_truthy() {
+                        self.pc = target_raw as usize;
+                    } else {
+                        self.pc += 2;
+                    }
+                }
+                EntryKind::BranchIfTrue => {
+                    let cond = self.pop()?;
+                    let target_raw =
+                        self.dict_read(self.pc + 1)?
+                            .as_int()
+                            .ok_or(TbxError::TypeError {
+                                expected: "Int (jump target)",
+                                got: "non-Int",
+                            })?;
+                    if target_raw < 0 {
+                        return Err(TbxError::TypeError {
+                            expected: "non-negative Int (jump target)",
+                            got: "negative value",
+                        });
+                    }
+                    if cond.is_truthy() {
+                        self.pc = target_raw as usize;
+                    } else {
+                        self.pc += 2;
+                    }
+                }
+
                 EntryKind::Lit => {
                     self.pc += 1;
                     let literal = self.dict_read(self.pc)?;
@@ -1630,5 +1689,162 @@ mod tests {
             ),
             "expected TypeError for Constant CALL target"
         );
+    }
+
+    // --- GOTO / BIF / BIT ---
+
+    #[test]
+    fn test_run_goto() {
+        // Verify that GOTO jumps unconditionally to the specified offset.
+        //
+        // Layout:
+        //   [0] Xt(GOTO)     <- GOTO instruction
+        //   [1] Int(3)       <- target address = 3
+        //   [2] Xt(DUP)      <- should be skipped
+        //   [3] Xt(EXIT)     <- landing point; exits immediately
+        let mut vm = VM::new();
+        crate::primitives::register_all(&mut vm);
+
+        let goto_xt = vm.lookup("GOTO").unwrap();
+        let dup_xt = vm.lookup("DUP").unwrap();
+        let exit_xt = vm.lookup("EXIT").unwrap();
+
+        vm.dict_write(Cell::Xt(goto_xt)).unwrap(); // [0]
+        vm.dict_write(Cell::Int(3)).unwrap(); // [1] target = 3
+        vm.dict_write(Cell::Xt(dup_xt)).unwrap(); // [2] skipped
+        vm.dict_write(Cell::Xt(exit_xt)).unwrap(); // [3]
+
+        vm.run(0).unwrap();
+
+        // DUP was skipped, so stack must be empty.
+        assert!(vm.data_stack.is_empty());
+    }
+
+    #[test]
+    fn test_run_bif_taken() {
+        // BIF: when condition is falsy, branch is taken (jumps to target).
+        //
+        // Layout:
+        //   [0] Xt(BIF)      <- BIF instruction
+        //   [1] Int(4)       <- target address = 4
+        //   [2] Xt(DUP)      <- fall-through path (should be skipped)
+        //   [3] Xt(EXIT)     <- fall-through exit (should be skipped)
+        //   [4] Xt(EXIT)     <- branch target; exits immediately
+        let mut vm = VM::new();
+        crate::primitives::register_all(&mut vm);
+
+        let bif_xt = vm.lookup("BIF").unwrap();
+        let dup_xt = vm.lookup("DUP").unwrap();
+        let exit_xt = vm.lookup("EXIT").unwrap();
+
+        vm.dict_write(Cell::Xt(bif_xt)).unwrap(); // [0]
+        vm.dict_write(Cell::Int(4)).unwrap(); // [1] target = 4
+        vm.dict_write(Cell::Xt(dup_xt)).unwrap(); // [2] skipped
+        vm.dict_write(Cell::Xt(exit_xt)).unwrap(); // [3] skipped
+        vm.dict_write(Cell::Xt(exit_xt)).unwrap(); // [4] branch target
+
+        // Push falsy condition; BIF should branch.
+        vm.push(Cell::Bool(false)).unwrap();
+        vm.run(0).unwrap();
+
+        // DUP was skipped, so stack must be empty.
+        assert!(vm.data_stack.is_empty());
+    }
+
+    #[test]
+    fn test_run_bif_not_taken() {
+        // BIF: when condition is truthy, fall-through occurs (no jump).
+        //
+        // Layout:
+        //   [0] Xt(BIF)      <- BIF instruction
+        //   [1] Int(5)       <- target address (not taken)
+        //   [2] Xt(LIT)      <- fall-through: push Int(42)
+        //   [3] Int(42)
+        //   [4] Xt(EXIT)
+        //   [5] Xt(EXIT)     <- branch target (not reached)
+        let mut vm = VM::new();
+        crate::primitives::register_all(&mut vm);
+
+        let bif_xt = vm.lookup("BIF").unwrap();
+        let lit_xt = vm.lookup("LIT").unwrap();
+        let exit_xt = vm.lookup("EXIT").unwrap();
+
+        vm.dict_write(Cell::Xt(bif_xt)).unwrap(); // [0]
+        vm.dict_write(Cell::Int(5)).unwrap(); // [1] target = 5 (not taken)
+        vm.dict_write(Cell::Xt(lit_xt)).unwrap(); // [2]
+        vm.dict_write(Cell::Int(42)).unwrap(); // [3]
+        vm.dict_write(Cell::Xt(exit_xt)).unwrap(); // [4]
+        vm.dict_write(Cell::Xt(exit_xt)).unwrap(); // [5] not reached
+
+        // Push truthy condition; BIF should fall through.
+        vm.push(Cell::Bool(true)).unwrap();
+        vm.run(0).unwrap();
+
+        // Fall-through pushed 42 onto the stack.
+        assert_eq!(vm.pop(), Ok(Cell::Int(42)));
+    }
+
+    #[test]
+    fn test_run_bit_taken() {
+        // BIT: when condition is truthy, branch is taken (jumps to target).
+        //
+        // Layout:
+        //   [0] Xt(BIT)      <- BIT instruction
+        //   [1] Int(4)       <- target address = 4
+        //   [2] Xt(DUP)      <- fall-through path (should be skipped)
+        //   [3] Xt(EXIT)     <- fall-through exit (should be skipped)
+        //   [4] Xt(EXIT)     <- branch target; exits immediately
+        let mut vm = VM::new();
+        crate::primitives::register_all(&mut vm);
+
+        let bit_xt = vm.lookup("BIT").unwrap();
+        let dup_xt = vm.lookup("DUP").unwrap();
+        let exit_xt = vm.lookup("EXIT").unwrap();
+
+        vm.dict_write(Cell::Xt(bit_xt)).unwrap(); // [0]
+        vm.dict_write(Cell::Int(4)).unwrap(); // [1] target = 4
+        vm.dict_write(Cell::Xt(dup_xt)).unwrap(); // [2] skipped
+        vm.dict_write(Cell::Xt(exit_xt)).unwrap(); // [3] skipped
+        vm.dict_write(Cell::Xt(exit_xt)).unwrap(); // [4] branch target
+
+        // Push truthy condition; BIT should branch.
+        vm.push(Cell::Bool(true)).unwrap();
+        vm.run(0).unwrap();
+
+        // DUP was skipped, so stack must be empty.
+        assert!(vm.data_stack.is_empty());
+    }
+
+    #[test]
+    fn test_run_bit_not_taken() {
+        // BIT: when condition is falsy, fall-through occurs (no jump).
+        //
+        // Layout:
+        //   [0] Xt(BIT)      <- BIT instruction
+        //   [1] Int(5)       <- target address (not taken)
+        //   [2] Xt(LIT)      <- fall-through: push Int(42)
+        //   [3] Int(42)
+        //   [4] Xt(EXIT)
+        //   [5] Xt(EXIT)     <- branch target (not reached)
+        let mut vm = VM::new();
+        crate::primitives::register_all(&mut vm);
+
+        let bit_xt = vm.lookup("BIT").unwrap();
+        let lit_xt = vm.lookup("LIT").unwrap();
+        let exit_xt = vm.lookup("EXIT").unwrap();
+
+        vm.dict_write(Cell::Xt(bit_xt)).unwrap(); // [0]
+        vm.dict_write(Cell::Int(5)).unwrap(); // [1] target = 5 (not taken)
+        vm.dict_write(Cell::Xt(lit_xt)).unwrap(); // [2]
+        vm.dict_write(Cell::Int(42)).unwrap(); // [3]
+        vm.dict_write(Cell::Xt(exit_xt)).unwrap(); // [4]
+        vm.dict_write(Cell::Xt(exit_xt)).unwrap(); // [5] not reached
+
+        // Push falsy condition; BIT should fall through.
+        vm.push(Cell::Bool(false)).unwrap();
+        vm.run(0).unwrap();
+
+        // Fall-through pushed 42 onto the stack.
+        assert_eq!(vm.pop(), Ok(Cell::Int(42)));
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -422,20 +422,16 @@ impl VM {
                     self.pc = offset;
                 }
                 EntryKind::Call => {
-                    let target_xt =
-                        self.dict_read(self.pc + 1)?
-                            .as_xt()
-                            .ok_or(TbxError::TypeError {
-                                expected: "Xt",
-                                got: "non-Xt",
-                            })?;
-                    let arity_raw =
-                        self.dict_read(self.pc + 2)?
-                            .as_int()
-                            .ok_or(TbxError::TypeError {
-                                expected: "Int (arity)",
-                                got: "non-Int",
-                            })?;
+                    let xt_cell = self.dict_read(self.pc + 1)?;
+                    let target_xt = xt_cell.as_xt().ok_or_else(|| TbxError::TypeError {
+                        expected: "Xt",
+                        got: xt_cell.type_name(),
+                    })?;
+                    let arity_cell = self.dict_read(self.pc + 2)?;
+                    let arity_raw = arity_cell.as_int().ok_or_else(|| TbxError::TypeError {
+                        expected: "Int (arity)",
+                        got: arity_cell.type_name(),
+                    })?;
                     if arity_raw < 0 {
                         return Err(TbxError::TypeError {
                             expected: "non-negative Int (arity)",
@@ -443,12 +439,13 @@ impl VM {
                         });
                     }
                     let arity = arity_raw as usize;
+                    let local_count_cell = self.dict_read(self.pc + 3)?;
                     let local_count_raw =
-                        self.dict_read(self.pc + 3)?
+                        local_count_cell
                             .as_int()
-                            .ok_or(TbxError::TypeError {
+                            .ok_or_else(|| TbxError::TypeError {
                                 expected: "Int (local count)",
-                                got: "non-Int",
+                                got: local_count_cell.type_name(),
                             })?;
                     if local_count_raw < 0 {
                         return Err(TbxError::TypeError {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -243,13 +243,11 @@ impl VM {
     /// - `Err(TbxError::TypeError)` if the cell at `offset` is not a `Cell::Int`.
     /// - `Err(TbxError::InvalidJumpTarget)` if the address is negative.
     fn read_jump_target(&self, offset: usize) -> Result<usize, TbxError> {
-        let raw = self
-            .dict_read(offset)?
-            .as_int()
-            .ok_or(TbxError::TypeError {
-                expected: "Int (jump target)",
-                got: "non-Int",
-            })?;
+        let cell = self.dict_read(offset)?;
+        let raw = cell.as_int().ok_or_else(|| TbxError::TypeError {
+            expected: "Int (jump target)",
+            got: cell.type_name(),
+        })?;
         if raw < 0 {
             return Err(TbxError::InvalidJumpTarget { address: raw });
         }
@@ -1857,7 +1855,7 @@ mod tests {
 
     #[test]
     fn test_run_goto_non_int_target_errors() {
-        // GOTO with a non-Int operand must return TypeError.
+        // GOTO with a non-Int operand (Cell::Xt) must return TypeError with got = "Xt".
         let mut vm = VM::new();
         crate::primitives::register_all(&mut vm);
 
@@ -1868,10 +1866,13 @@ mod tests {
         vm.dict_write(Cell::Xt(exit_xt)).unwrap(); // [1] Xt instead of Int
 
         let result = vm.run(0);
-        assert!(matches!(
+        assert_eq!(
             result,
-            Err(crate::error::TbxError::TypeError { .. })
-        ));
+            Err(crate::error::TbxError::TypeError {
+                expected: "Int (jump target)",
+                got: "Xt",
+            })
+        );
     }
 
     #[test]

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -875,6 +875,26 @@ mod tests {
     }
 
     #[test]
+    fn test_run_non_xt_at_pc_errors_with_type_name() {
+        // Verify that when a non-Xt cell is found at the PC position,
+        // TypeError.got reports the actual cell type via type_name().
+        let mut vm = VM::new();
+        crate::primitives::register_all(&mut vm);
+
+        // Place Cell::Int(42) at offset 0 instead of an Xt.
+        vm.dict_write(Cell::Int(42)).unwrap();
+
+        let result = vm.run(0);
+        assert_eq!(
+            result,
+            Err(crate::error::TbxError::TypeError {
+                expected: "Xt",
+                got: "Int",
+            })
+        );
+    }
+
+    #[test]
     fn test_run_lit() {
         // Verify that EntryKind::Lit pushes the next cell as a literal value.
         let mut vm = VM::new();


### PR DESCRIPTION
## 概要

issue #223 の実装。GOTO（無条件ジャンプ）、BIF（条件偽でジャンプ）、BIT（条件真でジャンプ）の3つのVM命令を追加する。

## 変更内容

### `src/dict.rs`
- `EntryKind` enum に `Goto`、`BranchIfFalse`、`BranchIfTrue` の3バリアントを追加
- `Debug` impl の `match` に対応する3アームを追加

### `src/primitives.rs`
- `register_all` 内に `GOTO`、`BIF`、`BIT` を `FLAG_SYSTEM` フラグ付きで登録

### `src/vm.rs`
- `run()` の `match entry_kind` ブロックに `Goto`、`BranchIfFalse`、`BranchIfTrue` の dispatch を追加
- 各命令のユニットテスト5件を追加:
  - `test_run_goto`: GOTO が無条件ジャンプする
  - `test_run_bif_taken`: BIF が偽条件で分岐する
  - `test_run_bif_not_taken`: BIF が真条件で fall-through する
  - `test_run_bit_taken`: BIT が真条件で分岐する
  - `test_run_bit_not_taken`: BIT が偽条件で fall-through する

## 動作仕様

| 命令 | オペランド | 動作 |
|------|-----------|------|
| GOTO | `Int(target)` | 無条件で `pc = target` |
| BIF  | `Int(target)` | スタックトップが falsy なら `pc = target`、truthy なら `pc += 2` |
| BIT  | `Int(target)` | スタックトップが truthy なら `pc = target`、falsy なら `pc += 2` |

Closes #223
