### PR TITLE
VMトークンバッファ機構の設計と実装

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -81,6 +81,11 @@ pub enum TbxError {
         value: i64,
         reason: &'static str,
     },
+    /// The token stream is empty or has not been set on the VM.
+    ///
+    /// Returned by `VM::next_token()` when `token_stream` is `None` or the
+    /// `VecDeque` has been fully consumed.
+    TokenStreamEmpty,
 }
 
 impl std::fmt::Display for TbxError {
@@ -145,6 +150,7 @@ impl std::fmt::Display for TbxError {
             } => {
                 write!(f, "invalid operand '{name}' (value: {value}): {reason}")
             }
+            TbxError::TokenStreamEmpty => write!(f, "token stream is empty or not set"),
         }
     }
 }
@@ -223,5 +229,11 @@ mod tests {
         assert!(msg.contains("arity"));
         assert!(msg.contains("-1"));
         assert!(msg.contains("must be non-negative"));
+    }
+
+    #[test]
+    fn test_token_stream_empty_display() {
+        let e = TbxError::TokenStreamEmpty;
+        assert!(e.to_string().contains("token stream"));
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -90,6 +90,12 @@ impl VM {
     /// Consume the next token from the token stream.
     ///
     /// Returns `TbxError::TokenStreamEmpty` if `token_stream` is `None` or empty.
+    ///
+    /// Note: when the stream is exhausted, `token_stream` remains `Some([])` rather
+    /// than being reset to `None`. The caller (outer interpreter) is responsible for
+    /// setting `token_stream` back to `None` after the immediate-word execution
+    /// completes, so that `is_some()` reliably indicates "currently in an
+    /// immediate-word execution context".
     pub fn next_token(&mut self) -> Result<SpannedToken, TbxError> {
         match &mut self.token_stream {
             Some(stream) => stream.pop_front().ok_or(TbxError::TokenStreamEmpty),
@@ -2222,7 +2228,7 @@ mod tests {
 
     #[test]
     fn test_next_token_fifo_order() {
-        // Two tokens are returned in FIFO (push-front / pop-front) order
+        // Two tokens are returned in FIFO (push-back / pop-front) order
         let mut vm = VM::new();
         let tok1 = make_spanned(crate::lexer::Token::IntLit(1));
         let tok2 = make_spanned(crate::lexer::Token::IntLit(2));

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -2,6 +2,8 @@ use crate::cell::{Cell, ReturnFrame, Xt};
 use crate::constants::{MAX_DATA_STACK_DEPTH, MAX_DICTIONARY_CELLS, MAX_RETURN_STACK_DEPTH};
 use crate::dict::WordEntry;
 use crate::error::TbxError;
+use crate::lexer::SpannedToken;
+use std::collections::VecDeque;
 
 /// The TBX virtual machine.
 ///
@@ -54,6 +56,10 @@ pub struct VM {
     /// Compile mode flag: false = execution mode (STATE=0), true = compile mode (STATE=1).
     /// Toggled by DEF (enter compile mode) and END (return to execution mode).
     pub is_compiling: bool,
+    /// Token stream set by the outer interpreter before calling vm.run() for IMMEDIATE words.
+    /// Primitives consume tokens one at a time via `next_token()`.
+    /// Set to `None` outside of immediate-word execution.
+    pub token_stream: Option<VecDeque<SpannedToken>>,
 }
 
 impl VM {
@@ -77,6 +83,17 @@ impl VM {
             latest: None,
             output_buffer: String::new(),
             is_compiling: false,
+            token_stream: None,
+        }
+    }
+
+    /// Consume the next token from the token stream.
+    ///
+    /// Returns `TbxError::TokenStreamEmpty` if `token_stream` is `None` or empty.
+    pub fn next_token(&mut self) -> Result<SpannedToken, TbxError> {
+        match &mut self.token_stream {
+            Some(stream) => stream.pop_front().ok_or(TbxError::TokenStreamEmpty),
+            None => Err(TbxError::TokenStreamEmpty),
         }
     }
 
@@ -2147,5 +2164,70 @@ mod tests {
             result,
             Err(crate::error::TbxError::InvalidJumpTarget { address: -2 })
         );
+    }
+
+    // ── next_token() tests ────────────────────────────────────────────────────
+
+    fn make_spanned(token: crate::lexer::Token) -> crate::lexer::SpannedToken {
+        crate::lexer::SpannedToken {
+            token,
+            pos: crate::lexer::Position { line: 1, col: 1 },
+            source_offset: 0,
+            source_len: 1,
+        }
+    }
+
+    #[test]
+    fn test_next_token_none_stream() {
+        // token_stream is None → TokenStreamEmpty
+        let mut vm = VM::new();
+        assert_eq!(
+            vm.next_token(),
+            Err(crate::error::TbxError::TokenStreamEmpty)
+        );
+    }
+
+    #[test]
+    fn test_next_token_empty_stream() {
+        // token_stream is an empty VecDeque → TokenStreamEmpty
+        let mut vm = VM::new();
+        vm.token_stream = Some(VecDeque::new());
+        assert_eq!(
+            vm.next_token(),
+            Err(crate::error::TbxError::TokenStreamEmpty)
+        );
+    }
+
+    #[test]
+    fn test_next_token_single_token() {
+        // Providing one token returns Ok(token)
+        let mut vm = VM::new();
+        let tok = make_spanned(crate::lexer::Token::Ident("HELLO".to_string()));
+        vm.token_stream = Some(VecDeque::from([tok.clone()]));
+        assert_eq!(vm.next_token(), Ok(tok));
+    }
+
+    #[test]
+    fn test_next_token_exhausted_after_consume() {
+        // After consuming the single token, the next call returns TokenStreamEmpty
+        let mut vm = VM::new();
+        let tok = make_spanned(crate::lexer::Token::Ident("X".to_string()));
+        vm.token_stream = Some(VecDeque::from([tok]));
+        let _ = vm.next_token(); // consume
+        assert_eq!(
+            vm.next_token(),
+            Err(crate::error::TbxError::TokenStreamEmpty)
+        );
+    }
+
+    #[test]
+    fn test_next_token_fifo_order() {
+        // Two tokens are returned in FIFO (push-front / pop-front) order
+        let mut vm = VM::new();
+        let tok1 = make_spanned(crate::lexer::Token::IntLit(1));
+        let tok2 = make_spanned(crate::lexer::Token::IntLit(2));
+        vm.token_stream = Some(VecDeque::from([tok1.clone(), tok2.clone()]));
+        assert_eq!(vm.next_token(), Ok(tok1));
+        assert_eq!(vm.next_token(), Ok(tok2));
     }
 }


### PR DESCRIPTION
## 概要

issue #240「VMトークンバッファ機構の設計と実装」の実装です（変更スコープ: `src/error.rs`, `src/vm.rs` の2ファイル）。

アウターインタプリタが IMMEDIATE ワード実行前にトークンストリームを VM にセットし、プリミティブが `next_token()` を通じて1トークンずつ消費できる機構を追加しました。

> **Note**: issue #240 に記載されているアウターインタプリタ側の対応（`vm.token_stream` のセット・残留トークンの引き取り）は issue #230・#144 のスコープであり、このPRには含まれません。

## 変更内容

### `src/error.rs`
- `TbxError::TokenStreamEmpty` バリアントを追加
- Display 実装: `"token stream is empty or not set"`
- テスト: Display 出力に `"token stream"` が含まれること

### `src/vm.rs`
- `use std::collections::VecDeque` と `use crate::lexer::SpannedToken` を追加
- `VM` 構造体に `pub token_stream: Option<VecDeque<SpannedToken>>` フィールドを追加
- `VM::new()` に `token_stream: None` を追加
- `VM::next_token()` メソッドを追加（ストリームが `None` または空のとき `TbxError::TokenStreamEmpty` を返す）
- 以下の5テストを追加:
  - `token_stream` が `None` のとき `Err(TokenStreamEmpty)` を返す
  - `token_stream` が空 `VecDeque` のとき `Err(TokenStreamEmpty)` を返す
  - 1トークンをセットして `Ok(token)` を返す
  - 1トークン消費後の再呼び出しが `Err(TokenStreamEmpty)` を返す
  - 2トークンをセットして FIFO 順（tok1 → tok2）で返る

Closes #240
