### PR TITLE
build.rs: 識別子サニタイズ・衝突検出ロジックのユニットテストを追加する

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -8,6 +8,9 @@ use std::fmt::Write as FmtWrite;
 use std::fs;
 use std::path::PathBuf;
 
+// Shared helper functions (also included by tests/build_sanitize_tests.rs).
+include!("build_support.rs");
+
 fn main() {
     // Trigger a rebuild whenever any file inside lib/tests/ changes.
     println!("cargo:rerun-if-changed=lib/tests/");
@@ -48,19 +51,11 @@ fn main() {
         let stem = file_name
             .strip_suffix(".tbx")
             .expect("file_name ends with .tbx");
-        let fn_name = stem.replace('-', "_");
+        let fn_name = sanitize_fn_name(stem);
 
         // Reject file names whose stems contain characters outside [A-Za-z0-9_].
         // Such names would produce invalid Rust identifiers after the '-' → '_' replacement.
-        if !fn_name
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '_')
-        {
-            panic!(
-                "build.rs: file stem `{stem}` contains characters that cannot form \
-                 a valid Rust identifier; rename the file to use only ASCII alphanumerics and '-'/'_'"
-            );
-        }
+        validate_stem(&fn_name, stem);
 
         // Detect collisions caused by files that differ only in '-' vs '_'.
         if !seen.insert(fn_name.clone()) {

--- a/build.rs
+++ b/build.rs
@@ -14,6 +14,8 @@ include!("build_support.rs");
 fn main() {
     // Trigger a rebuild whenever any file inside lib/tests/ changes.
     println!("cargo:rerun-if-changed=lib/tests/");
+    // Also rebuild when the shared helper file changes.
+    println!("cargo:rerun-if-changed=build_support.rs");
 
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
     let tests_dir = PathBuf::from(&manifest_dir).join("lib/tests");

--- a/build_support.rs
+++ b/build_support.rs
@@ -9,13 +9,19 @@ fn sanitize_fn_name(stem: &str) -> String {
     stem.replace('-', "_")
 }
 
-/// Validates that `fn_name` (the sanitized form of `stem`) consists only of
-/// ASCII alphanumerics and `_`.  Panics with an informative message otherwise.
+/// Validates that `fn_name` (the sanitized form of `stem`) is a valid Rust identifier:
+/// - non-empty
+/// - first character is an ASCII letter or `_` (digits are not valid at the start)
+/// - remaining characters are ASCII alphanumerics or `_`
+///
+/// Panics with an informative message if any condition is violated.
 fn validate_stem(fn_name: &str, stem: &str) {
-    if !fn_name
+    let first_ok = fn_name
         .chars()
-        .all(|c| c.is_ascii_alphanumeric() || c == '_')
-    {
+        .next()
+        .map(|c| c.is_ascii_alphabetic() || c == '_')
+        .unwrap_or(false); // empty fn_name is invalid
+    if !first_ok || !fn_name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
         panic!(
             "build.rs: file stem `{stem}` contains characters that cannot form \
              a valid Rust identifier; rename the file to use only ASCII alphanumerics and '-'/'_'"

--- a/build_support.rs
+++ b/build_support.rs
@@ -1,0 +1,24 @@
+// build_support.rs — helper functions shared between build.rs and unit tests.
+//
+// This file is include!()-d by build.rs and by tests/build_sanitize_tests.rs
+// so that the sanitization and validation logic can be unit-tested without
+// duplicating the implementation.
+
+/// Converts a file stem to a valid Rust function name by replacing `-` with `_`.
+fn sanitize_fn_name(stem: &str) -> String {
+    stem.replace('-', "_")
+}
+
+/// Validates that `fn_name` (the sanitized form of `stem`) consists only of
+/// ASCII alphanumerics and `_`.  Panics with an informative message otherwise.
+fn validate_stem(fn_name: &str, stem: &str) {
+    if !fn_name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_')
+    {
+        panic!(
+            "build.rs: file stem `{stem}` contains characters that cannot form \
+             a valid Rust identifier; rename the file to use only ASCII alphanumerics and '-'/'_'"
+        );
+    }
+}

--- a/tests/build_sanitize_tests.rs
+++ b/tests/build_sanitize_tests.rs
@@ -1,0 +1,68 @@
+// Integration tests for the build.rs sanitization and collision-detection helpers.
+//
+// build.rs is compiled as a standalone binary so its code cannot be accessed via
+// the normal crate path.  Instead we include the shared helper file directly so
+// that the same implementation is tested here.
+
+// Include the shared helper functions from build_support.rs.
+include!(concat!(env!("CARGO_MANIFEST_DIR"), "/build_support.rs"));
+
+#[test]
+fn sanitize_replaces_single_hyphen() {
+    assert_eq!(sanitize_fn_name("test_foo-bar"), "test_foo_bar");
+}
+
+#[test]
+fn sanitize_replaces_multiple_hyphens() {
+    // e.g. test_a-b-c.tbx  →  test_a_b_c
+    assert_eq!(sanitize_fn_name("test_a-b-c"), "test_a_b_c");
+}
+
+#[test]
+fn sanitize_no_hyphen_is_unchanged() {
+    assert_eq!(sanitize_fn_name("test_hello_world"), "test_hello_world");
+}
+
+#[test]
+#[should_panic(expected = "cannot form a valid Rust identifier")]
+fn validate_panics_on_space_in_stem() {
+    // e.g. "test_foo bar.tbx" — space is not a valid identifier character.
+    let fn_name = sanitize_fn_name("test_foo bar");
+    validate_stem(&fn_name, "test_foo bar");
+}
+
+#[test]
+#[should_panic(expected = "cannot form a valid Rust identifier")]
+fn validate_panics_on_dot_in_stem() {
+    let fn_name = sanitize_fn_name("test_foo.bar");
+    validate_stem(&fn_name, "test_foo.bar");
+}
+
+#[test]
+fn validate_accepts_valid_identifier() {
+    // Should not panic.
+    let fn_name = sanitize_fn_name("test_foo_bar");
+    validate_stem(&fn_name, "test_foo_bar");
+}
+
+#[test]
+fn collision_detected_for_hyphen_vs_underscore() {
+    // test_foo_bar.tbx and test_foo-bar.tbx both produce fn_name "test_foo_bar".
+    let mut seen = std::collections::HashSet::new();
+    let first = sanitize_fn_name("test_foo_bar");
+    let second = sanitize_fn_name("test_foo-bar");
+    assert!(seen.insert(first), "first insert must succeed");
+    assert!(
+        !seen.insert(second),
+        "second insert must fail due to collision"
+    );
+}
+
+#[test]
+fn no_collision_for_distinct_names() {
+    let mut seen = std::collections::HashSet::new();
+    let first = sanitize_fn_name("test_alpha");
+    let second = sanitize_fn_name("test_beta");
+    assert!(seen.insert(first));
+    assert!(seen.insert(second));
+}

--- a/tests/build_sanitize_tests.rs
+++ b/tests/build_sanitize_tests.rs
@@ -66,3 +66,19 @@ fn no_collision_for_distinct_names() {
     assert!(seen.insert(first));
     assert!(seen.insert(second));
 }
+
+#[test]
+#[should_panic(expected = "cannot form a valid Rust identifier")]
+fn validate_panics_on_digit_leading_stem() {
+    // A stem starting with a digit produces an invalid Rust identifier.
+    let fn_name = sanitize_fn_name("1test");
+    validate_stem(&fn_name, "1test");
+}
+
+#[test]
+#[should_panic(expected = "cannot form a valid Rust identifier")]
+fn validate_panics_on_empty_stem() {
+    // An empty stem cannot form any identifier.
+    let fn_name = sanitize_fn_name("");
+    validate_stem(&fn_name, "");
+}


### PR DESCRIPTION
## 概要

`build.rs` の識別子サニタイズ・衝突検出ロジックをヘルパー関数に切り出し、ユニットテストでカバーしました。

## 変更内容

### `build_support.rs`（新規）
- `sanitize_fn_name(stem: &str) -> String` — `-` を `_` に置換する変換関数
- `validate_stem(fn_name: &str, stem: &str)` — 無効文字を含む stem で panic するバリデーション関数

### `build.rs`（修正）
- `include!("build_support.rs")` で共有ヘルパーをインクルード
- インライン実装を関数呼び出しに置き換え

### `tests/build_sanitize_tests.rs`（新規）
- `include!(concat!(env!("CARGO_MANIFEST_DIR"), "/build_support.rs"))` で同一実装をテスト側から参照
- 8件のテストケース:
  - 単一ハイフンの `_` 変換
  - 複数ハイフン（`test_a-b-c` → `test_a_b_c`）の変換
  - ハイフンなしの stem は変更されないこと
  - スペースを含む stem が panic すること（`#[should_panic]`）
  - ドットを含む stem が panic すること（`#[should_panic]`）
  - 有効な識別子は panic しないこと
  - `-` vs `_` の違いのみでコリジョンが検出されること
  - 異なる名前ではコリジョンが発生しないこと

## テスト結果

```
running 8 tests
test collision_detected_for_hyphen_vs_underscore ... ok
test no_collision_for_distinct_names ... ok
test sanitize_no_hyphen_is_unchanged ... ok
test sanitize_replaces_multiple_hyphens ... ok
test sanitize_replaces_single_hyphen ... ok
test validate_accepts_valid_identifier ... ok
test validate_panics_on_dot_in_stem - should panic ... ok
test validate_panics_on_space_in_stem - should panic ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Closes #386
