### PR TITLE
IMMEDIATE ワードの FNAME(args) 形式テストを追加 (#279)

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1990,8 +1990,8 @@ PUTDEC 42";
         // Verify that an IMMEDIATE word used in FNAME(args) form inside an expression
         // produces an InvalidExpression error (compile_program path).
         //
-        // FLAG_IMMEDIATE check (expr.rs L168) executes before the next_is_lparen check
-        // (expr.rs L175), so function-call syntax IWORD(1) also triggers the same error.
+        // The FLAG_IMMEDIATE check in the expression evaluator runs before the
+        // function-call syntax check, so FNAME(args) form also triggers InvalidExpression.
         let mut interp = Interpreter::new();
         // Define a plain Word entry and mark it IMMEDIATE.
         interp
@@ -2002,6 +2002,28 @@ PUTDEC 42";
         assert!(
             result.is_err(),
             "expected error when IMMEDIATE word appears in FNAME(args) form inside an expression"
+        );
+        assert!(
+            matches!(
+                result.unwrap_err().kind,
+                crate::error::TbxError::InvalidExpression { .. }
+            ),
+            "expected TbxError::InvalidExpression"
+        );
+    }
+
+    #[test]
+    fn test_compile_program_immediate_fname_zero_args_in_expression_is_error() {
+        // Verify that an IMMEDIATE word used in FNAME() zero-argument form inside an
+        // expression also produces an InvalidExpression error (compile_program path).
+        let mut interp = Interpreter::new();
+        interp
+            .exec_source("DEF IWORD\nRETURN\nEND\nIMMEDIATE IWORD")
+            .unwrap();
+        let result = interp.compile_program("PUTDEC IWORD()");
+        assert!(
+            result.is_err(),
+            "expected error when IMMEDIATE word appears in FNAME() form inside an expression"
         );
         assert!(
             matches!(
@@ -2024,6 +2046,28 @@ PUTDEC 42";
         assert!(
             result.is_err(),
             "expected error when IMMEDIATE word appears in FNAME(args) form inside an expression (exec_source)"
+        );
+        assert!(
+            matches!(
+                result.unwrap_err().kind,
+                crate::error::TbxError::InvalidExpression { .. }
+            ),
+            "expected TbxError::InvalidExpression"
+        );
+    }
+
+    #[test]
+    fn test_exec_source_immediate_fname_zero_args_in_expression_is_error() {
+        // Verify that an IMMEDIATE word used in FNAME() zero-argument form inside an
+        // expression also produces an InvalidExpression error (exec_source path).
+        let mut interp = Interpreter::new();
+        interp
+            .exec_source("DEF IWORD\nRETURN\nEND\nIMMEDIATE IWORD")
+            .unwrap();
+        let result = interp.exec_source("PUTDEC IWORD()");
+        assert!(
+            result.is_err(),
+            "expected error when IMMEDIATE word appears in FNAME() form inside an expression (exec_source)"
         );
         assert!(
             matches!(

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1986,6 +1986,55 @@ PUTDEC 42";
     }
 
     #[test]
+    fn test_compile_program_immediate_fname_call_in_expression_is_error() {
+        // Verify that an IMMEDIATE word used in FNAME(args) form inside an expression
+        // produces an InvalidExpression error (compile_program path).
+        //
+        // FLAG_IMMEDIATE check (expr.rs L168) executes before the next_is_lparen check
+        // (expr.rs L175), so function-call syntax IWORD(1) also triggers the same error.
+        let mut interp = Interpreter::new();
+        // Define a plain Word entry and mark it IMMEDIATE.
+        interp
+            .exec_source("DEF IWORD\nRETURN\nEND\nIMMEDIATE IWORD")
+            .unwrap();
+        // Using IWORD in FNAME(args) form inside an expression should fail.
+        let result = interp.compile_program("PUTDEC IWORD(1)");
+        assert!(
+            result.is_err(),
+            "expected error when IMMEDIATE word appears in FNAME(args) form inside an expression"
+        );
+        assert!(
+            matches!(
+                result.unwrap_err().kind,
+                crate::error::TbxError::InvalidExpression { .. }
+            ),
+            "expected TbxError::InvalidExpression"
+        );
+    }
+
+    #[test]
+    fn test_exec_source_immediate_fname_call_in_expression_is_error() {
+        // Verify that an IMMEDIATE word used in FNAME(args) form inside an expression
+        // produces an InvalidExpression error (exec_source path).
+        let mut interp = Interpreter::new();
+        interp
+            .exec_source("DEF IWORD\nRETURN\nEND\nIMMEDIATE IWORD")
+            .unwrap();
+        let result = interp.exec_source("PUTDEC IWORD(1)");
+        assert!(
+            result.is_err(),
+            "expected error when IMMEDIATE word appears in FNAME(args) form inside an expression (exec_source)"
+        );
+        assert!(
+            matches!(
+                result.unwrap_err().kind,
+                crate::error::TbxError::InvalidExpression { .. }
+            ),
+            "expected TbxError::InvalidExpression"
+        );
+    }
+
+    #[test]
     fn test_immediate_in_def_body_expression_is_error() {
         // An IMMEDIATE word used inside an expression within a DEF body must also
         // produce an InvalidExpression error (both in exec_source and compile_program).


### PR DESCRIPTION
## 概要

IMMEDIATE ワードを `FNAME(args)` 形式（関数呼び出し構文）で式内に使用した場合も `InvalidExpression` エラーになることを確認するテストを `src/interpreter.rs` に追加した。プロダクションコードの変更はない。

## 変更内容

`src/interpreter.rs` に2つのテストを追加：

- `test_compile_program_immediate_fname_call_in_expression_is_error`  
  `compile_program` パス経由で `PUTDEC IWORD(1)` が `InvalidExpression` を返すことを確認
- `test_exec_source_immediate_fname_call_in_expression_is_error`  
  `exec_source` パス経由で同様に確認

## 背景

`src/expr.rs` L168 の `FLAG_IMMEDIATE` チェックは `next_is_lparen` 判定（L175）より先に実行されるため、`IWORD(1)` のような `FNAME(args)` 形式でも既存の変数参照形式（`PUTDEC V`）と同じ `InvalidExpression` エラーになる。このコードパスを直接確認するテストが欠落していたため追加した。

Closes #279
