### PR TITLE
統合テストをテストファイルごとの独立した #[test] に分割する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,10 @@ cargo fmt --check
 | `review-implementation` | PRのコードをレビューし問題をコメント・issueに登録 |
 | `blueprint-updater` | `blueprint.md` / `blueprint-language.md` / `blueprint-compiler.md` に設計方針を記録しPRを作成 |
 
+## ユーザーへの確認ルール
+
+- `ask_user` でトレードオフを伴う選択を求めるときは、**先に選択肢の pros/cons を会話中または issue コメントとして提示**してから選択 UI を表示すること（理由: ユーザーが根拠なしに選択を迫られる）
+
 ## 言語ルール
 
 - コードのコメントは**英語**で記述する。

--- a/build.rs
+++ b/build.rs
@@ -31,7 +31,12 @@ fn main() {
         })
         .collect();
     tbx_files.sort();
+    assert!(
+        !tbx_files.is_empty(),
+        "no test_*.tbx files found in lib/tests/"
+    );
 
+    let mut seen = std::collections::HashSet::new();
     let mut out = String::new();
     for path in &tbx_files {
         let file_name = path
@@ -44,6 +49,14 @@ fn main() {
             .strip_suffix(".tbx")
             .expect("file_name ends with .tbx");
         let fn_name = stem.replace('-', "_");
+
+        // Detect collisions caused by files that differ only in '-' vs '_'.
+        if !seen.insert(fn_name.clone()) {
+            panic!(
+                "build.rs: duplicate test function name `{fn_name}` \
+                 (check for files differing only in `-` vs `_`)"
+            );
+        }
 
         writeln!(
             out,

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,67 @@
+// build.rs — generates one #[test] function per lib/tests/test_*.tbx file.
+//
+// The generated source is written to $OUT_DIR/tbx_lib_tests_generated.rs and
+// included by tests/tbx_lib_tests.rs via include!().
+
+use std::env;
+use std::fmt::Write as FmtWrite;
+use std::fs;
+use std::path::PathBuf;
+
+fn main() {
+    // Trigger a rebuild whenever any file inside lib/tests/ changes.
+    println!("cargo:rerun-if-changed=lib/tests/");
+
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
+    let tests_dir = PathBuf::from(&manifest_dir).join("lib/tests");
+
+    // Collect test_*.tbx files in sorted order for deterministic output.
+    let mut tbx_files: Vec<PathBuf> = fs::read_dir(&tests_dir)
+        .unwrap_or_else(|e| panic!("cannot read lib/tests/: {e}"))
+        .map(|e| {
+            e.unwrap_or_else(|e| panic!("cannot read dir entry: {e}"))
+                .path()
+        })
+        .filter(|p| {
+            p.is_file()
+                && p.file_name()
+                    .and_then(|n| n.to_str())
+                    .map(|n| n.starts_with("test_") && n.ends_with(".tbx"))
+                    .unwrap_or(false)
+        })
+        .collect();
+    tbx_files.sort();
+
+    let mut out = String::new();
+    for path in &tbx_files {
+        let file_name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .expect("non-UTF-8 file name");
+
+        // Strip the .tbx extension and replace '-' with '_' to form a valid Rust identifier.
+        let stem = file_name
+            .strip_suffix(".tbx")
+            .expect("file_name ends with .tbx");
+        let fn_name = stem.replace('-', "_");
+
+        writeln!(
+            out,
+            r#"#[test]
+fn {fn_name}() {{
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let base_dir = ::std::path::PathBuf::from(manifest_dir);
+    let path = base_dir.join("lib/tests/{file_name}");
+    if let Err(e) = run_tbx_test(&path, &base_dir) {{
+        panic!("{{}}", e);
+    }}
+}}
+"#
+        )
+        .expect("write to String never fails");
+    }
+
+    let out_dir = env::var("OUT_DIR").expect("OUT_DIR not set");
+    let dest = PathBuf::from(out_dir).join("tbx_lib_tests_generated.rs");
+    fs::write(&dest, &out).unwrap_or_else(|e| panic!("cannot write {}: {e}", dest.display()));
+}

--- a/build.rs
+++ b/build.rs
@@ -50,6 +50,18 @@ fn main() {
             .expect("file_name ends with .tbx");
         let fn_name = stem.replace('-', "_");
 
+        // Reject file names whose stems contain characters outside [A-Za-z0-9_].
+        // Such names would produce invalid Rust identifiers after the '-' → '_' replacement.
+        if !fn_name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_')
+        {
+            panic!(
+                "build.rs: file stem `{stem}` contains characters that cannot form \
+                 a valid Rust identifier; rename the file to use only ASCII alphanumerics and '-'/'_'"
+            );
+        }
+
         // Detect collisions caused by files that differ only in '-' vs '_'.
         if !seen.insert(fn_name.clone()) {
             panic!(
@@ -58,13 +70,17 @@ fn main() {
             );
         }
 
+        // Produce a properly escaped Rust string literal for the relative path so that
+        // any '"' or '\' in the file name cannot break the generated source syntax.
+        let path_literal = format!("{:?}", format!("lib/tests/{file_name}"));
+
         writeln!(
             out,
             r#"#[test]
 fn {fn_name}() {{
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     let base_dir = ::std::path::PathBuf::from(manifest_dir);
-    let path = base_dir.join("lib/tests/{file_name}");
+    let path = base_dir.join({path_literal});
     if let Err(e) = run_tbx_test(&path, &base_dir) {{
         panic!("{{}}", e);
     }}

--- a/tests/tbx_lib_tests.rs
+++ b/tests/tbx_lib_tests.rs
@@ -19,42 +19,6 @@ fn run_tbx_test(path: &PathBuf, base_dir: &Path) -> Result<(), String> {
         .map_err(|e| format!("{}: {e}", path.display()))
 }
 
-#[test]
-fn test_lib_tbx_files() {
-    let manifest_dir = env!("CARGO_MANIFEST_DIR");
-    let base_dir = PathBuf::from(manifest_dir);
-    let tests_dir = base_dir.join("lib/tests");
-    let mut test_files: Vec<PathBuf> = std::fs::read_dir(&tests_dir)
-        .unwrap_or_else(|e| panic!("cannot read lib/tests/: {e}"))
-        .map(|e| e.unwrap_or_else(|e| panic!("cannot read dir entry in lib/tests/: {e}")))
-        .map(|e| e.path())
-        .filter(|p| {
-            p.is_file()
-                && p.file_name()
-                    .and_then(|n| n.to_str())
-                    .map(|n| n.starts_with("test_") && n.ends_with(".tbx"))
-                    .unwrap_or(false)
-        })
-        .collect();
-    test_files.sort();
-    assert!(
-        !test_files.is_empty(),
-        "no test_*.tbx files found in lib/tests/"
-    );
-
-    // Run all files and collect failures before reporting.
-    let mut failures: Vec<String> = Vec::new();
-    for path in &test_files {
-        eprintln!("running tbx test: {}", path.display());
-        if let Err(e) = run_tbx_test(path, &base_dir) {
-            failures.push(e);
-        }
-    }
-    if !failures.is_empty() {
-        panic!(
-            "{} TBX test(s) failed:\n{}",
-            failures.len(),
-            failures.join("\n")
-        );
-    }
-}
+// Individual #[test] functions for each lib/tests/test_*.tbx file are generated
+// by build.rs and included here.
+include!(concat!(env!("OUT_DIR"), "/tbx_lib_tests_generated.rs"));


### PR DESCRIPTION
## 概要

`lib/tests/test_*.tbx` ファイルを単一の `#[test]` でまとめて実行していたため、失敗時にどのファイルが原因か特定しにくかった。`build.rs` によるコード生成により、各 `.tbx` ファイルに対応する独立した `#[test]` 関数を自動生成するよう変更した。

## 変更内容

- `build.rs`（新規）: `lib/tests/test_*.tbx` を走査し、ファイルごとに `#[test]` 関数を `$OUT_DIR/tbx_lib_tests_generated.rs` へ生成する
- `tests/tbx_lib_tests.rs`: `test_lib_tbx_files` 関数を削除し、末尾に `include!(concat!(env!("OUT_DIR"), "/tbx_lib_tests_generated.rs"))` を追加
- `cargo:rerun-if-changed=lib/tests/` により差分ビルドも機能する
- ファイル名中の `-` は `_` に置換して有効なRust識別子にする

現在の3テスト（`test_if_endif`、`test_if_elsif_else`、`test_while_endwh`）はそれぞれ独立した `#[test]` 関数として実行される。

Closes #313
