### PR TITLE
improve: implement-issueエージェントのdescriptionにレビューループを追記

### DIFF
--- a/.github/agents/implement-issue.agent.md
+++ b/.github/agents/implement-issue.agent.md
@@ -1,6 +1,6 @@
 ---
 name: implement-issue
-description: TBXプロジェクトのissueを読み込み、Rustコードを実装してPull Requestを作成するエージェント。「issue #N を実装して」というプロンプトで起動する。
+description: TBXプロジェクトのissueを読み込み、Rustコードを実装してPull Requestを作成し、レビューループ（最大3回）で品質を担保するエージェント。「issue #N を実装して」というプロンプトで起動する。
 ---
 
 ## 役割


### PR DESCRIPTION
## 概要

`implement-issue` エージェントの frontmatter `description` と body の整合チェックを実施したところ、レビューループ（ステップ6/6A/6B）がdescriptionに反映されていなかったため修正。

## 変更内容

- `description` にレビューループ（最大3回）で品質を担保する旨を追記

## 解決策の根拠

bodyの約半分はレビューループ・後処理・issueフィードバック登録で構成されており、description からその存在が読み取れない状態だった。description-body整合チェックの指摘を受けて修正した。
