### PR TITLE
ユーザー入力プリミティブ ACCEPT と GETDEC を実装する

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -144,6 +144,14 @@ pub enum TbxError {
     InvalidArgument {
         message: String,
     },
+    /// GETDEC was called but the input buffer is empty (ACCEPT was not called first).
+    InputBufferEmpty,
+    /// GETDEC could not parse the input buffer contents as an integer.
+    ///
+    /// `input` is the string that failed to parse.
+    ParseIntError {
+        input: String,
+    },
 }
 
 impl std::fmt::Display for TbxError {
@@ -240,6 +248,15 @@ impl std::fmt::Display for TbxError {
             }
             TbxError::InvalidArgument { message } => {
                 write!(f, "invalid argument: {message}")
+            }
+            TbxError::InputBufferEmpty => {
+                write!(
+                    f,
+                    "GETDEC: input buffer is empty (ACCEPT must be called first)"
+                )
+            }
+            TbxError::ParseIntError { input } => {
+                write!(f, "GETDEC: cannot parse {:?} as integer", input)
             }
         }
     }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1,6 +1,7 @@
 //! Outer interpreter: tokenizes source text and executes statements via the inner interpreter.
 
 use std::collections::{HashSet, VecDeque};
+use std::io::BufRead;
 use std::path::PathBuf;
 
 use crate::cell::{Cell, ReturnFrame, Xt};
@@ -67,6 +68,25 @@ impl std::error::Error for InterpreterError {
         // error reporters like `anyhow` / `eyre` to print the same message twice.
         None
     }
+}
+
+/// Read one line from stdin, stripping the trailing newline.
+///
+/// Returns the line as a `String` on success, or an `io::Error` on failure.
+/// An empty line (bare newline) returns an empty `String`.
+/// EOF (no input) returns an empty `String`.
+fn read_line_from_stdin() -> Result<String, std::io::Error> {
+    let stdin = std::io::stdin();
+    let mut line = String::new();
+    stdin.lock().read_line(&mut line)?;
+    // Strip trailing newline characters (\r\n or \n).
+    if line.ends_with('\n') {
+        line.pop();
+        if line.ends_with('\r') {
+            line.pop();
+        }
+    }
+    Ok(line)
 }
 
 /// Token list and segment boundaries produced by `parse_line_into_segments`.
@@ -392,7 +412,26 @@ impl Interpreter {
             self.vm.bp = saved_bp;
         }
 
-        run_result.map_err(make_err)
+        run_result.map_err(make_err)?;
+
+        // If ACCEPT set the pending_input_request flag, read one line from stdin
+        // and store it in vm.input_buffer for the next GETDEC call.
+        if self.vm.pending_input_request {
+            self.vm.pending_input_request = false;
+            let line = read_line_from_stdin().map_err(|e| {
+                InterpreterError::new(
+                    stmt_pos_line,
+                    stmt_pos_col,
+                    source_line,
+                    TbxError::InvalidArgument {
+                        message: format!("ACCEPT: failed to read from stdin: {e}"),
+                    },
+                )
+            })?;
+            self.vm.input_buffer = Some(line);
+        }
+
+        Ok(())
     }
 
     /// Write a single statement and its arguments to the dictionary.

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -334,6 +334,36 @@ pub fn putdec_prim(vm: &mut VM) -> Result<(), TbxError> {
     Ok(())
 }
 
+/// ACCEPT — read one line of user input into the VM's input buffer.
+///
+/// Sets `vm.pending_input_request` to request that the outer interpreter read a line from
+/// stdin and store it in `vm.input_buffer`.  The primitive itself does not perform I/O;
+/// the actual read is done by the interpreter layer after `vm.run()` returns.
+///
+/// Stack effect: `( -- )`
+pub fn accept_prim(vm: &mut VM) -> Result<(), TbxError> {
+    vm.pending_input_request = true;
+    Ok(())
+}
+
+/// GETDEC — consume the input buffer and push the parsed integer onto the data stack.
+///
+/// Takes the string stored in `vm.input_buffer` by a prior ACCEPT call, parses it
+/// as a signed decimal integer, and pushes the result as `Cell::Int`.
+///
+/// Returns `TbxError::InputBufferEmpty` if no input has been buffered yet,
+/// or `TbxError::ParseIntError` if the buffered string is not a valid integer.
+///
+/// Stack effect: `( -- n )`
+pub fn getdec_prim(vm: &mut VM) -> Result<(), TbxError> {
+    let s = vm.input_buffer.take().ok_or(TbxError::InputBufferEmpty)?;
+    let n = s
+        .trim()
+        .parse::<i64>()
+        .map_err(|_| TbxError::ParseIntError { input: s.clone() })?;
+    vm.push(Cell::Int(n))
+}
+
 /// PUTHEX — output the integer value on the stack as $-prefixed uppercase hex (no newline).
 /// Negative values are output as two's complement 64-bit representation.
 pub fn puthex_prim(vm: &mut VM) -> Result<(), TbxError> {
@@ -1451,6 +1481,8 @@ pub fn register_all(vm: &mut VM) {
     vm.register(WordEntry::new_primitive("PUTCHR", putchr_prim));
     vm.register(WordEntry::new_primitive("PUTDEC", putdec_prim));
     vm.register(WordEntry::new_primitive("PUTHEX", puthex_prim));
+    vm.register(WordEntry::new_primitive("ACCEPT", accept_prim));
+    vm.register(WordEntry::new_primitive("GETDEC", getdec_prim));
     vm.register(WordEntry::new_primitive("APPEND", append_prim));
     vm.register(WordEntry::new_primitive("ALLOT", allot_prim));
     vm.register(WordEntry::new_primitive("HERE", here_prim));
@@ -4886,6 +4918,101 @@ mod tests {
         assert!(
             matches!(result, Err(TbxError::InvalidExpression { .. })),
             "expected InvalidExpression for non-'=' token"
+        );
+    }
+
+    // --- accept_prim ---
+
+    #[test]
+    fn test_accept_sets_pending_input_request() {
+        let mut vm = VM::new();
+        register_all(&mut vm);
+        assert!(!vm.pending_input_request);
+        accept_prim(&mut vm).unwrap();
+        assert!(
+            vm.pending_input_request,
+            "pending_input_request should be set after ACCEPT"
+        );
+    }
+
+    #[test]
+    fn test_accept_does_not_push_to_stack() {
+        let mut vm = VM::new();
+        register_all(&mut vm);
+        let before = vm.data_stack.len();
+        accept_prim(&mut vm).unwrap();
+        assert_eq!(
+            vm.data_stack.len(),
+            before,
+            "ACCEPT must not change the data stack"
+        );
+    }
+
+    // --- getdec_prim ---
+
+    #[test]
+    fn test_getdec_parses_positive_integer() {
+        let mut vm = VM::new();
+        register_all(&mut vm);
+        vm.input_buffer = Some("42".to_string());
+        getdec_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop_int().unwrap(), 42);
+    }
+
+    #[test]
+    fn test_getdec_parses_negative_integer() {
+        let mut vm = VM::new();
+        register_all(&mut vm);
+        vm.input_buffer = Some("-7".to_string());
+        getdec_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop_int().unwrap(), -7);
+    }
+
+    #[test]
+    fn test_getdec_parses_with_whitespace() {
+        let mut vm = VM::new();
+        register_all(&mut vm);
+        vm.input_buffer = Some("  100  ".to_string());
+        getdec_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop_int().unwrap(), 100);
+    }
+
+    #[test]
+    fn test_getdec_empty_buffer_error() {
+        let mut vm = VM::new();
+        register_all(&mut vm);
+        // input_buffer is None — ACCEPT was not called
+        let result = getdec_prim(&mut vm);
+        assert!(
+            matches!(result, Err(TbxError::InputBufferEmpty)),
+            "expected InputBufferEmpty, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_getdec_parse_error() {
+        let mut vm = VM::new();
+        register_all(&mut vm);
+        vm.input_buffer = Some("abc".to_string());
+        let result = getdec_prim(&mut vm);
+        assert!(
+            matches!(result, Err(TbxError::ParseIntError { .. })),
+            "expected ParseIntError, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_getdec_consumes_input_buffer() {
+        let mut vm = VM::new();
+        register_all(&mut vm);
+        vm.input_buffer = Some("5".to_string());
+        getdec_prim(&mut vm).unwrap();
+        // Buffer should be consumed (None) after GETDEC
+        assert!(
+            vm.input_buffer.is_none(),
+            "input_buffer should be None after GETDEC"
         );
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -132,6 +132,14 @@ pub struct VM {
     /// Output buffer: collects text from PUTSTR / PUTCHR / PUTDEC / PUTHEX.
     /// Flushed to stdout at appropriate points (e.g. end of interpretation cycle).
     pub output_buffer: String,
+    /// Input buffer: holds a line of text read from stdin by the outer interpreter.
+    /// Filled by the interpreter layer before ACCEPT is executed; consumed by GETDEC.
+    /// Set to `None` when no input has been received yet or after it has been consumed.
+    pub input_buffer: Option<String>,
+    /// Flag set by the ACCEPT primitive to request that the outer interpreter
+    /// read one line from stdin and store it in `input_buffer`.
+    /// Cleared by the interpreter after fulfilling the request.
+    pub(crate) pending_input_request: bool,
     /// Compile mode flag: false = execution mode (STATE=0), true = compile mode (STATE=1).
     /// Toggled by DEF (enter compile mode) and END (return to execution mode).
     pub is_compiling: bool,
@@ -175,6 +183,8 @@ impl VM {
             dp: 0,
             latest: None,
             output_buffer: String::new(),
+            input_buffer: None,
+            pending_input_request: false,
             is_compiling: false,
             token_stream: None,
             compile_state: None,


### PR DESCRIPTION
## 概要

issue #394「ユーザーとの対話機能の実装」のうち、ACCEPT と GETDEC プリミティブを実装します。
GETKEY は複雑度が高いため別issueとし、今回はスコープ外です。

## 変更内容

- `src/vm.rs`: VM に `input_buffer: Option<String>` と `pending_input_request: bool` フィールドを追加
- `src/error.rs`: `TbxError::InputBufferEmpty` および `TbxError::ParseIntError` エラーバリアントを追加
- `src/primitives.rs`: `accept_prim` と `getdec_prim` を実装し、`register_all` で登録
- `src/interpreter.rs`: exec_segment の実行後に `pending_input_request` を確認し、stdin から1行読み取って `vm.input_buffer` に充填する処理を追加

### ACCEPT の設計

- シグネチャ: `ACCEPT  ( -- )`
- プリミティブは `vm.pending_input_request = true` をセットするのみで、I/O は Interpreter 層が担当
- Interpreter が `vm.run()` 完了後にフラグを確認し、stdin 1行読んで `vm.input_buffer` に格納する
- 既存の `output_buffer` / `pending_use_path` と対称的な設計

### GETDEC の設計

- シグネチャ: `GETDEC  ( -- n )`
- `vm.input_buffer.take()` で文字列を取り出し、`trim().parse::<i64>()` で整数にパース
- バッファが `None` の場合は `TbxError::InputBufferEmpty`、パース失敗時は `TbxError::ParseIntError` を返す

### テスト

- `vm.input_buffer` に直接値をセットするモック方式で stdin 非依存のユニットテストを追加
- 既存の `output_buffer` テスト方式に倣った設計

Closes #394
