### PR TITLE
fix: TbxError::InvalidOperand を追加し、CALL の値域エラー誤用を修正 (#226)

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -72,6 +72,14 @@ pub enum TbxError {
     DuplicateLabel {
         label: i64,
     },
+    /// An operand value is outside the valid range.
+    ///
+    /// The operand has the correct type but its value is not acceptable
+    /// (e.g., a negative arity or local_count in a CALL instruction).
+    InvalidOperand {
+        name: &'static str,
+        reason: &'static str,
+    },
 }
 
 impl std::fmt::Display for TbxError {
@@ -129,6 +137,9 @@ impl std::fmt::Display for TbxError {
             }
             TbxError::UndefinedLabel { label } => write!(f, "undefined label: {label}"),
             TbxError::DuplicateLabel { label } => write!(f, "duplicate label: {label}"),
+            TbxError::InvalidOperand { name, reason } => {
+                write!(f, "invalid operand '{name}': {reason}")
+            }
         }
     }
 }
@@ -193,5 +204,16 @@ mod tests {
         let msg = e.to_string();
         assert!(msg.contains("-7"));
         assert!(msg.contains("negative"));
+    }
+
+    #[test]
+    fn test_invalid_operand_display() {
+        let e = TbxError::InvalidOperand {
+            name: "arity",
+            reason: "must be non-negative",
+        };
+        let msg = e.to_string();
+        assert!(msg.contains("arity"));
+        assert!(msg.contains("must be non-negative"));
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -78,6 +78,7 @@ pub enum TbxError {
     /// (e.g., a negative arity or local_count in a CALL instruction).
     InvalidOperand {
         name: &'static str,
+        value: i64,
         reason: &'static str,
     },
 }
@@ -137,8 +138,12 @@ impl std::fmt::Display for TbxError {
             }
             TbxError::UndefinedLabel { label } => write!(f, "undefined label: {label}"),
             TbxError::DuplicateLabel { label } => write!(f, "duplicate label: {label}"),
-            TbxError::InvalidOperand { name, reason } => {
-                write!(f, "invalid operand '{name}': {reason}")
+            TbxError::InvalidOperand {
+                name,
+                value,
+                reason,
+            } => {
+                write!(f, "invalid operand '{name}' (value: {value}): {reason}")
             }
         }
     }
@@ -210,10 +215,13 @@ mod tests {
     fn test_invalid_operand_display() {
         let e = TbxError::InvalidOperand {
             name: "arity",
+            value: -1,
             reason: "must be non-negative",
         };
         let msg = e.to_string();
+        assert!(msg.contains("invalid operand"));
         assert!(msg.contains("arity"));
+        assert!(msg.contains("-1"));
         assert!(msg.contains("must be non-negative"));
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1145,7 +1145,11 @@ mod tests {
         let result = vm.run(start);
         assert!(matches!(
             result,
-            Err(crate::error::TbxError::InvalidOperand { value: -1, .. })
+            Err(crate::error::TbxError::InvalidOperand {
+                name: "arity",
+                value: -1,
+                ..
+            })
         ));
     }
 
@@ -1173,7 +1177,11 @@ mod tests {
         let result = vm.run(start);
         assert!(matches!(
             result,
-            Err(crate::error::TbxError::InvalidOperand { value: -1, .. })
+            Err(crate::error::TbxError::InvalidOperand {
+                name: "local_count",
+                value: -1,
+                ..
+            })
         ));
     }
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -457,6 +457,7 @@ impl VM {
                     if arity_raw < 0 {
                         return Err(TbxError::InvalidOperand {
                             name: "arity",
+                            value: arity_raw,
                             reason: "must be non-negative",
                         });
                     }
@@ -472,6 +473,7 @@ impl VM {
                     if local_count_raw < 0 {
                         return Err(TbxError::InvalidOperand {
                             name: "local_count",
+                            value: local_count_raw,
                             reason: "must be non-negative",
                         });
                     }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1145,7 +1145,7 @@ mod tests {
         let result = vm.run(start);
         assert!(matches!(
             result,
-            Err(crate::error::TbxError::InvalidOperand { .. })
+            Err(crate::error::TbxError::InvalidOperand { value: -1, .. })
         ));
     }
 
@@ -1173,7 +1173,7 @@ mod tests {
         let result = vm.run(start);
         assert!(matches!(
             result,
-            Err(crate::error::TbxError::InvalidOperand { .. })
+            Err(crate::error::TbxError::InvalidOperand { value: -1, .. })
         ));
     }
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -455,9 +455,9 @@ impl VM {
                         got: arity_cell.type_name(),
                     })?;
                     if arity_raw < 0 {
-                        return Err(TbxError::TypeError {
-                            expected: "non-negative Int (arity)",
-                            got: "negative value",
+                        return Err(TbxError::InvalidOperand {
+                            name: "arity",
+                            reason: "must be non-negative",
                         });
                     }
                     let arity = arity_raw as usize;
@@ -470,9 +470,9 @@ impl VM {
                                 got: local_count_cell.type_name(),
                             })?;
                     if local_count_raw < 0 {
-                        return Err(TbxError::TypeError {
-                            expected: "non-negative Int (local count)",
-                            got: "negative value",
+                        return Err(TbxError::InvalidOperand {
+                            name: "local_count",
+                            reason: "must be non-negative",
                         });
                     }
                     let local_count = local_count_raw as usize;
@@ -1121,7 +1121,7 @@ mod tests {
 
     #[test]
     fn test_call_negative_arity_returns_error() {
-        // Verify that a negative arity operand in CALL returns a TypeError.
+        // Verify that a negative arity operand in CALL returns an InvalidOperand error.
         let mut vm = VM::new();
         crate::primitives::register_all(&mut vm);
 
@@ -1143,7 +1143,35 @@ mod tests {
         let result = vm.run(start);
         assert!(matches!(
             result,
-            Err(crate::error::TbxError::TypeError { .. })
+            Err(crate::error::TbxError::InvalidOperand { .. })
+        ));
+    }
+
+    #[test]
+    fn test_call_negative_local_count_returns_error() {
+        // Verify that a negative local_count operand in CALL returns an InvalidOperand error.
+        let mut vm = VM::new();
+        crate::primitives::register_all(&mut vm);
+
+        let call_xt = vm.lookup("CALL").unwrap();
+        let exit_xt = vm.lookup("EXIT").unwrap();
+
+        // Dummy word body: just EXIT
+        let word_offset = vm.dp;
+        vm.dict_write(Cell::Xt(exit_xt)).unwrap();
+        let dummy_xt = vm.register(crate::dict::WordEntry::new_word("DUMMY_LC", word_offset));
+
+        // Top-level: CALL DUMMY_LC arity=0 local_count=-1
+        let start = vm.dp;
+        vm.dict_write(Cell::Xt(call_xt)).unwrap();
+        vm.dict_write(Cell::Xt(dummy_xt)).unwrap();
+        vm.dict_write(Cell::Int(0)).unwrap(); // arity=0
+        vm.dict_write(Cell::Int(-1)).unwrap(); // negative local_count
+
+        let result = vm.run(start);
+        assert!(matches!(
+            result,
+            Err(crate::error::TbxError::InvalidOperand { .. })
         ));
     }
 


### PR DESCRIPTION
## 概要

`TbxError::TypeError` を値域エラーに誤用していた箇所を修正する。
型は正しく `Int` として解析できているにもかかわらず値が負（不正な値域）であることを理由に `TypeError` を返していた。

## 変更内容

### error.rs
- `TbxError::InvalidOperand { name: &'static str, reason: &'static str }` バリアントを追加
- `Display` 実装に対応アームを追加: `"invalid operand '{name}': {reason}"`
- `test_invalid_operand_display` テストを追加

### vm.rs
- CALL の `arity_raw < 0` チェック: `TypeError` → `InvalidOperand { name: "arity", reason: "must be non-negative" }`
- CALL の `local_count_raw < 0` チェック: `TypeError` → `InvalidOperand { name: "local_count", reason: "must be non-negative" }`
- `test_call_negative_arity_returns_error`: 期待エラーを `TypeError` → `InvalidOperand` に更新
- `test_call_negative_local_count_returns_error` を新規追加

## 非変更箇所

- GOTO / BIF / BIT のジャンプターゲットチェックは `read_jump_target()` を通じて既に `InvalidJumpTarget { address }` を返しているため修正不要
- `test_call_non_word_target_rejected` は CALL 先が Word 以外の型という真の型エラーのため `TypeError` のまま変更不要

Closes #226
