### PR TITLE
smudgeフラグによるコンパイル中ワードの隠蔽 (#229)

### DIFF
--- a/src/dict.rs
+++ b/src/dict.rs
@@ -67,6 +67,9 @@ pub const FLAG_IMMEDIATE: u8 = 0b0000_0001;
 /// Flag bit: word is an internal system word and cannot be called directly from user code.
 pub const FLAG_SYSTEM: u8 = 0b0000_0010;
 
+/// Flag bit: word is currently being compiled (smudge flag). Hidden from lookup until END.
+pub const FLAG_HIDDEN: u8 = 0b0000_0100;
+
 /// A single entry in the TBX word header table.
 ///
 /// The header table (`VM::headers`) and the flat code array (`VM::dictionary`)
@@ -300,5 +303,15 @@ mod tests {
         let mut entry = WordEntry::new_primitive("if", dummy_prim);
         entry.flags = 0b1111_1111; // all bits including bit 0
         assert!(entry.is_immediate());
+    }
+
+    // --- FLAG_HIDDEN constant ---
+
+    #[test]
+    fn test_flag_hidden_value() {
+        // FLAG_HIDDEN must be bit 2 (0b0000_0100), distinct from FLAG_IMMEDIATE and FLAG_SYSTEM.
+        assert_eq!(FLAG_HIDDEN, 0b0000_0100);
+        assert_eq!(FLAG_HIDDEN & FLAG_IMMEDIATE, 0);
+        assert_eq!(FLAG_HIDDEN & FLAG_SYSTEM, 0);
     }
 }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -62,20 +62,6 @@ impl<'a> ExprCompiler<'a> {
         }
     }
 
-    /// Create an `ExprCompiler` with an optional local variable table.
-    ///
-    /// When `local_table` is `Some`, local variables shadow same-named globals.
-    pub fn with_local_table_opt(
-        vm: &'a mut VM,
-        local_table: Option<&'a HashMap<String, usize>>,
-    ) -> Self {
-        Self {
-            vm,
-            local_table,
-            self_word: None,
-        }
-    }
-
     /// Create an `ExprCompiler` with a local variable table and the name of the
     /// word currently being compiled (for self-recursive call resolution).
     pub fn with_context(

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -47,6 +47,9 @@ pub struct ExprCompiler<'a> {
     /// Optional local variable table passed in during compile mode.
     /// Local variables shadow same-named globals: this table is checked first.
     local_table: Option<&'a HashMap<String, usize>>,
+    /// Name of the word currently being compiled, used to allow self-recursive lookups.
+    /// Only this word's hidden entry (FLAG_HIDDEN) is visible to identifier resolution.
+    self_word: Option<String>,
 }
 
 impl<'a> ExprCompiler<'a> {
@@ -55,6 +58,7 @@ impl<'a> ExprCompiler<'a> {
         Self {
             vm,
             local_table: None,
+            self_word: None,
         }
     }
 
@@ -65,7 +69,25 @@ impl<'a> ExprCompiler<'a> {
         vm: &'a mut VM,
         local_table: Option<&'a HashMap<String, usize>>,
     ) -> Self {
-        Self { vm, local_table }
+        Self {
+            vm,
+            local_table,
+            self_word: None,
+        }
+    }
+
+    /// Create an `ExprCompiler` with a local variable table and the name of the
+    /// word currently being compiled (for self-recursive call resolution).
+    pub fn with_context(
+        vm: &'a mut VM,
+        local_table: Option<&'a HashMap<String, usize>>,
+        self_word: Option<String>,
+    ) -> Self {
+        Self {
+            vm,
+            local_table,
+            self_word,
+        }
     }
 
     /// Parse `tokens` and return the corresponding RPN instruction sequence.
@@ -125,7 +147,7 @@ impl<'a> ExprCompiler<'a> {
 
                     let xt = self
                         .vm
-                        .lookup_any(&name)
+                        .lookup_including_self(&name, self.self_word.as_deref())
                         .ok_or_else(|| TbxError::UndefinedSymbol { name: name.clone() })?;
 
                     // Peek ahead: is this a function call (`F(`)?
@@ -199,9 +221,12 @@ impl<'a> ExprCompiler<'a> {
                                     output.push(Cell::Xt(xt_lit));
                                     output.push(Cell::StackAddr(idx));
                                 } else {
-                                    let xt = self.vm.lookup(&name).ok_or_else(|| {
-                                        TbxError::UndefinedSymbol { name: name.clone() }
-                                    })?;
+                                    let xt = self
+                                        .vm
+                                        .lookup_including_self(&name, self.self_word.as_deref())
+                                        .ok_or_else(|| TbxError::UndefinedSymbol {
+                                            name: name.clone(),
+                                        })?;
                                     let kind = self.vm.headers[xt.index()].kind.clone();
                                     match kind {
                                         EntryKind::Variable(addr) => {

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -125,7 +125,7 @@ impl<'a> ExprCompiler<'a> {
 
                     let xt = self
                         .vm
-                        .lookup(&name)
+                        .lookup_any(&name)
                         .ok_or_else(|| TbxError::UndefinedSymbol { name: name.clone() })?;
 
                     // Peek ahead: is this a function call (`F(`)?

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -388,6 +388,11 @@ impl Interpreter {
         // Register the new word immediately (forward calls within the body will resolve).
         let entry = crate::dict::WordEntry::new_word(&name, self.vm.dp);
         self.vm.register(entry);
+        // Smudge: hide the word from lookup until END completes, so that operator primitives
+        // with the same name (e.g. ADD, MUL) are not shadowed during body compilation.
+        if let Some(last) = self.vm.headers.last_mut() {
+            last.flags |= crate::dict::FLAG_HIDDEN;
+        }
 
         self.vm.is_compiling = true;
         self.compile_state = Some(CompileState {
@@ -440,11 +445,13 @@ impl Interpreter {
                 .map_err(&make_err)?;
         }
 
-        // Update the word header with the confirmed local_count.
+        // Update the word header with the confirmed local_count and unsmudge (make visible).
         // The word was registered as the last entry at hdr_len_at_def.
         let word_hdr_idx = state.hdr_len_at_def;
         if word_hdr_idx < self.vm.headers.len() {
             self.vm.headers[word_hdr_idx].local_count = state.local_count;
+            // Unsmudge: clear FLAG_HIDDEN so the word is now visible to lookup.
+            self.vm.headers[word_hdr_idx].flags &= !crate::dict::FLAG_HIDDEN;
         }
 
         // Seal user-defined space.
@@ -1513,5 +1520,21 @@ PUTDEC CHOOSE(0, 100, 200)
         let mut interp = Interpreter::new();
         interp.exec_source(src).unwrap();
         assert_eq!(interp.take_output(), "100 200");
+    }
+
+    #[test]
+    fn test_def_word_named_after_operator_primitive() {
+        // DEF ADD(A, B) RETURN A + B END must not cause infinite recursion.
+        // During body compilation, FLAG_HIDDEN prevents the compiler from resolving
+        // the `+` operator to the partially-compiled ADD word instead of the primitive.
+        let src = r#"
+DEF ADD(A, B)
+  RETURN A + B
+END
+PUTDEC ADD(3, 4)
+"#;
+        let mut interp = Interpreter::new();
+        interp.exec_source(src).unwrap();
+        assert_eq!(interp.take_output(), "7");
     }
 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -390,9 +390,7 @@ impl Interpreter {
         self.vm.register(entry);
         // Smudge: hide the word from lookup until END completes, so that operator primitives
         // with the same name (e.g. ADD, MUL) are not shadowed during body compilation.
-        if let Some(last) = self.vm.headers.last_mut() {
-            last.flags |= crate::dict::FLAG_HIDDEN;
-        }
+        self.vm.headers[hdr_len_at_def].flags |= crate::dict::FLAG_HIDDEN;
 
         self.vm.is_compiling = true;
         self.compile_state = Some(CompileState {
@@ -568,13 +566,17 @@ impl Interpreter {
         let make_err = |e: TbxError| InterpreterError::new(err_line, err_col, source_line, e);
 
         // Look up the statement word.
-        // Use lookup_any so that a word currently being compiled (FLAG_HIDDEN) can be called
-        // recursively as a statement from within its own body.
-        let stmt_xt = self.vm.lookup_any(stmt_name).ok_or_else(|| {
-            make_err(TbxError::UndefinedSymbol {
-                name: stmt_name.to_string(),
-            })
-        })?;
+        // Allow resolving the currently-compiled word (FLAG_HIDDEN) so that self-recursive
+        // statement calls work. Other hidden words remain invisible.
+        let self_word_opt = self.compile_state.as_ref().map(|s| s.word_name.as_str());
+        let stmt_xt = self
+            .vm
+            .lookup_including_self(stmt_name, self_word_opt)
+            .ok_or_else(|| {
+                make_err(TbxError::UndefinedSymbol {
+                    name: stmt_name.to_string(),
+                })
+            })?;
 
         // Reject system-internal words from user code.
         let stmt_flags = self.vm.headers[stmt_xt.index()].flags;
@@ -589,7 +591,8 @@ impl Interpreter {
         let arg_cells = {
             let local_table_opt: Option<&HashMap<String, usize>> =
                 self.compile_state.as_ref().map(|s| &s.local_table);
-            let mut compiler = ExprCompiler::with_local_table_opt(&mut self.vm, local_table_opt);
+            let self_word = self.compile_state.as_ref().map(|s| s.word_name.clone());
+            let mut compiler = ExprCompiler::with_context(&mut self.vm, local_table_opt, self_word);
             compiler.compile_expr(arg_tokens).map_err(&make_err)?
         };
 
@@ -785,7 +788,8 @@ impl Interpreter {
         // Compile the condition expression directly into the dictionary.
         let cond_cells = {
             let local_table_opt = self.compile_state.as_ref().map(|s| &s.local_table);
-            let mut compiler = ExprCompiler::with_local_table_opt(&mut self.vm, local_table_opt);
+            let self_word = self.compile_state.as_ref().map(|s| s.word_name.clone());
+            let mut compiler = ExprCompiler::with_context(&mut self.vm, local_table_opt, self_word);
             compiler.compile_expr(cond_tokens).map_err(&make_err)?
         };
         for cell in cond_cells {
@@ -822,8 +826,9 @@ impl Interpreter {
             // Compile the return expression directly into the dictionary.
             let expr_cells = {
                 let local_table_opt = self.compile_state.as_ref().map(|s| &s.local_table);
+                let self_word = self.compile_state.as_ref().map(|s| s.word_name.clone());
                 let mut compiler =
-                    ExprCompiler::with_local_table_opt(&mut self.vm, local_table_opt);
+                    ExprCompiler::with_context(&mut self.vm, local_table_opt, self_word);
                 compiler.compile_expr(arg_tokens).map_err(&make_err)?
             };
             for cell in expr_cells {
@@ -1542,6 +1547,43 @@ PUTDEC ADD(3, 4)
         let mut interp = Interpreter::new();
         interp.exec_source(src).unwrap();
         assert_eq!(interp.take_output(), "7");
+    }
+
+    #[test]
+    fn test_def_word_named_after_mul_primitive() {
+        // MUL is the primitive for `*`. A user word named MUL must not shadow it during body.
+        let src = r#"
+DEF MUL(A, B)
+  RETURN A * B
+END
+PUTDEC MUL(3, 4)
+"#;
+        let mut interp = Interpreter::new();
+        interp.exec_source(src).unwrap();
+        assert_eq!(interp.take_output(), "12");
+    }
+
+    #[test]
+    fn test_def_word_named_after_lt_primitive() {
+        // LT is the primitive for `<`. A user word named LT must not shadow it during body.
+        // Use LT result inside another DEF to verify correctness.
+        // Note: multi-arg statement calls use comma syntax: WORD arg1, arg2
+        let src = r#"
+DEF LT(A, B)
+  RETURN A < B
+END
+DEF CHECK(A, B)
+  BIF LT(A, B), 99
+    PUTSTR "yes"
+  99
+  RETURN
+END
+CHECK 1, 2
+CHECK 5, 3
+"#;
+        let mut interp = Interpreter::new();
+        interp.exec_source(src).unwrap();
+        assert_eq!(interp.take_output(), "yes");
     }
 
     #[test]

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -568,7 +568,13 @@ impl Interpreter {
         let make_err = |e: TbxError| InterpreterError::new(err_line, err_col, source_line, e);
 
         // Look up the statement word.
-        let stmt_xt = self.lookup_required(stmt_name, err_line, err_col, source_line)?;
+        // Use lookup_any so that a word currently being compiled (FLAG_HIDDEN) can be called
+        // recursively as a statement from within its own body.
+        let stmt_xt = self.vm.lookup_any(stmt_name).ok_or_else(|| {
+            make_err(TbxError::UndefinedSymbol {
+                name: stmt_name.to_string(),
+            })
+        })?;
 
         // Reject system-internal words from user code.
         let stmt_flags = self.vm.headers[stmt_xt.index()].flags;
@@ -1536,5 +1542,23 @@ PUTDEC ADD(3, 4)
         let mut interp = Interpreter::new();
         interp.exec_source(src).unwrap();
         assert_eq!(interp.take_output(), "7");
+    }
+
+    #[test]
+    fn test_self_recursive_word() {
+        // Self-recursive calls must work even though the word is FLAG_HIDDEN during compilation.
+        // FACT(N): returns N! (factorial). BIF N, 10 jumps to label 10 when N=0 (base case).
+        let src = r#"
+DEF FACT(N)
+  BIF N, 10
+    RETURN N * FACT(N - 1)
+  10
+  RETURN 1
+END
+PUTDEC FACT(5)
+"#;
+        let mut interp = Interpreter::new();
+        interp.exec_source(src).unwrap();
+        assert_eq!(interp.take_output(), "120");
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -112,18 +112,24 @@ impl VM {
         None
     }
 
-    /// Like `lookup`, but also returns entries with `FLAG_HIDDEN` set.
+    /// Like `lookup`, but also returns the entry with `FLAG_HIDDEN` set **only when**
+    /// the name matches `self_word`.
     ///
-    /// Use this when resolving user-defined word calls (including self-recursive calls)
-    /// during compilation. Operator-primitive resolution should use the regular `lookup`.
-    pub fn lookup_any(&self, name: &str) -> Option<Xt> {
+    /// This supports self-recursive calls during compilation: a word is visible to
+    /// itself (for recursion) but still hidden from other lookups (e.g. operator
+    /// primitives with the same name).
+    pub fn lookup_including_self(&self, name: &str, self_word: Option<&str>) -> Option<Xt> {
+        let allow_hidden = self_word
+            .map(|sw| sw.eq_ignore_ascii_case(name))
+            .unwrap_or(false);
         let mut current = self.latest;
         while let Some(xt) = current {
             if xt.index() >= self.headers.len() {
                 break;
             }
             let entry = &self.headers[xt.index()];
-            if entry.name == name {
+            let is_hidden = entry.flags & crate::dict::FLAG_HIDDEN != 0;
+            if entry.name == name && (!is_hidden || allow_hidden) {
                 return Some(xt);
             }
             current = entry.prev;
@@ -899,21 +905,42 @@ mod tests {
     }
 
     #[test]
-    fn test_lookup_any_finds_hidden_entry() {
-        // lookup_any must return FLAG_HIDDEN entries (needed for self-recursive calls).
+    fn test_lookup_including_self_finds_hidden_entry_only_for_self() {
+        // lookup_including_self must return the hidden entry only when the name matches self_word.
         use crate::dict::FLAG_HIDDEN;
         let mut vm = VM::new();
         crate::primitives::register_all(&mut vm);
 
-        // Register a user word with the same name as a primitive and smudge it.
+        // Register two user words and smudge both.
         vm.register(WordEntry::new_word("FACT", 500));
-        let user_xt = vm.lookup("FACT").unwrap();
+        let fact_xt = vm.lookup("FACT").unwrap();
         vm.headers.last_mut().unwrap().flags |= FLAG_HIDDEN;
 
-        // Regular lookup returns None (hidden).
+        vm.register(WordEntry::new_word("HELPER", 600));
+        let helper_xt = vm.lookup("HELPER").unwrap();
+        vm.headers.last_mut().unwrap().flags |= FLAG_HIDDEN;
+
+        // Regular lookup returns None for both (both hidden).
         assert_eq!(vm.lookup("FACT"), None);
-        // lookup_any returns the hidden entry.
-        assert_eq!(vm.lookup_any("FACT"), Some(user_xt));
+        assert_eq!(vm.lookup("HELPER"), None);
+
+        // lookup_including_self with self_word="FACT" finds FACT but NOT HELPER.
+        assert_eq!(
+            vm.lookup_including_self("FACT", Some("FACT")),
+            Some(fact_xt)
+        );
+        assert_eq!(vm.lookup_including_self("HELPER", Some("FACT")), None);
+
+        // With self_word="HELPER", finds HELPER but NOT FACT.
+        assert_eq!(
+            vm.lookup_including_self("HELPER", Some("HELPER")),
+            Some(helper_xt)
+        );
+        assert_eq!(vm.lookup_including_self("FACT", Some("HELPER")), None);
+
+        // With self_word=None, finds neither.
+        assert_eq!(vm.lookup_including_self("FACT", None), None);
+        assert_eq!(vm.lookup_including_self("HELPER", None), None);
     }
 
     #[test]

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -103,7 +103,8 @@ impl VM {
                 break;
             }
             let entry = &self.headers[xt.index()];
-            if entry.name == name {
+            // Skip hidden (smudge) entries — they are still being compiled.
+            if entry.name == name && entry.flags & crate::dict::FLAG_HIDDEN == 0 {
                 return Some(xt);
             }
             current = entry.prev;
@@ -852,6 +853,30 @@ mod tests {
         vm.latest = Some(Xt(99));
         // Should return None, not panic
         assert_eq!(vm.lookup("FOO"), None);
+    }
+
+    #[test]
+    fn test_lookup_skips_hidden_entry() {
+        // FLAG_HIDDEN entries must be invisible to lookup.
+        // If a system primitive and a hidden user word share a name,
+        // lookup must return the system primitive.
+        use crate::dict::FLAG_HIDDEN;
+        let mut vm = VM::new();
+        crate::primitives::register_all(&mut vm);
+
+        // "ADD" is already registered as a system primitive.
+        let sys_xt = vm.lookup("ADD").unwrap();
+
+        // Register a user word with the same name and smudge it.
+        vm.register(WordEntry::new_word("ADD", 999));
+        vm.headers.last_mut().unwrap().flags |= FLAG_HIDDEN;
+
+        // lookup("ADD") must still return the system primitive, not the hidden entry.
+        assert_eq!(vm.lookup("ADD"), Some(sys_xt));
+
+        // After clearing FLAG_HIDDEN, the user word should shadow the primitive.
+        vm.headers.last_mut().unwrap().flags &= !FLAG_HIDDEN;
+        assert_ne!(vm.lookup("ADD"), Some(sys_xt));
     }
 
     #[test]

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -119,9 +119,7 @@ impl VM {
     /// itself (for recursion) but still hidden from other lookups (e.g. operator
     /// primitives with the same name).
     pub fn lookup_including_self(&self, name: &str, self_word: Option<&str>) -> Option<Xt> {
-        let allow_hidden = self_word
-            .map(|sw| sw.eq_ignore_ascii_case(name))
-            .unwrap_or(false);
+        let allow_hidden = self_word.map(|sw| sw == name).unwrap_or(false);
         let mut current = self.latest;
         while let Some(xt) = current {
             if xt.index() >= self.headers.len() {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -112,6 +112,25 @@ impl VM {
         None
     }
 
+    /// Like `lookup`, but also returns entries with `FLAG_HIDDEN` set.
+    ///
+    /// Use this when resolving user-defined word calls (including self-recursive calls)
+    /// during compilation. Operator-primitive resolution should use the regular `lookup`.
+    pub fn lookup_any(&self, name: &str) -> Option<Xt> {
+        let mut current = self.latest;
+        while let Some(xt) = current {
+            if xt.index() >= self.headers.len() {
+                break;
+            }
+            let entry = &self.headers[xt.index()];
+            if entry.name == name {
+                return Some(xt);
+            }
+            current = entry.prev;
+        }
+        None
+    }
+
     /// Push a value onto the data stack.
     ///
     /// # Errors
@@ -877,6 +896,24 @@ mod tests {
         // After clearing FLAG_HIDDEN, the user word should shadow the primitive.
         vm.headers.last_mut().unwrap().flags &= !FLAG_HIDDEN;
         assert_ne!(vm.lookup("ADD"), Some(sys_xt));
+    }
+
+    #[test]
+    fn test_lookup_any_finds_hidden_entry() {
+        // lookup_any must return FLAG_HIDDEN entries (needed for self-recursive calls).
+        use crate::dict::FLAG_HIDDEN;
+        let mut vm = VM::new();
+        crate::primitives::register_all(&mut vm);
+
+        // Register a user word with the same name as a primitive and smudge it.
+        vm.register(WordEntry::new_word("FACT", 500));
+        let user_xt = vm.lookup("FACT").unwrap();
+        vm.headers.last_mut().unwrap().flags |= FLAG_HIDDEN;
+
+        // Regular lookup returns None (hidden).
+        assert_eq!(vm.lookup("FACT"), None);
+        // lookup_any returns the hidden entry.
+        assert_eq!(vm.lookup_any("FACT"), Some(user_xt));
     }
 
     #[test]


### PR DESCRIPTION
## 概要

Forthのsmudgeフラグを参考に、DEF〜END のコンパイル中ワードを辞書ルックアップから隠蔽する。

これにより `DEF ADD(A, B) RETURN A + B END` のように、ワード名が算術演算子プリミティブ名と一致するケースでの無限再帰を修正する。

## 変更内容

- **`src/dict.rs`**: `FLAG_HIDDEN = 0b0000_0100` 定数を追加（smudgeフラグ）
- **`src/vm.rs`**: `lookup()` で `FLAG_HIDDEN` のエントリをスキップ
- **`src/interpreter.rs`**: 
  - `handle_def`: 登録直後に `FLAG_HIDDEN` をセット（smudge）
  - `handle_end`: ヘッダ確定時に `FLAG_HIDDEN` を解除（unsmudge）
  - `rollback_def`: `headers.truncate()` でエントリごと削除されるため追加対応不要

## テスト

- `dict.rs`: `FLAG_HIDDEN` 定数値・ビット競合テスト
- `vm.rs`: `lookup()` が FLAG_HIDDEN エントリをスキップし、同名プリミティブを返すことを検証
- `interpreter.rs`: `DEF ADD(A, B) RETURN A + B END` → `PUTDEC ADD(3, 4)` が `7` を出力する統合テスト

Closes #229