### PR TITLE
test: DEF文の1番目と3番目パラメータ重複チェックテストを追加

### DIFF
--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -2809,7 +2809,7 @@ mod tests {
         ]));
         let err = def_prim(&mut vm).unwrap_err();
         assert!(
-            matches!(err, TbxError::InvalidExpression { .. }),
+            matches!(err, TbxError::InvalidExpression { reason } if reason.contains("duplicate parameter name")),
             "expected InvalidExpression for duplicate param name, got {err:?}"
         );
     }
@@ -2832,7 +2832,7 @@ mod tests {
         ]));
         let err = def_prim(&mut vm).unwrap_err();
         assert!(
-            matches!(err, TbxError::InvalidExpression { .. }),
+            matches!(err, TbxError::InvalidExpression { reason } if reason.contains("duplicate parameter name")),
             "expected InvalidExpression for first-and-third duplicate param, got {err:?}"
         );
     }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -2815,6 +2815,29 @@ mod tests {
     }
 
     #[test]
+    fn test_def_duplicate_param_name_first_and_third() {
+        // DEF WORD(X, Y, X) — duplicate between 1st and 3rd param must return InvalidExpression.
+        use std::collections::VecDeque;
+        let mut vm = VM::new();
+        register_all(&mut vm);
+        vm.token_stream = Some(VecDeque::from([
+            make_ident_token("WORD"),
+            make_lparen_token(),
+            make_ident_token("X"),
+            make_comma_token(),
+            make_ident_token("Y"),
+            make_comma_token(),
+            make_ident_token("X"),
+            make_rparen_token(),
+        ]));
+        let err = def_prim(&mut vm).unwrap_err();
+        assert!(
+            matches!(err, TbxError::InvalidExpression { .. }),
+            "expected InvalidExpression for first-and-third duplicate param, got {err:?}"
+        );
+    }
+
+    #[test]
     fn test_def_invalid_token_after_comma() {
         // DEF WORD(X, 42) — non-ident token after comma must return InvalidExpression.
         use std::collections::VecDeque;


### PR DESCRIPTION
## 概要

`test_def_duplicate_param_name` は `DEF WORD(X, X)` の2パラメータ重複のみカバーしていた。
本PRでは `DEF WORD(X, Y, X)` のように1番目と3番目のパラメータが重複するケースを検証するテストを追加する。

## 変更内容

- `src/primitives.rs`: `test_def_duplicate_param_name_first_and_third` テストを追加
  - `DEF WORD(X, Y, X)` トークン列を `def_prim` に渡し、`InvalidExpression` が返ることをアサート

Closes #262
