### PR TITLE
plan-issue エージェントのプロンプトを empirical-prompt-tuning で改善

### DIFF
--- a/.github/agents/plan-issue.agent.md
+++ b/.github/agents/plan-issue.agent.md
@@ -25,7 +25,7 @@ issue本文またはコメントに `Closes #N`・`Depends on #N`・`Blocked by 
 
 ### ステップ2：コードベース調査
 
-- `blueprint.md` を読み込み、issueに関連する設計方針を特定する。
+- `blueprint.md`（およびそこから参照される `blueprint-bootstrap.md`・`blueprint-language.md`）を読み込み、issueに関連する設計方針を特定する。
 - 既存のソースファイル（`src/` 配下）をglobで一覧し、関連するコードを把握する。
 - `Cargo.toml` が存在する場合は依存クレートや設定を確認する。
 
@@ -48,7 +48,7 @@ issue本文またはコメントに `Closes #N`・`Depends on #N`・`Blocked by 
 ```
 
 複数の実装方針が考えられる場合は、候補を列挙して各方針のトレードオフを記載すること。
-blueprint.mdに記載のない仕様については「未確定」と明示する。
+issueやblueprint.mdに記載のない仕様・実装判断については「未確定」と明示し、合理的なデフォルトを選択して注意点セクションに記載した上で実装者の判断に委ねる。
 
 #### 計画の品質チェックリスト
 


### PR DESCRIPTION
## 概要

`plan-issue` エージェントのプロンプトを `empirical-prompt-tuning` スキルで評価・改善しました。

## 変更内容

### Fix 1: blueprint.md 参照先の明示

ステップ2の調査対象を「`blueprint.md` **およびその参照先（`blueprint-bootstrap.md`・`blueprint-language.md`）**」と明記しました。

**改善前**: `blueprint.md` を読み込み、issueに関連する設計方針を特定する。  
**改善後**: `blueprint.md`（およびそこから参照される `blueprint-bootstrap.md`・`blueprint-language.md`）を読み込み…

**背景**: 従来は `blueprint.md` のみ指定されており、詳細設計が `blueprint-bootstrap.md` に記載されている場合に、エージェントが自己判断で参照先を切り替えるかどうかが不安定でした（Discretionary fill-in として検出）。

### Fix 2: 「未確定」ルールの適用範囲を実装判断にも拡張

**改善前**: `blueprint.mdに記載のない仕様については「未確定」と明示する。`  
**改善後**: `issueやblueprint.mdに記載のない仕様・実装判断については「未確定」と明示し、合理的なデフォルトを選択して注意点セクションに記載した上で実装者の判断に委ねる。`

**背景**: issue/blueprint 双方に記載のない実装レベルの判断（例: `fs::canonicalize` 失敗時のフォールバック戦略）を、エージェントが unclear point として浮上させていました。「未確定」ルールを実装判断にも適用することで、デフォルト選択＋明示委譲という安定した処理パターンに誘導します。

## 評価結果サマリ

| イテレーション | シナリオA unclear | シナリオB unclear |
|---|---|---|
| Iter1 (ベースライン) | 2 | 0 |
| Iter2 (Fix 1適用後) | 0 | 0 |
| Iter3 | 1 | 0 |
| Iter4 (Fix 2適用後) | 0 | 0 |
| Iter5 | 0 | 0 |

2連続クリア達成 → 収束。hold-out シナリオ（issue #276）でも accuracy 100%（過学習なし）。