### PR TITLE
fix: 式中の自己再帰 CALL で local_count が 0 のまま埋め込まれる問題を修正（ExprCompiler のパッチ漏れ）

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -50,6 +50,14 @@ pub struct ExprCompiler<'a> {
     /// Name of the word currently being compiled, used to allow self-recursive lookups.
     /// Only this word's hidden entry (FLAG_HIDDEN) is visible to identifier resolution.
     self_word: Option<String>,
+    /// Header index of the word currently being compiled (for self-recursive call detection).
+    /// `None` outside of compile mode or when patching is not needed.
+    self_hdr_idx: Option<usize>,
+    /// Offsets within the compiled output `Vec<Cell>` where a `local_count` placeholder
+    /// (`Cell::Int(0)`) was written for a self-recursive CALL instruction.
+    /// The caller must translate these to absolute dictionary positions and add them to
+    /// `CompileState::call_patch_list` after writing the cells to the dictionary.
+    pub patch_offsets: Vec<usize>,
 }
 
 impl<'a> ExprCompiler<'a> {
@@ -59,20 +67,28 @@ impl<'a> ExprCompiler<'a> {
             vm,
             local_table: None,
             self_word: None,
+            self_hdr_idx: None,
+            patch_offsets: Vec::new(),
         }
     }
 
     /// Create an `ExprCompiler` with a local variable table and the name of the
     /// word currently being compiled (for self-recursive call resolution).
+    /// `self_hdr_idx` is the header index of the word being compiled; when
+    /// a call to that same index is encountered in an expression, a `local_count`
+    /// placeholder is emitted and its offset recorded in `patch_offsets`.
     pub fn with_context(
         vm: &'a mut VM,
         local_table: Option<&'a HashMap<String, usize>>,
         self_word: Option<String>,
+        self_hdr_idx: Option<usize>,
     ) -> Self {
         Self {
             vm,
             local_table,
             self_word,
+            self_hdr_idx,
+            patch_offsets: Vec::new(),
         }
     }
 
@@ -151,7 +167,14 @@ impl<'a> ExprCompiler<'a> {
 
                         if next_is_rparen {
                             // Zero-argument call: emit based on entry kind.
-                            emit_call_by_kind(&mut output, xt, 0, self.vm)?;
+                            emit_call_by_kind(
+                                &mut output,
+                                xt,
+                                0,
+                                self.vm,
+                                self.self_hdr_idx,
+                                &mut self.patch_offsets,
+                            )?;
                             i += 2; // skip '(' and ')'
                             prev_was_operand = true;
                         } else {
@@ -172,7 +195,14 @@ impl<'a> ExprCompiler<'a> {
                             }
                             _ => {
                                 // Treat as a nullary call: emit based on entry kind.
-                                emit_call_by_kind(&mut output, xt, 0, self.vm)?;
+                                emit_call_by_kind(
+                                    &mut output,
+                                    xt,
+                                    0,
+                                    self.vm,
+                                    self.self_hdr_idx,
+                                    &mut self.patch_offsets,
+                                )?;
                             }
                         }
                         prev_was_operand = true;
@@ -307,7 +337,14 @@ impl<'a> ExprCompiler<'a> {
                         call: Some((xt, arity)),
                     }) = op_stack.pop()
                     {
-                        emit_call_by_kind(&mut output, xt, arity, self.vm)?;
+                        emit_call_by_kind(
+                            &mut output,
+                            xt,
+                            arity,
+                            self.vm,
+                            self.self_hdr_idx,
+                            &mut self.patch_offsets,
+                        )?;
                     }
                     prev_was_operand = true;
                 }
@@ -416,6 +453,8 @@ fn emit_local_read(output: &mut Vec<Cell>, idx: usize, vm: &VM) -> Result<(), Tb
 /// Emit the function-call sequence based on the `EntryKind` of `xt`.
 ///
 /// - `EntryKind::Word`: emits `Xt(CALL)`, `Xt(xt)`, `Int(arity)`, `Int(local_count)`
+///   - When `xt.index() == self_hdr_idx` (self-recursive call), emits `Int(0)` as a
+///     placeholder and records the offset in `patch_offsets` for later back-patching.
 /// - `EntryKind::Primitive` / `Variable` / `Constant`: emits `Xt(xt)` directly
 /// - Any internal kind (Lit, Call, Exit, ReturnVal, DropToMarker): returns `InvalidExpression`
 fn emit_call_by_kind(
@@ -423,16 +462,25 @@ fn emit_call_by_kind(
     xt: Xt,
     arity: usize,
     vm: &VM,
+    self_hdr_idx: Option<usize>,
+    patch_offsets: &mut Vec<usize>,
 ) -> Result<(), TbxError> {
     let kind = vm.headers[xt.index()].kind.clone();
     match kind {
         EntryKind::Word(_) => {
             let call_xt = require_xt(vm, "CALL")?;
-            let local_count = vm.headers[xt.index()].local_count;
             output.push(Cell::Xt(call_xt));
             output.push(Cell::Xt(xt));
             output.push(Cell::Int(arity as i64));
-            output.push(Cell::Int(local_count as i64));
+            // For a self-recursive call the local_count is not yet finalized — emit
+            // a placeholder (0) and record the offset so the caller can back-patch it.
+            if self_hdr_idx.is_some_and(|idx| idx == xt.index()) {
+                patch_offsets.push(output.len());
+                output.push(Cell::Int(0));
+            } else {
+                let local_count = vm.headers[xt.index()].local_count;
+                output.push(Cell::Int(local_count as i64));
+            }
         }
         EntryKind::Primitive(_) | EntryKind::Variable(_) | EntryKind::Constant(_) => {
             output.push(Cell::Xt(xt));

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -57,7 +57,7 @@ pub struct ExprCompiler<'a> {
     /// (`Cell::Int(0)`) was written for a self-recursive CALL instruction.
     /// The caller must translate these to absolute dictionary positions and add them to
     /// `CompileState::call_patch_list` after writing the cells to the dictionary.
-    pub patch_offsets: Vec<usize>,
+    pub(crate) patch_offsets: Vec<usize>,
 }
 
 impl<'a> ExprCompiler<'a> {

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1667,4 +1667,45 @@ PUTSTR "\n"
         interp.exec_source(src).unwrap();
         assert_eq!(interp.take_output(), "120\n");
     }
+
+    #[test]
+    fn test_recursive_self_call_in_return_expr() {
+        // Regression test for issue #222: self-recursive call inside RETURN expression
+        // (compile_return path) must have its local_count back-patched.
+        let src = r#"
+DEF FACT(N)
+  VAR R
+  BIT N <= 1, 10
+    LET &R, N - 1
+    RETURN N * FACT(R)
+  10 RETURN 1
+END
+PUTDEC FACT(5)
+PUTSTR "\n"
+"#;
+        let mut interp = Interpreter::new();
+        interp.exec_source(src).unwrap();
+        assert_eq!(interp.take_output(), "120\n");
+    }
+
+    #[test]
+    fn test_recursive_self_call_in_bif_condition() {
+        // Regression test for issue #222: self-recursive call inside BIF/BIT condition
+        // expression (compile_branch path) must have its local_count back-patched.
+        // COUNTDOWN(N) uses BIF with a recursive sub-expression in the condition.
+        let src = r#"
+DEF SUM(N)
+  VAR R
+  BIT N <= 0, 10
+    LET &R, SUM(N - 1)
+    RETURN N + R
+  10 RETURN 0
+END
+PUTDEC SUM(5)
+PUTSTR "\n"
+"#;
+        let mut interp = Interpreter::new();
+        interp.exec_source(src).unwrap();
+        assert_eq!(interp.take_output(), "15\n");
+    }
 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1692,20 +1692,28 @@ PUTSTR "\n"
     fn test_recursive_self_call_in_bif_condition() {
         // Regression test for issue #222: self-recursive call inside BIF/BIT condition
         // expression (compile_branch path) must have its local_count back-patched.
-        // COUNTDOWN(N) uses BIF with a recursive sub-expression in the condition.
+        //
+        // MYGT(R) appears directly inside the BIT condition `MYGT(R) > 0`, which is
+        // compiled by compile_branch via ExprCompiler. Without the fix, local_count=0
+        // would be permanently embedded, causing IndexOutOfBounds when the VAR R slot
+        // is accessed inside the recursive call.
+        //
+        // Trace: MYGT(3)->2, MYGT(2)->2, MYGT(1)->1, MYGT(0)->0
         let src = r#"
-DEF SUM(N)
+DEF MYGT(N)
   VAR R
   BIT N <= 0, 10
-    LET &R, SUM(N - 1)
-    RETURN N + R
+    LET &R, N - 1
+    BIT MYGT(R) > 0, 20
+      RETURN 1
+    20 RETURN 2
   10 RETURN 0
 END
-PUTDEC SUM(5)
+PUTDEC MYGT(3)
 PUTSTR "\n"
 "#;
         let mut interp = Interpreter::new();
         interp.exec_source(src).unwrap();
-        assert_eq!(interp.take_output(), "15\n");
+        assert_eq!(interp.take_output(), "2\n");
     }
 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -588,12 +588,16 @@ impl Interpreter {
 
         // Compile the argument expression to a cell sequence.
         // Local variables in the current compile scope shadow globals (local_table checked first).
-        let arg_cells = {
+        let (arg_cells, expr_patch_offsets) = {
             let local_table_opt: Option<&HashMap<String, usize>> =
                 self.compile_state.as_ref().map(|s| &s.local_table);
             let self_word = self.compile_state.as_ref().map(|s| s.word_name.clone());
-            let mut compiler = ExprCompiler::with_context(&mut self.vm, local_table_opt, self_word);
-            compiler.compile_expr(arg_tokens).map_err(&make_err)?
+            let self_hdr_idx = self.compile_state.as_ref().map(|s| s.hdr_len_at_def);
+            let mut compiler =
+                ExprCompiler::with_context(&mut self.vm, local_table_opt, self_word, self_hdr_idx);
+            let cells = compiler.compile_expr(arg_tokens).map_err(&make_err)?;
+            let offsets = std::mem::take(&mut compiler.patch_offsets);
+            (cells, offsets)
         };
 
         // Determine arity from top-level comma count.
@@ -622,8 +626,18 @@ impl Interpreter {
         self.vm
             .dict_write(Cell::Xt(lit_marker_xt))
             .map_err(&make_err)?;
+        // Record base_dp after LIT_MARKER so that expr_patch_offsets can be
+        // translated to absolute dictionary positions.
+        let base_dp = self.vm.dp;
         for cell in arg_cells {
             self.vm.dict_write(cell).map_err(&make_err)?;
+        }
+        // Register self-recursive local_count placeholder positions found inside
+        // the argument expression.
+        if let Some(state) = &mut self.compile_state {
+            for offset in expr_patch_offsets {
+                state.call_patch_list.push(base_dp + offset);
+            }
         }
         if stmt_is_word {
             // Determine local_count for the CALL instruction.
@@ -786,14 +800,26 @@ impl Interpreter {
         })?;
 
         // Compile the condition expression directly into the dictionary.
-        let cond_cells = {
+        let (cond_cells, expr_patch_offsets) = {
             let local_table_opt = self.compile_state.as_ref().map(|s| &s.local_table);
             let self_word = self.compile_state.as_ref().map(|s| s.word_name.clone());
-            let mut compiler = ExprCompiler::with_context(&mut self.vm, local_table_opt, self_word);
-            compiler.compile_expr(cond_tokens).map_err(&make_err)?
+            let self_hdr_idx = self.compile_state.as_ref().map(|s| s.hdr_len_at_def);
+            let mut compiler =
+                ExprCompiler::with_context(&mut self.vm, local_table_opt, self_word, self_hdr_idx);
+            let cells = compiler.compile_expr(cond_tokens).map_err(&make_err)?;
+            let offsets = std::mem::take(&mut compiler.patch_offsets);
+            (cells, offsets)
         };
+        let base_dp = self.vm.dp;
         for cell in cond_cells {
             self.vm.dict_write(cell).map_err(&make_err)?;
+        }
+        // Register self-recursive local_count placeholder positions found inside
+        // the condition expression.
+        if let Some(state) = &mut self.compile_state {
+            for offset in expr_patch_offsets {
+                state.call_patch_list.push(base_dp + offset);
+            }
         }
 
         // Emit BIF or BIT.
@@ -824,15 +850,30 @@ impl Interpreter {
 
         if !arg_tokens.is_empty() {
             // Compile the return expression directly into the dictionary.
-            let expr_cells = {
+            let (expr_cells, expr_patch_offsets) = {
                 let local_table_opt = self.compile_state.as_ref().map(|s| &s.local_table);
                 let self_word = self.compile_state.as_ref().map(|s| s.word_name.clone());
-                let mut compiler =
-                    ExprCompiler::with_context(&mut self.vm, local_table_opt, self_word);
-                compiler.compile_expr(arg_tokens).map_err(&make_err)?
+                let self_hdr_idx = self.compile_state.as_ref().map(|s| s.hdr_len_at_def);
+                let mut compiler = ExprCompiler::with_context(
+                    &mut self.vm,
+                    local_table_opt,
+                    self_word,
+                    self_hdr_idx,
+                );
+                let cells = compiler.compile_expr(arg_tokens).map_err(&make_err)?;
+                let offsets = std::mem::take(&mut compiler.patch_offsets);
+                (cells, offsets)
             };
+            let base_dp = self.vm.dp;
             for cell in expr_cells {
                 self.vm.dict_write(cell).map_err(&make_err)?;
+            }
+            // Register self-recursive local_count placeholder positions found inside
+            // the return expression.
+            if let Some(state) = &mut self.compile_state {
+                for offset in expr_patch_offsets {
+                    state.call_patch_list.push(base_dp + offset);
+                }
             }
             // Emit RETURN_VAL to return the top-of-stack value from the word.
             let return_val_xt = self.lookup_required("RETURN_VAL", line, col, source_line)?;
@@ -1602,5 +1643,28 @@ PUTDEC FACT(5)
         let mut interp = Interpreter::new();
         interp.exec_source(src).unwrap();
         assert_eq!(interp.take_output(), "120");
+    }
+
+    #[test]
+    fn test_recursive_with_var_expr() {
+        // Regression test for issue #222: self-recursive call inside a LET expression
+        // (processed by ExprCompiler) must have its local_count back-patched.
+        // Previously, local_count=0 was permanently embedded and caused IndexOutOfBounds
+        // at runtime when the VAR slot was accessed.
+        // Uses BIT (branch if true) so the base case label is reached when N <= 1 is true.
+        let src = r#"
+DEF FACT(N)
+  VAR R
+  BIT N <= 1, 10
+    LET &R, N * FACT(N - 1)
+    RETURN R
+  10 RETURN 1
+END
+PUTDEC FACT(5)
+PUTSTR "\n"
+"#;
+        let mut interp = Interpreter::new();
+        interp.exec_source(src).unwrap();
+        assert_eq!(interp.take_output(), "120\n");
     }
 }


### PR DESCRIPTION
## 概要

`ExprCompiler` が式中のワード呼び出し（`FACT(N-1)` など）に対して CALL 命令を生成する際、コンパイル中のワードの `local_count`（まだ 0）を永続的に埋め込んでいた問題を修正する。

## 問題の詳細

`interpreter.rs` の `write_stmt_to_dict` はステートメントレベルの自己再帰に対して `call_patch_list` パッチ機構を持つが、`ExprCompiler` にはこの機構がなかった。VAR ローカル変数を持つワードが `LET &R, N * FACT(N-1)` のように式中で自己再帰すると、CALL の `local_count=0` が確定値として埋め込まれ、実行時に `IndexOutOfBounds` エラーが発生していた。

## 変更内容

### `src/expr.rs`

- `ExprCompiler` に `self_hdr_idx: Option<usize>` と `pub patch_offsets: Vec<usize>` フィールドを追加
- `with_context` に `self_hdr_idx` 第4パラメータを追加
- `emit_call_by_kind` に `self_hdr_idx` と `patch_offsets` パラメータを追加し、自己再帰を検出した場合は `local_count` プレースホルダ（`Int(0)`）を書いてオフセットを `patch_offsets` に記録するよう変更
- `compile_expr` 内の `emit_call_by_kind` 3呼び出し箇所を更新

### `src/interpreter.rs`

- `write_stmt_to_dict`・`compile_branch`・`compile_return` の `with_context` 呼び出しに `self_hdr_idx`（`compile_state.hdr_len_at_def`）を渡すよう更新
- 各箇所でコンパイル後に `compiler.patch_offsets` を取り出し、`base_dp + offset` を `CompileState::call_patch_list` に追加
- `write_stmt_to_dict` では `LIT_MARKER` 書き込み直後の `dp` を `base_dp` として使用

### テスト追加

`test_recursive_with_var_expr`（`src/interpreter.rs`）:
```basic
DEF FACT(N)
  VAR R
  BIT N <= 1, 10
    LET &R, N * FACT(N - 1)
    RETURN R
  10 RETURN 1
END
PUTDEC FACT(5)
PUTSTR "\n"
```
`FACT(5)` が `120` を出力することを確認。

Closes #222
