### PR TITLE
制御構造の対応不整合をコンパイル時に検知する仕組みを追加する

### DIFF
--- a/blueprint-compiler.md
+++ b/blueprint-compiler.md
@@ -90,7 +90,7 @@ DEF 開始時に両構造体を生成し、END 完了後に破棄する。行番
 
 ## コンパイルスタックプリミティブ
 
-コンパイルワードの実装に使用するプリミティブ群。このうち `CS_PUSH` / `CS_POP` / `CS_SWAP` / `CS_DROP` / `CS_DUP` / `CS_OVER` / `CS_ROT` / `PATCH_ADDR` / `COMPILE_EXPR` は **コンパイルモード（`is_compiling = true`）専用** であり、実行モード中に呼ばれた場合はエラーとする。`APPEND` / `HERE` / `JUMP_FALSE` / `JUMP_TRUE` / `JUMP_ALWAYS` は汎用プリミティブであり、コンパイルモード以外でも使用できる。
+コンパイルワードの実装に使用するプリミティブ群。このうち `CS_PUSH` / `CS_POP` / `CS_SWAP` / `CS_DROP` / `CS_DUP` / `CS_OVER` / `CS_ROT` / `PATCH_ADDR` / `COMPILE_EXPR` / `CTRL_OPEN_IF` / `CTRL_OPEN_WHILE` / `CTRL_CLOSE_IF` / `CTRL_CLOSE_WHILE` は **コンパイルモード（`is_compiling = true`）専用** であり、実行モード中に呼ばれた場合はエラーとする。`APPEND` / `HERE` / `JUMP_FALSE` / `JUMP_TRUE` / `JUMP_ALWAYS` は汎用プリミティブであり、コンパイルモード以外でも使用できる。
 
 | プリミティブ | スタック効果 | 説明 |
 | ------------ | ------------ | ---- |
@@ -108,6 +108,10 @@ DEF 開始時に両構造体を生成し、END 完了後に破棄する。行番
 | `JUMP_FALSE` | `( -- xt )` | `BranchIfFalse`（BIF）のXt定数をデータスタックに積む |
 | `JUMP_TRUE`  | `( -- xt )` | `BranchIfTrue`（BIT）のXt定数をデータスタックに積む |
 | `JUMP_ALWAYS` | `( -- xt )` | `Goto` のXt定数をデータスタックに積む |
+| `CTRL_OPEN_IF`     | `( -- )` | `control_stack` に `ControlKind::If` を積む（IF の先頭で呼ぶ） |
+| `CTRL_OPEN_WHILE`  | `( -- )` | `control_stack` に `ControlKind::While` を積む（WHILE の先頭で呼ぶ） |
+| `CTRL_CLOSE_IF`    | `( -- )` | `control_stack` のトップが `If` か検証してポップする（ENDIF の先頭でフェイルファスト） |
+| `CTRL_CLOSE_WHILE` | `( -- )` | `control_stack` のトップが `While` か検証してポップする（ENDWH の先頭でフェイルファスト） |
 
 `PATCH_ADDR` はコンパイルスタックと組み合わせて分岐命令のアドレスを事後的に埋める用途で使用する。典型的なパターン:
 
@@ -129,6 +133,7 @@ ENDIF は WHILE ループで複数の JUMP_ALWAYS プレースホルダーをパ
 
 ```
 DEF IF
+  CTRL_OPEN_IF
   COMPILE_EXPR
   APPEND JUMP_FALSE
   CS_PUSH 0        REM initial count: number of ELSIF calls so far
@@ -138,6 +143,7 @@ END
 IMMEDIATE IF
 
 DEF ENDIF
+  CTRL_CLOSE_IF
   PATCH_ADDR CS_POP     REM patch last BIF/JUMP_ALWAYS placeholder (C)
   VAR N
   SET &N, CS_POP        REM retrieve ELSIF call count
@@ -184,10 +190,11 @@ ENDIF の拡張方針は issue #338 で**カウント方式**に決定した。
 
 ### IF（変更）
 
-`CS_PUSH 0`（初期カウント）を追加し、コンパイルスタックを `[0, A]` 形式に変更した。
+`CTRL_OPEN_IF`（初期カウント前）と `CS_PUSH 0`（初期カウント）を追加し、コンパイルスタックを `[0, A]` 形式に変更した。
 
 ```
 DEF IF
+  CTRL_OPEN_IF
   COMPILE_EXPR
   APPEND JUMP_FALSE
   CS_PUSH 0        REM initial count: number of ELSIF calls so far
@@ -199,11 +206,12 @@ IMMEDIATE IF
 
 ### ENDIF（変更）
 
-`WHILE`/`ENDWH` ループで蓄積された `JUMP_ALWAYS` プレースホルダーを一括パッチする。
+`CTRL_CLOSE_IF` を先頭に追加し、compile_stack を触る前にフェイルファストで制御スタックを検証する。`WHILE`/`ENDWH` ループで蓄積された `JUMP_ALWAYS` プレースホルダーを一括パッチする。
 `WHILE`/`ENDWH` は `lib/basic.tbx` で ENDIF より前に定義されていること。
 
 ```
 DEF ENDIF
+  CTRL_CLOSE_IF
   PATCH_ADDR CS_POP     REM patch last BIF/JUMP_ALWAYS placeholder (C)
   VAR N
   SET &N, CS_POP        REM retrieve ELSIF call count
@@ -309,6 +317,7 @@ WHILE と ENDWH は `lib/basic.tbx` に TBX コードとして実装されたコ
 ```
 REM WHILE expr ... ENDWH
 DEF WHILE
+  CTRL_OPEN_WHILE
   CS_PUSH HERE
   COMPILE_EXPR
   APPEND JUMP_FALSE
@@ -318,6 +327,7 @@ END
 IMMEDIATE WHILE
 
 DEF ENDWH
+  CTRL_CLOSE_WHILE
   CS_SWAP
   APPEND JUMP_ALWAYS
   APPEND CS_POP
@@ -349,10 +359,11 @@ D:  ...（ENDWH 直後）
 
 ### ENDWH の動作トレース
 
-1. `CS_SWAP` — CS を `[A, Caddr]` → `[Caddr, A]` に並び替える（A がトップ）
-2. `APPEND JUMP_ALWAYS` — 無条件ジャンプ命令の Xt を辞書に書き込む
-3. `APPEND CS_POP` — CS から A（DictAddr）をポップして辞書に書き込む（JUMP_ALWAYS のジャンプ先ターゲット）
-4. `PATCH_ADDR CS_POP` — CS から Caddr をポップし、`dictionary[Caddr]` に現在の DP（= ENDWH 直後）を書き込む（BIF のジャンプ先を確定）
+1. `CTRL_CLOSE_WHILE` — `control_stack` のトップが `While` か検証してポップする（フェイルファスト）
+2. `CS_SWAP` — CS を `[A, Caddr]` → `[Caddr, A]` に並び替える（A がトップ）
+3. `APPEND JUMP_ALWAYS` — 無条件ジャンプ命令の Xt を辞書に書き込む
+4. `APPEND CS_POP` — CS から A（DictAddr）をポップして辞書に書き込む（JUMP_ALWAYS のジャンプ先ターゲット）
+5. `PATCH_ADDR CS_POP` — CS から Caddr をポップし、`dictionary[Caddr]` に現在の DP（= ENDWH 直後）を書き込む（BIF のジャンプ先を確定）
 
 ### `read_jump_target` の簡略化
 

--- a/lib/basic.tbx
+++ b/lib/basic.tbx
@@ -9,6 +9,7 @@ REM  emits JUMP_ALWAYS back to the loop start (as DictAddr), then patches the
 REM  JUMP_FALSE placeholder with the current HERE value (= ENDWH+1).
 
 DEF WHILE
+  CTRL_OPEN_WHILE
   CS_PUSH HERE
   COMPILE_EXPR
   APPEND JUMP_FALSE
@@ -18,6 +19,7 @@ END
 IMMEDIATE WHILE
 
 DEF ENDWH
+  CTRL_CLOSE_WHILE
   CS_SWAP
   APPEND JUMP_ALWAYS
   APPEND CS_POP
@@ -45,6 +47,7 @@ REM  and patches each accumulated JUMP_ALWAYS placeholder B1...BN using WHILE/EN
 REM  WHILE/ENDWH must be defined before ENDIF.
 
 DEF IF
+  CTRL_OPEN_IF
   COMPILE_EXPR
   APPEND JUMP_FALSE
   REM push initial ELSIF count (0), then BIF placeholder address (A)
@@ -55,6 +58,7 @@ END
 IMMEDIATE IF
 
 DEF ENDIF
+  CTRL_CLOSE_IF
   REM patch last BIF/JUMP_ALWAYS placeholder (C)
   PATCH_ADDR CS_POP
   VAR N

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -1,3 +1,23 @@
+/// Identifies which kind of control structure opened a compile-time scope.
+///
+/// Pushed onto `VM::control_stack` by `CTRL_OPEN_IF` / `CTRL_OPEN_WHILE` and
+/// popped (with validation) by `CTRL_CLOSE_IF` / `CTRL_CLOSE_WHILE`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ControlKind {
+    If,
+    While,
+}
+
+impl ControlKind {
+    /// Returns a human-readable keyword name used in error messages.
+    pub fn keyword(&self) -> &'static str {
+        match self {
+            ControlKind::If => "IF",
+            ControlKind::While => "WHILE",
+        }
+    }
+}
+
 /// Execution token: a type-safe index into `VM::headers` (the word header table).
 ///
 /// Distinct from an index into `VM::dictionary` (the flat code/data array).

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -2,7 +2,7 @@
 ///
 /// Pushed onto `VM::control_stack` by `CTRL_OPEN_IF` / `CTRL_OPEN_WHILE` and
 /// popped (with validation) by `CTRL_CLOSE_IF` / `CTRL_CLOSE_WHILE`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ControlKind {
     If,
     While,

--- a/src/error.rs
+++ b/src/error.rs
@@ -113,6 +113,24 @@ pub enum TbxError {
         path: String,
     },
 
+    /// ENDIF/ENDWH was reached but the control stack top does not match.
+    ///
+    /// For example, `IF ... WHILE ... ENDIF` causes `CTRL_CLOSE_IF` to find
+    /// `While` on the top of the control stack instead of `If`.
+    MismatchedControlStructure {
+        /// The closing keyword that was encountered (e.g. "ENDIF")
+        close_word: &'static str,
+        /// The opening keyword at the top of the control stack (e.g. "WHILE")
+        open_word: &'static str,
+    },
+    /// ENDIF/ENDWH was reached but the control stack is empty.
+    ///
+    /// Indicates a closing keyword without a matching opening keyword.
+    UnopenedControlStructure {
+        /// The closing keyword that was encountered (e.g. "ENDWH")
+        keyword: &'static str,
+    },
+
     /// Assertion explicitly failed via ASSERT_FAIL.
     AssertionFailed,
     /// Assertion explicitly failed via ASSERT_FAIL_MSG with a custom message.
@@ -198,6 +216,18 @@ impl std::fmt::Display for TbxError {
             }
             TbxError::CircularUse { path } => {
                 write!(f, "USE: circular USE detected: '{path}'")
+            }
+            TbxError::MismatchedControlStructure {
+                close_word,
+                open_word,
+            } => {
+                write!(
+                    f,
+                    "mismatched control structure: '{close_word}' does not match '{open_word}'"
+                )
+            }
+            TbxError::UnopenedControlStructure { keyword } => {
+                write!(f, "no matching open for '{keyword}'")
             }
             TbxError::AssertionFailed => write!(f, "assertion failed"),
             TbxError::AssertionFailedWithMessage { message } => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -93,6 +93,13 @@ pub enum TbxError {
     CompileStackNotEmpty {
         count: usize,
     },
+    /// control_stack has leftover items when END is executed.
+    ///
+    /// Word definition is incomplete — some control-structure open words (IF/WHILE)
+    /// were not closed by matching ENDIF/ENDWH.
+    ControlStackNotEmpty {
+        count: usize,
+    },
     /// A file requested via USE could not be found or read.
     FileNotFound {
         path: String,
@@ -206,6 +213,12 @@ impl std::fmt::Display for TbxError {
                 write!(
                     f,
                     "compile stack has {count} unpatched item(s) at END; word definition is incomplete"
+                )
+            }
+            TbxError::ControlStackNotEmpty { count } => {
+                write!(
+                    f,
+                    "control stack has {count} unclosed structure(s) at END; missing ENDIF or ENDWH"
                 )
             }
             TbxError::FileNotFound { path, reason } => {

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -3715,4 +3715,24 @@ NOOP_LOOP(4)";
             other => panic!("expected MismatchedControlStructure(ENDWH/IF), got {other:?}"),
         }
     }
+
+    #[test]
+    fn test_if_elsif_endwh_cross_nesting_error() {
+        // IF ... ELSIF ... ENDWH must fail with MismatchedControlStructure.
+        // ELSIF does not push to control_stack, so ENDWH sees ControlKind::If on top.
+        let mut interp = Interpreter::new();
+        let src = "DEF BAD(X)\n  IF X > 2\n    PUTDEC X\n  ELSIF X > 0\n    PUTDEC 1\n  ENDWH\nEND";
+        let result = interp.exec_source(src);
+        match result {
+            Err(e)
+                if matches!(
+                    e.kind,
+                    crate::error::TbxError::MismatchedControlStructure {
+                        close_word: "ENDWH",
+                        open_word: "IF",
+                    }
+                ) => {}
+            other => panic!("expected MismatchedControlStructure(ENDWH/IF), got {other:?}"),
+        }
+    }
 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -3695,4 +3695,24 @@ NOOP_LOOP(4)";
             .exec_source(src)
             .expect("correct nesting must succeed");
     }
+
+    #[test]
+    fn test_if_else_endwh_cross_nesting_error() {
+        // IF ... ELSE ... ENDWH must fail with MismatchedControlStructure.
+        // ELSE does not push to control_stack, so ENDWH sees ControlKind::If on top.
+        let mut interp = Interpreter::new();
+        let src = "DEF BAD(X)\n  IF X > 0\n    PUTDEC X\n  ELSE\n    PUTDEC 0\n  ENDWH\nEND";
+        let result = interp.exec_source(src);
+        match result {
+            Err(e)
+                if matches!(
+                    e.kind,
+                    crate::error::TbxError::MismatchedControlStructure {
+                        close_word: "ENDWH",
+                        open_word: "IF",
+                    }
+                ) => {}
+            other => panic!("expected MismatchedControlStructure(ENDWH/IF), got {other:?}"),
+        }
+    }
 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -3585,4 +3585,114 @@ TRYROT";
             "ELSE at top level should return an error (no compile mode)"
         );
     }
+
+    // --- Control-structure mismatch detection (issue #358) ---
+
+    #[test]
+    fn test_if_while_endif_endwh_cross_nesting_error() {
+        // IF ... WHILE ... ENDIF  must fail with MismatchedControlStructure.
+        let mut interp = Interpreter::new();
+        let src =
+            "DEF BAD(X)\n  IF X > 0\n    WHILE X > 0\n      SET &X, X - 1\n    ENDIF\n  ENDWH\nEND";
+        let result = interp.exec_source(src);
+        match result {
+            Err(e)
+                if matches!(
+                    e.kind,
+                    crate::error::TbxError::MismatchedControlStructure {
+                        close_word: "ENDIF",
+                        open_word: "WHILE",
+                    }
+                ) => {}
+            other => panic!("expected MismatchedControlStructure(ENDIF/WHILE), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_if_endwh_cross_nesting_error() {
+        // IF ... ENDWH  must fail with MismatchedControlStructure.
+        let mut interp = Interpreter::new();
+        let src = "DEF BAD(X)\n  IF X > 0\n    PUTDEC X\n  ENDWH\nEND";
+        let result = interp.exec_source(src);
+        match result {
+            Err(e)
+                if matches!(
+                    e.kind,
+                    crate::error::TbxError::MismatchedControlStructure {
+                        close_word: "ENDWH",
+                        open_word: "IF",
+                    }
+                ) => {}
+            other => panic!("expected MismatchedControlStructure(ENDWH/IF), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_endwh_without_while_unopened_error() {
+        // ENDWH with no preceding WHILE must fail with UnopenedControlStructure.
+        let mut interp = Interpreter::new();
+        let src = "DEF BAD()\n  ENDWH\nEND";
+        let result = interp.exec_source(src);
+        match result {
+            Err(e)
+                if matches!(
+                    e.kind,
+                    crate::error::TbxError::UnopenedControlStructure { keyword: "ENDWH" }
+                ) => {}
+            other => panic!("expected UnopenedControlStructure(ENDWH), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_endif_without_if_unopened_error() {
+        // ENDIF with no preceding IF must fail with UnopenedControlStructure.
+        let mut interp = Interpreter::new();
+        let src = "DEF BAD()\n  ENDIF\nEND";
+        let result = interp.exec_source(src);
+        match result {
+            Err(e)
+                if matches!(
+                    e.kind,
+                    crate::error::TbxError::UnopenedControlStructure { keyword: "ENDIF" }
+                ) => {}
+            other => panic!("expected UnopenedControlStructure(ENDIF), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_correct_if_while_endwh_endif_nesting() {
+        // IF ... WHILE ... ENDWH ... ENDIF  must compile and run correctly.
+        let mut interp = Interpreter::new();
+        let src = "\
+DEF COUNT_DOWN(X)
+  IF X > 0
+    WHILE X > 0
+      SET &X, X - 1
+    ENDWH
+  ENDIF
+END
+COUNT_DOWN(3)";
+        interp
+            .exec_source(src)
+            .expect("correct nesting must succeed");
+    }
+
+    #[test]
+    fn test_correct_while_if_endif_endwh_nesting() {
+        // WHILE ... IF ... ENDIF ... ENDWH  must compile and run correctly.
+        let mut interp = Interpreter::new();
+        let src = "\
+DEF NOOP_LOOP(X)
+  WHILE X > 0
+    IF X > 1
+      SET &X, X - 1
+    ENDIF
+    SET &X, X - 1
+  ENDWH
+END
+NOOP_LOOP(4)";
+        interp
+            .exec_source(src)
+            .expect("correct nesting must succeed");
+    }
 }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -652,7 +652,7 @@ pub fn end_prim(vm: &mut VM) -> Result<(), TbxError> {
     if !vm.control_stack.is_empty() {
         let count = vm.control_stack.len();
         vm.rollback_def();
-        return Err(TbxError::CompileStackNotEmpty { count });
+        return Err(TbxError::ControlStackNotEmpty { count });
     }
 
     // Write EXIT to terminate the word body.

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1,4 +1,4 @@
-use crate::cell::Cell;
+use crate::cell::{Cell, ControlKind};
 use crate::constants::MAX_DICTIONARY_CELLS;
 use crate::dict::{EntryKind, WordEntry, FLAG_IMMEDIATE, FLAG_SYSTEM};
 use crate::error::TbxError;
@@ -1138,6 +1138,78 @@ fn cs_rot_prim(vm: &mut VM) -> Result<(), TbxError> {
     Ok(())
 }
 
+/// CTRL_OPEN_IF — push `ControlKind::If` onto the control stack.
+///
+/// Called at the start of `DEF IF` to record that an IF-block is being opened.
+/// Must be called in compile mode.
+fn ctrl_open_if_prim(vm: &mut VM) -> Result<(), TbxError> {
+    if !vm.is_compiling {
+        return Err(TbxError::InvalidExpression {
+            reason: "CTRL_OPEN_IF outside compile mode",
+        });
+    }
+    vm.control_stack.push(ControlKind::If);
+    Ok(())
+}
+
+/// CTRL_OPEN_WHILE — push `ControlKind::While` onto the control stack.
+///
+/// Called at the start of `DEF WHILE` to record that a WHILE-loop is being opened.
+/// Must be called in compile mode.
+fn ctrl_open_while_prim(vm: &mut VM) -> Result<(), TbxError> {
+    if !vm.is_compiling {
+        return Err(TbxError::InvalidExpression {
+            reason: "CTRL_OPEN_WHILE outside compile mode",
+        });
+    }
+    vm.control_stack.push(ControlKind::While);
+    Ok(())
+}
+
+/// CTRL_CLOSE_IF — validate and pop `ControlKind::If` from the control stack.
+///
+/// Called at the start of `DEF ENDIF` before touching `compile_stack` (fail-fast).
+/// Returns `UnopenedControlStructure` if the stack is empty, or
+/// `MismatchedControlStructure` if the top entry is not `If`.
+/// Must be called in compile mode.
+fn ctrl_close_if_prim(vm: &mut VM) -> Result<(), TbxError> {
+    if !vm.is_compiling {
+        return Err(TbxError::InvalidExpression {
+            reason: "CTRL_CLOSE_IF outside compile mode",
+        });
+    }
+    match vm.control_stack.pop() {
+        None => Err(TbxError::UnopenedControlStructure { keyword: "ENDIF" }),
+        Some(ControlKind::If) => Ok(()),
+        Some(got) => Err(TbxError::MismatchedControlStructure {
+            close_word: "ENDIF",
+            open_word: got.keyword(),
+        }),
+    }
+}
+
+/// CTRL_CLOSE_WHILE — validate and pop `ControlKind::While` from the control stack.
+///
+/// Called at the start of `DEF ENDWH` before touching `compile_stack` (fail-fast).
+/// Returns `UnopenedControlStructure` if the stack is empty, or
+/// `MismatchedControlStructure` if the top entry is not `While`.
+/// Must be called in compile mode.
+fn ctrl_close_while_prim(vm: &mut VM) -> Result<(), TbxError> {
+    if !vm.is_compiling {
+        return Err(TbxError::InvalidExpression {
+            reason: "CTRL_CLOSE_WHILE outside compile mode",
+        });
+    }
+    match vm.control_stack.pop() {
+        None => Err(TbxError::UnopenedControlStructure { keyword: "ENDWH" }),
+        Some(ControlKind::While) => Ok(()),
+        Some(got) => Err(TbxError::MismatchedControlStructure {
+            close_word: "ENDWH",
+            open_word: got.keyword(),
+        }),
+    }
+}
+
 /// PATCH_ADDR — pop a DictAddr from the data stack, then write Cell::DictAddr(dp) at that address.
 ///
 /// Used by ENDIF, ENDWH, and future ELSE to back-patch a previously emitted
@@ -1441,6 +1513,21 @@ pub fn register_all(vm: &mut VM) {
     vm.register(WordEntry::new_primitive("CS_ROT", cs_rot_prim));
     vm.register(WordEntry::new_primitive("PATCH_ADDR", patch_addr_prim));
     vm.register(WordEntry::new_primitive("COMPILE_EXPR", compile_expr_prim));
+    // Control-structure kind stack primitives.
+    // Used by IF/WHILE/ENDIF/ENDWH to detect cross-nesting at compile time.
+    vm.register(WordEntry::new_primitive("CTRL_OPEN_IF", ctrl_open_if_prim));
+    vm.register(WordEntry::new_primitive(
+        "CTRL_OPEN_WHILE",
+        ctrl_open_while_prim,
+    ));
+    vm.register(WordEntry::new_primitive(
+        "CTRL_CLOSE_IF",
+        ctrl_close_if_prim,
+    ));
+    vm.register(WordEntry::new_primitive(
+        "CTRL_CLOSE_WHILE",
+        ctrl_close_while_prim,
+    ));
 
     // Runtime branch/jump Xt constants — allows TBX code to write:
     //   APPEND JUMP_FALSE, APPEND JUMP_ALWAYS, etc.
@@ -1469,7 +1556,7 @@ pub fn register_all(vm: &mut VM) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cell::Cell;
+    use crate::cell::{Cell, ControlKind};
     use crate::constants::MAX_DICTIONARY_CELLS;
 
     // --- drop_prim ---
@@ -4318,5 +4405,147 @@ mod tests {
         );
         // Data stack must be empty.
         assert_eq!(vm.pop(), Err(TbxError::StackUnderflow));
+    }
+
+    // --- CTRL_OPEN_IF / CTRL_OPEN_WHILE / CTRL_CLOSE_IF / CTRL_CLOSE_WHILE ---
+
+    #[test]
+    fn test_ctrl_open_if_outside_compile_mode_error() {
+        let mut vm = VM::new();
+        assert_eq!(
+            ctrl_open_if_prim(&mut vm),
+            Err(TbxError::InvalidExpression {
+                reason: "CTRL_OPEN_IF outside compile mode"
+            })
+        );
+    }
+
+    #[test]
+    fn test_ctrl_open_while_outside_compile_mode_error() {
+        let mut vm = VM::new();
+        assert_eq!(
+            ctrl_open_while_prim(&mut vm),
+            Err(TbxError::InvalidExpression {
+                reason: "CTRL_OPEN_WHILE outside compile mode"
+            })
+        );
+    }
+
+    #[test]
+    fn test_ctrl_close_if_outside_compile_mode_error() {
+        let mut vm = VM::new();
+        assert_eq!(
+            ctrl_close_if_prim(&mut vm),
+            Err(TbxError::InvalidExpression {
+                reason: "CTRL_CLOSE_IF outside compile mode"
+            })
+        );
+    }
+
+    #[test]
+    fn test_ctrl_close_while_outside_compile_mode_error() {
+        let mut vm = VM::new();
+        assert_eq!(
+            ctrl_close_while_prim(&mut vm),
+            Err(TbxError::InvalidExpression {
+                reason: "CTRL_CLOSE_WHILE outside compile mode"
+            })
+        );
+    }
+
+    #[test]
+    fn test_ctrl_open_if_pushes_if_kind() {
+        let mut vm = VM::new();
+        vm.is_compiling = true;
+        ctrl_open_if_prim(&mut vm).unwrap();
+        assert_eq!(vm.control_stack, vec![ControlKind::If]);
+    }
+
+    #[test]
+    fn test_ctrl_open_while_pushes_while_kind() {
+        let mut vm = VM::new();
+        vm.is_compiling = true;
+        ctrl_open_while_prim(&mut vm).unwrap();
+        assert_eq!(vm.control_stack, vec![ControlKind::While]);
+    }
+
+    #[test]
+    fn test_ctrl_close_if_empty_stack_error() {
+        let mut vm = VM::new();
+        vm.is_compiling = true;
+        assert_eq!(
+            ctrl_close_if_prim(&mut vm),
+            Err(TbxError::UnopenedControlStructure { keyword: "ENDIF" })
+        );
+    }
+
+    #[test]
+    fn test_ctrl_close_while_empty_stack_error() {
+        let mut vm = VM::new();
+        vm.is_compiling = true;
+        assert_eq!(
+            ctrl_close_while_prim(&mut vm),
+            Err(TbxError::UnopenedControlStructure { keyword: "ENDWH" })
+        );
+    }
+
+    #[test]
+    fn test_ctrl_close_if_matching_pops_if() {
+        let mut vm = VM::new();
+        vm.is_compiling = true;
+        vm.control_stack.push(ControlKind::If);
+        ctrl_close_if_prim(&mut vm).unwrap();
+        assert!(vm.control_stack.is_empty());
+    }
+
+    #[test]
+    fn test_ctrl_close_while_matching_pops_while() {
+        let mut vm = VM::new();
+        vm.is_compiling = true;
+        vm.control_stack.push(ControlKind::While);
+        ctrl_close_while_prim(&mut vm).unwrap();
+        assert!(vm.control_stack.is_empty());
+    }
+
+    #[test]
+    fn test_ctrl_close_if_mismatched_while_error() {
+        // Simulates: WHILE ... ENDIF  (cross-nesting error)
+        let mut vm = VM::new();
+        vm.is_compiling = true;
+        vm.control_stack.push(ControlKind::While);
+        assert_eq!(
+            ctrl_close_if_prim(&mut vm),
+            Err(TbxError::MismatchedControlStructure {
+                close_word: "ENDIF",
+                open_word: "WHILE"
+            })
+        );
+    }
+
+    #[test]
+    fn test_ctrl_close_while_mismatched_if_error() {
+        // Simulates: IF ... ENDWH  (cross-nesting error)
+        let mut vm = VM::new();
+        vm.is_compiling = true;
+        vm.control_stack.push(ControlKind::If);
+        assert_eq!(
+            ctrl_close_while_prim(&mut vm),
+            Err(TbxError::MismatchedControlStructure {
+                close_word: "ENDWH",
+                open_word: "IF"
+            })
+        );
+    }
+
+    #[test]
+    fn test_ctrl_nested_if_while_correct_order() {
+        // Simulates: IF ... WHILE ... ENDWH ... ENDIF  (correct nesting)
+        let mut vm = VM::new();
+        vm.is_compiling = true;
+        ctrl_open_if_prim(&mut vm).unwrap();
+        ctrl_open_while_prim(&mut vm).unwrap();
+        ctrl_close_while_prim(&mut vm).unwrap();
+        ctrl_close_if_prim(&mut vm).unwrap();
+        assert!(vm.control_stack.is_empty());
     }
 }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -4560,4 +4560,32 @@ mod tests {
         ctrl_close_if_prim(&mut vm).unwrap();
         assert!(vm.control_stack.is_empty());
     }
+
+    #[test]
+    fn test_end_prim_control_stack_not_empty_error() {
+        // end_prim must return ControlStackNotEmpty and rollback when control_stack
+        // has leftover items (defensive check for future code paths).
+        let mut vm = make_compiling_vm("MYWORD2");
+        // Manually leave an item on control_stack without a matching compile_stack entry.
+        vm.control_stack.push(ControlKind::If);
+        let err = end_prim(&mut vm).unwrap_err();
+        assert!(
+            matches!(err, TbxError::ControlStackNotEmpty { count: 1 }),
+            "expected ControlStackNotEmpty {{ count: 1 }}, got {err:?}"
+        );
+        // VM must have been rolled back.
+        assert!(
+            !vm.is_compiling,
+            "is_compiling must be false after rollback"
+        );
+        // Both stacks must be cleared after rollback.
+        assert!(
+            vm.compile_stack.is_empty(),
+            "compile_stack must be empty after rollback"
+        );
+        assert!(
+            vm.control_stack.is_empty(),
+            "control_stack must be empty after rollback"
+        );
+    }
 }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -643,6 +643,18 @@ pub fn end_prim(vm: &mut VM) -> Result<(), TbxError> {
         return Err(TbxError::CompileStackNotEmpty { count });
     }
 
+    // Defensive check: control_stack must also be empty at END.
+    // Under normal operation this invariant is guaranteed because each CTRL_OPEN_*
+    // call is paired with a matching CTRL_CLOSE_* call, and CTRL_CLOSE_* also
+    // empties compile_stack items (so CompileStackNotEmpty fires first).
+    // The explicit check here guards against future code paths where CTRL_OPEN_*
+    // is called without a corresponding CS_PUSH.
+    if !vm.control_stack.is_empty() {
+        let count = vm.control_stack.len();
+        vm.rollback_def();
+        return Err(TbxError::CompileStackNotEmpty { count });
+    }
+
     // Write EXIT to terminate the word body.
     let exit_xt =
         vm.find_by_kind(|k| matches!(k, EntryKind::Exit))

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -145,6 +145,13 @@ pub struct VM {
     /// Compile-time stack: used by IMMEDIATE words to pass values between
     /// compile-time word invocations (e.g. CS_PUSH / CS_POP for IF/ENDIF).
     pub(crate) compile_stack: Vec<Cell>,
+    /// Control-structure kind stack: tracks which control structures are currently
+    /// open during compilation, independently of `compile_stack`.
+    ///
+    /// `CTRL_OPEN_IF` / `CTRL_OPEN_WHILE` push onto this stack; `CTRL_CLOSE_IF` /
+    /// `CTRL_CLOSE_WHILE` pop and validate the top entry (fail-fast before touching
+    /// `compile_stack`).  Cleared on rollback alongside `compile_stack`.
+    pub(crate) control_stack: Vec<crate::cell::ControlKind>,
     /// Path of a file to be loaded after the current IMMEDIATE word returns.
     ///
     /// Set by `use_prim` when it encounters a USE "path" statement.
@@ -177,6 +184,7 @@ impl VM {
             token_stream: None,
             compile_state: None,
             compile_stack: Vec::new(),
+            control_stack: Vec::new(),
             pending_use_path: None,
         }
     }
@@ -831,6 +839,7 @@ impl VM {
         // Always clear the compile stack on rollback to prevent state leakage
         // into the next DEF..END compilation.
         self.compile_stack.clear();
+        self.control_stack.clear();
     }
 
     /// Perform a definition rollback using explicitly supplied snapshot values.
@@ -853,6 +862,7 @@ impl VM {
         // Always clear the compile stack on rollback to prevent state leakage
         // into the next DEF..END compilation.
         self.compile_stack.clear();
+        self.control_stack.clear();
     }
 
     /// Find the first header entry whose `kind` satisfies `pred`.


### PR DESCRIPTION
## 概要

`IF/WHILE/ENDIF/ENDWH` などの制御構造が対応していないクロスネスト（例: `IF ... WHILE ... ENDIF ... ENDWH`）を、コンパイル時に明確なエラーとして検知できるようにする。

## 変更内容

### `src/cell.rs`
- `ControlKind` enum を追加（`If` / `While` の2バリアント、`keyword()` メソッド付き）

### `src/vm.rs`
- `VM` 構造体に `control_stack: Vec<ControlKind>` フィールドを追加
- `VM::new()` に `control_stack: Vec::new()` を追加
- `rollback_def()` / `rollback_def_explicit()` で `control_stack.clear()` を呼ぶ

### `src/error.rs`
- `TbxError::MismatchedControlStructure { close_word, open_word }` を追加
- `TbxError::UnopenedControlStructure { keyword }` を追加
- 両バリアントの `Display` 実装を追加

### `src/primitives.rs`
- 4 つのプリミティブを追加・登録:
  - `CTRL_OPEN_IF` — `control_stack.push(ControlKind::If)`
  - `CTRL_OPEN_WHILE` — `control_stack.push(ControlKind::While)`
  - `CTRL_CLOSE_IF` — スタックトップが `If` か検証してポップ（フェイルファスト）
  - `CTRL_CLOSE_WHILE` — スタックトップが `While` か検証してポップ（フェイルファスト）
- 各プリミティブの単体テストを追加

### `lib/basic.tbx`
- `DEF IF` 先頭に `CTRL_OPEN_IF` を追加
- `DEF WHILE` 先頭に `CTRL_OPEN_WHILE` を追加
- `DEF ENDIF` 先頭に `CTRL_CLOSE_IF` を追加（compile_stack を触る前にフェイルファスト）
- `DEF ENDWH` 先頭に `CTRL_CLOSE_WHILE` を追加（同上）

Closes #358
