### PR TITLE
USE の循環参照を HashSet で精確に検出する

### DIFF
--- a/apm.yml
+++ b/apm.yml
@@ -1,8 +1,0 @@
-name: tbx
-version: 1.0.0
-description: APM project for tbx
-author: SHIMADA Keiki
-dependencies:
-  apm: []
-  mcp: []
-scripts: {}

--- a/apm.yml
+++ b/apm.yml
@@ -1,0 +1,8 @@
+name: tbx
+version: 1.0.0
+description: APM project for tbx
+author: SHIMADA Keiki
+dependencies:
+  apm: []
+  mcp: []
+scripts: {}

--- a/blueprint-language.md
+++ b/blueprint-language.md
@@ -154,7 +154,8 @@ USE "path/to/file.tbx"    ( -- )
 - **冪等性**: 毎回ロード（include 方式）。同一ファイルを複数回 USE すると複数回実行される
 - **制限**: `DEF…END` ブロック内での使用は不可（compile_state を壊すため）
 - **エラー**: ファイルが存在しない・読み込めない場合は `TbxError::FileNotFound` を返す
-- **ネスト深さ制限**: USE はネストして呼び出せる（USE されたファイル内からさらに USE できる）が、深さが `MAX_USE_DEPTH`（64）を超えると `TbxError::UseNestingDepthExceeded` を返す。循環 USE（A が B を USE し B が A を USE するなど）もこの制限で検出される
+- **ネスト深さ制限**: USE はネストして呼び出せる（USE されたファイル内からさらに USE できる）が、深さが `MAX_USE_DEPTH`（256）を超えると `TbxError::UseNestingDepthExceeded` を返す
+- **循環参照の検出**: `Interpreter` は現在ロード中のファイルのセット（`loading_files: HashSet<PathBuf>`）を保持している。USE 実行時にパスを正規化（`canonicalize`）し、すでにセット内に存在する場合は `TbxError::CircularUse { path }` を返す。循環 USE（A が B を USE し B が A を USE するなど）は `UseNestingDepthExceeded` ではなく `CircularUse` で精確に検出される。`UseNestingDepthExceeded` は非循環の異常な深さに対する安全網として機能する
 - **USE 先の HALT**: USE されたファイル内で `HALT` が実行された場合、そのファイルの処理は終了するが、呼び出し元のプログラムは継続する（`exec_source` が `TbxError::Halted` を `Ok(())` として処理するため）
 
 ```basic

--- a/blueprint-language.md
+++ b/blueprint-language.md
@@ -154,7 +154,7 @@ USE "path/to/file.tbx"    ( -- )
 - **冪等性**: 毎回ロード（include 方式）。同一ファイルを複数回 USE すると複数回実行される
 - **制限**: `DEF…END` ブロック内での使用は不可（compile_state を壊すため）
 - **エラー**: ファイルが存在しない・読み込めない場合は `TbxError::FileNotFound` を返す
-- **ネスト深さ制限**: USE はネストして呼び出せる（USE されたファイル内からさらに USE できる）が、深さが `MAX_USE_DEPTH`（256）を超えると `TbxError::UseNestingDepthExceeded` を返す
+- **ネスト深さ制限**: USE はネストして呼び出せる（USE されたファイル内からさらに USE できる）が、深さが `MAX_USE_DEPTH`（64）を超えると `TbxError::UseNestingDepthExceeded` を返す
 - **循環参照の検出**: `Interpreter` は現在ロード中のファイルのセット（`loading_files: HashSet<PathBuf>`）を保持している。USE 実行時にパスを正規化（`canonicalize`）し、すでにセット内に存在する場合は `TbxError::CircularUse { path }` を返す。循環 USE（A が B を USE し B が A を USE するなど）は `UseNestingDepthExceeded` ではなく `CircularUse` で精確に検出される。`UseNestingDepthExceeded` は非循環の異常な深さに対する安全網として機能する
 - **USE 先の HALT**: USE されたファイル内で `HALT` が実行された場合、そのファイルの処理は終了するが、呼び出し元のプログラムは継続する（`exec_source` が `TbxError::Halted` を `Ok(())` として処理するため）
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -104,10 +104,17 @@ pub enum TbxError {
     },
     /// USE nesting depth exceeded the maximum allowed limit.
     ///
-    /// Prevents infinite recursion caused by circular USE chains
-    /// (e.g. A.tbx USEs B.tbx which USEs A.tbx again).
+    /// Acts as a safety net for non-circular but excessively deep USE chains.
     UseNestingDepthExceeded {
         limit: usize,
+    },
+    /// A circular USE was detected: the same file is already being loaded.
+    ///
+    /// Returned when `exec_source` detects that the file to be loaded is
+    /// already present in the `loading_files` set, indicating a cycle such as
+    /// A.tbx → B.tbx → A.tbx.
+    CircularUse {
+        path: String,
     },
 
     /// Assertion explicitly failed via ASSERT_FAIL.
@@ -198,6 +205,9 @@ impl std::fmt::Display for TbxError {
                     f,
                     "USE: nesting depth exceeded limit of {limit} (possible circular USE)"
                 )
+            }
+            TbxError::CircularUse { path } => {
+                write!(f, "USE: circular USE detected: '{path}'")
             }
             TbxError::AssertionFailed => write!(f, "assertion failed"),
             TbxError::AssertionFailedWithMessage { message } => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -201,10 +201,7 @@ impl std::fmt::Display for TbxError {
                 write!(f, "USE: file not found: '{path}': {reason}")
             }
             TbxError::UseNestingDepthExceeded { limit } => {
-                write!(
-                    f,
-                    "USE: nesting depth exceeded limit of {limit} (possible circular USE)"
-                )
+                write!(f, "USE: nesting depth exceeded limit of {limit}")
             }
             TbxError::CircularUse { path } => {
                 write!(f, "USE: circular USE detected: '{path}'")

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -14,9 +14,15 @@ use crate::vm::VM;
 /// Maximum allowed nesting depth for USE statements.
 ///
 /// Acts as a safety net for non-circular but excessively deep USE chains.
-/// Circular references are detected precisely by `loading_files` (method B)
-/// before this limit is reached.
-const MAX_USE_DEPTH: usize = 256;
+/// Circular references are detected precisely by `loading_files` before this
+/// limit is reached, so this constant guards only against pathological
+/// (non-circular) deep nesting.
+///
+/// 64 levels is sufficient for any realistic library hierarchy; each
+/// `exec_source` frame allocates several KB of stack space (lexer, token
+/// buffer, VM execution context), and the typical thread stack (1–8 MB) is
+/// exhausted well before 256 levels regardless of platform.
+const MAX_USE_DEPTH: usize = 64;
 
 /// Error produced by the outer interpreter, including source location information.
 pub struct InterpreterError {
@@ -83,12 +89,23 @@ pub struct Interpreter {
     /// via a USE statement, decremented on return. Acts as a safety net against
     /// excessively deep (but non-circular) USE chains.
     use_depth: usize,
+    /// Effective upper bound for `use_depth`. Defaults to `MAX_USE_DEPTH`.
+    /// Exposed as a field so that tests can set a smaller value without
+    /// creating hundreds of temporary files.
+    max_use_depth: usize,
     /// Set of canonicalized paths currently being loaded via USE.
     ///
     /// A path is inserted before `exec_source` is called and removed after it
     /// returns (whether with success or error). If a path is already present
     /// when a USE is about to start, a circular reference is detected and
     /// `TbxError::CircularUse` is returned.
+    ///
+    /// Note: if `exec_source` panics, `loading_files` will not be cleaned up.
+    /// A full RAII guard is not feasible here because holding a mutable
+    /// borrow of `loading_files` (via the guard) conflicts with the
+    /// `&mut self` borrow required by the recursive `exec_source` call.
+    /// In practice this is acceptable: panics in `exec_source` signal
+    /// unrecoverable programmer errors and typically abort the process.
     loading_files: HashSet<PathBuf>,
 }
 
@@ -123,6 +140,7 @@ impl Interpreter {
         let mut interp = Self {
             vm: init_vm(),
             use_depth: 0,
+            max_use_depth: MAX_USE_DEPTH,
             loading_files: HashSet::new(),
         };
         const STDLIB: &str = include_str!("../lib/basic.tbx");
@@ -535,6 +553,15 @@ impl Interpreter {
         self.vm.take_output()
     }
 
+    /// Override the maximum USE nesting depth (test-only).
+    ///
+    /// Allows unit tests to trigger `TbxError::UseNestingDepthExceeded`
+    /// without creating hundreds of temporary files.
+    #[cfg(test)]
+    fn set_max_use_depth(&mut self, max: usize) {
+        self.max_use_depth = max;
+    }
+
     /// Execute an IMMEDIATE word, regardless of compile/interpret mode.
     ///
     /// Sets up `vm.token_stream` with the remaining tokens, dispatches the word
@@ -606,9 +633,9 @@ impl Interpreter {
 
         // If use_prim stored a path, read the file and execute it now.
         if let Some(path) = self.vm.pending_use_path.take() {
-            if self.use_depth >= MAX_USE_DEPTH {
+            if self.use_depth >= self.max_use_depth {
                 return Err(make_err(TbxError::UseNestingDepthExceeded {
-                    limit: MAX_USE_DEPTH,
+                    limit: self.max_use_depth,
                 }));
             }
             // Canonicalize the path before reading so that different textual
@@ -2529,6 +2556,42 @@ PUTDEC 42";
         assert!(
             interp.take_output().contains("hello"),
             "linear chain A→B→C must succeed and define HELLO"
+        );
+    }
+
+    #[test]
+    fn test_use_nesting_depth_exceeded() {
+        // Verify that a non-circular but excessively deep USE chain triggers
+        // UseNestingDepthExceeded.  We reduce max_use_depth to 2 so only 3
+        // temporary files are needed (A→B→C where C tries to USE D, which
+        // exceeds the limit).
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path_d = dir.path().join("d.tbx");
+        let path_c = dir.path().join("c.tbx");
+        let path_b = dir.path().join("b.tbx");
+        let path_a = dir.path().join("a.tbx");
+        // d.tbx is never actually loaded; it just needs to exist so that
+        // canonicalize() in a.tbx/b.tbx/c.tbx does not fail.
+        // (The depth check fires before canonicalize for c.tbx → d.tbx.)
+        // Actually the depth check fires before we attempt to load d.tbx at all.
+        std::fs::write(&path_d, "PUTDEC 4\n").unwrap();
+        std::fs::write(&path_c, format!("USE \"{}\"\n", path_d.display())).unwrap();
+        std::fs::write(&path_b, format!("USE \"{}\"\n", path_c.display())).unwrap();
+        std::fs::write(&path_a, format!("USE \"{}\"\n", path_b.display())).unwrap();
+
+        let mut interp = Interpreter::new();
+        // With max_use_depth=2, the chain A(depth=0)→B(depth=1)→C(depth=2)
+        // reaches the limit when C tries to USE D.
+        interp.set_max_use_depth(2);
+        let src = format!("USE \"{}\"", path_a.display());
+        let result = interp.exec_source(&src);
+        assert!(result.is_err());
+        assert!(
+            matches!(
+                result.unwrap_err().kind,
+                TbxError::UseNestingDepthExceeded { .. }
+            ),
+            "expected TbxError::UseNestingDepthExceeded for non-circular deep USE"
         );
     }
 

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1,6 +1,7 @@
 //! Outer interpreter: tokenizes source text and executes statements via the inner interpreter.
 
-use std::collections::VecDeque;
+use std::collections::{HashSet, VecDeque};
+use std::path::PathBuf;
 
 use crate::cell::{Cell, Xt};
 use crate::dict::FLAG_SYSTEM;
@@ -12,8 +13,10 @@ use crate::vm::VM;
 
 /// Maximum allowed nesting depth for USE statements.
 ///
-/// Prevents stack overflows caused by circular USE chains.
-const MAX_USE_DEPTH: usize = 64;
+/// Acts as a safety net for non-circular but excessively deep USE chains.
+/// Circular references are detected precisely by `loading_files` (method B)
+/// before this limit is reached.
+const MAX_USE_DEPTH: usize = 256;
 
 /// Error produced by the outer interpreter, including source location information.
 pub struct InterpreterError {
@@ -77,8 +80,16 @@ type ParsedSegments = (Vec<SpannedToken>, Vec<(usize, usize)>);
 pub struct Interpreter {
     vm: VM,
     /// Current USE nesting depth. Incremented each time `exec_source` is called
-    /// via a USE statement, decremented on return. Guards against circular USE chains.
+    /// via a USE statement, decremented on return. Acts as a safety net against
+    /// excessively deep (but non-circular) USE chains.
     use_depth: usize,
+    /// Set of canonicalized paths currently being loaded via USE.
+    ///
+    /// A path is inserted before `exec_source` is called and removed after it
+    /// returns (whether with success or error). If a path is already present
+    /// when a USE is about to start, a circular reference is detected and
+    /// `TbxError::CircularUse` is returned.
+    loading_files: HashSet<PathBuf>,
 }
 
 impl Default for Interpreter {
@@ -112,6 +123,7 @@ impl Interpreter {
         let mut interp = Self {
             vm: init_vm(),
             use_depth: 0,
+            loading_files: HashSet::new(),
         };
         const STDLIB: &str = include_str!("../lib/basic.tbx");
         interp.exec_source(STDLIB)?;
@@ -599,15 +611,35 @@ impl Interpreter {
                     limit: MAX_USE_DEPTH,
                 }));
             }
-            let source = std::fs::read_to_string(&path).map_err(|e| {
+            // Canonicalize the path before reading so that different textual
+            // representations of the same file (e.g. relative vs absolute)
+            // are treated as identical for circular-reference detection.
+            // canonicalize() fails if the file does not exist, so we report
+            // FileNotFound in that case rather than the generic IO error.
+            let canonical = std::fs::canonicalize(&path).map_err(|e| {
                 make_err(TbxError::FileNotFound {
-                    path,
+                    path: path.clone(),
                     reason: e.to_string(),
                 })
             })?;
+            // Detect circular USE: if this path is already being loaded we
+            // are in a cycle (e.g. A → B → A).
+            if self.loading_files.contains(&canonical) {
+                return Err(make_err(TbxError::CircularUse {
+                    path: canonical.display().to_string(),
+                }));
+            }
+            let source = std::fs::read_to_string(&canonical).map_err(|e| {
+                make_err(TbxError::FileNotFound {
+                    path: canonical.display().to_string(),
+                    reason: e.to_string(),
+                })
+            })?;
+            self.loading_files.insert(canonical.clone());
             self.use_depth += 1;
             let result = self.exec_source(&source);
             self.use_depth -= 1;
+            self.loading_files.remove(&canonical);
             result?;
         }
 
@@ -2439,8 +2471,9 @@ PUTDEC 42";
     }
 
     #[test]
-    fn test_use_nesting_depth_exceeded() {
-        // Create a file that USEs itself to trigger circular USE detection.
+    fn test_use_self_reference_returns_circular_error() {
+        // A file that USEs itself must be detected as a circular USE (not
+        // UseNestingDepthExceeded) because loading_files catches the cycle.
         let dir = tempfile::tempdir().expect("tempdir");
         let lib_path = dir.path().join("self_use.tbx");
         // Write a file that USEs itself.
@@ -2452,11 +2485,50 @@ PUTDEC 42";
         let result = interp.exec_source(&src);
         assert!(result.is_err());
         assert!(
-            matches!(
-                result.unwrap_err().kind,
-                TbxError::UseNestingDepthExceeded { .. }
-            ),
-            "expected TbxError::UseNestingDepthExceeded for circular USE"
+            matches!(result.unwrap_err().kind, TbxError::CircularUse { .. }),
+            "expected TbxError::CircularUse for self-referencing USE"
+        );
+    }
+
+    #[test]
+    fn test_use_mutual_circular_returns_circular_error() {
+        // A → B → A must be detected as circular USE.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path_a = dir.path().join("a.tbx");
+        let path_b = dir.path().join("b.tbx");
+        // a.tbx USEs b.tbx; b.tbx USEs a.tbx back.
+        std::fs::write(&path_a, format!("USE \"{}\"\n", path_b.display())).unwrap();
+        std::fs::write(&path_b, format!("USE \"{}\"\n", path_a.display())).unwrap();
+
+        let mut interp = Interpreter::new();
+        let src = format!("USE \"{}\"", path_a.display());
+        let result = interp.exec_source(&src);
+        assert!(result.is_err());
+        assert!(
+            matches!(result.unwrap_err().kind, TbxError::CircularUse { .. }),
+            "expected TbxError::CircularUse for mutual circular USE (A→B→A)"
+        );
+    }
+
+    #[test]
+    fn test_use_linear_chain_succeeds() {
+        // A non-circular chain A → B → C must succeed.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path_c = dir.path().join("c.tbx");
+        let path_b = dir.path().join("b.tbx");
+        let path_a = dir.path().join("a.tbx");
+        std::fs::write(&path_c, "DEF HELLO\nPUTSTR \"hello\"\nEND\n").unwrap();
+        std::fs::write(&path_b, format!("USE \"{}\"\n", path_c.display())).unwrap();
+        std::fs::write(&path_a, format!("USE \"{}\"\n", path_b.display())).unwrap();
+
+        let mut interp = Interpreter::new();
+        let src = format!("USE \"{}\"", path_a.display());
+        interp.exec_source(&src).unwrap();
+        // HELLO (defined in c.tbx) must be callable after the chain completes.
+        interp.exec_source("HELLO").unwrap();
+        assert!(
+            interp.take_output().contains("hello"),
+            "linear chain A→B→C must succeed and define HELLO"
         );
     }
 

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -656,10 +656,15 @@ impl Interpreter {
                     path: canonical.display().to_string(),
                 }));
             }
+            // canonicalize() succeeded, so the file exists.  If read_to_string
+            // fails here (e.g. permission denied), we still report FileNotFound
+            // because there is no separate "file unreadable" error variant.
+            // The reason string (e.g. "Permission denied (os error 13)") tells
+            // the user the actual cause.
             let source = std::fs::read_to_string(&canonical).map_err(|e| {
                 make_err(TbxError::FileNotFound {
                     path: canonical.display().to_string(),
-                    reason: e.to_string(),
+                    reason: format!("read failed: {e}"),
                 })
             })?;
             self.loading_files.insert(canonical.clone());
@@ -2565,16 +2570,16 @@ PUTDEC 42";
         // UseNestingDepthExceeded.  We reduce max_use_depth to 2 so only 3
         // temporary files are needed (A→B→C where C tries to USE D, which
         // exceeds the limit).
+        //
+        // The depth check fires before canonicalize(), so d.tbx does not need
+        // to exist on disk — we never get that far.
         let dir = tempfile::tempdir().expect("tempdir");
-        let path_d = dir.path().join("d.tbx");
         let path_c = dir.path().join("c.tbx");
         let path_b = dir.path().join("b.tbx");
         let path_a = dir.path().join("a.tbx");
-        // d.tbx is never actually loaded; it just needs to exist so that
-        // canonicalize() in a.tbx/b.tbx/c.tbx does not fail.
-        // (The depth check fires before canonicalize for c.tbx → d.tbx.)
-        // Actually the depth check fires before we attempt to load d.tbx at all.
-        std::fs::write(&path_d, "PUTDEC 4\n").unwrap();
+        // Use a non-existent path for d.tbx; the depth check fires before
+        // canonicalize() is called, so the file need not exist.
+        let path_d = dir.path().join("d.tbx");
         std::fs::write(&path_c, format!("USE \"{}\"\n", path_d.display())).unwrap();
         std::fs::write(&path_b, format!("USE \"{}\"\n", path_c.display())).unwrap();
         std::fs::write(&path_a, format!("USE \"{}\"\n", path_b.display())).unwrap();


### PR DESCRIPTION
## 概要

`USE` による循環ファイルロードが無限再帰でプロセスパニックする問題（issue #305）を修正する。
`Interpreter` に `loading_files: HashSet<PathBuf>` を追加し、ロード中のファイルを精確に検出する（方式B）。

## 変更内容

- `src/error.rs`: `TbxError::CircularUse { path: String }` バリアントを追加し、Display を実装
- `src/interpreter.rs`:
  - `Interpreter` に `loading_files: HashSet<PathBuf>` フィールドを追加
  - USE 処理時に `canonicalize` でパスを正規化し、`loading_files` で循環参照を検出
  - `exec_source` 完了後（エラー時も含む）`loading_files` からパスを除去
  - `MAX_USE_DEPTH` は 64 のまま維持（循環は方式Bで精確に検出するため安全網として機能する旨をコメントに明記）
  - `max_use_depth` フィールドを追加（テスト用に `set_max_use_depth` メソッドを公開）
  - テスト追加: 自己参照 USE・相互循環 USE (A→B→A)・正常なネスト USE (A→B→C)・非循環の深過ぎるネスト（`UseNestingDepthExceeded`）
- `blueprint-language.md`: USE セクションの循環検出説明を方式Bの実装に合わせて更新

Closes #305
