### PR TITLE
compile_stackとcontrol_stackを統合してCompileEntryを導入する

### DIFF
--- a/blueprint-compiler.md
+++ b/blueprint-compiler.md
@@ -90,14 +90,14 @@ DEF 開始時に両構造体を生成し、END 完了後に破棄する。行番
 
 ## コンパイルスタックプリミティブ
 
-コンパイルワードの実装に使用するプリミティブ群。このうち `CS_PUSH` / `CS_POP` / `CS_SWAP` / `CS_DROP` / `CS_DUP` / `CS_OVER` / `CS_ROT` / `PATCH_ADDR` / `COMPILE_EXPR` / `CTRL_OPEN_IF` / `CTRL_OPEN_WHILE` / `CTRL_CLOSE_IF` / `CTRL_CLOSE_WHILE` は **コンパイルモード（`is_compiling = true`）専用** であり、実行モード中に呼ばれた場合はエラーとする。`APPEND` / `HERE` / `JUMP_FALSE` / `JUMP_TRUE` / `JUMP_ALWAYS` は汎用プリミティブであり、コンパイルモード以外でも使用できる。
+コンパイルワードの実装に使用するプリミティブ群。このうち `CS_PUSH` / `CS_POP` / `CS_SWAP` / `CS_DROP` / `CS_DUP` / `CS_OVER` / `CS_ROT` / `PATCH_ADDR` / `COMPILE_EXPR` / `CS_OPEN_TAG` / `CS_CLOSE_TAG` は **コンパイルモード（`is_compiling = true`）専用** であり、実行モード中に呼ばれた場合はエラーとする。`APPEND` / `HERE` / `JUMP_FALSE` / `JUMP_TRUE` / `JUMP_ALWAYS` は汎用プリミティブであり、コンパイルモード以外でも使用できる。
 
 | プリミティブ | スタック効果 | 説明 |
 | ------------ | ------------ | ---- |
 | `APPEND`     | `( cell -- )` | スタックトップの Cell を `dictionary[DP]` に書き込み DP を +1 進める |
 | `HERE`       | `( -- addr )` | 現在の辞書ポインタ（次の書き込み先の DictAddr）をデータスタックに積む |
 | `CS_PUSH`    | `( val -- )` | データスタックのトップを compile_stack に移動する |
-| `CS_POP`     | `( -- val )` | compile_stack のトップをデータスタックに移動する |
+| `CS_POP`     | `( -- val )` | compile_stack のトップ（`Cell` エントリ）をデータスタックに移動する。`Tag` エントリがトップにある場合は `TypeError` を返す |
 | `CS_SWAP`    | `( a b -- b a )` | compile_stack のトップ2要素を交換する |
 | `CS_DROP`    | `( a -- )` | compile_stack のトップを捨てる |
 | `CS_DUP`     | `( a -- a a )` | compile_stack のトップを複製する |
@@ -108,10 +108,10 @@ DEF 開始時に両構造体を生成し、END 完了後に破棄する。行番
 | `JUMP_FALSE` | `( -- xt )` | `BranchIfFalse`（BIF）のXt定数をデータスタックに積む |
 | `JUMP_TRUE`  | `( -- xt )` | `BranchIfTrue`（BIT）のXt定数をデータスタックに積む |
 | `JUMP_ALWAYS` | `( -- xt )` | `Goto` のXt定数をデータスタックに積む |
-| `CTRL_OPEN_IF`     | `( -- )` | `control_stack` に `ControlKind::If` を積む（IF の先頭で呼ぶ） |
-| `CTRL_OPEN_WHILE`  | `( -- )` | `control_stack` に `ControlKind::While` を積む（WHILE の先頭で呼ぶ） |
-| `CTRL_CLOSE_IF`    | `( -- )` | `control_stack` のトップが `If` か検証してポップする（ENDIF の先頭でフェイルファスト） |
-| `CTRL_CLOSE_WHILE` | `( -- )` | `control_stack` のトップが `While` か検証してポップする（ENDWH の先頭でフェイルファスト） |
+| `CS_OPEN_TAG` | `( str -- )` | データスタックから `StringDesc` をポップし、文字列を解決して `CompileEntry::Tag(string)` を compile_stack に積む。制御構造の開始を記録するために使用する |
+| `CS_CLOSE_TAG` | `( str -- )` | データスタックから `StringDesc` をポップし、compile_stack のトップが一致する `Tag` であることを検証してポップする。不一致なら `MismatchedTag`、タグがなければ `NoOpenTag` を返す |
+
+`CS_SWAP` / `CS_DROP` / `CS_DUP` / `CS_OVER` / `CS_ROT` は `CompileEntry` の種別（`Cell` / `Tag`）を問わず操作する。タグの整合性チェックは `CS_OPEN_TAG` / `CS_CLOSE_TAG` を通じて tbx 側のコードが責任を持つ。
 
 `PATCH_ADDR` はコンパイルスタックと組み合わせて分岐命令のアドレスを事後的に埋める用途で使用する。典型的なパターン:
 
@@ -133,17 +133,17 @@ ENDIF は WHILE ループで複数の JUMP_ALWAYS プレースホルダーをパ
 
 ```
 DEF IF
-  CTRL_OPEN_IF
   COMPILE_EXPR
   APPEND JUMP_FALSE
   CS_PUSH 0        REM initial count: number of ELSIF calls so far
   CS_PUSH HERE     REM BIF jump-target placeholder address (A)
   APPEND 0
+  CS_OPEN_TAG "IF" REM push Tag("IF") last (tag-last layout)
 END
 IMMEDIATE IF
 
 DEF ENDIF
-  CTRL_CLOSE_IF
+  CS_CLOSE_TAG "IF"     REM validate and pop Tag("IF") first (fail-fast)
   PATCH_ADDR CS_POP     REM patch last BIF/JUMP_ALWAYS placeholder (C)
   VAR N
   SET &N, CS_POP        REM retrieve ELSIF call count
@@ -182,36 +182,37 @@ ENDIF の拡張方針は issue #338 で**カウント方式**に決定した。
 
 ### コンパイルスタック構造（カウント方式）
 
-コンパイルスタックのフォーマットは `[B1...BN, N, C]`（C がトップ）。
+コンパイルスタックのフォーマットは `[B1...BN, N, C, Tag("IF")]`（`Tag("IF")` がトップ、タグラスト方式）。
 
 - `C` : 直前の条件分岐（BIF）のジャンプ先プレースホルダーアドレス
 - `N` : ELSIF の呼び出し回数（= 蓄積された JUMP_ALWAYS プレースホルダーの数）
 - `B1...BN` : 各 if/elsif ブロック末尾の JUMP_ALWAYS プレースホルダーアドレス
+- `Tag("IF")` : 制御構造の種別タグ（常にスタックの最上位に位置する）
 
-### IF（変更）
+### IF
 
-`CTRL_OPEN_IF`（初期カウント前）と `CS_PUSH 0`（初期カウント）を追加し、コンパイルスタックを `[0, A]` 形式に変更した。
+`CS_OPEN_TAG "IF"` を末尾に追加し、タグラスト方式でコンパイルスタックを `[0, A, Tag("IF")]` 形式にする。
 
 ```
 DEF IF
-  CTRL_OPEN_IF
   COMPILE_EXPR
   APPEND JUMP_FALSE
   CS_PUSH 0        REM initial count: number of ELSIF calls so far
   CS_PUSH HERE     REM BIF jump-target placeholder address (A)
   APPEND 0
+  CS_OPEN_TAG "IF" REM push Tag("IF") last (tag-last layout)
 END
 IMMEDIATE IF
 ```
 
-### ENDIF（変更）
+### ENDIF
 
-`CTRL_CLOSE_IF` を先頭に追加し、compile_stack を触る前にフェイルファストで制御スタックを検証する。`WHILE`/`ENDWH` ループで蓄積された `JUMP_ALWAYS` プレースホルダーを一括パッチする。
+`CS_CLOSE_TAG "IF"` を先頭に追加し、compile_stack を触る前にフェイルファストでタグを検証する。`WHILE`/`ENDWH` ループで蓄積された `JUMP_ALWAYS` プレースホルダーを一括パッチする。
 `WHILE`/`ENDWH` は `lib/basic.tbx` で ENDIF より前に定義されていること。
 
 ```
 DEF ENDIF
-  CTRL_CLOSE_IF
+  CS_CLOSE_TAG "IF"     REM validate and pop Tag("IF") first (fail-fast)
   PATCH_ADDR CS_POP     REM patch last BIF/JUMP_ALWAYS placeholder (C)
   VAR N
   SET &N, CS_POP        REM retrieve ELSIF call count
@@ -225,16 +226,17 @@ END
 IMMEDIATE ENDIF
 ```
 
-### ELSIF（新規）
+### ELSIF
 
-直前の BIF プレースホルダーをパッチし、JUMP_ALWAYS と新しい BIF をコンパイルスタックに積む。
+`CS_CLOSE_TAG "IF"` を先頭に、`CS_OPEN_TAG "IF"` を末尾に追加し、タグを取り外して操作後に積み直す。
 
 コンパイルスタックの遷移:
-- 入力: `CS = [..., N, C]`（C がトップ）
-- 出力: `CS = [..., B, N+1, C_new]`（C パッチ済み、B は JUMP_ALWAYS プレースホルダー）
+- 入力: `CS = [..., N, C, Tag("IF")]`（Tag がトップ）
+- 出力: `CS = [..., B, N+1, C_new, Tag("IF")]`（C パッチ済み、B は JUMP_ALWAYS プレースホルダー）
 
 ```
 DEF ELSIF
+  CS_CLOSE_TAG "IF"        REM pop Tag("IF") first
   APPEND JUMP_ALWAYS       REM emit unconditional jump at end of current branch body
   VAR B
   SET &B, HERE             REM save JUMP_ALWAYS placeholder address (B)
@@ -248,26 +250,29 @@ DEF ELSIF
   APPEND JUMP_FALSE        REM emit new BIF instruction
   CS_PUSH HERE             REM push new BIF placeholder address (C_new)
   APPEND 0
+  CS_OPEN_TAG "IF"         REM push Tag("IF") back
 END
 IMMEDIATE ELSIF
 ```
 
-### ELSE（新規）
+### ELSE
 
-直前の BIF プレースホルダーをパッチし、JUMP_ALWAYS プレースホルダーをカウントの上に積む。
+`CS_CLOSE_TAG "IF"` を先頭に、`CS_OPEN_TAG "IF"` を末尾に追加し、タグを取り外して操作後に積み直す。
 
 コンパイルスタックの遷移:
-- 入力: `CS = [..., N, C]`（C がトップ）
-- 出力: `CS = [..., N, B]`（C パッチ済み、B は JUMP_ALWAYS プレースホルダー、N は変化なし）
+- 入力: `CS = [..., N, C, Tag("IF")]`（Tag がトップ）
+- 出力: `CS = [..., N, B, Tag("IF")]`（C パッチ済み、B は JUMP_ALWAYS プレースホルダー、N は変化なし）
 
 ```
 DEF ELSE
+  CS_CLOSE_TAG "IF"        REM pop Tag("IF") first
   APPEND JUMP_ALWAYS       REM emit unconditional jump at end of if/elsif branch
   VAR B
   SET &B, HERE             REM save JUMP_ALWAYS placeholder address (B)
   APPEND 0                 REM emit placeholder
   PATCH_ADDR CS_POP        REM patch previous BIF placeholder (C); DP now = else body start
   CS_PUSH B                REM push B on top of N
+  CS_OPEN_TAG "IF"         REM push Tag("IF") back
 END
 IMMEDIATE ELSE
 ```
@@ -278,25 +283,25 @@ IMMEDIATE ELSE
 
 | 時点 | CS |
 |---|---|
-| IF 後 | `[0, A]` |
-| ELSE 後 | `[0, B]`（A パッチ済み）|
+| IF 後 | `[0, A, Tag("IF")]` |
+| ELSE 後 | `[0, B, Tag("IF")]`（A パッチ済み）|
 | ENDIF 後 | `[]`（B パッチ、N=0、ループ 0 回）|
 
 **IF...ELSIF...ENDIF**:
 
 | 時点 | CS |
 |---|---|
-| IF 後 | `[0, A]` |
-| ELSIF 後 | `[B1, 1, C]`（A パッチ済み）|
+| IF 後 | `[0, A, Tag("IF")]` |
+| ELSIF 後 | `[B1, 1, C, Tag("IF")]`（A パッチ済み）|
 | ENDIF 後 | `[]`（C パッチ、N=1、B1 パッチ）|
 
 **IF...ELSIF...ELSE...ENDIF**:
 
 | 時点 | CS |
 |---|---|
-| IF 後 | `[0, A]` |
-| ELSIF 後 | `[B1, 1, C]`（A パッチ済み）|
-| ELSE 後 | `[B1, 1, B_new]`（C パッチ済み）|
+| IF 後 | `[0, A, Tag("IF")]` |
+| ELSIF 後 | `[B1, 1, C, Tag("IF")]`（A パッチ済み）|
+| ELSE 後 | `[B1, 1, B_new, Tag("IF")]`（C パッチ済み）|
 | ENDIF 後 | `[]`（B_new パッチ、N=1、B1 パッチ）|
 
 ### 既知の制限事項
@@ -305,8 +310,8 @@ IMMEDIATE ELSE
   2番目の `ELSE` は最初の ELSE が積んだ JUMP_ALWAYS プレースホルダーを BIF プレースホルダーとして扱い、
   誤ったアドレスにパッチしてしまう。現時点では二重 ELSE の検出は行わず、未定義動作とする。
 
-- **ELSIF/ELSE を IF なしで使用**: コンパイルスタックが空の状態で `CS_POP` が呼ばれ、
-  `StackUnderflow` エラーとなる。実用上は問題ないが、エラーメッセージは汎用的なスタックアンダーフローとなる。
+- **ELSIF/ELSE を IF なしで使用**: `CS_CLOSE_TAG "IF"` が空スタックを検出し `NoOpenTag { expected: "IF" }` を返す。
+
 
 ---
 
@@ -317,17 +322,17 @@ WHILE と ENDWH は `lib/basic.tbx` に TBX コードとして実装されたコ
 ```
 REM WHILE expr ... ENDWH
 DEF WHILE
-  CTRL_OPEN_WHILE
   CS_PUSH HERE
   COMPILE_EXPR
   APPEND JUMP_FALSE
   CS_PUSH HERE
   APPEND 0
+  CS_OPEN_TAG "WHILE" REM push Tag("WHILE") last (tag-last layout)
 END
 IMMEDIATE WHILE
 
 DEF ENDWH
-  CTRL_CLOSE_WHILE
+  CS_CLOSE_TAG "WHILE" REM validate and pop Tag("WHILE") first (fail-fast)
   CS_SWAP
   APPEND JUMP_ALWAYS
   APPEND CS_POP
@@ -351,15 +356,16 @@ D:  ...（ENDWH 直後）
 | 時点 | コンパイルスタック |
 |---|---|
 | WHILE 実行直前 | `[]` |
-| WHILE 実行後 | `[A, Caddr]`（A が底、Caddr がトップ） |
+| WHILE 実行後 | `[A, Caddr, Tag("WHILE")]`（Tag がトップ、タグラスト方式） |
 | ENDWH 実行後 | `[]` |
 
 - `A` = ループ先頭の DictAddr（WHILE が `CS_PUSH HERE` で積む）
 - `Caddr` = BIF のジャンプ先プレースホルダーの DictAddr（WHILE が `APPEND 0` の直前に `CS_PUSH HERE` で積む）
+- `Tag("WHILE")` = 制御構造の種別タグ（`CS_OPEN_TAG "WHILE"` で最後に積む）
 
 ### ENDWH の動作トレース
 
-1. `CTRL_CLOSE_WHILE` — `control_stack` のトップが `While` か検証してポップする（フェイルファスト）
+1. `CS_CLOSE_TAG "WHILE"` — compile_stack のトップが `Tag("WHILE")` か検証してポップする（フェイルファスト）。空スタックなら `NoOpenTag { expected: "WHILE" }`、別タグなら `MismatchedTag` を返す
 2. `CS_SWAP` — CS を `[A, Caddr]` → `[Caddr, A]` に並び替える（A がトップ）
 3. `APPEND JUMP_ALWAYS` — 無条件ジャンプ命令の Xt を辞書に書き込む
 4. `APPEND CS_POP` — CS から A（DictAddr）をポップして辞書に書き込む（JUMP_ALWAYS のジャンプ先ターゲット）

--- a/lib/basic.tbx
+++ b/lib/basic.tbx
@@ -3,23 +3,26 @@ REM basic.tbx — BASIC-style control structures standard library
 REM WHILE expr ... ENDWH
 REM
 REM  WHILE compiles the condition expression, saves the loop-start address on the
-REM  compile stack, emits JUMP_FALSE, saves the placeholder address, and emits a
-REM  0 placeholder. ENDWH uses CS_SWAP to reorder the two saved addresses,
-REM  emits JUMP_ALWAYS back to the loop start (as DictAddr), then patches the
-REM  JUMP_FALSE placeholder with the current HERE value (= ENDWH+1).
+REM  compile stack, emits JUMP_FALSE, saves the placeholder address, emits a
+REM  0 placeholder, then pushes a Tag("WHILE") marker last (tag-last layout).
+REM  Compile stack after WHILE: [loop-start, BIF-placeholder, Tag("WHILE")].
+REM
+REM  ENDWH validates the tag first (CS_CLOSE_TAG "WHILE"), then uses CS_SWAP to
+REM  reorder the two saved addresses, emits JUMP_ALWAYS back to the loop start,
+REM  and patches the JUMP_FALSE placeholder with HERE (= ENDWH+1).
 
 DEF WHILE
-  CTRL_OPEN_WHILE
   CS_PUSH HERE
   COMPILE_EXPR
   APPEND JUMP_FALSE
   CS_PUSH HERE
   APPEND 0
+  CS_OPEN_TAG "WHILE"
 END
 IMMEDIATE WHILE
 
 DEF ENDWH
-  CTRL_CLOSE_WHILE
+  CS_CLOSE_TAG "WHILE"
   CS_SWAP
   APPEND JUMP_ALWAYS
   APPEND CS_POP
@@ -31,34 +34,38 @@ REM IF expr ... ELSIF expr ... ELSE ... ENDIF
 REM
 REM  IF compiles the condition expression, emits a JUMP_FALSE instruction,
 REM  pushes an initial ELSIF count (0) and the placeholder address on the compile
-REM  stack, and emits a 0 placeholder.  The compile stack after IF is [0, A].
+REM  stack, emits a 0 placeholder, then pushes a Tag("IF") marker last (tag-last).
+REM  Compile stack after IF: [0, A, Tag("IF")].
 REM
-REM  ELSIF patches the current BIF placeholder (C), pops the count N, emits
-REM  JUMP_ALWAYS (saving its placeholder B), increments the count, compiles the
-REM  new condition, and emits a new BIF with its placeholder C_new.
-REM  Compile stack after ELSIF: [B1...BN, B, N+1, C_new].
+REM  ELSIF validates the tag (CS_CLOSE_TAG "IF"), patches the current BIF
+REM  placeholder (C), pops the count N, emits JUMP_ALWAYS (saving its placeholder
+REM  B), increments the count, compiles the new condition, emits a new BIF with
+REM  its placeholder C_new, then pushes Tag("IF") back.
+REM  Compile stack after ELSIF: [B1...BN, B, N+1, C_new, Tag("IF")].
 REM
-REM  ELSE patches the current BIF placeholder (C), emits JUMP_ALWAYS (saving its
-REM  placeholder B), and pushes B on top of the unchanged count N.
-REM  Compile stack after ELSE: [B1...BN, N, B].
+REM  ELSE validates the tag (CS_CLOSE_TAG "IF"), patches the current BIF
+REM  placeholder (C), emits JUMP_ALWAYS (saving its placeholder B), and pushes
+REM  B on top of the unchanged count N, then pushes Tag("IF") back.
+REM  Compile stack after ELSE: [B1...BN, N, B, Tag("IF")].
 REM
-REM  ENDIF patches the last placeholder (C or B from ELSE), then pops the count N
-REM  and patches each accumulated JUMP_ALWAYS placeholder B1...BN using WHILE/ENDWH.
+REM  ENDIF validates the tag (CS_CLOSE_TAG "IF"), patches the last placeholder
+REM  (C or B from ELSE), pops the count N, and patches each accumulated
+REM  JUMP_ALWAYS placeholder B1...BN using WHILE/ENDWH.
 REM  WHILE/ENDWH must be defined before ENDIF.
 
 DEF IF
-  CTRL_OPEN_IF
   COMPILE_EXPR
   APPEND JUMP_FALSE
   REM push initial ELSIF count (0), then BIF placeholder address (A)
   CS_PUSH 0
   CS_PUSH HERE
   APPEND 0
+  CS_OPEN_TAG "IF"
 END
 IMMEDIATE IF
 
 DEF ENDIF
-  CTRL_CLOSE_IF
+  CS_CLOSE_TAG "IF"
   REM patch last BIF/JUMP_ALWAYS placeholder (C)
   PATCH_ADDR CS_POP
   VAR N
@@ -75,6 +82,7 @@ END
 IMMEDIATE ENDIF
 
 DEF ELSIF
+  CS_CLOSE_TAG "IF"
   REM emit unconditional jump at end of current branch body
   APPEND JUMP_ALWAYS
   VAR B
@@ -96,10 +104,12 @@ DEF ELSIF
   APPEND JUMP_FALSE
   CS_PUSH HERE
   APPEND 0
+  CS_OPEN_TAG "IF"
 END
 IMMEDIATE ELSIF
 
 DEF ELSE
+  CS_CLOSE_TAG "IF"
   REM emit unconditional jump at end of if/elsif branch
   APPEND JUMP_ALWAYS
   VAR B
@@ -111,5 +121,6 @@ DEF ELSE
   PATCH_ADDR CS_POP
   REM count N remains on compile stack; push B on top
   CS_PUSH B
+  CS_OPEN_TAG "IF"
 END
 IMMEDIATE ELSE

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -1,19 +1,23 @@
-/// Identifies which kind of control structure opened a compile-time scope.
+/// An entry on the compile-time stack (`VM::compile_stack`).
 ///
-/// Pushed onto `VM::control_stack` by `CTRL_OPEN_IF` / `CTRL_OPEN_WHILE` and
-/// popped (with validation) by `CTRL_CLOSE_IF` / `CTRL_CLOSE_WHILE`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ControlKind {
-    If,
-    While,
+/// `Cell` holds a regular value (address, integer, Xt, …) used by CS_PUSH/CS_POP
+/// and related compile-time stack manipulation primitives.
+/// `Tag` holds a string label that identifies an open control-structure scope
+/// (e.g. `"IF"` or `"WHILE"`); it is pushed by CS_OPEN_TAG and validated/popped
+/// by CS_CLOSE_TAG.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CompileEntry {
+    /// A regular runtime cell stored on the compile stack.
+    Cell(Cell),
+    /// A string tag that marks an open control-structure scope.
+    Tag(String),
 }
 
-impl ControlKind {
-    /// Returns a human-readable keyword name used in error messages.
-    pub fn keyword(&self) -> &'static str {
+impl std::fmt::Display for CompileEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ControlKind::If => "IF",
-            ControlKind::While => "WHILE",
+            CompileEntry::Cell(c) => write!(f, "Cell({})", c),
+            CompileEntry::Tag(s) => write!(f, "Tag({})", s),
         }
     }
 }

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -17,7 +17,7 @@ impl std::fmt::Display for CompileEntry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             CompileEntry::Cell(c) => write!(f, "Cell({})", c),
-            CompileEntry::Tag(s) => write!(f, "Tag({})", s),
+            CompileEntry::Tag(s) => write!(f, "Tag(\"{}\")", s),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -93,13 +93,6 @@ pub enum TbxError {
     CompileStackNotEmpty {
         count: usize,
     },
-    /// control_stack has leftover items when END is executed.
-    ///
-    /// Word definition is incomplete — some control-structure open words (IF/WHILE)
-    /// were not closed by matching ENDIF/ENDWH.
-    ControlStackNotEmpty {
-        count: usize,
-    },
     /// A file requested via USE could not be found or read.
     FileNotFound {
         path: String,
@@ -120,22 +113,23 @@ pub enum TbxError {
         path: String,
     },
 
-    /// ENDIF/ENDWH was reached but the control stack top does not match.
+    /// CS_CLOSE_TAG found a tag that does not match the expected tag.
     ///
-    /// For example, `IF ... WHILE ... ENDIF` causes `CTRL_CLOSE_IF` to find
-    /// `While` on the top of the control stack instead of `If`.
-    MismatchedControlStructure {
-        /// The closing keyword that was encountered (e.g. "ENDIF")
-        close_word: &'static str,
-        /// The opening keyword at the top of the control stack (e.g. "WHILE")
-        open_word: &'static str,
+    /// For example, `IF ... WHILE ... ENDIF` causes CS_CLOSE_TAG to find
+    /// `"WHILE"` at the top of the compile stack instead of the expected `"IF"`.
+    MismatchedTag {
+        /// The tag that CS_CLOSE_TAG was looking for (e.g. `"IF"`)
+        expected: String,
+        /// The tag that was actually found on the compile stack (e.g. `"WHILE"`)
+        found: String,
     },
-    /// ENDIF/ENDWH was reached but the control stack is empty.
+    /// CS_CLOSE_TAG was called but the compile stack has no matching tag.
     ///
-    /// Indicates a closing keyword without a matching opening keyword.
-    UnopenedControlStructure {
-        /// The closing keyword that was encountered (e.g. "ENDWH")
-        keyword: &'static str,
+    /// Either the compile stack is empty or its top entry is a `Cell` rather
+    /// than a `Tag`, meaning no matching open control-structure tag exists.
+    NoOpenTag {
+        /// The tag that CS_CLOSE_TAG was looking for (e.g. `"WHILE"`)
+        expected: String,
     },
 
     /// Assertion explicitly failed via ASSERT_FAIL.
@@ -215,12 +209,6 @@ impl std::fmt::Display for TbxError {
                     "compile stack has {count} unpatched item(s) at END; word definition is incomplete"
                 )
             }
-            TbxError::ControlStackNotEmpty { count } => {
-                write!(
-                    f,
-                    "control stack has {count} unclosed structure(s) at END; missing ENDIF or ENDWH"
-                )
-            }
             TbxError::FileNotFound { path, reason } => {
                 write!(f, "USE: file not found: '{path}': {reason}")
             }
@@ -230,17 +218,15 @@ impl std::fmt::Display for TbxError {
             TbxError::CircularUse { path } => {
                 write!(f, "USE: circular USE detected: '{path}'")
             }
-            TbxError::MismatchedControlStructure {
-                close_word,
-                open_word,
-            } => {
+            TbxError::MismatchedTag { expected, found } => {
                 write!(
                     f,
-                    "mismatched control structure: '{close_word}' does not match '{open_word}'"
+                    "mismatched tag: expected '{}', found '{}'",
+                    expected, found
                 )
             }
-            TbxError::UnopenedControlStructure { keyword } => {
-                write!(f, "no matching open for '{keyword}'")
+            TbxError::NoOpenTag { expected } => {
+                write!(f, "no open tag for '{}'", expected)
             }
             TbxError::AssertionFailed => write!(f, "assertion failed"),
             TbxError::AssertionFailedWithMessage { message } => {

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -3590,7 +3590,7 @@ TRYROT";
 
     #[test]
     fn test_if_while_endif_endwh_cross_nesting_error() {
-        // IF ... WHILE ... ENDIF  must fail with MismatchedControlStructure.
+        // IF ... WHILE ... ENDIF  must fail with MismatchedTag.
         let mut interp = Interpreter::new();
         let src =
             "DEF BAD(X)\n  IF X > 0\n    WHILE X > 0\n      SET &X, X - 1\n    ENDIF\n  ENDWH\nEND";
@@ -3599,18 +3599,18 @@ TRYROT";
             Err(e)
                 if matches!(
                     e.kind,
-                    crate::error::TbxError::MismatchedControlStructure {
-                        close_word: "ENDIF",
-                        open_word: "WHILE",
-                    }
+                    crate::error::TbxError::MismatchedTag {
+                        ref expected,
+                        ref found,
+                    } if expected == "IF" && found == "WHILE"
                 ) => {}
-            other => panic!("expected MismatchedControlStructure(ENDIF/WHILE), got {other:?}"),
+            other => panic!("expected MismatchedTag(IF/WHILE), got {other:?}"),
         }
     }
 
     #[test]
     fn test_if_endwh_cross_nesting_error() {
-        // IF ... ENDWH  must fail with MismatchedControlStructure.
+        // IF ... ENDWH  must fail with MismatchedTag.
         let mut interp = Interpreter::new();
         let src = "DEF BAD(X)\n  IF X > 0\n    PUTDEC X\n  ENDWH\nEND";
         let result = interp.exec_source(src);
@@ -3618,18 +3618,18 @@ TRYROT";
             Err(e)
                 if matches!(
                     e.kind,
-                    crate::error::TbxError::MismatchedControlStructure {
-                        close_word: "ENDWH",
-                        open_word: "IF",
-                    }
+                    crate::error::TbxError::MismatchedTag {
+                        ref expected,
+                        ref found,
+                    } if expected == "WHILE" && found == "IF"
                 ) => {}
-            other => panic!("expected MismatchedControlStructure(ENDWH/IF), got {other:?}"),
+            other => panic!("expected MismatchedTag(WHILE/IF), got {other:?}"),
         }
     }
 
     #[test]
     fn test_endwh_without_while_unopened_error() {
-        // ENDWH with no preceding WHILE must fail with UnopenedControlStructure.
+        // ENDWH with no preceding WHILE must fail with NoOpenTag.
         let mut interp = Interpreter::new();
         let src = "DEF BAD()\n  ENDWH\nEND";
         let result = interp.exec_source(src);
@@ -3637,15 +3637,15 @@ TRYROT";
             Err(e)
                 if matches!(
                     e.kind,
-                    crate::error::TbxError::UnopenedControlStructure { keyword: "ENDWH" }
+                    crate::error::TbxError::NoOpenTag { ref expected } if expected == "WHILE"
                 ) => {}
-            other => panic!("expected UnopenedControlStructure(ENDWH), got {other:?}"),
+            other => panic!("expected NoOpenTag(WHILE), got {other:?}"),
         }
     }
 
     #[test]
     fn test_endif_without_if_unopened_error() {
-        // ENDIF with no preceding IF must fail with UnopenedControlStructure.
+        // ENDIF with no preceding IF must fail with NoOpenTag.
         let mut interp = Interpreter::new();
         let src = "DEF BAD()\n  ENDIF\nEND";
         let result = interp.exec_source(src);
@@ -3653,9 +3653,9 @@ TRYROT";
             Err(e)
                 if matches!(
                     e.kind,
-                    crate::error::TbxError::UnopenedControlStructure { keyword: "ENDIF" }
+                    crate::error::TbxError::NoOpenTag { ref expected } if expected == "IF"
                 ) => {}
-            other => panic!("expected UnopenedControlStructure(ENDIF), got {other:?}"),
+            other => panic!("expected NoOpenTag(IF), got {other:?}"),
         }
     }
 
@@ -3698,8 +3698,8 @@ NOOP_LOOP(4)";
 
     #[test]
     fn test_if_else_endwh_cross_nesting_error() {
-        // IF ... ELSE ... ENDWH must fail with MismatchedControlStructure.
-        // ELSE does not push to control_stack, so ENDWH sees ControlKind::If on top.
+        // IF ... ELSE ... ENDWH must fail with MismatchedTag.
+        // ELSE keeps Tag("IF") on compile_stack, so ENDWH sees "IF" instead of "WHILE".
         let mut interp = Interpreter::new();
         let src = "DEF BAD(X)\n  IF X > 0\n    PUTDEC X\n  ELSE\n    PUTDEC 0\n  ENDWH\nEND";
         let result = interp.exec_source(src);
@@ -3707,19 +3707,19 @@ NOOP_LOOP(4)";
             Err(e)
                 if matches!(
                     e.kind,
-                    crate::error::TbxError::MismatchedControlStructure {
-                        close_word: "ENDWH",
-                        open_word: "IF",
-                    }
+                    crate::error::TbxError::MismatchedTag {
+                        ref expected,
+                        ref found,
+                    } if expected == "WHILE" && found == "IF"
                 ) => {}
-            other => panic!("expected MismatchedControlStructure(ENDWH/IF), got {other:?}"),
+            other => panic!("expected MismatchedTag(WHILE/IF), got {other:?}"),
         }
     }
 
     #[test]
     fn test_if_elsif_endwh_cross_nesting_error() {
-        // IF ... ELSIF ... ENDWH must fail with MismatchedControlStructure.
-        // ELSIF does not push to control_stack, so ENDWH sees ControlKind::If on top.
+        // IF ... ELSIF ... ENDWH must fail with MismatchedTag.
+        // ELSIF keeps Tag("IF") on compile_stack, so ENDWH sees "IF" instead of "WHILE".
         let mut interp = Interpreter::new();
         let src = "DEF BAD(X)\n  IF X > 2\n    PUTDEC X\n  ELSIF X > 0\n    PUTDEC 1\n  ENDWH\nEND";
         let result = interp.exec_source(src);
@@ -3727,12 +3727,12 @@ NOOP_LOOP(4)";
             Err(e)
                 if matches!(
                     e.kind,
-                    crate::error::TbxError::MismatchedControlStructure {
-                        close_word: "ENDWH",
-                        open_word: "IF",
-                    }
+                    crate::error::TbxError::MismatchedTag {
+                        ref expected,
+                        ref found,
+                    } if expected == "WHILE" && found == "IF"
                 ) => {}
-            other => panic!("expected MismatchedControlStructure(ENDWH/IF), got {other:?}"),
+            other => panic!("expected MismatchedTag(WHILE/IF), got {other:?}"),
         }
     }
 }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -4002,7 +4002,25 @@ mod tests {
         assert_eq!(vm.pop(), Ok(Cell::Int(99)));
     }
 
-    // --- cs_swap_prim ---
+    #[test]
+    fn test_cs_pop_prim_tag_on_top_type_error() {
+        // CS_POP with a Tag on top must return TypeError and leave the tag intact.
+        let mut vm = make_compiling_vm("TESTWORD");
+        vm.compile_stack
+            .push(CompileEntry::Tag("IF".to_string()));
+        let err = cs_pop_prim(&mut vm).unwrap_err();
+        assert!(
+            matches!(err, TbxError::TypeError { .. }),
+            "expected TypeError, got {err:?}"
+        );
+        // Tag must be preserved on the compile_stack.
+        assert_eq!(
+            vm.compile_stack.last(),
+            Some(&CompileEntry::Tag("IF".to_string()))
+        );
+    }
+
+
 
     #[test]
     fn test_cs_swap_outside_compile_mode_error() {
@@ -4453,7 +4471,18 @@ mod tests {
         );
     }
 
-    // --- cs_close_tag_prim ---
+    #[test]
+    fn test_cs_open_tag_empty_data_stack_error() {
+        // CS_OPEN_TAG with empty data stack must return StackUnderflow.
+        let mut vm = make_compiling_vm("TESTWORD");
+        let err = cs_open_tag_prim(&mut vm).unwrap_err();
+        assert!(
+            matches!(err, TbxError::StackUnderflow),
+            "expected StackUnderflow, got {err:?}"
+        );
+    }
+
+
 
     #[test]
     fn test_cs_close_tag_outside_compile_mode_error() {

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -3965,7 +3965,10 @@ mod tests {
         // data stack must be empty.
         assert_eq!(vm.pop(), Err(TbxError::StackUnderflow));
         // compile_stack must hold the value.
-        assert_eq!(vm.compile_stack.last(), Some(&CompileEntry::Cell(Cell::Int(7))));
+        assert_eq!(
+            vm.compile_stack.last(),
+            Some(&CompileEntry::Cell(Cell::Int(7)))
+        );
     }
 
     // --- cs_pop_prim ---
@@ -4006,8 +4009,7 @@ mod tests {
     fn test_cs_pop_prim_tag_on_top_type_error() {
         // CS_POP with a Tag on top must return TypeError and leave the tag intact.
         let mut vm = make_compiling_vm("TESTWORD");
-        vm.compile_stack
-            .push(CompileEntry::Tag("IF".to_string()));
+        vm.compile_stack.push(CompileEntry::Tag("IF".to_string()));
         let err = cs_pop_prim(&mut vm).unwrap_err();
         assert!(
             matches!(err, TbxError::TypeError { .. }),
@@ -4019,8 +4021,6 @@ mod tests {
             Some(&CompileEntry::Tag("IF".to_string()))
         );
     }
-
-
 
     #[test]
     fn test_cs_swap_outside_compile_mode_error() {
@@ -4052,8 +4052,14 @@ mod tests {
         vm.compile_stack.push(CompileEntry::Cell(Cell::Int(10)));
         vm.compile_stack.push(CompileEntry::Cell(Cell::Int(20)));
         cs_swap_prim(&mut vm).unwrap();
-        assert_eq!(vm.compile_stack.pop(), Some(CompileEntry::Cell(Cell::Int(10))));
-        assert_eq!(vm.compile_stack.pop(), Some(CompileEntry::Cell(Cell::Int(20))));
+        assert_eq!(
+            vm.compile_stack.pop(),
+            Some(CompileEntry::Cell(Cell::Int(10)))
+        );
+        assert_eq!(
+            vm.compile_stack.pop(),
+            Some(CompileEntry::Cell(Cell::Int(20)))
+        );
         assert!(vm.compile_stack.is_empty());
     }
 
@@ -4061,11 +4067,19 @@ mod tests {
     fn test_cs_swap_swaps_dict_addr_values() {
         // CS_SWAP must work with Cell::DictAddr values, as used in WHILE/ENDWH.
         let mut vm = make_compiling_vm("TESTWORD");
-        vm.compile_stack.push(CompileEntry::Cell(Cell::DictAddr(10)));
-        vm.compile_stack.push(CompileEntry::Cell(Cell::DictAddr(20)));
+        vm.compile_stack
+            .push(CompileEntry::Cell(Cell::DictAddr(10)));
+        vm.compile_stack
+            .push(CompileEntry::Cell(Cell::DictAddr(20)));
         cs_swap_prim(&mut vm).unwrap();
-        assert_eq!(vm.compile_stack.pop(), Some(CompileEntry::Cell(Cell::DictAddr(10))));
-        assert_eq!(vm.compile_stack.pop(), Some(CompileEntry::Cell(Cell::DictAddr(20))));
+        assert_eq!(
+            vm.compile_stack.pop(),
+            Some(CompileEntry::Cell(Cell::DictAddr(10)))
+        );
+        assert_eq!(
+            vm.compile_stack.pop(),
+            Some(CompileEntry::Cell(Cell::DictAddr(20)))
+        );
         assert!(vm.compile_stack.is_empty());
     }
 
@@ -4131,7 +4145,8 @@ mod tests {
     fn test_cs_dup_duplicates_dict_addr() {
         // CS_DUP must work with Cell::DictAddr values.
         let mut vm = make_compiling_vm("TESTWORD");
-        vm.compile_stack.push(CompileEntry::Cell(Cell::DictAddr(42)));
+        vm.compile_stack
+            .push(CompileEntry::Cell(Cell::DictAddr(42)));
         cs_dup_prim(&mut vm).unwrap();
         assert_eq!(vm.compile_stack.len(), 2);
         assert_eq!(vm.compile_stack[0], CompileEntry::Cell(Cell::DictAddr(42)));
@@ -4181,8 +4196,10 @@ mod tests {
     fn test_cs_over_copies_dict_addr() {
         // CS_OVER must work with Cell::DictAddr values.
         let mut vm = make_compiling_vm("TESTWORD");
-        vm.compile_stack.push(CompileEntry::Cell(Cell::DictAddr(10)));
-        vm.compile_stack.push(CompileEntry::Cell(Cell::DictAddr(20)));
+        vm.compile_stack
+            .push(CompileEntry::Cell(Cell::DictAddr(10)));
+        vm.compile_stack
+            .push(CompileEntry::Cell(Cell::DictAddr(20)));
         cs_over_prim(&mut vm).unwrap();
         assert_eq!(vm.compile_stack.len(), 3);
         assert_eq!(vm.compile_stack[2], CompileEntry::Cell(Cell::DictAddr(10)));
@@ -4285,8 +4302,7 @@ mod tests {
         // end_prim must return CompileStackNotEmpty and rollback when a Tag entry
         // is left on compile_stack (simulates an unclosed IF or WHILE).
         let mut vm = make_compiling_vm("MYWORD3");
-        vm.compile_stack
-            .push(CompileEntry::Tag("IF".to_string()));
+        vm.compile_stack.push(CompileEntry::Tag("IF".to_string()));
         let err = end_prim(&mut vm).unwrap_err();
         assert!(
             matches!(err, TbxError::CompileStackNotEmpty { count: 1 }),
@@ -4302,7 +4318,6 @@ mod tests {
             "compile_stack must be empty after rollback"
         );
     }
-
 
     #[test]
     fn test_compile_expr_prim_outside_compile_mode_error() {
@@ -4482,8 +4497,6 @@ mod tests {
         );
     }
 
-
-
     #[test]
     fn test_cs_close_tag_outside_compile_mode_error() {
         // CS_CLOSE_TAG outside compile mode must return InvalidExpression.
@@ -4556,8 +4569,7 @@ mod tests {
     fn test_cs_close_tag_cell_on_top_error() {
         // CS_CLOSE_TAG with a Cell (not Tag) on top of compile_stack must return NoOpenTag.
         let mut vm = make_compiling_vm("TESTWORD");
-        vm.compile_stack
-            .push(CompileEntry::Cell(Cell::Int(42)));
+        vm.compile_stack.push(CompileEntry::Cell(Cell::Int(42)));
         let idx = vm.intern_string("IF").unwrap();
         vm.push(Cell::StringDesc(idx)).unwrap();
         let err = cs_close_tag_prim(&mut vm).unwrap_err();
@@ -4599,4 +4611,3 @@ mod tests {
         assert!(vm.compile_stack.is_empty());
     }
 }
-

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -4513,6 +4513,9 @@ mod tests {
     #[test]
     fn test_cs_close_tag_mismatched_tag_error() {
         // CS_CLOSE_TAG with a tag that does not match must return MismatchedTag.
+        // Unlike the Cell-on-top case, a mismatched Tag is consumed (not restored):
+        // the caller always encounters a compile error and rollback_def() clears
+        // compile_stack anyway.
         let mut vm = make_compiling_vm("TESTWORD");
         vm.compile_stack.push(CompileEntry::Tag("IF".to_string()));
         let idx = vm.intern_string("WHILE").unwrap();
@@ -4527,6 +4530,12 @@ mod tests {
                 } if expected == "WHILE" && found == "IF"
             ),
             "expected MismatchedTag(WHILE/IF), got {err:?}"
+        );
+        // After MismatchedTag the tag is consumed (not restored), which is intentional:
+        // a compile error always triggers rollback_def() that clears compile_stack.
+        assert!(
+            vm.compile_stack.is_empty(),
+            "mismatched tag must be consumed, not restored"
         );
     }
 

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1,4 +1,4 @@
-use crate::cell::{Cell, ControlKind};
+use crate::cell::{Cell, CompileEntry};
 use crate::constants::MAX_DICTIONARY_CELLS;
 use crate::dict::{EntryKind, WordEntry, FLAG_IMMEDIATE, FLAG_SYSTEM};
 use crate::error::TbxError;
@@ -643,18 +643,6 @@ pub fn end_prim(vm: &mut VM) -> Result<(), TbxError> {
         return Err(TbxError::CompileStackNotEmpty { count });
     }
 
-    // Defensive check: control_stack must also be empty at END.
-    // Under normal operation this invariant is guaranteed because each CTRL_OPEN_*
-    // call is paired with a matching CTRL_CLOSE_* call, and CTRL_CLOSE_* also
-    // empties compile_stack items (so CompileStackNotEmpty fires first).
-    // The explicit check here guards against future code paths where CTRL_OPEN_*
-    // is called without a corresponding CS_PUSH.
-    if !vm.control_stack.is_empty() {
-        let count = vm.control_stack.len();
-        vm.rollback_def();
-        return Err(TbxError::ControlStackNotEmpty { count });
-    }
-
     // Write EXIT to terminate the word body.
     let exit_xt =
         vm.find_by_kind(|k| matches!(k, EntryKind::Exit))
@@ -1040,6 +1028,9 @@ pub fn dim_prim(vm: &mut VM) -> Result<(), TbxError> {
 /// CS_PUSH — move a value from the data stack to the compile stack.
 ///
 /// Must be called in compile mode (inside a IMMEDIATE word invocation).
+/// CS_PUSH — move a value from the data stack to the compile stack.
+///
+/// Must be called in compile mode (inside an IMMEDIATE word invocation).
 fn cs_push_prim(vm: &mut VM) -> Result<(), TbxError> {
     if !vm.is_compiling {
         return Err(TbxError::InvalidExpression {
@@ -1047,12 +1038,14 @@ fn cs_push_prim(vm: &mut VM) -> Result<(), TbxError> {
         });
     }
     let val = vm.pop()?;
-    vm.compile_stack.push(val);
+    vm.compile_stack.push(CompileEntry::Cell(val));
     Ok(())
 }
 
 /// CS_POP — move a value from the compile stack to the data stack.
 ///
+/// Only `CompileEntry::Cell` entries can be moved; a `CompileEntry::Tag` on top
+/// returns `TypeError` (the tag is left on the compile stack unchanged).
 /// Must be called in compile mode (inside a IMMEDIATE word invocation).
 fn cs_pop_prim(vm: &mut VM) -> Result<(), TbxError> {
     if !vm.is_compiling {
@@ -1060,9 +1053,21 @@ fn cs_pop_prim(vm: &mut VM) -> Result<(), TbxError> {
             reason: "CS_POP outside compile mode",
         });
     }
-    let val = vm.compile_stack.pop().ok_or(TbxError::StackUnderflow)?;
-    vm.push(val)?;
-    Ok(())
+    let entry = vm.compile_stack.pop().ok_or(TbxError::StackUnderflow)?;
+    match entry {
+        CompileEntry::Cell(val) => {
+            vm.push(val)?;
+            Ok(())
+        }
+        CompileEntry::Tag(s) => {
+            // Restore the tag and signal a type error: CS_POP cannot pop a tag.
+            vm.compile_stack.push(CompileEntry::Tag(s));
+            Err(TbxError::TypeError {
+                expected: "Cell",
+                got: "Tag",
+            })
+        }
+    }
 }
 
 /// CS_SWAP — swap the top two values on the compile stack: ( a b -- b a ).
@@ -1150,75 +1155,49 @@ fn cs_rot_prim(vm: &mut VM) -> Result<(), TbxError> {
     Ok(())
 }
 
-/// CTRL_OPEN_IF — push `ControlKind::If` onto the control stack.
+/// CS_OPEN_TAG — pop a StringDesc from the data stack and push a `CompileEntry::Tag`
+/// onto the compile stack.
 ///
-/// Called at the start of `DEF IF` to record that an IF-block is being opened.
+/// Used by IMMEDIATE words (e.g. WHILE, IF) to mark the start of a control-structure
+/// scope.  The string (e.g. `"WHILE"` or `"IF"`) is matched by a later CS_CLOSE_TAG
+/// call to validate correct nesting.
 /// Must be called in compile mode.
-fn ctrl_open_if_prim(vm: &mut VM) -> Result<(), TbxError> {
+fn cs_open_tag_prim(vm: &mut VM) -> Result<(), TbxError> {
     if !vm.is_compiling {
         return Err(TbxError::InvalidExpression {
-            reason: "CTRL_OPEN_IF outside compile mode",
+            reason: "CS_OPEN_TAG outside compile mode",
         });
     }
-    vm.control_stack.push(ControlKind::If);
+    let idx = vm.pop_string_desc()?;
+    let tag = vm.resolve_string(idx)?;
+    vm.compile_stack.push(CompileEntry::Tag(tag));
     Ok(())
 }
 
-/// CTRL_OPEN_WHILE — push `ControlKind::While` onto the control stack.
+/// CS_CLOSE_TAG — pop a StringDesc from the data stack, then validate and remove the
+/// matching `CompileEntry::Tag` from the top of the compile stack.
 ///
-/// Called at the start of `DEF WHILE` to record that a WHILE-loop is being opened.
+/// Returns `NoOpenTag` if the compile stack is empty or its top entry is a `Cell`
+/// (not a `Tag`).  Returns `MismatchedTag` if the top is a `Tag` but does not match
+/// the expected string.
 /// Must be called in compile mode.
-fn ctrl_open_while_prim(vm: &mut VM) -> Result<(), TbxError> {
+fn cs_close_tag_prim(vm: &mut VM) -> Result<(), TbxError> {
     if !vm.is_compiling {
         return Err(TbxError::InvalidExpression {
-            reason: "CTRL_OPEN_WHILE outside compile mode",
+            reason: "CS_CLOSE_TAG outside compile mode",
         });
     }
-    vm.control_stack.push(ControlKind::While);
-    Ok(())
-}
-
-/// CTRL_CLOSE_IF — validate and pop `ControlKind::If` from the control stack.
-///
-/// Called at the start of `DEF ENDIF` before touching `compile_stack` (fail-fast).
-/// Returns `UnopenedControlStructure` if the stack is empty, or
-/// `MismatchedControlStructure` if the top entry is not `If`.
-/// Must be called in compile mode.
-fn ctrl_close_if_prim(vm: &mut VM) -> Result<(), TbxError> {
-    if !vm.is_compiling {
-        return Err(TbxError::InvalidExpression {
-            reason: "CTRL_CLOSE_IF outside compile mode",
-        });
-    }
-    match vm.control_stack.pop() {
-        None => Err(TbxError::UnopenedControlStructure { keyword: "ENDIF" }),
-        Some(ControlKind::If) => Ok(()),
-        Some(got) => Err(TbxError::MismatchedControlStructure {
-            close_word: "ENDIF",
-            open_word: got.keyword(),
-        }),
-    }
-}
-
-/// CTRL_CLOSE_WHILE — validate and pop `ControlKind::While` from the control stack.
-///
-/// Called at the start of `DEF ENDWH` before touching `compile_stack` (fail-fast).
-/// Returns `UnopenedControlStructure` if the stack is empty, or
-/// `MismatchedControlStructure` if the top entry is not `While`.
-/// Must be called in compile mode.
-fn ctrl_close_while_prim(vm: &mut VM) -> Result<(), TbxError> {
-    if !vm.is_compiling {
-        return Err(TbxError::InvalidExpression {
-            reason: "CTRL_CLOSE_WHILE outside compile mode",
-        });
-    }
-    match vm.control_stack.pop() {
-        None => Err(TbxError::UnopenedControlStructure { keyword: "ENDWH" }),
-        Some(ControlKind::While) => Ok(()),
-        Some(got) => Err(TbxError::MismatchedControlStructure {
-            close_word: "ENDWH",
-            open_word: got.keyword(),
-        }),
+    let idx = vm.pop_string_desc()?;
+    let expected = vm.resolve_string(idx)?;
+    match vm.compile_stack.pop() {
+        None => Err(TbxError::NoOpenTag { expected }),
+        Some(CompileEntry::Tag(found)) if found == expected => Ok(()),
+        Some(CompileEntry::Tag(found)) => Err(TbxError::MismatchedTag { expected, found }),
+        Some(CompileEntry::Cell(c)) => {
+            // Restore the cell and report no matching open tag.
+            vm.compile_stack.push(CompileEntry::Cell(c));
+            Err(TbxError::NoOpenTag { expected })
+        }
     }
 }
 
@@ -1525,21 +1504,11 @@ pub fn register_all(vm: &mut VM) {
     vm.register(WordEntry::new_primitive("CS_ROT", cs_rot_prim));
     vm.register(WordEntry::new_primitive("PATCH_ADDR", patch_addr_prim));
     vm.register(WordEntry::new_primitive("COMPILE_EXPR", compile_expr_prim));
-    // Control-structure kind stack primitives.
-    // Used by IF/WHILE/ENDIF/ENDWH to detect cross-nesting at compile time.
-    vm.register(WordEntry::new_primitive("CTRL_OPEN_IF", ctrl_open_if_prim));
-    vm.register(WordEntry::new_primitive(
-        "CTRL_OPEN_WHILE",
-        ctrl_open_while_prim,
-    ));
-    vm.register(WordEntry::new_primitive(
-        "CTRL_CLOSE_IF",
-        ctrl_close_if_prim,
-    ));
-    vm.register(WordEntry::new_primitive(
-        "CTRL_CLOSE_WHILE",
-        ctrl_close_while_prim,
-    ));
+    // Tag-based control-structure scope primitives.
+    // CS_OPEN_TAG pushes a string tag onto the compile stack to mark the start of a
+    // control-structure scope; CS_CLOSE_TAG validates and pops the matching tag.
+    vm.register(WordEntry::new_primitive("CS_OPEN_TAG", cs_open_tag_prim));
+    vm.register(WordEntry::new_primitive("CS_CLOSE_TAG", cs_close_tag_prim));
 
     // Runtime branch/jump Xt constants — allows TBX code to write:
     //   APPEND JUMP_FALSE, APPEND JUMP_ALWAYS, etc.
@@ -1568,7 +1537,7 @@ pub fn register_all(vm: &mut VM) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cell::{Cell, ControlKind};
+    use crate::cell::{Cell, CompileEntry};
     use crate::constants::MAX_DICTIONARY_CELLS;
 
     // --- drop_prim ---
@@ -3999,7 +3968,7 @@ mod tests {
         // data stack must be empty.
         assert_eq!(vm.pop(), Err(TbxError::StackUnderflow));
         // compile_stack must hold the value.
-        assert_eq!(vm.compile_stack.last(), Some(&Cell::Int(7)));
+        assert_eq!(vm.compile_stack.last(), Some(&CompileEntry::Cell(Cell::Int(7))));
     }
 
     // --- cs_pop_prim ---
@@ -4009,7 +3978,7 @@ mod tests {
         // CS_POP called when is_compiling == false must return InvalidExpression.
         let mut vm = VM::new();
         register_all(&mut vm);
-        vm.compile_stack.push(Cell::Int(1));
+        vm.compile_stack.push(CompileEntry::Cell(Cell::Int(1)));
         let err = cs_pop_prim(&mut vm).unwrap_err();
         assert!(
             matches!(err, TbxError::InvalidExpression { .. }),
@@ -4030,7 +3999,7 @@ mod tests {
     fn test_cs_pop_prim_moves_value_to_data_stack() {
         // CS_POP must pop the top of compile_stack and push it onto the data stack.
         let mut vm = make_compiling_vm("TESTWORD");
-        vm.compile_stack.push(Cell::Int(99));
+        vm.compile_stack.push(CompileEntry::Cell(Cell::Int(99)));
         cs_pop_prim(&mut vm).unwrap();
         assert!(vm.compile_stack.is_empty());
         assert_eq!(vm.pop(), Ok(Cell::Int(99)));
@@ -4052,7 +4021,7 @@ mod tests {
     #[test]
     fn test_cs_swap_underflow_one_element() {
         let mut vm = make_compiling_vm("TESTWORD");
-        vm.compile_stack.push(Cell::Int(1));
+        vm.compile_stack.push(CompileEntry::Cell(Cell::Int(1)));
         assert_eq!(cs_swap_prim(&mut vm), Err(TbxError::StackUnderflow));
     }
 
@@ -4065,11 +4034,11 @@ mod tests {
     #[test]
     fn test_cs_swap_swaps_top_two() {
         let mut vm = make_compiling_vm("TESTWORD");
-        vm.compile_stack.push(Cell::Int(10));
-        vm.compile_stack.push(Cell::Int(20));
+        vm.compile_stack.push(CompileEntry::Cell(Cell::Int(10)));
+        vm.compile_stack.push(CompileEntry::Cell(Cell::Int(20)));
         cs_swap_prim(&mut vm).unwrap();
-        assert_eq!(vm.compile_stack.pop(), Some(Cell::Int(10)));
-        assert_eq!(vm.compile_stack.pop(), Some(Cell::Int(20)));
+        assert_eq!(vm.compile_stack.pop(), Some(CompileEntry::Cell(Cell::Int(10))));
+        assert_eq!(vm.compile_stack.pop(), Some(CompileEntry::Cell(Cell::Int(20))));
         assert!(vm.compile_stack.is_empty());
     }
 
@@ -4077,11 +4046,11 @@ mod tests {
     fn test_cs_swap_swaps_dict_addr_values() {
         // CS_SWAP must work with Cell::DictAddr values, as used in WHILE/ENDWH.
         let mut vm = make_compiling_vm("TESTWORD");
-        vm.compile_stack.push(Cell::DictAddr(10));
-        vm.compile_stack.push(Cell::DictAddr(20));
+        vm.compile_stack.push(CompileEntry::Cell(Cell::DictAddr(10)));
+        vm.compile_stack.push(CompileEntry::Cell(Cell::DictAddr(20)));
         cs_swap_prim(&mut vm).unwrap();
-        assert_eq!(vm.compile_stack.pop(), Some(Cell::DictAddr(10)));
-        assert_eq!(vm.compile_stack.pop(), Some(Cell::DictAddr(20)));
+        assert_eq!(vm.compile_stack.pop(), Some(CompileEntry::Cell(Cell::DictAddr(10))));
+        assert_eq!(vm.compile_stack.pop(), Some(CompileEntry::Cell(Cell::DictAddr(20))));
         assert!(vm.compile_stack.is_empty());
     }
 
@@ -4107,11 +4076,11 @@ mod tests {
     #[test]
     fn test_cs_drop_removes_top() {
         let mut vm = make_compiling_vm("TESTWORD");
-        vm.compile_stack.push(Cell::Int(1));
-        vm.compile_stack.push(Cell::Int(2));
+        vm.compile_stack.push(CompileEntry::Cell(Cell::Int(1)));
+        vm.compile_stack.push(CompileEntry::Cell(Cell::Int(2)));
         cs_drop_prim(&mut vm).unwrap();
         assert_eq!(vm.compile_stack.len(), 1);
-        assert_eq!(vm.compile_stack[0], Cell::Int(1));
+        assert_eq!(vm.compile_stack[0], CompileEntry::Cell(Cell::Int(1)));
     }
 
     // --- cs_dup_prim ---
@@ -4136,22 +4105,22 @@ mod tests {
     #[test]
     fn test_cs_dup_duplicates_top() {
         let mut vm = make_compiling_vm("TESTWORD");
-        vm.compile_stack.push(Cell::Int(42));
+        vm.compile_stack.push(CompileEntry::Cell(Cell::Int(42)));
         cs_dup_prim(&mut vm).unwrap();
         assert_eq!(vm.compile_stack.len(), 2);
-        assert_eq!(vm.compile_stack[0], Cell::Int(42));
-        assert_eq!(vm.compile_stack[1], Cell::Int(42));
+        assert_eq!(vm.compile_stack[0], CompileEntry::Cell(Cell::Int(42)));
+        assert_eq!(vm.compile_stack[1], CompileEntry::Cell(Cell::Int(42)));
     }
 
     #[test]
     fn test_cs_dup_duplicates_dict_addr() {
         // CS_DUP must work with Cell::DictAddr values.
         let mut vm = make_compiling_vm("TESTWORD");
-        vm.compile_stack.push(Cell::DictAddr(42));
+        vm.compile_stack.push(CompileEntry::Cell(Cell::DictAddr(42)));
         cs_dup_prim(&mut vm).unwrap();
         assert_eq!(vm.compile_stack.len(), 2);
-        assert_eq!(vm.compile_stack[0], Cell::DictAddr(42));
-        assert_eq!(vm.compile_stack[1], Cell::DictAddr(42));
+        assert_eq!(vm.compile_stack[0], CompileEntry::Cell(Cell::DictAddr(42)));
+        assert_eq!(vm.compile_stack[1], CompileEntry::Cell(Cell::DictAddr(42)));
     }
 
     // --- cs_over_prim ---
@@ -4176,34 +4145,34 @@ mod tests {
     #[test]
     fn test_cs_over_underflow_one_element() {
         let mut vm = make_compiling_vm("TESTWORD");
-        vm.compile_stack.push(Cell::Int(1));
+        vm.compile_stack.push(CompileEntry::Cell(Cell::Int(1)));
         assert_eq!(cs_over_prim(&mut vm), Err(TbxError::StackUnderflow));
     }
 
     #[test]
     fn test_cs_over_copies_second_to_top() {
         let mut vm = make_compiling_vm("TESTWORD");
-        vm.compile_stack.push(Cell::Int(10)); // bottom
-        vm.compile_stack.push(Cell::Int(20)); // top
+        vm.compile_stack.push(CompileEntry::Cell(Cell::Int(10))); // bottom
+        vm.compile_stack.push(CompileEntry::Cell(Cell::Int(20))); // top
         cs_over_prim(&mut vm).unwrap();
         // Stack should be [10, 20, 10] with 10 on top
         assert_eq!(vm.compile_stack.len(), 3);
-        assert_eq!(vm.compile_stack[2], Cell::Int(10));
-        assert_eq!(vm.compile_stack[1], Cell::Int(20));
-        assert_eq!(vm.compile_stack[0], Cell::Int(10));
+        assert_eq!(vm.compile_stack[2], CompileEntry::Cell(Cell::Int(10)));
+        assert_eq!(vm.compile_stack[1], CompileEntry::Cell(Cell::Int(20)));
+        assert_eq!(vm.compile_stack[0], CompileEntry::Cell(Cell::Int(10)));
     }
 
     #[test]
     fn test_cs_over_copies_dict_addr() {
         // CS_OVER must work with Cell::DictAddr values.
         let mut vm = make_compiling_vm("TESTWORD");
-        vm.compile_stack.push(Cell::DictAddr(10));
-        vm.compile_stack.push(Cell::DictAddr(20));
+        vm.compile_stack.push(CompileEntry::Cell(Cell::DictAddr(10)));
+        vm.compile_stack.push(CompileEntry::Cell(Cell::DictAddr(20)));
         cs_over_prim(&mut vm).unwrap();
         assert_eq!(vm.compile_stack.len(), 3);
-        assert_eq!(vm.compile_stack[2], Cell::DictAddr(10));
-        assert_eq!(vm.compile_stack[1], Cell::DictAddr(20));
-        assert_eq!(vm.compile_stack[0], Cell::DictAddr(10));
+        assert_eq!(vm.compile_stack[2], CompileEntry::Cell(Cell::DictAddr(10)));
+        assert_eq!(vm.compile_stack[1], CompileEntry::Cell(Cell::DictAddr(20)));
+        assert_eq!(vm.compile_stack[0], CompileEntry::Cell(Cell::DictAddr(10)));
     }
 
     // --- cs_rot_prim ---
@@ -4228,15 +4197,15 @@ mod tests {
     #[test]
     fn test_cs_rot_underflow_one_element() {
         let mut vm = make_compiling_vm("TESTWORD");
-        vm.compile_stack.push(Cell::Int(1));
+        vm.compile_stack.push(CompileEntry::Cell(Cell::Int(1)));
         assert_eq!(cs_rot_prim(&mut vm), Err(TbxError::StackUnderflow));
     }
 
     #[test]
     fn test_cs_rot_underflow_two_elements() {
         let mut vm = make_compiling_vm("TESTWORD");
-        vm.compile_stack.push(Cell::Int(1));
-        vm.compile_stack.push(Cell::Int(2));
+        vm.compile_stack.push(CompileEntry::Cell(Cell::Int(1)));
+        vm.compile_stack.push(CompileEntry::Cell(Cell::Int(2)));
         assert_eq!(cs_rot_prim(&mut vm), Err(TbxError::StackUnderflow));
     }
 
@@ -4244,15 +4213,15 @@ mod tests {
     fn test_cs_rot_rotates_top_three() {
         // ( a b c -- b c a )  where a=1 (bottom), b=2, c=3 (top)
         let mut vm = make_compiling_vm("TESTWORD");
-        vm.compile_stack.push(Cell::Int(1)); // a
-        vm.compile_stack.push(Cell::Int(2)); // b
-        vm.compile_stack.push(Cell::Int(3)); // c
+        vm.compile_stack.push(CompileEntry::Cell(Cell::Int(1))); // a
+        vm.compile_stack.push(CompileEntry::Cell(Cell::Int(2))); // b
+        vm.compile_stack.push(CompileEntry::Cell(Cell::Int(3))); // c
         cs_rot_prim(&mut vm).unwrap();
         // Result: [b=2, c=3, a=1] with a=1 on top
         assert_eq!(vm.compile_stack.len(), 3);
-        assert_eq!(vm.compile_stack[0], Cell::Int(2));
-        assert_eq!(vm.compile_stack[1], Cell::Int(3));
-        assert_eq!(vm.compile_stack[2], Cell::Int(1));
+        assert_eq!(vm.compile_stack[0], CompileEntry::Cell(Cell::Int(2)));
+        assert_eq!(vm.compile_stack[1], CompileEntry::Cell(Cell::Int(3)));
+        assert_eq!(vm.compile_stack[2], CompileEntry::Cell(Cell::Int(1)));
     }
 
     #[test]
@@ -4260,14 +4229,14 @@ mod tests {
         // CS_ROT must work with Cell::DictAddr values (as used in WHILE/ENDWH).
         // ( a b c -- b c a ) with DictAddr values
         let mut vm = make_compiling_vm("TESTWORD");
-        vm.compile_stack.push(Cell::DictAddr(1)); // a
-        vm.compile_stack.push(Cell::DictAddr(2)); // b
-        vm.compile_stack.push(Cell::DictAddr(3)); // c
+        vm.compile_stack.push(CompileEntry::Cell(Cell::DictAddr(1))); // a
+        vm.compile_stack.push(CompileEntry::Cell(Cell::DictAddr(2))); // b
+        vm.compile_stack.push(CompileEntry::Cell(Cell::DictAddr(3))); // c
         cs_rot_prim(&mut vm).unwrap();
         assert_eq!(vm.compile_stack.len(), 3);
-        assert_eq!(vm.compile_stack[0], Cell::DictAddr(2));
-        assert_eq!(vm.compile_stack[1], Cell::DictAddr(3));
-        assert_eq!(vm.compile_stack[2], Cell::DictAddr(1));
+        assert_eq!(vm.compile_stack[0], CompileEntry::Cell(Cell::DictAddr(2)));
+        assert_eq!(vm.compile_stack[1], CompileEntry::Cell(Cell::DictAddr(3)));
+        assert_eq!(vm.compile_stack[2], CompileEntry::Cell(Cell::DictAddr(1)));
     }
 
     // --- compile_expr_prim ---
@@ -4278,7 +4247,7 @@ mod tests {
         // has leftover items at the end of the word definition.
         let mut vm = make_compiling_vm("MYWORD");
         // Manually leave an item on compile_stack to simulate an incomplete definition.
-        vm.compile_stack.push(Cell::Int(1));
+        vm.compile_stack.push(CompileEntry::Cell(Cell::Int(1)));
         let err = end_prim(&mut vm).unwrap_err();
         assert!(
             matches!(err, TbxError::CompileStackNotEmpty { count: 1 }),
@@ -4419,173 +4388,156 @@ mod tests {
         assert_eq!(vm.pop(), Err(TbxError::StackUnderflow));
     }
 
-    // --- CTRL_OPEN_IF / CTRL_OPEN_WHILE / CTRL_CLOSE_IF / CTRL_CLOSE_WHILE ---
+    // --- cs_open_tag_prim ---
 
     #[test]
-    fn test_ctrl_open_if_outside_compile_mode_error() {
+    fn test_cs_open_tag_outside_compile_mode_error() {
+        // CS_OPEN_TAG outside compile mode must return InvalidExpression.
         let mut vm = VM::new();
-        assert_eq!(
-            ctrl_open_if_prim(&mut vm),
-            Err(TbxError::InvalidExpression {
-                reason: "CTRL_OPEN_IF outside compile mode"
-            })
-        );
-    }
-
-    #[test]
-    fn test_ctrl_open_while_outside_compile_mode_error() {
-        let mut vm = VM::new();
-        assert_eq!(
-            ctrl_open_while_prim(&mut vm),
-            Err(TbxError::InvalidExpression {
-                reason: "CTRL_OPEN_WHILE outside compile mode"
-            })
-        );
-    }
-
-    #[test]
-    fn test_ctrl_close_if_outside_compile_mode_error() {
-        let mut vm = VM::new();
-        assert_eq!(
-            ctrl_close_if_prim(&mut vm),
-            Err(TbxError::InvalidExpression {
-                reason: "CTRL_CLOSE_IF outside compile mode"
-            })
-        );
-    }
-
-    #[test]
-    fn test_ctrl_close_while_outside_compile_mode_error() {
-        let mut vm = VM::new();
-        assert_eq!(
-            ctrl_close_while_prim(&mut vm),
-            Err(TbxError::InvalidExpression {
-                reason: "CTRL_CLOSE_WHILE outside compile mode"
-            })
-        );
-    }
-
-    #[test]
-    fn test_ctrl_open_if_pushes_if_kind() {
-        let mut vm = VM::new();
-        vm.is_compiling = true;
-        ctrl_open_if_prim(&mut vm).unwrap();
-        assert_eq!(vm.control_stack, vec![ControlKind::If]);
-    }
-
-    #[test]
-    fn test_ctrl_open_while_pushes_while_kind() {
-        let mut vm = VM::new();
-        vm.is_compiling = true;
-        ctrl_open_while_prim(&mut vm).unwrap();
-        assert_eq!(vm.control_stack, vec![ControlKind::While]);
-    }
-
-    #[test]
-    fn test_ctrl_close_if_empty_stack_error() {
-        let mut vm = VM::new();
-        vm.is_compiling = true;
-        assert_eq!(
-            ctrl_close_if_prim(&mut vm),
-            Err(TbxError::UnopenedControlStructure { keyword: "ENDIF" })
-        );
-    }
-
-    #[test]
-    fn test_ctrl_close_while_empty_stack_error() {
-        let mut vm = VM::new();
-        vm.is_compiling = true;
-        assert_eq!(
-            ctrl_close_while_prim(&mut vm),
-            Err(TbxError::UnopenedControlStructure { keyword: "ENDWH" })
-        );
-    }
-
-    #[test]
-    fn test_ctrl_close_if_matching_pops_if() {
-        let mut vm = VM::new();
-        vm.is_compiling = true;
-        vm.control_stack.push(ControlKind::If);
-        ctrl_close_if_prim(&mut vm).unwrap();
-        assert!(vm.control_stack.is_empty());
-    }
-
-    #[test]
-    fn test_ctrl_close_while_matching_pops_while() {
-        let mut vm = VM::new();
-        vm.is_compiling = true;
-        vm.control_stack.push(ControlKind::While);
-        ctrl_close_while_prim(&mut vm).unwrap();
-        assert!(vm.control_stack.is_empty());
-    }
-
-    #[test]
-    fn test_ctrl_close_if_mismatched_while_error() {
-        // Simulates: WHILE ... ENDIF  (cross-nesting error)
-        let mut vm = VM::new();
-        vm.is_compiling = true;
-        vm.control_stack.push(ControlKind::While);
-        assert_eq!(
-            ctrl_close_if_prim(&mut vm),
-            Err(TbxError::MismatchedControlStructure {
-                close_word: "ENDIF",
-                open_word: "WHILE"
-            })
-        );
-    }
-
-    #[test]
-    fn test_ctrl_close_while_mismatched_if_error() {
-        // Simulates: IF ... ENDWH  (cross-nesting error)
-        let mut vm = VM::new();
-        vm.is_compiling = true;
-        vm.control_stack.push(ControlKind::If);
-        assert_eq!(
-            ctrl_close_while_prim(&mut vm),
-            Err(TbxError::MismatchedControlStructure {
-                close_word: "ENDWH",
-                open_word: "IF"
-            })
-        );
-    }
-
-    #[test]
-    fn test_ctrl_nested_if_while_correct_order() {
-        // Simulates: IF ... WHILE ... ENDWH ... ENDIF  (correct nesting)
-        let mut vm = VM::new();
-        vm.is_compiling = true;
-        ctrl_open_if_prim(&mut vm).unwrap();
-        ctrl_open_while_prim(&mut vm).unwrap();
-        ctrl_close_while_prim(&mut vm).unwrap();
-        ctrl_close_if_prim(&mut vm).unwrap();
-        assert!(vm.control_stack.is_empty());
-    }
-
-    #[test]
-    fn test_end_prim_control_stack_not_empty_error() {
-        // end_prim must return ControlStackNotEmpty and rollback when control_stack
-        // has leftover items (defensive check for future code paths).
-        let mut vm = make_compiling_vm("MYWORD2");
-        // Manually leave an item on control_stack without a matching compile_stack entry.
-        vm.control_stack.push(ControlKind::If);
-        let err = end_prim(&mut vm).unwrap_err();
+        register_all(&mut vm);
+        let idx = vm.intern_string("IF").unwrap();
+        vm.push(Cell::StringDesc(idx)).unwrap();
+        let err = cs_open_tag_prim(&mut vm).unwrap_err();
         assert!(
-            matches!(err, TbxError::ControlStackNotEmpty { count: 1 }),
-            "expected ControlStackNotEmpty {{ count: 1 }}, got {err:?}"
+            matches!(err, TbxError::InvalidExpression { .. }),
+            "expected InvalidExpression, got {err:?}"
         );
-        // VM must have been rolled back.
+    }
+
+    #[test]
+    fn test_cs_open_tag_pushes_tag_to_compile_stack() {
+        // CS_OPEN_TAG must pop a StringDesc, resolve it and push Tag to compile_stack.
+        let mut vm = make_compiling_vm("TESTWORD");
+        let idx = vm.intern_string("WHILE").unwrap();
+        vm.push(Cell::StringDesc(idx)).unwrap();
+        cs_open_tag_prim(&mut vm).unwrap();
+        // data stack must be empty.
+        assert_eq!(vm.pop(), Err(TbxError::StackUnderflow));
+        // compile_stack must hold Tag("WHILE").
+        assert_eq!(
+            vm.compile_stack.last(),
+            Some(&CompileEntry::Tag("WHILE".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_cs_open_tag_type_error_non_string() {
+        // CS_OPEN_TAG with a non-StringDesc on the data stack must return TypeError.
+        let mut vm = make_compiling_vm("TESTWORD");
+        vm.push(Cell::Int(42)).unwrap();
+        let err = cs_open_tag_prim(&mut vm).unwrap_err();
         assert!(
-            !vm.is_compiling,
-            "is_compiling must be false after rollback"
+            matches!(err, TbxError::TypeError { .. }),
+            "expected TypeError, got {err:?}"
         );
-        // Both stacks must be cleared after rollback.
+    }
+
+    // --- cs_close_tag_prim ---
+
+    #[test]
+    fn test_cs_close_tag_outside_compile_mode_error() {
+        // CS_CLOSE_TAG outside compile mode must return InvalidExpression.
+        let mut vm = VM::new();
+        register_all(&mut vm);
+        let idx = vm.intern_string("IF").unwrap();
+        vm.push(Cell::StringDesc(idx)).unwrap();
+        let err = cs_close_tag_prim(&mut vm).unwrap_err();
         assert!(
-            vm.compile_stack.is_empty(),
-            "compile_stack must be empty after rollback"
+            matches!(err, TbxError::InvalidExpression { .. }),
+            "expected InvalidExpression, got {err:?}"
         );
+    }
+
+    #[test]
+    fn test_cs_close_tag_matching_pops_tag() {
+        // CS_CLOSE_TAG with matching Tag must succeed and pop it from compile_stack.
+        let mut vm = make_compiling_vm("TESTWORD");
+        vm.compile_stack
+            .push(CompileEntry::Tag("WHILE".to_string()));
+        let idx = vm.intern_string("WHILE").unwrap();
+        vm.push(Cell::StringDesc(idx)).unwrap();
+        cs_close_tag_prim(&mut vm).unwrap();
+        assert!(vm.compile_stack.is_empty());
+    }
+
+    #[test]
+    fn test_cs_close_tag_mismatched_tag_error() {
+        // CS_CLOSE_TAG with a tag that does not match must return MismatchedTag.
+        let mut vm = make_compiling_vm("TESTWORD");
+        vm.compile_stack.push(CompileEntry::Tag("IF".to_string()));
+        let idx = vm.intern_string("WHILE").unwrap();
+        vm.push(Cell::StringDesc(idx)).unwrap();
+        let err = cs_close_tag_prim(&mut vm).unwrap_err();
         assert!(
-            vm.control_stack.is_empty(),
-            "control_stack must be empty after rollback"
+            matches!(
+                err,
+                TbxError::MismatchedTag {
+                    ref expected,
+                    ref found
+                } if expected == "WHILE" && found == "IF"
+            ),
+            "expected MismatchedTag(WHILE/IF), got {err:?}"
         );
+    }
+
+    #[test]
+    fn test_cs_close_tag_empty_stack_error() {
+        // CS_CLOSE_TAG with an empty compile_stack must return NoOpenTag.
+        let mut vm = make_compiling_vm("TESTWORD");
+        let idx = vm.intern_string("WHILE").unwrap();
+        vm.push(Cell::StringDesc(idx)).unwrap();
+        let err = cs_close_tag_prim(&mut vm).unwrap_err();
+        assert!(
+            matches!(err, TbxError::NoOpenTag { ref expected } if expected == "WHILE"),
+            "expected NoOpenTag(WHILE), got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_cs_close_tag_cell_on_top_error() {
+        // CS_CLOSE_TAG with a Cell (not Tag) on top of compile_stack must return NoOpenTag.
+        let mut vm = make_compiling_vm("TESTWORD");
+        vm.compile_stack
+            .push(CompileEntry::Cell(Cell::Int(42)));
+        let idx = vm.intern_string("IF").unwrap();
+        vm.push(Cell::StringDesc(idx)).unwrap();
+        let err = cs_close_tag_prim(&mut vm).unwrap_err();
+        assert!(
+            matches!(err, TbxError::NoOpenTag { ref expected } if expected == "IF"),
+            "expected NoOpenTag(IF), got {err:?}"
+        );
+        // The cell must be restored on the compile_stack.
+        assert_eq!(
+            vm.compile_stack.last(),
+            Some(&CompileEntry::Cell(Cell::Int(42)))
+        );
+    }
+
+    #[test]
+    fn test_cs_open_close_tag_correct_nesting() {
+        // CS_OPEN_TAG and CS_CLOSE_TAG must support correct IF/WHILE nesting.
+        let mut vm = make_compiling_vm("TESTWORD");
+        // Simulate: IF ... WHILE ... ENDWH ... ENDIF
+        let idx_if = vm.intern_string("IF").unwrap();
+        let idx_while = vm.intern_string("WHILE").unwrap();
+
+        vm.push(Cell::StringDesc(idx_if)).unwrap();
+        cs_open_tag_prim(&mut vm).unwrap(); // push Tag("IF")
+
+        vm.push(Cell::StringDesc(idx_while)).unwrap();
+        cs_open_tag_prim(&mut vm).unwrap(); // push Tag("WHILE")
+
+        // Close WHILE
+        let idx_while2 = vm.intern_string("WHILE").unwrap();
+        vm.push(Cell::StringDesc(idx_while2)).unwrap();
+        cs_close_tag_prim(&mut vm).unwrap(); // pop Tag("WHILE")
+
+        // Close IF
+        let idx_if2 = vm.intern_string("IF").unwrap();
+        vm.push(Cell::StringDesc(idx_if2)).unwrap();
+        cs_close_tag_prim(&mut vm).unwrap(); // pop Tag("IF")
+
+        assert!(vm.compile_stack.is_empty());
     }
 }
+

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1027,9 +1027,6 @@ pub fn dim_prim(vm: &mut VM) -> Result<(), TbxError> {
 
 /// CS_PUSH — move a value from the data stack to the compile stack.
 ///
-/// Must be called in compile mode (inside a IMMEDIATE word invocation).
-/// CS_PUSH — move a value from the data stack to the compile stack.
-///
 /// Must be called in compile mode (inside an IMMEDIATE word invocation).
 fn cs_push_prim(vm: &mut VM) -> Result<(), TbxError> {
     if !vm.is_compiling {
@@ -4264,6 +4261,30 @@ mod tests {
             "compile_stack must be empty after rollback"
         );
     }
+
+    #[test]
+    fn test_end_prim_tag_on_compile_stack_error() {
+        // end_prim must return CompileStackNotEmpty and rollback when a Tag entry
+        // is left on compile_stack (simulates an unclosed IF or WHILE).
+        let mut vm = make_compiling_vm("MYWORD3");
+        vm.compile_stack
+            .push(CompileEntry::Tag("IF".to_string()));
+        let err = end_prim(&mut vm).unwrap_err();
+        assert!(
+            matches!(err, TbxError::CompileStackNotEmpty { count: 1 }),
+            "expected CompileStackNotEmpty {{ count: 1 }}, got {err:?}"
+        );
+        // VM must have been rolled back.
+        assert!(
+            !vm.is_compiling,
+            "is_compiling must be false after rollback"
+        );
+        assert!(
+            vm.compile_stack.is_empty(),
+            "compile_stack must be empty after rollback"
+        );
+    }
+
 
     #[test]
     fn test_compile_expr_prim_outside_compile_mode_error() {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1,4 +1,4 @@
-use crate::cell::{Cell, ReturnFrame, Xt};
+use crate::cell::{Cell, CompileEntry, ReturnFrame, Xt};
 use crate::constants::{MAX_DATA_STACK_DEPTH, MAX_DICTIONARY_CELLS, MAX_RETURN_STACK_DEPTH};
 use crate::dict::{EntryKind, WordEntry};
 use crate::error::TbxError;
@@ -144,14 +144,9 @@ pub struct VM {
     pub(crate) compile_state: Option<CompileState>,
     /// Compile-time stack: used by IMMEDIATE words to pass values between
     /// compile-time word invocations (e.g. CS_PUSH / CS_POP for IF/ENDIF).
-    pub(crate) compile_stack: Vec<Cell>,
-    /// Control-structure kind stack: tracks which control structures are currently
-    /// open during compilation, independently of `compile_stack`.
-    ///
-    /// `CTRL_OPEN_IF` / `CTRL_OPEN_WHILE` push onto this stack; `CTRL_CLOSE_IF` /
-    /// `CTRL_CLOSE_WHILE` pop and validate the top entry (fail-fast before touching
-    /// `compile_stack`).  Cleared on rollback alongside `compile_stack`.
-    pub(crate) control_stack: Vec<crate::cell::ControlKind>,
+    /// Holds both `Cell` values and string `Tag` entries (for open control-structure
+    /// scopes). Tags are pushed by CS_OPEN_TAG and validated/popped by CS_CLOSE_TAG.
+    pub(crate) compile_stack: Vec<CompileEntry>,
     /// Path of a file to be loaded after the current IMMEDIATE word returns.
     ///
     /// Set by `use_prim` when it encounters a USE "path" statement.
@@ -184,7 +179,6 @@ impl VM {
             token_stream: None,
             compile_state: None,
             compile_stack: Vec::new(),
-            control_stack: Vec::new(),
             pending_use_path: None,
         }
     }
@@ -839,7 +833,6 @@ impl VM {
         // Always clear the compile stack on rollback to prevent state leakage
         // into the next DEF..END compilation.
         self.compile_stack.clear();
-        self.control_stack.clear();
     }
 
     /// Perform a definition rollback using explicitly supplied snapshot values.
@@ -862,7 +855,6 @@ impl VM {
         // Always clear the compile stack on rollback to prevent state leakage
         // into the next DEF..END compilation.
         self.compile_stack.clear();
-        self.control_stack.clear();
     }
 
     /// Find the first header entry whose `kind` satisfies `pred`.


### PR DESCRIPTION
## 概要

VMの `compile_stack: Vec<Cell>` と `control_stack: Vec<ControlKind>` を
単一の `compile_stack: Vec<CompileEntry>` に統合し、タグベースの制御構造検証を導入する。
`CTRL_OPEN_IF` / `CTRL_OPEN_WHILE` / `CTRL_CLOSE_IF` / `CTRL_CLOSE_WHILE` の4プリミティブを
`CS_OPEN_TAG` / `CS_CLOSE_TAG` の2プリミティブに置き換える。

## 変更内容

- **`src/cell.rs`**: `ControlKind` enum を削除し、`CompileEntry` enum (`Cell(Cell)` / `Tag(String)`) を追加
- **`src/error.rs`**: `ControlStackNotEmpty` / `MismatchedControlStructure` / `UnopenedControlStructure` を削除し、`MismatchedTag` / `NoOpenTag` を追加
- **`src/vm.rs`**: `control_stack` フィールドを削除し、`compile_stack` を `Vec<CompileEntry>` に変更
- **`src/primitives.rs`**: `CTRL_*` 4プリミティブを `CS_OPEN_TAG` / `CS_CLOSE_TAG` に置き換え; テストを新設計に対応
- **`lib/basic.tbx`**: WHILE/ENDWH/IF/ENDIF/ELSIF/ELSE をタグラスト方式に書き直し
- **`src/interpreter.rs`**: 制御構造エラーのテスト期待値を新エラー型に更新

### 設計方針（タグラスト）

タグは compile_stack の一番上に積む（タグラスト）。
- WHILE 後: `[Cell(L), Cell(P), Tag("WHILE")]`
- IF 後: `[Cell(0), Cell(A), Tag("IF")]`
- CS_CLOSE_TAG が最初にタグを検証するため、クロスネストを確実に検出できる

Closes #363
