### PR TITLE
フルプログラムモード 統合テスト4件を追加 (issue #266)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /target
 *.un~
-/.github/skills/empirical-prompt-tuning

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 *.un~
+/.github/skills/empirical-prompt-tuning

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1927,12 +1927,9 @@ PUTDEC 99
         let mut interp = Interpreter::new();
         let src = "FORWARD_WORD\nDEF FORWARD_WORD\n  PUTDEC 1\nEND";
         let result = interp.compile_program(src);
+        let err = result.expect_err("expected UndefinedSymbol error for forward reference, but got Ok");
         assert!(
-            result.is_err(),
-            "expected UndefinedSymbol error for forward reference, but got Ok"
-        );
-        assert!(
-            matches!(result.unwrap_err().kind, TbxError::UndefinedSymbol { .. }),
+            matches!(err.kind, TbxError::UndefinedSymbol { .. }),
             "expected UndefinedSymbol error kind"
         );
     }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1917,6 +1917,73 @@ PUTDEC 99
         assert_eq!(interp.take_output(), "42");
     }
 
+    // --- compile_program integration tests (issue #266) ---
+
+    #[test]
+    fn test_compile_program_forward_reference_is_error() {
+        // In single-pass compilation, a ground-level reference to a word that
+        // has not yet been defined (i.e. the DEF appears after the reference)
+        // must produce an UndefinedSymbol error.
+        let mut interp = Interpreter::new();
+        let src = "FORWARD_WORD\nDEF FORWARD_WORD\n  PUTDEC 1\nEND";
+        let result = interp.compile_program(src);
+        assert!(
+            result.is_err(),
+            "expected UndefinedSymbol error for forward reference, but got Ok"
+        );
+        assert!(
+            matches!(result.unwrap_err().kind, TbxError::UndefinedSymbol { .. }),
+            "expected UndefinedSymbol error kind"
+        );
+    }
+
+    #[test]
+    fn test_exec_line_then_compile_program_coexistence() {
+        // A word defined via exec_line must be callable from a subsequent
+        // compile_program on the same Interpreter instance.
+        let mut interp = Interpreter::new();
+        interp.exec_line("DEF HELLO").unwrap();
+        interp.exec_line("PUTDEC 99").unwrap();
+        interp.exec_line("END").unwrap();
+        interp.compile_program("HELLO").unwrap();
+        assert_eq!(interp.take_output(), "99");
+    }
+
+    #[test]
+    fn test_compile_program_then_exec_line_coexistence() {
+        // A word defined inside compile_program must be callable via exec_line
+        // on the same Interpreter instance afterwards.
+        let mut interp = Interpreter::new();
+        interp
+            .compile_program("DEF ADD1(X)\nRETURN X + 1\nEND")
+            .unwrap();
+        interp.exec_line("PUTDEC ADD1(41)").unwrap();
+        assert_eq!(interp.take_output(), "42");
+    }
+
+    #[test]
+    fn test_compile_program_ground_deferred_execution() {
+        // Ground-level statements are executed after ALL DEFs have been compiled,
+        // even when DEFs and ground statements are interleaved in the source.
+        // Expected output is "12": PRINT_A runs first, then PRINT_B.
+        let mut interp = Interpreter::new();
+        let src = "\
+DEF PRINT_A
+  PUTDEC 1
+END
+PRINT_A
+DEF PRINT_B
+  PUTDEC 2
+END
+PRINT_B";
+        interp.compile_program(src).unwrap();
+        assert_eq!(
+            interp.take_output(),
+            "12",
+            "expected ground statements to execute after all DEFs are compiled"
+        );
+    }
+
     // --- compile_program + IMMEDIATE (issue #264) ---
 
     #[test]

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1963,24 +1963,35 @@ PUTDEC 99
 
     #[test]
     fn test_compile_program_ground_deferred_execution() {
-        // Ground-level statements are executed after ALL DEFs have been compiled,
-        // even when DEFs and ground statements are interleaved in the source.
-        // Expected output is "12": PRINT_A runs first, then PRINT_B.
+        // Verifies that ground-level statements in compile_program are collected
+        // into a main routine and executed as a unit after ALL DEFs are compiled —
+        // even when DEFs and ground statements are interleaved throughout the source.
+        //
+        // The scenario uses a shared variable whose value is written by one ground
+        // statement and read by another.  Because ground statements run in source
+        // order after all DEFs are compiled, the sequence VAR→SET→READ must be
+        // consistent regardless of where the DEF appears in the source.
         let mut interp = Interpreter::new();
         let src = "\
-DEF PRINT_A
-  PUTDEC 1
+VAR X
+SET &X, 0
+DEF INCX
+  SET &X, X + 10
 END
-PRINT_A
-DEF PRINT_B
-  PUTDEC 2
-END
-PRINT_B";
+SET &X, 5
+INCX
+PUTDEC X";
+        // Expected execution order of ground statements (deferred, run after DEF is compiled):
+        //   VAR X       → X defined (= 0)
+        //   SET &X, 0   → X = 0
+        //   SET &X, 5   → X = 5
+        //   INCX        → X = 5 + 10 = 15
+        //   PUTDEC X    → outputs "15"
         interp.compile_program(src).unwrap();
         assert_eq!(
             interp.take_output(),
-            "12",
-            "expected ground statements to execute after all DEFs are compiled"
+            "15",
+            "expected ground statements to execute in source order after all DEFs are compiled"
         );
     }
 

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1927,11 +1927,17 @@ PUTDEC 99
         let mut interp = Interpreter::new();
         let src = "FORWARD_WORD\nDEF FORWARD_WORD\n  PUTDEC 1\nEND";
         let result = interp.compile_program(src);
-        let err = result.expect_err("expected UndefinedSymbol error for forward reference, but got Ok");
+        let err =
+            result.expect_err("expected UndefinedSymbol error for forward reference, but got Ok");
         assert!(
             matches!(err.kind, TbxError::UndefinedSymbol { .. }),
             "expected UndefinedSymbol error kind"
         );
+        // The VM must be reusable after the error (no compile state left over).
+        interp
+            .compile_program("PUTDEC 1")
+            .expect("VM should be reusable after UndefinedSymbol error");
+        assert_eq!(interp.take_output(), "1");
     }
 
     #[test]
@@ -1960,35 +1966,36 @@ PUTDEC 99
 
     #[test]
     fn test_compile_program_ground_deferred_execution() {
-        // Verifies that ground-level statements in compile_program are collected
-        // into a main routine and executed as a unit after ALL DEFs are compiled —
-        // even when DEFs and ground statements are interleaved throughout the source.
+        // Proves that ground-level statements are deferred: they are collected into
+        // a main routine and executed AFTER all IMMEDIATE words have been processed.
         //
-        // The scenario uses a shared variable whose value is written by one ground
-        // statement and read by another.  Because ground statements run in source
-        // order after all DEFs are compiled, the sequence VAR→SET→READ must be
-        // consistent regardless of where the DEF appears in the source.
+        // The key observable property: an IMMEDIATE word that appears between two
+        // ground statements runs at compile time, so its output appears BEFORE the
+        // output of both ground statements, even though it sits between them in source.
+        //
+        // Source order:
+        //   PUTDEC 1              ← ground stmt (deferred)
+        //   IMMEDIATE SHOW        ← marks SHOW as IMMEDIATE (flag-set only, no output yet)
+        //   SHOW                  ← now IMMEDIATE: runs at compile time → outputs "99"
+        //   PUTDEC 2              ← ground stmt (deferred)
+        //
+        // Deferred execution produces: "99" (compile-time) + "1" + "2" (runtime) = "9912".
+        // If ground statements executed inline, PUTDEC 1 would run before SHOW:
+        // output would be "1" + "99" + "2" = "1992" — a different result.
         let mut interp = Interpreter::new();
         let src = "\
-VAR X
-SET &X, 0
-DEF INCX
-  SET &X, X + 10
+DEF SHOW
+  PUTDEC 99
 END
-SET &X, 5
-INCX
-PUTDEC X";
-        // Expected execution order of ground statements (deferred, run after DEF is compiled):
-        //   VAR X       → X defined (= 0)
-        //   SET &X, 0   → X = 0
-        //   SET &X, 5   → X = 5
-        //   INCX        → X = 5 + 10 = 15
-        //   PUTDEC X    → outputs "15"
+PUTDEC 1
+IMMEDIATE SHOW
+SHOW
+PUTDEC 2";
         interp.compile_program(src).unwrap();
         assert_eq!(
             interp.take_output(),
-            "15",
-            "expected ground statements to execute in source order after all DEFs are compiled"
+            "9912",
+            "expected IMMEDIATE output ('99') before deferred ground output ('12')"
         );
     }
 


### PR DESCRIPTION
## 概要

issue #266 で要求されたフルプログラムモード（`compile_program`）の統合テスト4件を `src/interpreter.rs` に追加しました。

## 追加テスト一覧

| テスト名 | 検証内容 |
|---|---|
| `test_compile_program_forward_reference_is_error` | シングルパスコンパイルで前方参照は `UndefinedSymbol` エラーになる |
| `test_exec_line_then_compile_program_coexistence` | `exec_line` で定義したワードを `compile_program` から呼び出せる |
| `test_compile_program_then_exec_line_coexistence` | `compile_program` で定義したワードを `exec_line` から呼び出せる |
| `test_compile_program_ground_deferred_execution` | DEFと地の文が混在しても、全DEFコンパイル後に地の文がまとめて実行される |

## 変更ファイル

- `src/interpreter.rs` のみ（本番コード変更なし、テスト追加のみ）

## チェック結果

- `cargo build` ✅
- `cargo test` ✅（4件すべてパス）
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo fmt --check` ✅

Closes #266
