### PR TITLE
implement-issueエージェントのレビューループ制御を修正

### DIFF
--- a/.github/agents/implement-issue.agent.md
+++ b/.github/agents/implement-issue.agent.md
@@ -99,6 +99,12 @@ INSERT OR REPLACE INTO session_state (key, value) VALUES ('review_before_review_
 
 #### 各ループ内の手順
 
+0. **ループ先頭での上限チェック**：ループカウンターを確認し、上限に達していれば直ちに終了する。
+   ```sql
+   SELECT CAST(value AS INTEGER) AS loop_count FROM session_state WHERE key = 'review_loop_count';
+   ```
+   `loop_count >= 3` の場合: **ステップ6後処理B**へ進む（以降の手順を実行しない）。
+
 1. `review-implementation` エージェントを起動する前に、現在の件数を SQL に保存する：
    ```sql
    -- <N_comments> と <N_reviews> は get_comments / get_reviews で取得した件数に置き換える
@@ -117,7 +123,7 @@ INSERT OR REPLACE INTO session_state (key, value) VALUES ('review_before_review_
 
 5. **新しいコメントまたはレビューが追加された場合**、追加された内容に **🔴** または **🟡** が含まれるか確認する：
    - **含まれない**（🟢 Info のみ、またはApproveレビュー）→ **ステップ6後処理A**へ進む。
-   - **含まれる** かつ `loop_count < 3` の場合：
+   - **含まれる** 場合（手順0のガードを通過済みのため `loop_count < 3` が保証されている）：
      - `loop_count` をインクリメントする：
        ```sql
        UPDATE session_state SET value = CAST(CAST(value AS INTEGER) + 1 AS TEXT) WHERE key = 'review_loop_count';
@@ -141,9 +147,7 @@ INSERT OR REPLACE INTO session_state (key, value) VALUES ('review_before_review_
        git commit -F "$(git rev-parse --git-dir)/COMMIT_MSG"
        git push
        ```
-     - ループの先頭（手順1）へ戻る
-   - **含まれる** かつ `loop_count >= 3` の場合：
-     - ループを終了し、**ステップ6後処理B**へ進む。
+     - ループの先頭（手順0）へ戻る
 
 ### ステップ6後処理A：🟢 Info 指摘の issue 登録
 


### PR DESCRIPTION
## 概要

`implement-issue` エージェントのレビュー＆修正ループに構造的なバグがあり、
意図した3回の上限を超えて4回目の `review-implementation` が起動されうる問題を修正する。

## 変更内容

- **手順0を追加**（ループ先頭での上限チェック）：各ループ反復の冒頭で `loop_count >= 3`
  を確認し、上限に達していれば `review-implementation` を一切起動せず直ちに後処理Bへ分岐する
- **手順5のデッドコードを除去**：手順0のガードにより「手順5到達時は必ず `loop_count < 3`」が
  保証されるため、手順5にあった `loop_count >= 3` 分岐（後処理Bへの分岐）を削除し、
  その保証をコメントとして明記

## 修正前の問題

```
ループ: 手順1 → 手順2(review起動) → ... → 手順5でカウント確認
```

3回目の修正コミット後、ループ先頭（旧: 手順1）に戻ると、
`review-implementation` を起動（手順2）してから初めてカウントチェックが行われていた。
→ 実質4回目のレビューが起動される。

## 修正後の動作

```
ループ: 手順0(カウントチェック) → 手順1 → 手順2(review起動) → ...
```

手順0がガードとして機能し、`loop_count >= 3` ならレビューを起動しない。

## 根拠

`empirical-prompt-tuning` スキルによる3イテレーション + ホールドアウトシナリオで検証済み。
修正前（Baseline）では Scenario B の subagent がこのバグを裁量補完で回避していた。
修正後は全シナリオで [critical] 要件 100% 達成、過適合なし。
