### PR TITLE
fix: FirstParamOrEnd状態の重複チェック(dead code)を削除 #251

### DIFF
--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -535,11 +535,6 @@ pub fn def_prim(vm: &mut VM) -> Result<(), TbxError> {
                     break; // Empty parameter list: DEF WORD().
                 }
                 (DefParseState::FirstParamOrEnd, crate::lexer::Token::Ident(param)) => {
-                    if local_table.contains_key(&param) {
-                        return Err(TbxError::InvalidExpression {
-                            reason: "duplicate parameter name in parameter list",
-                        });
-                    }
                     local_table.insert(param, arity);
                     arity += 1;
                     state = DefParseState::CommaOrRParen;


### PR DESCRIPTION
## 概要

`src/primitives.rs` の `def_prim()` 関数内、`FirstParamOrEnd` 状態の `Ident` ブランチに存在するdead codeを削除する。

## 変更内容

- `FirstParamOrEnd` 状態に到達した時点で `local_table` は常に空のため、`local_table.contains_key(&param)` が `true` になることはない
- 到達不能な `if` ブロック（重複パラメータ名チェック）を削除する

Closes #251
