### PR TITLE
set_base_dir のシグネチャを Result<(), TbxError> に変更する

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -334,4 +334,14 @@ mod tests {
         assert!(msg.contains("assertion failed"));
         assert!(msg.contains("SIGN(7) should be 1"));
     }
+
+    #[test]
+    fn test_invalid_argument_display() {
+        let e = TbxError::InvalidArgument {
+            message: "some error".to_string(),
+        };
+        let msg = e.to_string();
+        assert!(msg.contains("invalid argument"));
+        assert!(msg.contains("some error"));
+    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -138,6 +138,12 @@ pub enum TbxError {
     AssertionFailedWithMessage {
         message: String,
     },
+    /// An argument passed to a function or method has an invalid value.
+    ///
+    /// `message` describes what was wrong with the argument.
+    InvalidArgument {
+        message: String,
+    },
 }
 
 impl std::fmt::Display for TbxError {
@@ -231,6 +237,9 @@ impl std::fmt::Display for TbxError {
             TbxError::AssertionFailed => write!(f, "assertion failed"),
             TbxError::AssertionFailedWithMessage { message } => {
                 write!(f, "assertion failed: {message}")
+            }
+            TbxError::InvalidArgument { message } => {
+                write!(f, "invalid argument: {message}")
             }
         }
     }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -3335,6 +3335,34 @@ PUTDEC 42";
         );
     }
 
+    #[test]
+    fn test_set_base_dir_rejects_empty_path() {
+        // An empty string is also a relative path and must be rejected.
+        let mut interp = Interpreter::new();
+        let result = interp.set_base_dir(PathBuf::from(""));
+        assert!(result.is_err());
+        assert!(
+            matches!(result.unwrap_err(), TbxError::InvalidArgument { .. }),
+            "empty path should return InvalidArgument"
+        );
+    }
+
+    #[test]
+    fn test_set_base_dir_does_not_mutate_on_error() {
+        // When set_base_dir returns Err, base_dir must remain unset (None).
+        // Verified indirectly: exec_source with a relative USE path fails because
+        // base_dir is None, meaning the relative path is not resolved.
+        let mut interp = Interpreter::new();
+        let _ = interp.set_base_dir(PathBuf::from("relative/path"));
+        // If base_dir were erroneously set, exec_source would try to resolve the
+        // USE path and return FileNotFound; if base_dir is None the behaviour
+        // depends on the implementation — either way the test confirms the call
+        // after a failed set_base_dir does not crash.
+        let use_result = interp.exec_source("USE \"some_file.tbx\"");
+        // base_dir is None, so the relative path cannot be resolved; must error.
+        assert!(use_result.is_err());
+    }
+
     // --- IF / ENDIF (lib/basic.tbx) ---
 
     #[test]

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -3326,9 +3326,12 @@ PUTDEC 42";
         let mut interp = Interpreter::new();
         let result = interp.set_base_dir(PathBuf::from("relative/path"));
         assert!(result.is_err());
+        let TbxError::InvalidArgument { message } = result.unwrap_err() else {
+            panic!("expected TbxError::InvalidArgument");
+        };
         assert!(
-            matches!(result.unwrap_err(), TbxError::InvalidArgument { .. }),
-            "relative path should return InvalidArgument"
+            message.contains("relative/path"),
+            "error message should include the invalid path; got: {message}"
         );
     }
 

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -3349,18 +3349,13 @@ PUTDEC 42";
 
     #[test]
     fn test_set_base_dir_does_not_mutate_on_error() {
-        // When set_base_dir returns Err, base_dir must remain unset (None).
-        // Verified indirectly: exec_source with a relative USE path fails because
-        // base_dir is None, meaning the relative path is not resolved.
+        // When set_base_dir returns Err, base_dir must remain None (direct check).
         let mut interp = Interpreter::new();
         let _ = interp.set_base_dir(PathBuf::from("relative/path"));
-        // If base_dir were erroneously set, exec_source would try to resolve the
-        // USE path and return FileNotFound; if base_dir is None the behaviour
-        // depends on the implementation — either way the test confirms the call
-        // after a failed set_base_dir does not crash.
-        let use_result = interp.exec_source("USE \"some_file.tbx\"");
-        // base_dir is None, so the relative path cannot be resolved; must error.
-        assert!(use_result.is_err());
+        assert!(
+            interp.base_dir.is_none(),
+            "base_dir should remain None after a failed set_base_dir"
+        );
     }
 
     // --- IF / ENDIF (lib/basic.tbx) ---

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -589,20 +589,23 @@ impl Interpreter {
     /// The directory of the including file is **not** considered; resolution
     /// always starts from the single `base_dir` set here.
     ///
-    /// # Relative `dir`
+    /// # Errors
     ///
-    /// `dir` should be an absolute path. If a relative path is supplied,
-    /// `std::fs::canonicalize` will still resolve it against the process CWD,
-    /// so the CWD dependency is not eliminated. Use
-    /// `std::fs::canonicalize(&dir)` or `std::env::current_dir()` to obtain
+    /// Returns `Err(TbxError::InvalidArgument)` if `dir` is a relative path.
+    /// Use `std::fs::canonicalize(&dir)` or `std::env::current_dir()` to obtain
     /// an absolute path before calling this method.
-    pub fn set_base_dir(&mut self, dir: PathBuf) {
-        debug_assert!(
-            dir.is_absolute(),
-            "set_base_dir requires an absolute path; got: {}",
-            dir.display()
-        );
-        self.base_dir = Some(dir);
+    pub fn set_base_dir(&mut self, dir: PathBuf) -> Result<(), TbxError> {
+        if dir.is_absolute() {
+            self.base_dir = Some(dir);
+            Ok(())
+        } else {
+            Err(TbxError::InvalidArgument {
+                message: format!(
+                    "set_base_dir requires an absolute path; got: {}",
+                    dir.display()
+                ),
+            })
+        }
     }
 
     /// Execute an IMMEDIATE word, regardless of compile/interpret mode.
@@ -3227,7 +3230,7 @@ PUTDEC 42";
         let mut interp = Interpreter::new();
         // Set base_dir to the temp directory so that the relative path "lib.tbx"
         // resolves to the file created above.
-        interp.set_base_dir(dir.path().to_path_buf());
+        interp.set_base_dir(dir.path().to_path_buf()).unwrap();
         // Use a relative path: only the file name, relative to base_dir.
         interp.exec_source("USE \"lib.tbx\"\nHELLO").unwrap();
         assert!(
@@ -3243,7 +3246,7 @@ PUTDEC 42";
         let dir = tempfile::tempdir().expect("tempdir");
 
         let mut interp = Interpreter::new();
-        interp.set_base_dir(dir.path().to_path_buf());
+        interp.set_base_dir(dir.path().to_path_buf()).unwrap();
         let result = interp.exec_source("USE \"no_such_file.tbx\"");
         assert!(result.is_err());
         let err = result.unwrap_err();
@@ -3276,7 +3279,7 @@ PUTDEC 42";
         std::fs::write(&path_a, "USE \"b.tbx\"\n").unwrap();
 
         let mut interp = Interpreter::new();
-        interp.set_base_dir(dir.path().to_path_buf());
+        interp.set_base_dir(dir.path().to_path_buf()).unwrap();
         // All USE paths are relative; base_dir must be applied throughout the chain.
         interp.exec_source("USE \"a.tbx\"\nNESTED").unwrap();
         assert!(
@@ -3306,7 +3309,7 @@ PUTDEC 42";
         std::fs::write(&path_a, "USE \"utils.tbx\"\n").unwrap();
 
         let mut interp = Interpreter::new();
-        interp.set_base_dir(dir.path().to_path_buf());
+        interp.set_base_dir(dir.path().to_path_buf()).unwrap();
         // a.tbx USEs "utils.tbx" which resolves to base_dir/utils.tbx — success.
         interp
             .exec_source("USE \"modules/a.tbx\"\nUTIL_WORD")
@@ -3314,6 +3317,18 @@ PUTDEC 42";
         assert!(
             interp.take_output().contains("util"),
             "USE in subdirectory file should succeed when path is relative to base_dir"
+        );
+    }
+
+    #[test]
+    fn test_set_base_dir_rejects_relative_path() {
+        // Passing a relative path must return Err(TbxError::InvalidArgument).
+        let mut interp = Interpreter::new();
+        let result = interp.set_base_dir(PathBuf::from("relative/path"));
+        assert!(result.is_err());
+        assert!(
+            matches!(result.unwrap_err(), TbxError::InvalidArgument { .. }),
+            "relative path should return InvalidArgument"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,9 @@ fn run_file(path: &str) -> std::process::ExitCode {
     // when only a bare filename is given (e.g. "foo.tbx" -> parent is "").
     if let Ok(abs_path) = std::fs::canonicalize(path) {
         if let Some(parent) = abs_path.parent() {
-            interp.set_base_dir(parent.to_path_buf());
+            interp
+                .set_base_dir(parent.to_path_buf())
+                .expect("canonicalized path parent must be absolute");
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,8 @@ fn run_file(path: &str) -> std::process::ExitCode {
     // when only a bare filename is given (e.g. "foo.tbx" -> parent is "").
     if let Ok(abs_path) = std::fs::canonicalize(path) {
         if let Some(parent) = abs_path.parent() {
+            // canonicalize always returns an absolute path, so parent() is
+            // also absolute; set_base_dir will not return Err here in practice.
             if let Err(e) = interp.set_base_dir(parent.to_path_buf()) {
                 eprintln!("Error: {e}");
                 return std::process::ExitCode::FAILURE;

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,9 +25,10 @@ fn run_file(path: &str) -> std::process::ExitCode {
     // when only a bare filename is given (e.g. "foo.tbx" -> parent is "").
     if let Ok(abs_path) = std::fs::canonicalize(path) {
         if let Some(parent) = abs_path.parent() {
-            interp
-                .set_base_dir(parent.to_path_buf())
-                .expect("canonicalized path parent must be absolute");
+            if let Err(e) = interp.set_base_dir(parent.to_path_buf()) {
+                eprintln!("Error: {e}");
+                return std::process::ExitCode::FAILURE;
+            }
         }
     }
 

--- a/tests/tbx_lib_tests.rs
+++ b/tests/tbx_lib_tests.rs
@@ -9,7 +9,9 @@ use tbx::interpreter::Interpreter;
 
 fn run_tbx_test(path: &PathBuf, base_dir: &Path) -> Result<(), String> {
     let mut interp = Interpreter::new();
-    interp.set_base_dir(base_dir.to_path_buf());
+    interp
+        .set_base_dir(base_dir.to_path_buf())
+        .expect("CARGO_MANIFEST_DIR is always absolute");
     let src = std::fs::read_to_string(path)
         .map_err(|e| format!("cannot read {}: {e}", path.display()))?;
     interp


### PR DESCRIPTION
## 概要

`set_base_dir` が相対パスを受け取ってもパニックせず、呼び出し元がエラーを適切にハンドリングできるよう、シグネチャを `Result<(), TbxError>` に変更する（案A）。

## 変更内容

- `src/error.rs`: `TbxError::InvalidArgument { message: String }` バリアントと `Display` アームを追加
- `src/interpreter.rs`: `set_base_dir` のシグネチャを `pub fn set_base_dir(&mut self, dir: PathBuf) -> Result<(), TbxError>` に変更。相対パスを受け取った場合は `Err(TbxError::InvalidArgument { .. })` を返す。`debug_assert!` を削除し doc comment を更新。既存テストの呼び出しを `.unwrap()` に変更。相対パス拒否を確認する新規テスト `test_set_base_dir_rejects_relative_path` を追加
- `src/main.rs`: `set_base_dir(...)` の戻り値を `.expect()` で処理
- `tests/tbx_lib_tests.rs`: `set_base_dir(...)` の戻り値を `.expect()` で処理

Closes #375
