### PR TITLE
テスト: FNAME(args)テストの定義側と呼び出し側の引数数不一致を解消する

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1995,7 +1995,7 @@ PUTDEC 42";
         let mut interp = Interpreter::new();
         // Define a plain Word entry and mark it IMMEDIATE.
         interp
-            .exec_source("DEF IWORD\nRETURN\nEND\nIMMEDIATE IWORD")
+            .exec_source("DEF IWORD(X)\nRETURN\nEND\nIMMEDIATE IWORD")
             .unwrap();
         // Using IWORD in FNAME(args) form inside an expression should fail.
         let result = interp.compile_program("PUTDEC IWORD(1)");
@@ -2040,7 +2040,7 @@ PUTDEC 42";
         // produces an InvalidExpression error (exec_source path).
         let mut interp = Interpreter::new();
         interp
-            .exec_source("DEF IWORD\nRETURN\nEND\nIMMEDIATE IWORD")
+            .exec_source("DEF IWORD(X)\nRETURN\nEND\nIMMEDIATE IWORD")
             .unwrap();
         let result = interp.exec_source("PUTDEC IWORD(1)");
         assert!(


### PR DESCRIPTION
## 概要

`FNAME(args)` 形式でIMMEDIATEワードを式中で使用した際のエラーを検証するテスト2件で、
定義側の引数数（0個）と呼び出し側の引数数（1個）が一致していなかった問題を修正しました。

## 変更内容

- `test_compile_program_immediate_fname_call_in_expression_is_error`
  - `"DEF IWORD\n..."` → `"DEF IWORD(X)\n..."` に変更
- `test_exec_source_immediate_fname_call_in_expression_is_error`
  - `"DEF IWORD\n..."` → `"DEF IWORD(X)\n..."` に変更

ゼロ引数テスト（`*_zero_args_*`）は引数数が一致しているため変更なし。

Closes #281
