### PR TITLE
review-implementationエージェントのコメント投稿戦略を明確化

### DIFF
--- a/.github/agents/review-implementation.agent.md
+++ b/.github/agents/review-implementation.agent.md
@@ -110,17 +110,45 @@ Critical / Warning の問題および Info の気づきを以下の2段階で記
 
 #### 5-1. PRへのレビューコメント投稿
 
-`gh pr review` コマンドでレビューコメントを投稿する（PRへの書き込みはMCPサーバーに対応ツールがないため `gh` CLIを使用する）。
-全コメントをまとめて `REQUEST_CHANGES`（Criticalあり）または `COMMENT`（Warningのみ、またはInfoのみ）で提出する。
+**投稿は2種類に分けて行う**:
 
-> **注意**: `implement-issue` エージェントと同じユーザートークンで動作している場合、GitHubの制約により「PRの作成者は自分のPRをレビューできない」エラー（`GraphQL: Can't request changes on your own pull request`）が発生する。その場合は `gh pr comment` にフォールバックする。
+**① Critical / Warning のまとめ投稿**（`gh pr review`）
+
+Critical / Warning の指摘をまとめて1件のレビューとして投稿する。
+
+```bash
+cat > "$(git rev-parse --git-dir)/REVIEW_BODY.md" << 'EOF'
+（Critical / Warning の指摘内容。各指摘を上記フォーマットで並べる）
+EOF
+
+gh pr review <PR番号> --request-changes --body-file "$(git rev-parse --git-dir)/REVIEW_BODY.md"
+# Critical がない場合は --request-changes の代わりに --comment を使う
+```
+
+> **注意**: `implement-issue` エージェントと同じユーザートークンで動作している場合、GitHubの制約により「PRの作成者は自分のPRをレビューできない」エラー（`GraphQL: Can't request changes on your own pull request`）が発生する。その場合は **同じ REVIEW_BODY.md をそのまま使って** 以下にフォールバックする（フォールバック時は通常コメントになるため変更要求の強度は失われる）。
 >
 > ```bash
-> # フォールバック: 通常コメントとして投稿
+> # フォールバック: 通常コメントとして投稿（Critical/Warning まとめて1件、同じ REVIEW_BODY.md を再利用）
 > gh pr comment <PR番号> --body-file "$(git rev-parse --git-dir)/REVIEW_BODY.md"
 > ```
 
-コメントのフォーマット：
+**② Info の個別投稿**（`gh pr comment`）
+
+Info 指摘は `gh pr review` とは別に、**1指摘1コメント**でそれぞれ `gh pr comment` を呼び出して投稿する（`implement-issue` が後から個別に読み取って GitHub issue を登録するため、まとめて1件にしない）。
+
+```bash
+# Info 指摘ごとに別ファイルで投稿（Info が複数あれば繰り返す）
+cat > "$(git rev-parse --git-dir)/INFO_COMMENT_1.md" << 'EOF'
+🟢 **[Info]**
+（1件目の Info 指摘内容）
+**期待される状態**: （どう改善されるべきか）
+EOF
+gh pr comment <PR番号> --body-file "$(git rev-parse --git-dir)/INFO_COMMENT_1.md"
+```
+
+Critical / Warning がなく Info のみの場合も同様に `gh pr comment` で個別投稿する（`gh pr review` は使わない）。
+
+コメントの共通フォーマット：
 
 ```
 🔴 **[Critical]** または 🟡 **[Warning]** または 🟢 **[Info]**
@@ -131,9 +159,6 @@ Critical / Warning の問題および Info の気づきを以下の2段階で記
 
 （関連する blueprint.md のセクションがあれば）参照: blueprint.md「セクション名」
 ```
-
-Info 指摘は複数あっても1件のコメントにまとめず、**1指摘1コメント**で投稿する。
-これにより `implement-issue` が後から個別に読み取って GitHub issue を登録できる。
 
 #### 5-2. GitHub Issueの登録
 
@@ -167,7 +192,19 @@ Issueのフォーマット：
 PR #N のレビューで検出
 ```
 
-Issueにはラベル `review-finding` を付与する（ラベルが存在しない場合は作成する）。
+Issueにはラベル `review-finding` を付与する（ラベルが存在しない場合は以下で作成する）。
+
+```bash
+gh label create "review-finding" --description "Review-detected finding" --color "e11d48" 2>/dev/null || true
+
+# Issue本文をファイルに書き出してから登録する（本文が複数行になるため --body-file を使う）
+cat > "$(git rev-parse --git-dir)/ISSUE_BODY.md" << 'EOF'
+（上記フォーマットで本文を記述）
+EOF
+
+gh issue create --title "（問題の概要）" --label "review-finding" --body-file "$(git rev-parse --git-dir)/ISSUE_BODY.md"
+```
+
 Warning は Issue登録不要（PRコメントのみ）。
 
 ### ステップ6：レビュー結果のサマリ報告


### PR DESCRIPTION
## 概要

`review-implementation` エージェントのコメント投稿戦略に矛盾があったため、empirical prompt tuning（4 iter + hold-out）で修正。

## 変更内容

### ステップ5-1 のコメント投稿を2種類に分離

**問題（修正前）**: 「全コメントをまとめて `gh pr review` で投稿」かつ「Info は1指摘1コメント」が矛盾していた（`gh pr review --body` は1件しか投稿できない）。

**修正後**:
- ① Critical / Warning → `gh pr review` にまとめて1件（`--request-changes` or `--comment`）
- ② Info → `gh pr comment` で1指摘1コメントの個別投稿

### フォールバック挙動の明確化

- フォールバック時は「同じ REVIEW_BODY.md をそのまま使って `gh pr comment`」を明記
- フォールバック後は変更要求の強度が失われる旨を注記

### Issue 登録コマンドの完全化

- `review-finding` ラベル作成コマンドを明記（以前は未記載で subagent が自己推測していた）
- `gh issue create` に `--body-file` パターンを追加（ヒアドキュメントと `$()` の組み合わせによるシェルクォート問題を回避）

## 改善の根拠

empirical prompt tuning による検証結果:

| Iteration | Scenario A | Scenario B |
|---|---|---|
| 1 (Baseline) | 100% | 100% |
| 2 | 100% | 100% |
| 3 | 100% | 100% |
| 4 | 100% | 100% |
| Hold-out C | 100% | — |

- Iter 1: 旧定義でもコアロジックは正常動作したが、コメント投稿戦略の矛盾・ラベル作成コマンド未記載による裁量補完が発生
- Iter 2–4: 修正ごとに裁量補完が減少し、Iter 4 で新規 blocking 問題ゼロ
- Hold-out（Critical なし・Warning のみ・`--comment` 分岐）で 100%、過適合なし
