### PR TITLE
DEFワードのパース改善: 手書きDFAによるパラメータリスト解析

### DIFF
--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -501,14 +501,16 @@ pub fn def_prim(vm: &mut VM) -> Result<(), TbxError> {
 
     // Parse optional parameter list: DEF WORD(X, Y, ...)
     //
-    // DFA states:
-    //   LParenOrEnd    — after word name: expect '(' or EOL
-    //   ParamOrRParen  — after '(' or after registering a param: expect ident or ')'
-    //   Param          — after ',': next must be ident (')'  is trailing-comma error)
+    // DFA with 4 states:
+    //   LParenOrEnd      — after word name: expect '(' or EOL
+    //   FirstParamOrEnd  — right after '(': expect ident or ')'  (comma here = leading-comma error)
+    //   CommaOrRParen    — after registering a param: expect ',' or ')'  (ident here = missing-comma error)
+    //   NextParam        — after ',': next must be ident  (')' = trailing-comma error)
     enum DefParseState {
         LParenOrEnd,
-        ParamOrRParen,
-        Param,
+        FirstParamOrEnd,
+        CommaOrRParen,
+        NextParam,
     }
 
     let mut local_table: HashMap<String, usize> = HashMap::new();
@@ -520,7 +522,7 @@ pub fn def_prim(vm: &mut VM) -> Result<(), TbxError> {
             Ok(tok) => match (&state, tok.token) {
                 // --- LParenOrEnd ---
                 (DefParseState::LParenOrEnd, crate::lexer::Token::LParen) => {
-                    state = DefParseState::ParamOrRParen;
+                    state = DefParseState::FirstParamOrEnd;
                 }
                 (DefParseState::LParenOrEnd, _) => {
                     return Err(TbxError::InvalidExpression {
@@ -528,36 +530,46 @@ pub fn def_prim(vm: &mut VM) -> Result<(), TbxError> {
                     });
                 }
 
-                // --- ParamOrRParen ---
-                (DefParseState::ParamOrRParen, crate::lexer::Token::RParen) => {
-                    break; // Normal end of parameter list.
+                // --- FirstParamOrEnd: immediately after '(' ---
+                (DefParseState::FirstParamOrEnd, crate::lexer::Token::RParen) => {
+                    break; // Empty parameter list: DEF WORD().
                 }
-                (DefParseState::ParamOrRParen, crate::lexer::Token::Ident(param)) => {
+                (DefParseState::FirstParamOrEnd, crate::lexer::Token::Ident(param)) => {
                     local_table.insert(param, arity);
                     arity += 1;
-                    state = DefParseState::ParamOrRParen;
+                    state = DefParseState::CommaOrRParen;
                 }
-                (DefParseState::ParamOrRParen, crate::lexer::Token::Comma) => {
-                    state = DefParseState::Param;
-                }
-                (DefParseState::ParamOrRParen, _) => {
+                (DefParseState::FirstParamOrEnd, _) => {
                     return Err(TbxError::InvalidExpression {
-                        reason: "expected identifier, ',' or ')' in parameter list",
+                        reason: "expected identifier or ')' after '('",
                     });
                 }
 
-                // --- Param ---
-                (DefParseState::Param, crate::lexer::Token::Ident(param)) => {
+                // --- CommaOrRParen: after registering a parameter ---
+                (DefParseState::CommaOrRParen, crate::lexer::Token::RParen) => {
+                    break; // Normal end of parameter list.
+                }
+                (DefParseState::CommaOrRParen, crate::lexer::Token::Comma) => {
+                    state = DefParseState::NextParam;
+                }
+                (DefParseState::CommaOrRParen, _) => {
+                    return Err(TbxError::InvalidExpression {
+                        reason: "expected ',' or ')' after parameter name",
+                    });
+                }
+
+                // --- NextParam: after ',' ---
+                (DefParseState::NextParam, crate::lexer::Token::Ident(param)) => {
                     local_table.insert(param, arity);
                     arity += 1;
-                    state = DefParseState::ParamOrRParen;
+                    state = DefParseState::CommaOrRParen;
                 }
-                (DefParseState::Param, crate::lexer::Token::RParen) => {
+                (DefParseState::NextParam, crate::lexer::Token::RParen) => {
                     return Err(TbxError::InvalidExpression {
                         reason: "trailing comma before ')' is not allowed",
                     });
                 }
-                (DefParseState::Param, _) => {
+                (DefParseState::NextParam, _) => {
                     return Err(TbxError::InvalidExpression {
                         reason: "expected identifier after ',' in parameter list",
                     });
@@ -2641,6 +2653,46 @@ mod tests {
         assert!(
             matches!(err, TbxError::InvalidExpression { .. }),
             "expected InvalidExpression for trailing comma, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_def_params_without_comma() {
+        // DEF WORD(X Y) — missing comma between parameters must return InvalidExpression.
+        use std::collections::VecDeque;
+        let mut vm = VM::new();
+        register_all(&mut vm);
+        vm.token_stream = Some(VecDeque::from([
+            make_ident_token("WORD"),
+            make_lparen_token(),
+            make_ident_token("X"),
+            make_ident_token("Y"),
+            make_rparen_token(),
+        ]));
+        let err = def_prim(&mut vm).unwrap_err();
+        assert!(
+            matches!(err, TbxError::InvalidExpression { .. }),
+            "expected InvalidExpression for missing comma between params, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_def_leading_comma() {
+        // DEF WORD(,X) — leading comma must return InvalidExpression.
+        use std::collections::VecDeque;
+        let mut vm = VM::new();
+        register_all(&mut vm);
+        vm.token_stream = Some(VecDeque::from([
+            make_ident_token("WORD"),
+            make_lparen_token(),
+            make_comma_token(),
+            make_ident_token("X"),
+            make_rparen_token(),
+        ]));
+        let err = def_prim(&mut vm).unwrap_err();
+        assert!(
+            matches!(err, TbxError::InvalidExpression { .. }),
+            "expected InvalidExpression for leading comma, got {err:?}"
         );
     }
 

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -2761,6 +2761,28 @@ mod tests {
         assert_eq!(state.local_table.get("Y").copied(), Some(1));
     }
 
+    #[test]
+    fn test_def_prim_empty_params_enters_compile_mode() {
+        // DEF WORD() — explicit empty parameter list must enter compile mode with arity=0.
+        use std::collections::VecDeque;
+        let mut vm = VM::new();
+        register_all(&mut vm);
+        vm.token_stream = Some(VecDeque::from([
+            make_ident_token("WORD"),
+            make_lparen_token(),
+            make_rparen_token(),
+        ]));
+        def_prim(&mut vm).unwrap();
+        assert!(vm.is_compiling, "is_compiling must be true after DEF");
+        let state = vm
+            .compile_state
+            .as_ref()
+            .expect("compile_state must be set");
+        assert_eq!(state.word_name, "WORD");
+        assert_eq!(state.arity, 0);
+        assert!(state.local_table.is_empty());
+    }
+
     // --- end_prim normal case ---
 
     #[test]

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -2724,31 +2724,13 @@ mod tests {
         let mut vm = VM::new();
         register_all(&mut vm);
         // Tokens: WORD ( X , Y )
-        let lparen = crate::lexer::SpannedToken {
-            token: crate::lexer::Token::LParen,
-            pos: crate::lexer::Position { line: 1, col: 5 },
-            source_offset: 4,
-            source_len: 1,
-        };
-        let comma = crate::lexer::SpannedToken {
-            token: crate::lexer::Token::Comma,
-            pos: crate::lexer::Position { line: 1, col: 7 },
-            source_offset: 6,
-            source_len: 1,
-        };
-        let rparen = crate::lexer::SpannedToken {
-            token: crate::lexer::Token::RParen,
-            pos: crate::lexer::Position { line: 1, col: 9 },
-            source_offset: 8,
-            source_len: 1,
-        };
         vm.token_stream = Some(VecDeque::from([
             make_ident_token("WORD"),
-            lparen,
+            make_lparen_token(),
             make_ident_token("X"),
-            comma,
+            make_comma_token(),
             make_ident_token("Y"),
-            rparen,
+            make_rparen_token(),
         ]));
         def_prim(&mut vm).unwrap();
         assert!(vm.is_compiling, "is_compiling must be true after DEF");

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -500,50 +500,79 @@ pub fn def_prim(vm: &mut VM) -> Result<(), TbxError> {
     };
 
     // Parse optional parameter list: DEF WORD(X, Y, ...)
+    //
+    // DFA states:
+    //   LParenOrEnd    — after word name: expect '(' or EOL
+    //   ParamOrRParen  — after '(' or after registering a param: expect ident or ')'
+    //   Param          — after ',': next must be ident (')'  is trailing-comma error)
+    enum DefParseState {
+        LParenOrEnd,
+        ParamOrRParen,
+        Param,
+    }
+
     let mut local_table: HashMap<String, usize> = HashMap::new();
     let mut arity: usize = 0;
+    let mut state = DefParseState::LParenOrEnd;
 
-    match vm.next_token() {
-        Ok(tok) if matches!(tok.token, crate::lexer::Token::LParen) => {
-            // Parse parameters until ')'
-            loop {
-                match vm.next_token() {
-                    Ok(tok) => match tok.token {
-                        crate::lexer::Token::RParen => break,
-                        crate::lexer::Token::Ident(param) => {
-                            local_table.insert(param, arity);
-                            arity += 1;
-                            // Skip optional comma or check for RParen.
-                            match vm.next_token() {
-                                Ok(t) if matches!(t.token, crate::lexer::Token::Comma) => {}
-                                Ok(t) if matches!(t.token, crate::lexer::Token::RParen) => break,
-                                Ok(_) => {
-                                    return Err(TbxError::InvalidExpression {
-                                        reason: "expected ',' or ')' after parameter name",
-                                    })
-                                }
-                                Err(TbxError::TokenStreamEmpty) => break,
-                                Err(e) => return Err(e),
-                            }
-                        }
-                        _ => {
-                            return Err(TbxError::InvalidExpression {
-                                reason: "expected identifier or ')' in parameter list",
-                            })
-                        }
-                    },
-                    Err(TbxError::TokenStreamEmpty) => break,
-                    Err(e) => return Err(e),
+    loop {
+        match vm.next_token() {
+            Ok(tok) => match (&state, tok.token) {
+                // --- LParenOrEnd ---
+                (DefParseState::LParenOrEnd, crate::lexer::Token::LParen) => {
+                    state = DefParseState::ParamOrRParen;
                 }
-            }
+                (DefParseState::LParenOrEnd, _) => {
+                    return Err(TbxError::InvalidExpression {
+                        reason: "expected '(' or end of line after word name in DEF",
+                    });
+                }
+
+                // --- ParamOrRParen ---
+                (DefParseState::ParamOrRParen, crate::lexer::Token::RParen) => {
+                    break; // Normal end of parameter list.
+                }
+                (DefParseState::ParamOrRParen, crate::lexer::Token::Ident(param)) => {
+                    local_table.insert(param, arity);
+                    arity += 1;
+                    state = DefParseState::ParamOrRParen;
+                }
+                (DefParseState::ParamOrRParen, crate::lexer::Token::Comma) => {
+                    state = DefParseState::Param;
+                }
+                (DefParseState::ParamOrRParen, _) => {
+                    return Err(TbxError::InvalidExpression {
+                        reason: "expected identifier, ',' or ')' in parameter list",
+                    });
+                }
+
+                // --- Param ---
+                (DefParseState::Param, crate::lexer::Token::Ident(param)) => {
+                    local_table.insert(param, arity);
+                    arity += 1;
+                    state = DefParseState::ParamOrRParen;
+                }
+                (DefParseState::Param, crate::lexer::Token::RParen) => {
+                    return Err(TbxError::InvalidExpression {
+                        reason: "trailing comma before ')' is not allowed",
+                    });
+                }
+                (DefParseState::Param, _) => {
+                    return Err(TbxError::InvalidExpression {
+                        reason: "expected identifier after ',' in parameter list",
+                    });
+                }
+            },
+            Err(TbxError::TokenStreamEmpty) => match state {
+                DefParseState::LParenOrEnd => break, // No parameter list — normal end.
+                _ => {
+                    return Err(TbxError::InvalidExpression {
+                        reason: "unclosed '(' in parameter list",
+                    });
+                }
+            },
+            Err(e) => return Err(e),
         }
-        Ok(_) => {
-            return Err(TbxError::InvalidExpression {
-                reason: "expected '(' or end of line after word name in DEF",
-            })
-        }
-        Err(TbxError::TokenStreamEmpty) => {} // End of stream — no parameters
-        Err(e) => return Err(e),
     }
 
     // Snapshot for rollback.
@@ -2506,6 +2535,112 @@ mod tests {
         assert!(
             matches!(err, TbxError::InvalidExpression { .. }),
             "expected InvalidExpression for unexpected token after word name, got {err:?}"
+        );
+    }
+
+    // --- def_prim error paths: unclosed parentheses and trailing comma ---
+
+    /// Helper: build a SpannedToken with LParen.
+    fn make_lparen_token() -> crate::lexer::SpannedToken {
+        crate::lexer::SpannedToken {
+            token: crate::lexer::Token::LParen,
+            pos: crate::lexer::Position { line: 1, col: 5 },
+            source_offset: 4,
+            source_len: 1,
+        }
+    }
+
+    /// Helper: build a SpannedToken with Comma.
+    fn make_comma_token() -> crate::lexer::SpannedToken {
+        crate::lexer::SpannedToken {
+            token: crate::lexer::Token::Comma,
+            pos: crate::lexer::Position { line: 1, col: 7 },
+            source_offset: 6,
+            source_len: 1,
+        }
+    }
+
+    /// Helper: build a SpannedToken with RParen.
+    fn make_rparen_token() -> crate::lexer::SpannedToken {
+        crate::lexer::SpannedToken {
+            token: crate::lexer::Token::RParen,
+            pos: crate::lexer::Position { line: 1, col: 9 },
+            source_offset: 8,
+            source_len: 1,
+        }
+    }
+
+    #[test]
+    fn test_def_unclosed_paren_no_params() {
+        // DEF WORD( — unclosed '(' with no parameters must return InvalidExpression.
+        use std::collections::VecDeque;
+        let mut vm = VM::new();
+        register_all(&mut vm);
+        vm.token_stream = Some(VecDeque::from([
+            make_ident_token("WORD"),
+            make_lparen_token(),
+        ]));
+        let err = def_prim(&mut vm).unwrap_err();
+        assert!(
+            matches!(err, TbxError::InvalidExpression { .. }),
+            "expected InvalidExpression for unclosed '(', got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_def_unclosed_paren_with_param() {
+        // DEF WORD(X — unclosed '(' after one parameter must return InvalidExpression.
+        use std::collections::VecDeque;
+        let mut vm = VM::new();
+        register_all(&mut vm);
+        vm.token_stream = Some(VecDeque::from([
+            make_ident_token("WORD"),
+            make_lparen_token(),
+            make_ident_token("X"),
+        ]));
+        let err = def_prim(&mut vm).unwrap_err();
+        assert!(
+            matches!(err, TbxError::InvalidExpression { .. }),
+            "expected InvalidExpression for unclosed '(' after param, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_def_unclosed_paren_after_comma() {
+        // DEF WORD(X, — unclosed '(' after comma must return InvalidExpression.
+        use std::collections::VecDeque;
+        let mut vm = VM::new();
+        register_all(&mut vm);
+        vm.token_stream = Some(VecDeque::from([
+            make_ident_token("WORD"),
+            make_lparen_token(),
+            make_ident_token("X"),
+            make_comma_token(),
+        ]));
+        let err = def_prim(&mut vm).unwrap_err();
+        assert!(
+            matches!(err, TbxError::InvalidExpression { .. }),
+            "expected InvalidExpression for unclosed '(' after comma, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_def_trailing_comma() {
+        // DEF WORD(X,) — trailing comma before ')' must return InvalidExpression.
+        use std::collections::VecDeque;
+        let mut vm = VM::new();
+        register_all(&mut vm);
+        vm.token_stream = Some(VecDeque::from([
+            make_ident_token("WORD"),
+            make_lparen_token(),
+            make_ident_token("X"),
+            make_comma_token(),
+            make_rparen_token(),
+        ]));
+        let err = def_prim(&mut vm).unwrap_err();
+        assert!(
+            matches!(err, TbxError::InvalidExpression { .. }),
+            "expected InvalidExpression for trailing comma, got {err:?}"
         );
     }
 

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -535,6 +535,11 @@ pub fn def_prim(vm: &mut VM) -> Result<(), TbxError> {
                     break; // Empty parameter list: DEF WORD().
                 }
                 (DefParseState::FirstParamOrEnd, crate::lexer::Token::Ident(param)) => {
+                    if local_table.contains_key(&param) {
+                        return Err(TbxError::InvalidExpression {
+                            reason: "duplicate parameter name in parameter list",
+                        });
+                    }
                     local_table.insert(param, arity);
                     arity += 1;
                     state = DefParseState::CommaOrRParen;
@@ -560,6 +565,11 @@ pub fn def_prim(vm: &mut VM) -> Result<(), TbxError> {
 
                 // --- NextParam: after ',' ---
                 (DefParseState::NextParam, crate::lexer::Token::Ident(param)) => {
+                    if local_table.contains_key(&param) {
+                        return Err(TbxError::InvalidExpression {
+                            reason: "duplicate parameter name in parameter list",
+                        });
+                    }
                     local_table.insert(param, arity);
                     arity += 1;
                     state = DefParseState::CommaOrRParen;
@@ -2693,6 +2703,52 @@ mod tests {
         assert!(
             matches!(err, TbxError::InvalidExpression { .. }),
             "expected InvalidExpression for leading comma, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_def_duplicate_param_name() {
+        // DEF WORD(X, X) — duplicate parameter name must return InvalidExpression.
+        use std::collections::VecDeque;
+        let mut vm = VM::new();
+        register_all(&mut vm);
+        vm.token_stream = Some(VecDeque::from([
+            make_ident_token("WORD"),
+            make_lparen_token(),
+            make_ident_token("X"),
+            make_comma_token(),
+            make_ident_token("X"),
+            make_rparen_token(),
+        ]));
+        let err = def_prim(&mut vm).unwrap_err();
+        assert!(
+            matches!(err, TbxError::InvalidExpression { .. }),
+            "expected InvalidExpression for duplicate param name, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_def_invalid_token_after_comma() {
+        // DEF WORD(X, 42) — non-ident token after comma must return InvalidExpression.
+        use std::collections::VecDeque;
+        let mut vm = VM::new();
+        register_all(&mut vm);
+        vm.token_stream = Some(VecDeque::from([
+            make_ident_token("WORD"),
+            make_lparen_token(),
+            make_ident_token("X"),
+            make_comma_token(),
+            crate::lexer::SpannedToken {
+                token: crate::lexer::Token::IntLit(42),
+                pos: crate::lexer::Position { line: 1, col: 9 },
+                source_offset: 8,
+                source_len: 2,
+            },
+        ]));
+        let err = def_prim(&mut vm).unwrap_err();
+        assert!(
+            matches!(err, TbxError::InvalidExpression { .. }),
+            "expected InvalidExpression for non-ident after comma, got {err:?}"
         );
     }
 


### PR DESCRIPTION
## 概要

`def_prim()` 内の3重ネスト `match + loop` を手書きDFA（`enum DefParseState`）に置き換え、未閉鎖括弧や末尾コンマのエラー検出を正確に行えるようにした。

## 変更内容

### 実装

- `src/primitives.rs` の `def_prim()` 内にローカル `enum DefParseState` を定義
  - `LParenOrEnd` — ワード名読み後：`(` またはEOLを期待
  - `ParamOrRParen` — `(` 読み後またはパラメータ登録後：識別子または `)` を期待
  - `Param` — `,` 後：次は識別子が必須（`)` は末尾コンマエラー）
- 各状態で `TokenStreamEmpty` を個別に処理することで、未閉鎖括弧を正しくエラーにする
- `loop + match (state, token)` で状態遷移を平坦に表現し、可読性を向上

### バグ修正

- `DEF WORD(X` のように `)` がない場合でもコンパイルモードに入ってしまう問題を修正
- `DEF WORD(X,)` のような末尾コンマを許容していた問題を修正

### テスト追加

| テスト名 | 入力 | 期待結果 |
|---|---|---|
| `test_def_unclosed_paren_no_params` | `WORD (` | `InvalidExpression` |
| `test_def_unclosed_paren_with_param` | `WORD ( X` | `InvalidExpression` |
| `test_def_unclosed_paren_after_comma` | `WORD ( X ,` | `InvalidExpression` |
| `test_def_trailing_comma` | `WORD ( X , )` | `InvalidExpression` |

## 影響範囲

- `src/primitives.rs` の `def_prim()` 関数のみ
- 外部APIへの変更なし（関数シグネチャ不変）

Closes #248
