### PR TITLE
式内IMMEDIATEワードのコンパイルエラー検出とテスト追加 (#264)

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -163,6 +163,14 @@ impl<'a> ExprCompiler<'a> {
                         .lookup_including_self(&name, self.self_word.as_deref())
                         .ok_or_else(|| TbxError::UndefinedSymbol { name: name.clone() })?;
 
+                    // Reject IMMEDIATE words inside expressions.
+                    // Per spec, IMMEDIATE words are only allowed at statement level.
+                    if self.vm.headers[xt.index()].flags & crate::dict::FLAG_IMMEDIATE != 0 {
+                        return Err(TbxError::InvalidExpression {
+                            reason: "IMMEDIATE word cannot appear inside an expression",
+                        });
+                    }
+
                     // Peek ahead: is this a function call (`F(`)?
                     let next_is_lparen = tokens
                         .get(i + 1)

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -7,7 +7,7 @@
 use std::collections::HashMap;
 
 use crate::cell::{Cell, Xt};
-use crate::dict::EntryKind;
+use crate::dict::{EntryKind, FLAG_IMMEDIATE};
 use crate::error::TbxError;
 use crate::lexer::{SpannedToken, Token};
 use crate::vm::VM;
@@ -165,7 +165,7 @@ impl<'a> ExprCompiler<'a> {
 
                     // Reject IMMEDIATE words inside expressions.
                     // Per spec, IMMEDIATE words are only allowed at statement level.
-                    if self.vm.headers[xt.index()].flags & crate::dict::FLAG_IMMEDIATE != 0 {
+                    if self.vm.headers[xt.index()].flags & FLAG_IMMEDIATE != 0 {
                         return Err(TbxError::InvalidExpression {
                             reason: "IMMEDIATE word cannot appear inside an expression",
                         });

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1974,7 +1974,7 @@ PUTDEC 42";
         let result = interp.exec_source("PUTDEC V");
         assert!(
             result.is_err(),
-            "expected error when IMMEDIATE word appears inside an expression in exec_line"
+            "expected error when IMMEDIATE word appears inside an expression in exec_source"
         );
         assert!(
             matches!(

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1916,4 +1916,69 @@ PUTDEC 99
             .expect("compile_program should succeed after runtime error");
         assert_eq!(interp.take_output(), "42");
     }
+
+    // --- compile_program + IMMEDIATE (issue #264) ---
+
+    #[test]
+    fn test_compile_program_immediate_at_ground_level() {
+        // An IMMEDIATE word used at ground level during compile_program should execute
+        // immediately (not be compiled into the main routine).
+        let mut interp = Interpreter::new();
+        let src = "\
+DEF IWORD
+PUTDEC 55
+END
+IMMEDIATE IWORD
+IWORD";
+        interp.compile_program(src).unwrap();
+        // IWORD is IMMEDIATE, so it runs once during the compile phase (IMMEDIATE IWORD sets the
+        // flag, then IWORD is executed immediately as ground-level code).
+        let out = interp.take_output();
+        assert_eq!(
+            out, "55",
+            "expected '55' from IMMEDIATE word at ground level, got: {out:?}"
+        );
+    }
+
+    #[test]
+    fn test_compile_program_immediate_in_expression_is_error() {
+        // An IMMEDIATE word used inside an expression (argument to a statement) must
+        // produce an InvalidExpression error.
+        let mut interp = Interpreter::new();
+        // Create a global variable V and mark it IMMEDIATE.
+        interp.exec_source("VAR V\nIMMEDIATE V").unwrap();
+        // Using V inside an expression should fail.
+        let result = interp.compile_program("PUTDEC V");
+        assert!(
+            result.is_err(),
+            "expected error when IMMEDIATE word appears inside an expression"
+        );
+        assert!(
+            matches!(
+                result.unwrap_err().kind,
+                crate::error::TbxError::InvalidExpression { .. }
+            ),
+            "expected TbxError::InvalidExpression"
+        );
+    }
+
+    #[test]
+    fn test_exec_line_immediate_in_expression_is_error() {
+        // Regression: interpreter mode (exec_line) should also reject IMMEDIATE words
+        // inside expressions, returning InvalidExpression.
+        let mut interp = Interpreter::new();
+        interp.exec_source("VAR V\nIMMEDIATE V").unwrap();
+        let result = interp.exec_source("PUTDEC V");
+        assert!(
+            result.is_err(),
+            "expected error when IMMEDIATE word appears inside an expression in exec_line"
+        );
+        assert!(
+            matches!(
+                result.unwrap_err().kind,
+                crate::error::TbxError::InvalidExpression { .. }
+            ),
+            "expected TbxError::InvalidExpression"
+        );
+    }
 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1922,21 +1922,24 @@ PUTDEC 99
     #[test]
     fn test_compile_program_immediate_at_ground_level() {
         // An IMMEDIATE word used at ground level during compile_program should execute
-        // immediately (not be compiled into the main routine).
+        // immediately (not be compiled into the main routine), and subsequent ground-level
+        // statements must still be compiled and executed normally.
         let mut interp = Interpreter::new();
         let src = "\
 DEF IWORD
 PUTDEC 55
 END
 IMMEDIATE IWORD
-IWORD";
+IWORD
+PUTDEC 42";
         interp.compile_program(src).unwrap();
-        // IWORD is IMMEDIATE, so it runs once during the compile phase (IMMEDIATE IWORD sets the
-        // flag, then IWORD is executed immediately as ground-level code).
+        // IWORD executes immediately at ground level (output "55").
+        // The subsequent PUTDEC 42 is compiled into the main routine and executes after
+        // the IMMEDIATE word, producing "42".
         let out = interp.take_output();
         assert_eq!(
-            out, "55",
-            "expected '55' from IMMEDIATE word at ground level, got: {out:?}"
+            out, "5542",
+            "expected '5542': IMMEDIATE word output followed by continued compilation, got: {out:?}"
         );
     }
 
@@ -1963,8 +1966,8 @@ IWORD";
     }
 
     #[test]
-    fn test_exec_line_immediate_in_expression_is_error() {
-        // Regression: interpreter mode (exec_line) should also reject IMMEDIATE words
+    fn test_exec_source_immediate_in_expression_is_error() {
+        // Regression: interpreter mode (exec_source) should also reject IMMEDIATE words
         // inside expressions, returning InvalidExpression.
         let mut interp = Interpreter::new();
         interp.exec_source("VAR V\nIMMEDIATE V").unwrap();

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -2023,26 +2023,4 @@ IWORD";
             );
         }
     }
-
-    #[test]
-    fn test_compile_program_only_immediate_in_expression_is_error() {
-        // compile_program-only variant: VAR + IMMEDIATE + expression use all within a single
-        // compile_program call, confirming the mode-independent error path.
-        let mut interp = Interpreter::new();
-        // VAR V creates a global variable; IMMEDIATE V marks it FLAG_IMMEDIATE.
-        // PUTDEC V then uses V inside an expression — this must be rejected.
-        interp.exec_source("VAR V\nIMMEDIATE V").unwrap();
-        let result = interp.compile_program("PUTDEC V");
-        assert!(
-            result.is_err(),
-            "expected error when IMMEDIATE word appears inside an expression in compile_program"
-        );
-        assert!(
-            matches!(
-                result.unwrap_err().kind,
-                crate::error::TbxError::InvalidExpression { .. }
-            ),
-            "expected TbxError::InvalidExpression (compile_program only)"
-        );
-    }
 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1981,4 +1981,68 @@ IWORD";
             "expected TbxError::InvalidExpression"
         );
     }
+
+    #[test]
+    fn test_immediate_in_def_body_expression_is_error() {
+        // An IMMEDIATE word used inside an expression within a DEF body must also
+        // produce an InvalidExpression error (both in exec_source and compile_program).
+        //
+        // exec_source path
+        {
+            let mut interp = Interpreter::new();
+            interp.exec_source("VAR V\nIMMEDIATE V").unwrap();
+            let result = interp.exec_source("DEF FOO\nPUTDEC V\nEND");
+            assert!(
+                result.is_err(),
+                "expected error when IMMEDIATE word appears in DEF body expression (exec_source)"
+            );
+            assert!(
+                matches!(
+                    result.unwrap_err().kind,
+                    crate::error::TbxError::InvalidExpression { .. }
+                ),
+                "expected TbxError::InvalidExpression (exec_source)"
+            );
+        }
+        // compile_program path
+        {
+            let mut interp = Interpreter::new();
+            // Set up V as IMMEDIATE via exec_source, then compile a DEF body that uses it.
+            interp.exec_source("VAR V\nIMMEDIATE V").unwrap();
+            let result = interp.compile_program("DEF FOO\nPUTDEC V\nEND");
+            assert!(
+                result.is_err(),
+                "expected error when IMMEDIATE word appears in DEF body expression (compile_program)"
+            );
+            assert!(
+                matches!(
+                    result.unwrap_err().kind,
+                    crate::error::TbxError::InvalidExpression { .. }
+                ),
+                "expected TbxError::InvalidExpression (compile_program)"
+            );
+        }
+    }
+
+    #[test]
+    fn test_compile_program_only_immediate_in_expression_is_error() {
+        // compile_program-only variant: VAR + IMMEDIATE + expression use all within a single
+        // compile_program call, confirming the mode-independent error path.
+        let mut interp = Interpreter::new();
+        // VAR V creates a global variable; IMMEDIATE V marks it FLAG_IMMEDIATE.
+        // PUTDEC V then uses V inside an expression — this must be rejected.
+        interp.exec_source("VAR V\nIMMEDIATE V").unwrap();
+        let result = interp.compile_program("PUTDEC V");
+        assert!(
+            result.is_err(),
+            "expected error when IMMEDIATE word appears inside an expression in compile_program"
+        );
+        assert!(
+            matches!(
+                result.unwrap_err().kind,
+                crate::error::TbxError::InvalidExpression { .. }
+            ),
+            "expected TbxError::InvalidExpression (compile_program only)"
+        );
+    }
 }


### PR DESCRIPTION
## 概要

issue #264 の実装。フルプログラムモード（`compile_program`）における IMMEDIATE ワードの地の文コンパイル中即時実行は issue #263 の時点で既に動作していたため、本 PR では残作業の 2 点を実装する。

## 変更内容

### `src/expr.rs` — 式内 IMMEDIATE ワードのコンパイルエラー検出

`compile_expr` の `Token::Ident` アームにて、辞書ルックアップ成功後かつ種別ディスパッチの前に `FLAG_IMMEDIATE` チェックを追加した。式の中で IMMEDIATE ワードが使われた場合は `TbxError::InvalidExpression` を返す。

blueprint-bootstrap.md フェーズ4の仕様:
> 式評価中（SYA パーサー処理中）に IMMEDIATE ワードが現れた場合はコンパイルエラーとする。

インタプリタモード・フルプログラムモードの両方に対して一箇所で適用されるため、動作が一貫している。

### `src/interpreter.rs` — テスト 4 件追加

| テスト名 | 内容 |
|---|---|
| `test_compile_program_immediate_at_ground_level` | `compile_program` でIMMEDIATEワードが地の文レベルで即時実行され、後続の地の文コンパイルが継続されることを確認 |
| `test_compile_program_immediate_in_expression_is_error` | 式内に IMMEDIATE ワードが現れた場合に `InvalidExpression` が返ることを確認 |
| `test_exec_source_immediate_in_expression_is_error` | インタプリタモード（`exec_source`）でも同じエラーが返る回帰テスト |
| `test_immediate_in_def_body_expression_is_error` | DEF ボディ内の式で IMMEDIATE ワードが使われた場合も `InvalidExpression` になることを確認 |

Closes #264