### PR TITLE
IMMEDIATEプリミティブの追加とユーザー定義IMMEDIATEワードのサポート (#147, #245)

### DIFF
--- a/src/dict.rs
+++ b/src/dict.rs
@@ -83,6 +83,10 @@ pub struct WordEntry {
     pub flags: u8,
     /// How this entry is executed or accessed
     pub kind: EntryKind,
+    /// Number of formal parameters declared in `DEF WORD(A, B, ...)`.
+    /// Set to 0 at registration time and patched to the final count when END is compiled.
+    /// Used to detect unsupported IMMEDIATE dispatch of parameterised words.
+    pub arity: usize,
     /// Number of VAR-declared local variables in this word's body.
     /// Set to 0 at registration time and patched to the final count when END is compiled.
     /// Used by callers to emit the correct `local_count` operand in CALL instructions.
@@ -101,6 +105,7 @@ impl WordEntry {
             name: name.to_string(),
             flags: 0,
             kind: EntryKind::Primitive(f),
+            arity: 0,
             local_count: 0,
             prev: None,
         }
@@ -112,6 +117,7 @@ impl WordEntry {
             name: name.to_string(),
             flags: 0,
             kind: EntryKind::Word(offset),
+            arity: 0,
             local_count: 0,
             prev: None,
         }
@@ -123,6 +129,7 @@ impl WordEntry {
             name: name.to_string(),
             flags: 0,
             kind: EntryKind::Variable(idx),
+            arity: 0,
             local_count: 0,
             prev: None,
         }
@@ -134,6 +141,7 @@ impl WordEntry {
             name: name.to_string(),
             flags: 0,
             kind: EntryKind::Constant(value),
+            arity: 0,
             local_count: 0,
             prev: None,
         }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1239,6 +1239,7 @@ mod tests {
             name: "INTERNAL".to_string(),
             flags: 0,
             kind: EntryKind::Lit,
+            arity: 0,
             local_count: 0,
             prev: None,
         });

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -207,7 +207,10 @@ impl Interpreter {
 
                 // Clone the kind to determine how to dispatch without holding a borrow on self.vm.
                 let kind = self.vm.headers[xt.index()].kind.clone();
-                // Also capture local_count to guard against words that require a call frame.
+                // Capture arity and local_count to guard against words that require a call frame.
+                // vm.run() does not set up bp or local variable slots; words with formal
+                // parameters or VAR locals would access the wrong stack positions.
+                let arity = self.vm.headers[xt.index()].arity;
                 let local_count = self.vm.headers[xt.index()].local_count;
 
                 // Feed remaining tokens into vm.token_stream.
@@ -224,13 +227,14 @@ impl Interpreter {
                     // temporary-buffer issues when the primitive writes to the dictionary).
                     crate::dict::EntryKind::Primitive(f) => f(&mut self.vm),
                     // User-defined word: run via vm.run(), passing the body start address.
-                    // Guard: words with VAR locals require a CALL frame (bp/stack setup)
-                    // that vm.run() alone does not provide. Reject them here to prevent
+                    // Guard: words with formal parameters (arity > 0) or VAR locals
+                    // (local_count > 0) require a CALL frame (bp/stack setup) that
+                    // vm.run() alone does not provide. Reject them here to prevent
                     // silent stack corruption.
                     crate::dict::EntryKind::Word(body_addr) => {
-                        if local_count > 0 {
+                        if arity > 0 || local_count > 0 {
                             Err(TbxError::InvalidExpression {
-                                reason: "IMMEDIATE user word with VAR locals cannot be called without a CALL frame",
+                                reason: "IMMEDIATE user word with parameters or VAR locals cannot be called without a CALL frame",
                             })
                         } else {
                             self.vm.run(body_addr)
@@ -1386,7 +1390,8 @@ IWORD
 END
 OUTER";
         interp.exec_source(src).unwrap();
-        // IWORD runs at compile time (inside DEF OUTER) and at call time.
+        // IWORD is IMMEDIATE, so it executes immediately at compile time inside DEF OUTER
+        // and is NOT compiled into OUTER's body. Calling OUTER does not re-execute IWORD.
         let out = interp.take_output();
         assert!(
             out.contains("77"),
@@ -1398,7 +1403,7 @@ OUTER";
     #[test]
     fn test_user_defined_immediate_word_with_locals_returns_error() {
         // A user word with VAR locals cannot be IMMEDIATE-dispatched directly
-        // because vm.run() does not set up the CALL frame.
+        // because vm.run() does not set up the CALL frame (bp / local slots).
         let mut interp = Interpreter::new();
         let src = "\
 DEF ILOCAL
@@ -1411,6 +1416,24 @@ ILOCAL";
         assert!(
             result.is_err(),
             "expected error when IMMEDIATE word has VAR locals"
+        );
+    }
+
+    #[test]
+    fn test_user_defined_immediate_word_with_arity_returns_error() {
+        // A user word with formal parameters (arity > 0) cannot be IMMEDIATE-dispatched
+        // directly because vm.run() does not set up the CALL frame.
+        let mut interp = Interpreter::new();
+        let src = "\
+DEF IPARAM(X)
+PUTDEC X
+END
+IMMEDIATE IPARAM
+IPARAM 42";
+        let result = interp.exec_source(src);
+        assert!(
+            result.is_err(),
+            "expected error when IMMEDIATE word has formal parameters"
         );
     }
 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1371,26 +1371,41 @@ IWORD";
 
     #[test]
     fn test_user_defined_immediate_word_executes_during_compile() {
-        // A user word flagged as IMMEDIATE should also execute during compilation of another word.
+        // A user word flagged as IMMEDIATE should execute at compile time, not be compiled into
+        // the calling word's body.
+
         let mut interp = Interpreter::new();
-        let src = "\
+
+        // Phase 1: define IWORD, mark it IMMEDIATE, then compile OUTER which references IWORD.
+        // Because IWORD is IMMEDIATE it should be executed immediately during compilation of OUTER
+        // and must NOT be stored into OUTER's body.
+        interp
+            .exec_source(
+                "\
 DEF IWORD
 PUTDEC 77
 END
 IMMEDIATE IWORD
 DEF OUTER
 IWORD
-END
-OUTER";
-        interp.exec_source(src).unwrap();
-        // IWORD is IMMEDIATE, so it executes exactly once at compile time inside DEF OUTER
-        // and is NOT compiled into OUTER's body. Calling OUTER does not re-execute IWORD.
-        // Using exact-match to distinguish "compiled into body" (outputs "7777") from
-        // "IMMEDIATE only" (outputs "77" once at compile time).
-        let out = interp.take_output();
+END",
+            )
+            .unwrap();
+
+        // IWORD ran once at compile time, so output should be "77".
+        let compile_out = interp.take_output();
         assert_eq!(
-            out, "77",
-            "expected exactly '77' (compile-time only), got: {out:?}"
+            compile_out, "77",
+            "IWORD must execute during compilation of OUTER (got: {compile_out:?})"
+        );
+
+        // Phase 2: call OUTER at runtime. Since IWORD was not compiled into OUTER's body,
+        // executing OUTER should produce no output.
+        interp.exec_source("OUTER").unwrap();
+        let runtime_out = interp.take_output();
+        assert_eq!(
+            runtime_out, "",
+            "OUTER must not re-execute IWORD at runtime (got: {runtime_out:?})"
         );
     }
 

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -207,6 +207,8 @@ impl Interpreter {
 
                 // Clone the kind to determine how to dispatch without holding a borrow on self.vm.
                 let kind = self.vm.headers[xt.index()].kind.clone();
+                // Also capture local_count to guard against words that require a call frame.
+                let local_count = self.vm.headers[xt.index()].local_count;
 
                 // Feed remaining tokens into vm.token_stream.
                 let remaining: VecDeque<SpannedToken> = tokens[idx..].iter().cloned().collect();
@@ -222,7 +224,18 @@ impl Interpreter {
                     // temporary-buffer issues when the primitive writes to the dictionary).
                     crate::dict::EntryKind::Primitive(f) => f(&mut self.vm),
                     // User-defined word: run via vm.run(), passing the body start address.
-                    crate::dict::EntryKind::Word(body_addr) => self.vm.run(body_addr),
+                    // Guard: words with VAR locals require a CALL frame (bp/stack setup)
+                    // that vm.run() alone does not provide. Reject them here to prevent
+                    // silent stack corruption.
+                    crate::dict::EntryKind::Word(body_addr) => {
+                        if local_count > 0 {
+                            Err(TbxError::InvalidExpression {
+                                reason: "IMMEDIATE user word with VAR locals cannot be called without a CALL frame",
+                            })
+                        } else {
+                            self.vm.run(body_addr)
+                        }
+                    }
                     _ => {
                         self.vm.token_stream = None;
                         return Err(make_err(TbxError::InvalidExpression {
@@ -1336,5 +1349,68 @@ PUTSTR "\n"
         let mut interp = Interpreter::new();
         interp.exec_source(src).unwrap();
         assert_eq!(interp.take_output(), "2\n");
+    }
+
+    // --- user-defined IMMEDIATE word dispatch (issue #245) ---
+
+    #[test]
+    fn test_user_defined_immediate_word_executes_in_interpret_mode() {
+        // A user word flagged as IMMEDIATE should execute immediately in interpret mode.
+        let mut interp = Interpreter::new();
+        let src = "\
+DEF IWORD
+PUTDEC 99
+END
+IMMEDIATE IWORD
+IWORD";
+        interp.exec_source(src).unwrap();
+        let out = interp.take_output();
+        assert!(
+            out.contains("99"),
+            "expected '99' in output, got: {:?}",
+            out
+        );
+    }
+
+    #[test]
+    fn test_user_defined_immediate_word_executes_during_compile() {
+        // A user word flagged as IMMEDIATE should also execute during compilation of another word.
+        let mut interp = Interpreter::new();
+        let src = "\
+DEF IWORD
+PUTDEC 77
+END
+IMMEDIATE IWORD
+DEF OUTER
+IWORD
+END
+OUTER";
+        interp.exec_source(src).unwrap();
+        // IWORD runs at compile time (inside DEF OUTER) and at call time.
+        let out = interp.take_output();
+        assert!(
+            out.contains("77"),
+            "expected '77' in output, got: {:?}",
+            out
+        );
+    }
+
+    #[test]
+    fn test_user_defined_immediate_word_with_locals_returns_error() {
+        // A user word with VAR locals cannot be IMMEDIATE-dispatched directly
+        // because vm.run() does not set up the CALL frame.
+        let mut interp = Interpreter::new();
+        let src = "\
+DEF ILOCAL
+VAR X
+PUTDEC 1
+END
+IMMEDIATE ILOCAL
+ILOCAL";
+        let result = interp.exec_source(src);
+        assert!(
+            result.is_err(),
+            "expected error when IMMEDIATE word has VAR locals"
+        );
     }
 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -240,12 +240,9 @@ impl Interpreter {
                             self.vm.run(body_addr)
                         }
                     }
-                    _ => {
-                        self.vm.token_stream = None;
-                        return Err(make_err(TbxError::InvalidExpression {
-                            reason: "IMMEDIATE word kind is not executable",
-                        }));
-                    }
+                    _ => Err(TbxError::InvalidExpression {
+                        reason: "IMMEDIATE word kind is not executable",
+                    }),
                 };
 
                 // Clear token stream.
@@ -1369,11 +1366,7 @@ IMMEDIATE IWORD
 IWORD";
         interp.exec_source(src).unwrap();
         let out = interp.take_output();
-        assert!(
-            out.contains("99"),
-            "expected '99' in output, got: {:?}",
-            out
-        );
+        assert_eq!(out, "99", "expected '99' in output, got: {:?}", out);
     }
 
     #[test]
@@ -1435,6 +1428,69 @@ IPARAM 42";
         assert!(
             result.is_err(),
             "expected error when IMMEDIATE word has formal parameters"
+        );
+    }
+
+    #[test]
+    fn test_immediate_on_constant_returns_error_and_rolls_back() {
+        // Applying FLAG_IMMEDIATE to a Constant dictionary entry and invoking it should
+        // return an error (the `_ =>` branch) and roll back compile_state so
+        // that the interpreter can be reused normally.
+        let mut interp = Interpreter::new();
+
+        // Register a Constant entry with FLAG_IMMEDIATE directly via the VM,
+        // since TBX has no built-in CONSTANT keyword.
+        {
+            use crate::cell::Cell;
+            use crate::dict::{WordEntry, FLAG_IMMEDIATE};
+            let mut entry = WordEntry::new_constant("MAGIC", Cell::Int(42));
+            entry.flags |= FLAG_IMMEDIATE;
+            interp.vm.register(entry);
+        }
+
+        // Calling the IMMEDIATE-flagged constant inside a DEF should fail.
+        let bad = "DEF BAD\nMAGIC\nEND";
+        assert!(
+            interp.exec_source(bad).is_err(),
+            "expected error when an IMMEDIATE Constant is dispatched"
+        );
+
+        // After the error the interpreter must be fully recovered: define and
+        // call a valid word to confirm compile_state was properly rolled back.
+        interp
+            .exec_source("DEF OK\nPUTDEC 7\nEND\nOK")
+            .expect("interpreter should be reusable after IMMEDIATE-Constant error");
+        assert_eq!(
+            interp.take_output(),
+            "7",
+            "expected '7' from OK after rollback"
+        );
+    }
+
+    #[test]
+    fn test_immediate_on_variable_returns_error_and_rolls_back() {
+        // VAR X outside a DEF creates a global Variable entry. Marking it IMMEDIATE
+        // and invoking it inside a DEF should trigger the `_ =>` branch, return an
+        // error, and leave the interpreter in a clean state.
+        let mut interp = Interpreter::new();
+
+        // VAR outside DEF creates a global Variable; IMMEDIATE marks it FLAG_IMMEDIATE.
+        interp.exec_source("VAR V\nIMMEDIATE V").unwrap();
+
+        let bad = "DEF BAD\nV\nEND";
+        assert!(
+            interp.exec_source(bad).is_err(),
+            "expected error when an IMMEDIATE Variable is dispatched"
+        );
+
+        // The interpreter should be reusable after the rollback.
+        interp
+            .exec_source("DEF OK2\nPUTDEC 8\nEND\nOK2")
+            .expect("interpreter should be reusable after IMMEDIATE-Variable error");
+        assert_eq!(
+            interp.take_output(),
+            "8",
+            "expected '8' from OK2 after rollback"
         );
     }
 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -197,7 +197,7 @@ impl Interpreter {
 
         // IMMEDIATE word dispatch: execute immediately regardless of compile/interpret mode.
         // If the looked-up word has FLAG_IMMEDIATE set, feed the remaining tokens into
-        // vm.token_stream and call the primitive directly (not via vm.run()).
+        // vm.token_stream and execute it directly.
         if let Some(xt) = self.vm.lookup(&stmt_name) {
             let flags = self.vm.headers[xt.index()].flags;
             if flags & crate::dict::FLAG_IMMEDIATE != 0 {
@@ -205,17 +205,8 @@ impl Interpreter {
                     InterpreterError::new(stmt_pos_line, stmt_pos_col, source_line, e)
                 };
 
-                // Get the primitive function pointer before any other borrows.
-                let prim_fn = match self.vm.headers[xt.index()].kind.clone() {
-                    crate::dict::EntryKind::Primitive(f) => f,
-                    _ => {
-                        // TODO(#245): user-defined IMMEDIATE words are not yet supported.
-                        // Currently only EntryKind::Primitive can be flagged as IMMEDIATE.
-                        return Err(make_err(TbxError::InvalidExpression {
-                            reason: "IMMEDIATE word must be a primitive",
-                        }));
-                    }
-                };
+                // Clone the kind to determine how to dispatch without holding a borrow on self.vm.
+                let kind = self.vm.headers[xt.index()].kind.clone();
 
                 // Feed remaining tokens into vm.token_stream.
                 let remaining: VecDeque<SpannedToken> = tokens[idx..].iter().cloned().collect();
@@ -226,9 +217,19 @@ impl Interpreter {
                 let saved_return_stack_len = self.vm.return_stack.len();
                 let saved_bp = self.vm.bp;
 
-                // Call the primitive directly (not through vm.run() to avoid
-                // the temporary-buffer issues when the primitive writes to the dictionary).
-                let run_result = prim_fn(&mut self.vm);
+                let run_result = match kind {
+                    // Native primitive: call the function pointer directly (avoids
+                    // temporary-buffer issues when the primitive writes to the dictionary).
+                    crate::dict::EntryKind::Primitive(f) => f(&mut self.vm),
+                    // User-defined word: run via vm.run(), passing the body start address.
+                    crate::dict::EntryKind::Word(body_addr) => self.vm.run(body_addr),
+                    _ => {
+                        self.vm.token_stream = None;
+                        return Err(make_err(TbxError::InvalidExpression {
+                            reason: "IMMEDIATE word kind is not executable",
+                        }));
+                    }
+                };
 
                 // Clear token stream.
                 self.vm.token_stream = None;

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1390,13 +1390,14 @@ IWORD
 END
 OUTER";
         interp.exec_source(src).unwrap();
-        // IWORD is IMMEDIATE, so it executes immediately at compile time inside DEF OUTER
+        // IWORD is IMMEDIATE, so it executes exactly once at compile time inside DEF OUTER
         // and is NOT compiled into OUTER's body. Calling OUTER does not re-execute IWORD.
+        // Using exact-match to distinguish "compiled into body" (outputs "7777") from
+        // "IMMEDIATE only" (outputs "77" once at compile time).
         let out = interp.take_output();
-        assert!(
-            out.contains("77"),
-            "expected '77' in output, got: {:?}",
-            out
+        assert_eq!(
+            out, "77",
+            "expected exactly '77' (compile-time only), got: {out:?}"
         );
     }
 

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -2358,6 +2358,86 @@ mod tests {
         assert!(vm.headers[xt.index()].is_immediate());
     }
 
+    // --- immediate_prim ---
+
+    #[test]
+    fn test_immediate_prim_sets_flag() {
+        // IMMEDIATE FOO should set FLAG_IMMEDIATE on the word "FOO".
+        use std::collections::VecDeque;
+        let mut vm = VM::new();
+        // Register a plain word entry so lookup("FOO") succeeds.
+        let entry = crate::dict::WordEntry::new_word("FOO", 0);
+        vm.register(entry);
+        assert!(!vm.headers[vm.lookup("FOO").unwrap().index()].is_immediate());
+        vm.token_stream = Some(VecDeque::from([make_ident_token("FOO")]));
+        immediate_prim(&mut vm).unwrap();
+        assert!(vm.headers[vm.lookup("FOO").unwrap().index()].is_immediate());
+    }
+
+    #[test]
+    fn test_immediate_prim_is_idempotent() {
+        // Calling IMMEDIATE twice on the same word must not corrupt the flags.
+        use std::collections::VecDeque;
+        let mut vm = VM::new();
+        let entry = crate::dict::WordEntry::new_word("BAR", 0);
+        vm.register(entry);
+        for _ in 0..2 {
+            vm.token_stream = Some(VecDeque::from([make_ident_token("BAR")]));
+            immediate_prim(&mut vm).unwrap();
+        }
+        let xt = vm.lookup("BAR").unwrap();
+        // Only FLAG_IMMEDIATE should be set (bit-OR idempotent).
+        assert_eq!(
+            vm.headers[xt.index()].flags & crate::dict::FLAG_IMMEDIATE,
+            crate::dict::FLAG_IMMEDIATE
+        );
+    }
+
+    #[test]
+    fn test_immediate_prim_non_ident_token_returns_error() {
+        // A non-Ident token must produce an InvalidExpression error.
+        use std::collections::VecDeque;
+        let mut vm = VM::new();
+        let tok = crate::lexer::SpannedToken {
+            token: crate::lexer::Token::IntLit(1),
+            pos: crate::lexer::Position { line: 1, col: 1 },
+            source_offset: 0,
+            source_len: 1,
+        };
+        vm.token_stream = Some(VecDeque::from([tok]));
+        let err = immediate_prim(&mut vm).unwrap_err();
+        assert!(matches!(err, TbxError::InvalidExpression { .. }));
+    }
+
+    #[test]
+    fn test_immediate_prim_undefined_word_returns_error() {
+        // Specifying a word name that is not in the dictionary must return UndefinedSymbol.
+        use std::collections::VecDeque;
+        let mut vm = VM::new();
+        vm.token_stream = Some(VecDeque::from([make_ident_token("NOSUCHWORD")]));
+        let err = immediate_prim(&mut vm).unwrap_err();
+        assert!(
+            matches!(err, TbxError::UndefinedSymbol { ref name } if name == "NOSUCHWORD"),
+            "expected UndefinedSymbol(NOSUCHWORD), got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_immediate_prim_no_stream_returns_token_stream_empty() {
+        // token_stream is None → TokenStreamEmpty.
+        let mut vm = VM::new();
+        assert_eq!(immediate_prim(&mut vm), Err(TbxError::TokenStreamEmpty));
+    }
+
+    #[test]
+    fn test_immediate_prim_registered_in_register_all() {
+        // register_all() must include IMMEDIATE in the dictionary with FLAG_IMMEDIATE.
+        let mut vm = VM::new();
+        crate::primitives::register_all(&mut vm);
+        let xt = vm.lookup("IMMEDIATE").unwrap();
+        assert!(vm.headers[xt.index()].is_immediate());
+    }
+
     // ---------------------------------------------------------------------------
     // Error-path tests for IMMEDIATE primitives
     // ---------------------------------------------------------------------------

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -469,7 +469,7 @@ pub fn immediate_prim(vm: &mut VM) -> Result<(), TbxError> {
     };
     let xt = vm
         .lookup(&name)
-        .ok_or(TbxError::UndefinedSymbol { name: name.clone() })?;
+        .ok_or_else(|| TbxError::UndefinedSymbol { name: name.clone() })?;
     vm.headers[xt.index()].flags |= FLAG_IMMEDIATE;
     Ok(())
 }
@@ -616,9 +616,10 @@ pub fn end_prim(vm: &mut VM) -> Result<(), TbxError> {
             return Err(e);
         }
     }
-    // Update word header: confirm local_count, unsmudge.
+    // Update word header: confirm arity, local_count, unsmudge.
     let word_hdr_idx = state.word_hdr_idx();
     if word_hdr_idx < vm.headers.len() {
+        vm.headers[word_hdr_idx].arity = state.arity;
         vm.headers[word_hdr_idx].local_count = state.local_count;
         vm.headers[word_hdr_idx].flags &= !crate::dict::FLAG_HIDDEN;
     }
@@ -912,6 +913,7 @@ pub fn register_all(vm: &mut VM) {
         name: "CALL".to_string(),
         flags: FLAG_SYSTEM,
         kind: EntryKind::Call,
+        arity: 0,
         local_count: 0,
         prev: None,
     });
@@ -919,6 +921,7 @@ pub fn register_all(vm: &mut VM) {
         name: "EXIT".to_string(),
         flags: FLAG_SYSTEM,
         kind: EntryKind::Exit,
+        arity: 0,
         local_count: 0,
         prev: None,
     });
@@ -926,6 +929,7 @@ pub fn register_all(vm: &mut VM) {
         name: "RETURN_VAL".to_string(),
         flags: FLAG_SYSTEM,
         kind: EntryKind::ReturnVal,
+        arity: 0,
         local_count: 0,
         prev: None,
     });
@@ -933,6 +937,7 @@ pub fn register_all(vm: &mut VM) {
         name: "DROP_TO_MARKER".to_string(),
         flags: FLAG_SYSTEM,
         kind: EntryKind::DropToMarker,
+        arity: 0,
         local_count: 0,
         prev: None,
     });
@@ -940,6 +945,7 @@ pub fn register_all(vm: &mut VM) {
         name: "GOTO".to_string(),
         flags: FLAG_SYSTEM,
         kind: EntryKind::Goto,
+        arity: 0,
         local_count: 0,
         prev: None,
     });
@@ -947,6 +953,7 @@ pub fn register_all(vm: &mut VM) {
         name: "BIF".to_string(),
         flags: FLAG_SYSTEM,
         kind: EntryKind::BranchIfFalse,
+        arity: 0,
         local_count: 0,
         prev: None,
     });
@@ -954,6 +961,7 @@ pub fn register_all(vm: &mut VM) {
         name: "BIT".to_string(),
         flags: FLAG_SYSTEM,
         kind: EntryKind::BranchIfTrue,
+        arity: 0,
         local_count: 0,
         prev: None,
     });
@@ -964,6 +972,7 @@ pub fn register_all(vm: &mut VM) {
         name: "LIT".to_string(),
         flags: FLAG_SYSTEM,
         kind: EntryKind::Lit,
+        arity: 0,
         local_count: 0,
         prev: None,
     });

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -449,6 +449,31 @@ pub fn header_prim(vm: &mut VM) -> Result<(), TbxError> {
     Ok(())
 }
 
+/// IMMEDIATE — read the next token as a word name and set FLAG_IMMEDIATE on it.
+///
+/// `IMMEDIATE name ( -- )` — consumes the next identifier token from `vm.token_stream`,
+/// looks up the word in the dictionary, and sets its `FLAG_IMMEDIATE` flag.
+/// Returns an error if the word is not found or the token is not an identifier.
+///
+/// Unlike Forth's `IMMEDIATE` (which implicitly operates on the most recently defined word),
+/// TBX requires the target word name to be specified explicitly.
+pub fn immediate_prim(vm: &mut VM) -> Result<(), TbxError> {
+    let tok = vm.next_token()?;
+    let name = match tok.token {
+        Token::Ident(n) => n,
+        _ => {
+            return Err(TbxError::InvalidExpression {
+                reason: "IMMEDIATE: expected identifier token",
+            })
+        }
+    };
+    let xt = vm
+        .lookup(&name)
+        .ok_or(TbxError::UndefinedSymbol { name: name.clone() })?;
+    vm.headers[xt.index()].flags |= FLAG_IMMEDIATE;
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // IMMEDIATE compile-time primitives
 // ---------------------------------------------------------------------------
@@ -954,6 +979,10 @@ pub fn register_all(vm: &mut VM) {
     let mut header_entry = WordEntry::new_primitive("HEADER", header_prim);
     header_entry.flags = FLAG_IMMEDIATE | FLAG_SYSTEM;
     vm.register(header_entry);
+    // IMMEDIATE: reads next token and sets FLAG_IMMEDIATE on the named word.
+    let mut immediate_entry = WordEntry::new_primitive("IMMEDIATE", immediate_prim);
+    immediate_entry.flags = FLAG_IMMEDIATE | FLAG_SYSTEM;
+    vm.register(immediate_entry);
     // IMMEDIATE system words: DEF, END, VAR, GOTO, BIF, BIT, RETURN
     let mut def_entry = WordEntry::new_primitive("DEF", def_prim);
     def_entry.flags = FLAG_IMMEDIATE | FLAG_SYSTEM;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1927,6 +1927,7 @@ mod tests {
                 name: "TARGET".to_string(),
                 flags: 0,
                 kind,
+                arity: 0,
                 local_count: 0,
                 prev: None,
             });


### PR DESCRIPTION
## 概要

issue #147（`IMMEDIATE` プリミティブの追加）と issue #245（ユーザー定義 IMMEDIATE ワードのサポート）をまとめて実装します。

## 変更内容

### `src/primitives.rs`（issue #147）

- `immediate_prim` を実装
  - `vm.next_token()` で次のトークンを読み込み、`Ident(name)` 以外はエラー
  - `vm.lookup(&name)` で辞書を検索し、未定義なら `TbxError::UndefinedSymbol { name }` を返す
  - `vm.headers[xt.index()].flags |= FLAG_IMMEDIATE` でフラグを設定
- `register_all` に `"IMMEDIATE"` を `FLAG_IMMEDIATE | FLAG_SYSTEM` で登録

### `src/interpreter.rs`（issue #245）

- `exec_segment` の IMMEDIATE ディスパッチで `EntryKind::Word(body_addr)` ブランチを追加
  - `vm.run(body_addr)` でユーザー定義 IMMEDIATE ワードを実行
  - トークンセット処理を match の前に移動して構造を整理
  - `TODO(#245)` コメントを解消

Closes #147
Closes #245
