### PR TITLE
plan-issue: 依存issueチェックの仕様を明確化

### DIFF
--- a/.github/agents/plan-issue.agent.md
+++ b/.github/agents/plan-issue.agent.md
@@ -21,7 +21,7 @@ GitHubのissueに記載されたタスクを読み込み、`blueprint.md` と既
 ### ステップ1：issueの把握
 
 `github-mcp-server-issue_read`（method: `get`）でissueの本文を、（method: `get_comments`）でコメントを取得し、内容を日本語で要約する。
-依存issueが記載されている場合は、それらが完了済みか確認する（未完了なら実施前にユーザーに報告する）。
+issue本文またはコメントに `Closes #N`・`Depends on #N`・`Blocked by #N` などの形式で他のissue番号が参照されている場合は依存issueとして扱う。`github-mcp-server-issue_read`（method: `get`）でそれぞれの状態を取得し、`state` が `closed` であれば完了と判断する。未完了（`state` が `open`）のものがある場合は**計画作成を中断**し、その旨をユーザーに報告して依存issueの完了後に再起動するよう促す。
 
 ### ステップ2：コードベース調査
 


### PR DESCRIPTION
## 概要

`plan-issue` エージェントの依存 issue チェック仕様が曖昧だったため、empirical prompt tuning（4 iter + hold-out）で発見された問題点を修正します。

## 変更内容

`ステップ1：issueの把握` の依存 issue 確認文を以下の通り改善：

- **依存として扱うパターンを明示**: `Closes #N`・`Depends on #N`・`Blocked by #N` など
- **コメント欄も検出対象に追加**: issue本文だけでなくコメントも対象
- **確認ツールを明記**: `github-mcp-server-issue_read`（method: `get`）を使用
- **完了判断基準を明記**: `state` が `closed` であれば完了
- **未完了時の挙動を明確化**: 「報告する」から「計画作成を**中断**し…依存issueの完了後に再起動するよう促す」へ

## 解決策の根拠

Empirical prompt tuning の評価結果：

- **Iteration 1**: 依存 issue 未完了時に「続行するか中断するか」が不定義 → 中断を明示
- **Iteration 2**: 確認ツール・`state` 判断基準が裁量補完になっていた → ツールと基準を明記
- **Iteration 3**: `Closes #N` が依存と扱われるか不明 → パターンを列挙
- **Iteration 4 + hold-out C**: 全シナリオ 100%・新規不明瞭点なし → 収束確定
