### PR TITLE
ランタイムエラーにソース位置情報を埋め込む

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -731,7 +731,7 @@ impl Interpreter {
     /// This is the "full program mode" entry point; use `exec_source` for interactive mode.
     pub fn compile_program(&mut self, source: &str) -> Result<(), InterpreterError> {
         let mut main_cells: Vec<Cell> = Vec::new();
-        let mut stmt_positions: Vec<(usize, usize, usize, String)> = Vec::new();
+        let mut stmt_positions: Vec<StmtPosition> = Vec::new();
 
         for (line_idx, line) in source.lines().enumerate() {
             let line_num = line_idx + 1; // 1-based line number
@@ -876,7 +876,7 @@ impl Interpreter {
         tokens: &[SpannedToken],
         source_line: &str,
         main_cells: &mut Vec<Cell>,
-        stmt_positions: &mut Vec<(usize, usize, usize, String)>,
+        stmt_positions: &mut Vec<StmtPosition>,
         absolute_line: usize,
     ) -> Result<(), InterpreterError> {
         let mut idx = 0;
@@ -954,23 +954,34 @@ impl Interpreter {
 
         // Only record an entry when at least one cell was produced.
         if main_cells.len() > stmt_offset {
-            stmt_positions.push((
-                stmt_offset,
-                absolute_line,
-                stmt_pos_col,
-                source_line.to_string(),
-            ));
+            stmt_positions.push(StmtPosition {
+                offset: stmt_offset,
+                line: absolute_line,
+                col: stmt_pos_col,
+                source: source_line.to_string(),
+            });
         }
 
         Ok(())
     }
 }
 
+/// Source-position metadata for one ground-level statement compiled by `compile_program_segment`.
+struct StmtPosition {
+    /// Offset of the statement's first cell in the `main_cells` buffer.
+    offset: usize,
+    /// 1-based line number in the full source file.
+    line: usize,
+    /// 1-based column number of the statement keyword.
+    col: usize,
+    /// Full text of the source line containing the statement.
+    source: String,
+}
+
 /// Resolve the source position for a runtime error that occurred during `compile_program`.
 ///
-/// Looks up `stmt_positions` — a table of `(start_offset, line, col, source_text)` entries
-/// built by `compile_program_segment` — to find the statement that was executing when the
-/// error occurred.
+/// Looks up `stmt_positions` — a table of `StmtPosition` entries built by
+/// `compile_program_segment` — to find the statement that was executing when the error occurred.
 ///
 /// Two strategies are attempted in order:
 ///
@@ -981,7 +992,7 @@ impl Interpreter {
 ///    inside the main-routine range `(main_start, main_start + main_len)`.
 ///    Use `offset = return_pc - main_start - 1` (points at the call cell) and search the table.
 ///
-/// The table search finds the entry with the largest `start` that is ≤ `offset`.
+/// The table search finds the entry with the largest `offset` that is ≤ the computed offset.
 ///
 /// Returns `(0, 0, String::new())` when neither strategy finds a match (fallback).
 fn resolve_source_pos(
@@ -989,14 +1000,14 @@ fn resolve_source_pos(
     return_stack: &[ReturnFrame],
     main_start: usize,
     main_len: usize,
-    stmt_positions: &[(usize, usize, usize, String)],
+    stmt_positions: &[StmtPosition],
 ) -> (usize, usize, String) {
     let lookup = |offset: usize| -> Option<(usize, usize, String)> {
         stmt_positions
             .iter()
             .rev()
-            .find(|(start, ..)| *start <= offset)
-            .map(|(_, line, col, src)| (*line, *col, src.clone()))
+            .find(|sp| sp.offset <= offset)
+            .map(|sp| (sp.line, sp.col, sp.source.clone()))
     };
 
     // Strategy 1: error_pc is inside the main routine.
@@ -2924,5 +2935,36 @@ NESTED -1";
         interp.exec_source(src).unwrap();
         let out = interp.take_output();
         assert_eq!(out, "bigpospos", "expected 'bigpospos', got: {:?}", out);
+    }
+
+    #[test]
+    fn test_resolve_source_pos_fallback() {
+        // error_pc is outside main routine, return stack is empty → fallback (0, 0, "")
+        let (line, col, src) = resolve_source_pos(
+            999, // error_pc outside main
+            &[], // empty return stack
+            0,   // main_start
+            10,  // main_len
+            &[], // empty stmt_positions
+        );
+        assert_eq!(line, 0);
+        assert_eq!(col, 0);
+        assert!(src.is_empty());
+    }
+
+    #[test]
+    fn test_compile_program_runtime_error_nested_word_line_number() {
+        // DEF INNER → DEF OUTER(calls INNER) → OUTER call at line 7
+        // Error in INNER, but err.line should point to OUTER call site (line 7)
+        let mut interp = Interpreter::new();
+        let src = "DEF INNER\n  PUTDEC 1 / 0\nEND\nDEF OUTER\n  INNER\nEND\nOUTER";
+        let result = interp.compile_program(src);
+        let err = result.expect_err("expected runtime error");
+        assert_ne!(err.line, 0, "line must not be 0");
+        assert_eq!(
+            err.line, 7,
+            "error must point to OUTER call site at line 7, got {}",
+            err.line
+        );
     }
 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -978,7 +978,7 @@ impl Interpreter {
 ///    use `offset = error_pc - main_start` and search the table.
 /// 2. **Return-stack scan**: walk `return_stack` from the end (most-recently-pushed) toward
 ///    the front, looking for a `ReturnFrame::Call { return_pc }` whose `return_pc` falls
-///    just past the main-routine range `(main_start, main_start + main_len + 4]`.
+///    inside the main-routine range `(main_start, main_start + main_len)`.
 ///    Use `offset = return_pc - main_start - 1` (points at the call cell) and search the table.
 ///
 /// The table search finds the entry with the largest `start` that is ≤ `offset`.

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -2164,12 +2164,23 @@ PUTDEC 99
             "runtime error must point to line 2, got {}",
             err.line
         );
+        // Column and source line are also expected to be accurate.
+        assert_eq!(
+            err.col, 1,
+            "column should point to the start of the PUTDEC keyword (col 1), got {}",
+            err.col
+        );
+        assert!(
+            err.source_line.contains("1 / 0"),
+            "source_line should contain the failing expression, got: {:?}",
+            err.source_line
+        );
     }
 
     #[test]
     fn test_compile_program_runtime_error_in_user_word_line_number() {
-        // A runtime error inside a user-defined word called from line 3 must
-        // report line 3 (the call site in the main routine).
+        // A runtime error inside a user-defined word called from line 6 must
+        // report line 6 (the call site in the main routine).
         let mut interp = Interpreter::new();
         let src = "DEF BAD_WORD\n  PUTDEC 1 / 0\nEND\nPUTDEC 1\nPUTDEC 2\nBAD_WORD";
         let result = interp.compile_program(src);
@@ -2183,6 +2194,17 @@ PUTDEC 99
             err.line, 6,
             "runtime error must point to line 6 (the BAD_WORD call site), got {}",
             err.line
+        );
+        // Column and source line are also expected to be accurate.
+        assert_eq!(
+            err.col, 1,
+            "column should point to the start of BAD_WORD keyword (col 1), got {}",
+            err.col
+        );
+        assert!(
+            err.source_line.contains("BAD_WORD"),
+            "source_line should contain the call site identifier, got: {:?}",
+            err.source_line
         );
     }
 

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -3,7 +3,7 @@
 use std::collections::{HashSet, VecDeque};
 use std::path::PathBuf;
 
-use crate::cell::{Cell, Xt};
+use crate::cell::{Cell, ReturnFrame, Xt};
 use crate::dict::FLAG_SYSTEM;
 use crate::error::TbxError;
 use crate::expr::ExprCompiler;
@@ -731,13 +731,20 @@ impl Interpreter {
     /// This is the "full program mode" entry point; use `exec_source` for interactive mode.
     pub fn compile_program(&mut self, source: &str) -> Result<(), InterpreterError> {
         let mut main_cells: Vec<Cell> = Vec::new();
+        let mut stmt_positions: Vec<(usize, usize, usize, String)> = Vec::new();
 
         for (line_idx, line) in source.lines().enumerate() {
             let line_num = line_idx + 1; // 1-based line number
             let (tokens, boundaries) = self.parse_line_into_segments(line)?;
             for (seg_start, seg_end) in boundaries {
                 let was_compiling = self.vm.compile_state.is_some();
-                self.compile_program_segment(&tokens[seg_start..seg_end], line, &mut main_cells)?;
+                self.compile_program_segment(
+                    &tokens[seg_start..seg_end],
+                    line,
+                    &mut main_cells,
+                    &mut stmt_positions,
+                    line_num,
+                )?;
                 // If DEF just started on this segment, record the source line number.
                 if !was_compiling {
                     if let Some(state) = &mut self.vm.compile_state {
@@ -816,6 +823,8 @@ impl Interpreter {
 
         // Execute the main routine.
         let run_result = self.vm.run(main_start);
+        let error_pc = self.vm.pc;
+        let main_len = self.vm.dp - main_start;
 
         // Release main-routine memory regardless of outcome.
         self.vm.dp = main_start;
@@ -832,14 +841,17 @@ impl Interpreter {
                 Ok(())
             }
             Err(e) => {
+                let (line, col, source) = resolve_source_pos(
+                    error_pc,
+                    &self.vm.return_stack,
+                    main_start,
+                    main_len,
+                    &stmt_positions,
+                );
                 self.vm.data_stack.truncate(saved_data_stack_len);
                 self.vm.return_stack.truncate(saved_return_stack_len);
                 self.vm.bp = saved_bp;
-                // TODO(#275): Runtime errors from the main-routine execution carry no source
-                // position because compiled cells do not store their origin.  A future
-                // improvement would embed (line, col) metadata alongside each statement's
-                // cells so the inner interpreter can report accurate locations.
-                Err(InterpreterError::new(0, 0, "", e))
+                Err(InterpreterError::new(line, col, &source, e))
             }
         }
     }
@@ -849,11 +861,20 @@ impl Interpreter {
     /// Behaves like `exec_segment`, except ground-level (non-IMMEDIATE, non-DEF-body)
     /// statements are not executed immediately; instead their compiled cells are drained
     /// from the dictionary into `main_cells` for deferred execution.
+    ///
+    /// `stmt_positions` receives one entry per ground-level statement compiled:
+    /// `(start_offset_in_main_cells, line, col, source_line_text)`.
+    ///
+    /// `absolute_line` is the 1-based line number of this segment in the full source file
+    /// (the token positions produced by `parse_line_into_segments` are relative to a single
+    /// line and cannot be used for source-level position recording).
     fn compile_program_segment(
         &mut self,
         tokens: &[SpannedToken],
         source_line: &str,
         main_cells: &mut Vec<Cell>,
+        stmt_positions: &mut Vec<(usize, usize, usize, String)>,
+        absolute_line: usize,
     ) -> Result<(), InterpreterError> {
         let mut idx = 0;
 
@@ -919,14 +940,84 @@ impl Interpreter {
             return Err(e);
         }
 
+        // Record the offset of this statement in main_cells for source-position lookup.
+        let stmt_offset = main_cells.len();
+
         // Drain the newly written cells from the dictionary into the main-cells buffer.
         // This keeps the dictionary region clean so that subsequent DEF compilations
         // do not interleave with ground-level code.
         main_cells.extend(self.vm.dictionary.drain(buf_start..));
         self.vm.dp = buf_start;
 
+        // Only record an entry when at least one cell was produced.
+        if main_cells.len() > stmt_offset {
+            stmt_positions.push((
+                stmt_offset,
+                absolute_line,
+                stmt_pos_col,
+                source_line.to_string(),
+            ));
+        }
+
         Ok(())
     }
+}
+
+/// Resolve the source position for a runtime error that occurred during `compile_program`.
+///
+/// Looks up `stmt_positions` — a table of `(start_offset, line, col, source_text)` entries
+/// built by `compile_program_segment` — to find the statement that was executing when the
+/// error occurred.
+///
+/// Two strategies are attempted in order:
+///
+/// 1. **Direct PC match**: if `error_pc` falls inside `[main_start, main_start + main_len)`,
+///    use `offset = error_pc - main_start` and search the table.
+/// 2. **Return-stack scan**: walk `return_stack` from the end (most-recently-pushed) toward
+///    the front, looking for a `ReturnFrame::Call { return_pc }` whose `return_pc` falls
+///    just past the main-routine range `(main_start, main_start + main_len + 4]`.
+///    Use `offset = return_pc - main_start - 1` (points at the call cell) and search the table.
+///
+/// The table search finds the entry with the largest `start` that is ≤ `offset`.
+///
+/// Returns `(0, 0, String::new())` when neither strategy finds a match (fallback).
+fn resolve_source_pos(
+    error_pc: usize,
+    return_stack: &[ReturnFrame],
+    main_start: usize,
+    main_len: usize,
+    stmt_positions: &[(usize, usize, usize, String)],
+) -> (usize, usize, String) {
+    let lookup = |offset: usize| -> Option<(usize, usize, String)> {
+        stmt_positions
+            .iter()
+            .rev()
+            .find(|(start, ..)| *start <= offset)
+            .map(|(_, line, col, src)| (*line, *col, src.clone()))
+    };
+
+    // Strategy 1: error_pc is inside the main routine.
+    if error_pc >= main_start && error_pc < main_start + main_len {
+        let offset = error_pc - main_start;
+        if let Some(pos) = lookup(offset) {
+            return pos;
+        }
+    }
+
+    // Strategy 2: scan return stack for a call frame pointing just after the main routine.
+    let upper_bound = main_start + main_len + 4;
+    for frame in return_stack.iter().rev() {
+        if let ReturnFrame::Call { return_pc, .. } = frame {
+            if *return_pc > main_start && *return_pc <= upper_bound {
+                let offset = return_pc - main_start - 1;
+                if let Some(pos) = lookup(offset) {
+                    return pos;
+                }
+            }
+        }
+    }
+
+    (0, 0, String::new())
 }
 
 /// Count the number of top-level comma-separated arguments in a token slice.
@@ -2045,6 +2136,47 @@ PUTDEC 99
             .compile_program("PUTDEC 42")
             .expect("compile_program should succeed after runtime error");
         assert_eq!(interp.take_output(), "42");
+    }
+
+    #[test]
+    fn test_compile_program_runtime_error_line_number() {
+        // A runtime error must carry the correct 1-based source line number,
+        // not the placeholder 0 that was used before issue #275 was fixed.
+        let mut interp = Interpreter::new();
+        // The division-by-zero is on line 2.
+        let src = "PUTDEC 1\nPUTDEC 1 / 0\nPUTDEC 3";
+        let result = interp.compile_program(src);
+        let err = result.expect_err("expected runtime error from division by zero");
+        assert_ne!(
+            err.line, 0,
+            "runtime error line must not be 0 (was: {})",
+            err.line
+        );
+        assert_eq!(
+            err.line, 2,
+            "runtime error must point to line 2, got {}",
+            err.line
+        );
+    }
+
+    #[test]
+    fn test_compile_program_runtime_error_in_user_word_line_number() {
+        // A runtime error inside a user-defined word called from line 3 must
+        // report line 3 (the call site in the main routine).
+        let mut interp = Interpreter::new();
+        let src = "DEF BAD_WORD\n  PUTDEC 1 / 0\nEND\nPUTDEC 1\nPUTDEC 2\nBAD_WORD";
+        let result = interp.compile_program(src);
+        let err = result.expect_err("expected runtime error from division by zero in user word");
+        assert_ne!(
+            err.line, 0,
+            "runtime error line must not be 0 (was: {})",
+            err.line
+        );
+        assert_eq!(
+            err.line, 6,
+            "runtime error must point to line 6 (the BAD_WORD call site), got {}",
+            err.line
+        );
     }
 
     // --- compile_program integration tests (issue #266) ---

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -821,10 +821,13 @@ impl Interpreter {
         let saved_return_stack_len = self.vm.return_stack.len();
         let saved_bp = self.vm.bp;
 
+        // Capture main-routine size before execution so that ALLOT or other dp-advancing
+        // operations inside vm.run() do not skew the length used for position lookup.
+        let main_len = self.vm.dp - main_start;
+
         // Execute the main routine.
         let run_result = self.vm.run(main_start);
         let error_pc = self.vm.pc;
-        let main_len = self.vm.dp - main_start;
 
         // Release main-routine memory regardless of outcome.
         self.vm.dp = main_start;
@@ -1005,10 +1008,14 @@ fn resolve_source_pos(
     }
 
     // Strategy 2: scan return stack for a call frame pointing just after the main routine.
-    let upper_bound = main_start + main_len + 4;
+    // The main routine spans [main_start, main_start + main_len); EXIT occupies the last cell.
+    // A valid return_pc from a call inside the main routine must satisfy:
+    //   main_start < return_pc < main_start + main_len
+    // (return_pc = pc + 1 for EntryKind::Word, pc + 4 for EntryKind::Call; both are
+    // strictly less than main_start + main_len because EXIT follows the last statement.)
     for frame in return_stack.iter().rev() {
         if let ReturnFrame::Call { return_pc, .. } = frame {
-            if *return_pc > main_start && *return_pc <= upper_bound {
+            if *return_pc > main_start && *return_pc < main_start + main_len {
                 let offset = return_pc - main_start - 1;
                 if let Some(pos) = lookup(offset) {
                     return pos;

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -967,6 +967,7 @@ impl Interpreter {
 }
 
 /// Source-position metadata for one ground-level statement compiled by `compile_program_segment`.
+#[derive(Debug)]
 struct StmtPosition {
     /// Offset of the statement's first cell in the `main_cells` buffer.
     offset: usize,


### PR DESCRIPTION
## 概要

`compile_program` が `vm.run()` から返るエラーを `InterpreterError::new(0, 0, "", e)` で包むため、ファイル実行モードでランタイムエラーが起きても行番号が表示されない問題を修正する。
`Cell` / `VM` には一切手を加えず、`interpreter.rs` 1ファイルの変更で完結するアウトオブバンド位置テーブル方式を採用した（issue コメントの方針A）。

## 変更内容

### `src/interpreter.rs`

- **`compile_program_segment` の引数追加**:
  - `absolute_line: usize` — 全体ソースファイルにおける1ベース行番号（トークン位置は行内相対のため外から渡す）
  - `stmt_positions: &mut Vec<(usize, usize, usize, String)>` — グラウンドレベル文ごとの位置テーブル
- **位置テーブルへの記録**: グラウンドレベル文をコンパイルして `main_cells` にセルが追加された場合のみ `(オフセット, 行, 列, ソース行テキスト)` をテーブルに追加する
- **`resolve_source_pos` 追加**: `vm.pc` とリターンスタックからテーブルを引いて `(line, col, source)` を返すプライベート関数。2つの探索戦略を持つ:
  1. `error_pc` がメインルーティン内 → `offset = error_pc - main_start` でテーブルを引く
  2. リターンスタック末尾からメインルーティンへの復帰フレームを走査 → `offset = return_pc - main_start - 1` でテーブルを引く（ユーザー定義ワード内エラーのコールサイトを特定）
- **TODO コメント削除**: `Err(e)` アームの TODO(#275) を削除し、`resolve_source_pos` を呼び出すよう変更
- **テスト追加** (`test_compile_program_runtime_error_line_number`, `test_compile_program_runtime_error_in_user_word_line_number`): ランタイムエラー時の行番号が 0 でなく正確な値であることを検証

Closes #275
