### PR TITLE
IF/ENDIFの制御構造を実装する（lib/basic.tbx + PATCH_ADDRプリミティブ）

### DIFF
--- a/lib/basic.tbx
+++ b/lib/basic.tbx
@@ -1,0 +1,20 @@
+REM basic.tbx — BASIC-style control structures standard library
+
+REM IF expr ... ENDIF
+REM
+REM  IF compiles the condition expression, emits a JUMP_FALSE instruction,
+REM  saves the placeholder address on the compile stack, and emits a 0 placeholder.
+REM  ENDIF patches the placeholder with the current HERE value.
+
+DEF IF
+  COMPILE_EXPR
+  APPEND JUMP_FALSE
+  CS_PUSH HERE
+  APPEND 0
+END
+IMMEDIATE IF
+
+DEF ENDIF
+  PATCH_ADDR CS_POP
+END
+IMMEDIATE ENDIF

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -81,22 +81,33 @@ impl Default for Interpreter {
 impl Interpreter {
     /// Create a new `Interpreter` backed by a fully initialized VM.
     ///
-    /// The standard library (`lib/basic.tbx`) is embedded at compile time via
-    /// `include_str!` and evaluated during construction so that built-in control
-    /// structures such as `IF`/`ENDIF` are always available without an explicit `USE`.
+    /// Loads the standard library (`lib/basic.tbx`) embedded at compile time.
+    /// Panics if the standard library fails to load, which indicates a bug in
+    /// the library source rather than a runtime failure.
+    ///
+    /// For a fallible variant that returns an error instead of panicking,
+    /// use [`Interpreter::try_new`].
     pub fn new() -> Self {
+        // lib/basic.tbx is embedded at compile time and is always syntactically valid TBX.
+        // A panic here indicates a bug in the standard library source, not a runtime failure.
+        Self::try_new().unwrap_or_else(|e| {
+            panic!("internal error: failed to load lib/basic.tbx: {e}");
+        })
+    }
+
+    /// Create a new `Interpreter`, returning an error if the standard library fails to load.
+    ///
+    /// This is the fallible counterpart of [`Interpreter::new`]. Prefer this in contexts
+    /// where proper error propagation is possible.
+    pub fn try_new() -> Result<Self, InterpreterError> {
         let mut interp = Self {
             vm: init_vm(),
             use_depth: 0,
         };
         const STDLIB: &str = include_str!("../lib/basic.tbx");
-        // lib/basic.tbx is embedded at compile time and is always syntactically valid TBX.
-        // An error here indicates a bug in the standard library source, not a runtime failure.
-        if let Err(e) = interp.exec_source(STDLIB) {
-            panic!("internal error: failed to load lib/basic.tbx: {e}");
-        }
+        interp.exec_source(STDLIB)?;
         interp.vm.seal_lib();
-        interp
+        Ok(interp)
     }
 
     /// Look up a required symbol by name, returning an `InterpreterError` if not found.

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -80,11 +80,21 @@ impl Default for Interpreter {
 
 impl Interpreter {
     /// Create a new `Interpreter` backed by a fully initialized VM.
+    ///
+    /// The standard library (`lib/basic.tbx`) is embedded at compile time via
+    /// `include_str!` and evaluated during construction so that built-in control
+    /// structures such as `IF`/`ENDIF` are always available without an explicit `USE`.
     pub fn new() -> Self {
-        Self {
+        let mut interp = Self {
             vm: init_vm(),
             use_depth: 0,
-        }
+        };
+        const STDLIB: &str = include_str!("../lib/basic.tbx");
+        interp
+            .exec_source(STDLIB)
+            .expect("failed to load lib/basic.tbx");
+        interp.vm.seal_lib();
+        interp
     }
 
     /// Look up a required symbol by name, returning an `InterpreterError` if not found.
@@ -2463,6 +2473,74 @@ PUTDEC 42";
         assert!(
             matches!(result.unwrap_err().kind, TbxError::UndefinedSymbol { .. }),
             "expected UndefinedSymbol for word defined after HALT"
+        );
+    }
+
+    // --- IF / ENDIF (lib/basic.tbx) ---
+
+    #[test]
+    fn test_if_endif_condition_true_executes_body() {
+        // IF with a true condition must execute the body.
+        let mut interp = Interpreter::new();
+        let src = "\
+DEF CHECK(X)
+  IF X > 0
+    PUTSTR \"yes\"
+  ENDIF
+END
+CHECK 5";
+        interp.exec_source(src).unwrap();
+        let out = interp.take_output();
+        assert_eq!(out, "yes", "expected 'yes', got: {:?}", out);
+    }
+
+    #[test]
+    fn test_if_endif_condition_false_skips_body() {
+        // IF with a false condition must skip the body.
+        let mut interp = Interpreter::new();
+        let src = "\
+DEF CHECK(X)
+  IF X > 0
+    PUTSTR \"yes\"
+  ENDIF
+  PUTSTR \"done\"
+END
+CHECK 0";
+        interp.exec_source(src).unwrap();
+        let out = interp.take_output();
+        assert_eq!(out, "done", "expected 'done', got: {:?}", out);
+    }
+
+    #[test]
+    fn test_if_endif_in_def_multiple_calls() {
+        // A DEF containing IF/ENDIF must be callable multiple times with different results.
+        let mut interp = Interpreter::new();
+        let src = "\
+DEF SIGN(X)
+  IF X > 0
+    PUTSTR \"+\"
+  ENDIF
+  IF X < 0
+    PUTSTR \"-\"
+  ENDIF
+END
+SIGN 1
+SIGN -1
+SIGN 0";
+        interp.exec_source(src).unwrap();
+        let out = interp.take_output();
+        assert_eq!(out, "+-", "expected '+-', got: {:?}", out);
+    }
+
+    #[test]
+    fn test_if_endif_outside_def_is_error() {
+        // IF/ENDIF outside a DEF body requires compile mode; using them at top level
+        // (interpret mode) must return an error because COMPILE_EXPR needs compile mode.
+        let mut interp = Interpreter::new();
+        let result = interp.exec_line("IF 1 > 0");
+        assert!(
+            result.is_err(),
+            "IF outside DEF should return an error (no compile mode)"
         );
     }
 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -51,6 +51,12 @@ impl std::fmt::Display for InterpreterError {
     }
 }
 
+impl std::error::Error for InterpreterError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.kind)
+    }
+}
+
 /// Token list and segment boundaries produced by `parse_line_into_segments`.
 ///
 /// The `Vec<(usize, usize)>` contains `(start, end)` index pairs into the token list.

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -90,9 +90,11 @@ impl Interpreter {
             use_depth: 0,
         };
         const STDLIB: &str = include_str!("../lib/basic.tbx");
-        interp
-            .exec_source(STDLIB)
-            .expect("failed to load lib/basic.tbx");
+        // lib/basic.tbx is embedded at compile time and is always syntactically valid TBX.
+        // An error here indicates a bug in the standard library source, not a runtime failure.
+        if let Err(e) = interp.exec_source(STDLIB) {
+            panic!("internal error: failed to load lib/basic.tbx: {e}");
+        }
         interp.vm.seal_lib();
         interp
     }
@@ -2541,6 +2543,18 @@ SIGN 0";
         assert!(
             result.is_err(),
             "IF outside DEF should return an error (no compile mode)"
+        );
+    }
+
+    #[test]
+    fn test_endif_without_if_is_error() {
+        // ENDIF without a preceding IF leaves the compile stack empty when CS_POP is
+        // called inside the ENDIF body, which must produce a StackUnderflow error.
+        let mut interp = Interpreter::new();
+        let result = interp.exec_source("DEF FOO\n  ENDIF\nEND");
+        assert!(
+            result.is_err(),
+            "ENDIF without IF should return an error (empty compile stack)"
         );
     }
 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -2574,4 +2574,39 @@ SIGN 0";
             "ENDIF without IF should return an error (empty compile stack)"
         );
     }
+
+    #[test]
+    fn test_endif_outside_def_is_error() {
+        // ENDIF at top level (interpret mode) must return an error because CS_POP
+        // checks is_compiling before PATCH_ADDR is reached.
+        let mut interp = Interpreter::new();
+        let result = interp.exec_line("ENDIF");
+        assert!(
+            result.is_err(),
+            "ENDIF at top level should return an error (no compile mode)"
+        );
+    }
+
+    #[test]
+    fn test_if_endif_nested() {
+        // Nested IF/ENDIF must work correctly because compile_stack is LIFO.
+        // Inner ENDIF patches only the inner IF placeholder; outer ENDIF patches only
+        // the outer IF placeholder.
+        let mut interp = Interpreter::new();
+        let src = "\
+DEF NESTED(X)
+  IF X > 0
+    IF X > 10
+      PUTSTR \"big\"
+    ENDIF
+    PUTSTR \"pos\"
+  ENDIF
+END
+NESTED 15
+NESTED 5
+NESTED -1";
+        interp.exec_source(src).unwrap();
+        let out = interp.take_output();
+        assert_eq!(out, "bigpospos", "expected 'bigpospos', got: {:?}", out);
+    }
 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -53,7 +53,10 @@ impl std::fmt::Display for InterpreterError {
 
 impl std::error::Error for InterpreterError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        Some(&self.kind)
+        // Display already formats `self.kind` inline (see the Display impl above),
+        // so we do not chain the source here.  Returning Some(&self.kind) would cause
+        // error reporters like `anyhow` / `eyre` to print the same message twice.
+        None
     }
 }
 
@@ -2572,6 +2575,18 @@ SIGN 0";
         assert!(
             result.is_err(),
             "ENDIF without IF should return an error (empty compile stack)"
+        );
+    }
+
+    #[test]
+    fn test_if_without_endif_is_error() {
+        // IF without a matching ENDIF leaves the compile stack non-empty when END is
+        // reached, which must produce a CompileStackNotEmpty error.
+        let mut interp = Interpreter::new();
+        let result = interp.exec_source("DEF FOO(X)\n  IF X > 0\nEND");
+        assert!(
+            result.is_err(),
+            "IF without ENDIF should return an error (non-empty compile stack at END)"
         );
     }
 

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -902,6 +902,16 @@ fn compile_expr_taking_local_table(
 }
 
 /// Emit a jump target into the dictionary, with forward-reference back-patch support.
+///
+/// # Design note: why `Cell::Int`, not `Cell::DictAddr`
+///
+/// Jump targets are raw program-counter indices, not typed data pointers.
+/// `Cell::DictAddr` is a typed pointer used for FETCH/STORE (data access).
+/// `Cell::Int` is the untyped integer used for arithmetic *and* control flow (pc values).
+/// Writing `Cell::Int(target)` here, and having `read_jump_target` accept only `Cell::Int`,
+/// prevents accidental confusion between "data address" and "execution address" at runtime.
+/// `PATCH_ADDR` follows the same convention: it takes a `DictAddr` operand (where to write)
+/// and writes `Cell::Int(dp)` (the pc value) — each type carries the correct semantic.
 fn emit_jump_target_to_dict(vm: &mut VM, label_n: i64) -> Result<(), TbxError> {
     let target_opt = vm
         .compile_state
@@ -1031,6 +1041,29 @@ fn cs_pop_prim(vm: &mut VM) -> Result<(), TbxError> {
     let val = vm.compile_stack.pop().ok_or(TbxError::StackUnderflow)?;
     vm.push(val)?;
     Ok(())
+}
+
+/// PATCH_ADDR — pop a DictAddr from the data stack, then write Cell::Int(dp) at that address.
+///
+/// Used by ENDIF (and future ELSE, ENDWHILE) to back-patch a previously emitted
+/// jump-target placeholder.  The address on the stack is typically saved by IF via
+/// CS_PUSH/CS_POP.
+///
+/// Must be called in compile mode (inside an IMMEDIATE word invocation).
+fn patch_addr_prim(vm: &mut VM) -> Result<(), TbxError> {
+    if !vm.is_compiling {
+        return Err(TbxError::InvalidExpression {
+            reason: "PATCH_ADDR outside compile mode",
+        });
+    }
+    let addr = vm.pop()?;
+    match addr {
+        Cell::DictAddr(a) => vm.dict_write_at(a, Cell::Int(vm.dp as i64)),
+        _ => Err(TbxError::TypeError {
+            expected: "DictAddr",
+            got: addr.type_name(),
+        }),
+    }
 }
 
 /// COMPILE_EXPR — compile the remaining tokens in the token stream as an expression
@@ -1301,6 +1334,7 @@ pub fn register_all(vm: &mut VM) {
     // and called at runtime by IMMEDIATE words (e.g. IF/ENDIF).
     vm.register(WordEntry::new_primitive("CS_PUSH", cs_push_prim));
     vm.register(WordEntry::new_primitive("CS_POP", cs_pop_prim));
+    vm.register(WordEntry::new_primitive("PATCH_ADDR", patch_addr_prim));
     vm.register(WordEntry::new_primitive("COMPILE_EXPR", compile_expr_prim));
 
     // Runtime branch/jump Xt constants — allows TBX code to write:
@@ -3843,5 +3877,61 @@ mod tests {
                 .unwrap_or(true),
             "token_stream must be empty after COMPILE_EXPR"
         );
+    }
+
+    // --- patch_addr_prim ---
+
+    #[test]
+    fn test_patch_addr_prim_outside_compile_mode_error() {
+        // PATCH_ADDR called when is_compiling == false must return InvalidExpression.
+        let mut vm = VM::new();
+        register_all(&mut vm);
+        vm.push(Cell::DictAddr(0)).unwrap();
+        let err = patch_addr_prim(&mut vm).unwrap_err();
+        assert!(
+            matches!(err, TbxError::InvalidExpression { .. }),
+            "expected InvalidExpression, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_patch_addr_prim_wrong_type_error() {
+        // PATCH_ADDR with a non-DictAddr on the stack must return TypeError.
+        let mut vm = make_compiling_vm("TESTWORD");
+        vm.push(Cell::Int(99)).unwrap();
+        let err = patch_addr_prim(&mut vm).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                TbxError::TypeError {
+                    expected: "DictAddr",
+                    ..
+                }
+            ),
+            "expected TypeError(DictAddr), got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_patch_addr_prim_writes_int_dp_at_addr() {
+        // PATCH_ADDR must pop DictAddr(a) and write Cell::Int(dp) at dict[a].
+        let mut vm = make_compiling_vm("TESTWORD");
+        // Write a placeholder at a known position.
+        let placeholder_pos = vm.dp;
+        vm.dict_write(Cell::Int(0)).unwrap();
+        // Push some more cells so dp advances past the placeholder.
+        vm.dict_write(Cell::Int(1)).unwrap();
+        vm.dict_write(Cell::Int(2)).unwrap();
+        let expected_dp = vm.dp;
+        // Push the placeholder address onto the data stack and call PATCH_ADDR.
+        vm.push(Cell::DictAddr(placeholder_pos)).unwrap();
+        patch_addr_prim(&mut vm).unwrap();
+        // dict[placeholder_pos] must now hold Cell::Int(dp).
+        assert_eq!(
+            vm.dict_read(placeholder_pos).unwrap(),
+            Cell::Int(expected_dp as i64)
+        );
+        // Data stack must be empty.
+        assert_eq!(vm.pop(), Err(TbxError::StackUnderflow));
     }
 }


### PR DESCRIPTION
## 概要

issue #306 で設計された `IF expr ... ENDIF` 制御構造を実装します。
`PATCH_ADDR` プリミティブを Rust で追加し、TBX IMMEDIATE ワードとして `lib/basic.tbx` に `IF`/`ENDIF` を定義します。
標準ライブラリは `include_str!` でバイナリに埋め込まれ、インタプリタ起動時に自動ロードされます。

## 変更内容

### `src/primitives.rs`
- `emit_jump_target_to_dict` 直前に `Cell::Int` vs `Cell::DictAddr` の設計根拠コメントを追加
- `patch_addr_prim` 関数を追加（スタックから `DictAddr(a)` を取り出し `dict[a]` に `Cell::Int(dp)` を書き込む）
- `register_all` に `PATCH_ADDR` を CS_PUSH/CS_POP/COMPILE_EXPR の近くに登録
- `patch_addr_prim` の単体テスト3件を追加（compile mode 外エラー、型エラー、正常ケース）
- `Interpreter::try_new()` の追加（標準ライブラリロード失敗を `Result` として返す fallible constructor）
- `impl std::error::Error for InterpreterError` の実装（`source()` は Display が自己完結しているため `None` を返す設計）

### `lib/basic.tbx`（新規作成）
- `IF` / `ENDIF` を IMMEDIATE ワードとして定義

### `src/interpreter.rs`
- `Interpreter::new()` で `include_str!("../lib/basic.tbx")` を用いて標準ライブラリを自動ロード
- ロード後に `vm.seal_lib()` を呼び出して標準ライブラリ境界を記録
- `IF/ENDIF` の統合テスト4件を追加（true/false 条件、複数呼び出し、DEF 外エラー）

## 設計上の決断

- ファイル名は `lib/basic.tbx`（issue コメントの最終方針に従い `std.tbx` から変更）
- `PATCH_ADDR` は `FLAG_IMMEDIATE`・`FLAG_SYSTEM` なし（DEF ボディ内でコンパイルされ実行時呼び出しされるため）
- `IF` を DEF 外で呼ぶと `COMPILE_EXPR` が compile mode 外エラーを返す（仕様）

Closes #306
