### PR TITLE
ユーザー入力プリミティブ ACCEPT と GETDEC を実装する

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -144,6 +144,18 @@ pub enum TbxError {
     InvalidArgument {
         message: String,
     },
+    /// GETDEC was called but the input buffer was empty (ACCEPT had not been called first).
+    InputBufferEmpty,
+    /// GETDEC could not parse the input buffer as a signed decimal integer.
+    ParseIntError {
+        /// The string that failed to parse.
+        input: String,
+    },
+    /// An I/O error occurred while reading from the input source.
+    InputIoError {
+        /// Human-readable description of the I/O error.
+        reason: String,
+    },
 }
 
 impl std::fmt::Display for TbxError {
@@ -240,6 +252,15 @@ impl std::fmt::Display for TbxError {
             }
             TbxError::InvalidArgument { message } => {
                 write!(f, "invalid argument: {message}")
+            }
+            TbxError::InputBufferEmpty => {
+                write!(f, "GETDEC: input buffer is empty; call ACCEPT first")
+            }
+            TbxError::ParseIntError { input } => {
+                write!(f, "GETDEC: cannot parse {:?} as a decimal integer", input)
+            }
+            TbxError::InputIoError { reason } => {
+                write!(f, "ACCEPT: I/O error reading input: {reason}")
             }
         }
     }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1423,6 +1423,46 @@ fn use_prim(vm: &mut VM) -> Result<(), TbxError> {
     Ok(())
 }
 
+/// ACCEPT — read one line from the VM's input source and store it in the input buffer.
+///
+/// Reads until a newline (or EOF) and strips the trailing newline characters.
+/// Each call overwrites any previously buffered input.
+/// Stack signature: `( -- )`
+pub fn accept_prim(vm: &mut VM) -> Result<(), TbxError> {
+    let mut line = String::new();
+    vm.input_reader
+        .read_line(&mut line)
+        .map_err(|e| TbxError::InputIoError {
+            reason: e.to_string(),
+        })?;
+    // Strip trailing CR and LF so the stored string never includes line-ending bytes.
+    let trimmed = line
+        .trim_end_matches('\n')
+        .trim_end_matches('\r')
+        .to_string();
+    vm.input_buffer = Some(trimmed);
+    Ok(())
+}
+
+/// GETDEC — consume the input buffer and push its integer value onto the data stack.
+///
+/// Parses the string stored by the most recent ACCEPT call as a signed decimal integer
+/// (leading/trailing whitespace is ignored) and pushes the result as `Cell::Int`.
+///
+/// Returns `TbxError::InputBufferEmpty` if ACCEPT has not been called since the last
+/// GETDEC (or since VM creation), and `TbxError::ParseIntError` if the string cannot
+/// be parsed as a signed decimal integer.
+///
+/// Stack signature: `( -- n )`
+pub fn getdec_prim(vm: &mut VM) -> Result<(), TbxError> {
+    let s = vm.input_buffer.take().ok_or(TbxError::InputBufferEmpty)?;
+    let n = s
+        .trim()
+        .parse::<i64>()
+        .map_err(|_| TbxError::ParseIntError { input: s.clone() })?;
+    vm.push(Cell::Int(n))
+}
+
 /// Register all stack primitives into the VM's dictionary.
 pub fn register_all(vm: &mut VM) {
     vm.register(WordEntry::new_primitive("DROP", drop_prim));
@@ -1451,6 +1491,8 @@ pub fn register_all(vm: &mut VM) {
     vm.register(WordEntry::new_primitive("PUTCHR", putchr_prim));
     vm.register(WordEntry::new_primitive("PUTDEC", putdec_prim));
     vm.register(WordEntry::new_primitive("PUTHEX", puthex_prim));
+    vm.register(WordEntry::new_primitive("ACCEPT", accept_prim));
+    vm.register(WordEntry::new_primitive("GETDEC", getdec_prim));
     vm.register(WordEntry::new_primitive("APPEND", append_prim));
     vm.register(WordEntry::new_primitive("ALLOT", allot_prim));
     vm.register(WordEntry::new_primitive("HERE", here_prim));
@@ -4887,5 +4929,119 @@ mod tests {
             matches!(result, Err(TbxError::InvalidExpression { .. })),
             "expected InvalidExpression for non-'=' token"
         );
+    }
+
+    // --- accept_prim ---
+
+    #[test]
+    fn test_accept_stores_line_in_input_buffer() {
+        use std::io::Cursor;
+        let mut vm = VM::new();
+        vm.input_reader = Box::new(Cursor::new("hello\n"));
+        accept_prim(&mut vm).unwrap();
+        assert_eq!(vm.input_buffer, Some("hello".to_string()));
+    }
+
+    #[test]
+    fn test_accept_strips_trailing_newline() {
+        use std::io::Cursor;
+        let mut vm = VM::new();
+        vm.input_reader = Box::new(Cursor::new("world\r\n"));
+        accept_prim(&mut vm).unwrap();
+        assert_eq!(vm.input_buffer, Some("world".to_string()));
+    }
+
+    #[test]
+    fn test_accept_overwrites_previous_buffer() {
+        use std::io::Cursor;
+        let mut vm = VM::new();
+        vm.input_buffer = Some("old value".to_string());
+        vm.input_reader = Box::new(Cursor::new("new value\n"));
+        accept_prim(&mut vm).unwrap();
+        assert_eq!(vm.input_buffer, Some("new value".to_string()));
+    }
+
+    #[test]
+    fn test_accept_does_not_push_to_stack() {
+        use std::io::Cursor;
+        let mut vm = VM::new();
+        vm.input_reader = Box::new(Cursor::new("42\n"));
+        accept_prim(&mut vm).unwrap();
+        // Stack must remain empty — ACCEPT is ( -- ).
+        assert_eq!(vm.data_stack.len(), 0);
+    }
+
+    #[test]
+    fn test_accept_empty_line() {
+        use std::io::Cursor;
+        let mut vm = VM::new();
+        vm.input_reader = Box::new(Cursor::new("\n"));
+        accept_prim(&mut vm).unwrap();
+        assert_eq!(vm.input_buffer, Some("".to_string()));
+    }
+
+    // --- getdec_prim ---
+
+    #[test]
+    fn test_getdec_pushes_integer() {
+        let mut vm = VM::new();
+        vm.input_buffer = Some("42".to_string());
+        getdec_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Int(42)));
+    }
+
+    #[test]
+    fn test_getdec_negative_integer() {
+        let mut vm = VM::new();
+        vm.input_buffer = Some("-7".to_string());
+        getdec_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Int(-7)));
+    }
+
+    #[test]
+    fn test_getdec_trims_whitespace() {
+        let mut vm = VM::new();
+        vm.input_buffer = Some("  100  ".to_string());
+        getdec_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Int(100)));
+    }
+
+    #[test]
+    fn test_getdec_consumes_buffer() {
+        let mut vm = VM::new();
+        vm.input_buffer = Some("10".to_string());
+        getdec_prim(&mut vm).unwrap();
+        // input_buffer must be None after take().
+        assert_eq!(vm.input_buffer, None);
+    }
+
+    #[test]
+    fn test_getdec_empty_buffer_returns_error() {
+        let mut vm = VM::new();
+        // input_buffer is None by default.
+        let result = getdec_prim(&mut vm);
+        assert_eq!(result, Err(TbxError::InputBufferEmpty));
+    }
+
+    #[test]
+    fn test_getdec_non_integer_returns_error() {
+        let mut vm = VM::new();
+        vm.input_buffer = Some("abc".to_string());
+        let result = getdec_prim(&mut vm);
+        assert!(
+            matches!(result, Err(TbxError::ParseIntError { .. })),
+            "expected ParseIntError, got: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_accept_then_getdec_sequence() {
+        use std::io::Cursor;
+        let mut vm = VM::new();
+        vm.input_reader = Box::new(Cursor::new("123\n"));
+        accept_prim(&mut vm).unwrap();
+        getdec_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Int(123)));
     }
 }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1459,7 +1459,7 @@ pub fn getdec_prim(vm: &mut VM) -> Result<(), TbxError> {
     let n = s
         .trim()
         .parse::<i64>()
-        .map_err(|_| TbxError::ParseIntError { input: s.clone() })?;
+        .map_err(|_| TbxError::ParseIntError { input: s })?;
     vm.push(Cell::Int(n))
 }
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -5,6 +5,7 @@ use crate::error::TbxError;
 use crate::lexer::SpannedToken;
 use std::collections::HashMap;
 use std::collections::VecDeque;
+use std::io::{BufRead, BufReader};
 
 /// State maintained during compilation of a new word definition (DEF..END).
 #[derive(Debug)]
@@ -89,7 +90,6 @@ impl CompileState {
 /// The dictionary is split into two layers:
 /// - `headers`: word name/flag/kind metadata, forming a linked list via `prev`
 /// - `dictionary`: flat `Vec<Cell>` array of compiled code; `pc` indexes into this
-#[derive(Debug)]
 pub struct VM {
     /// Word header table (linked list via `WordEntry::prev`)
     pub headers: Vec<WordEntry>,
@@ -153,10 +153,37 @@ pub struct VM {
     /// Drained by `exec_immediate_word` in the interpreter, which calls
     /// `exec_source` on the file content.
     pub(crate) pending_use_path: Option<String>,
+    /// Internal buffer holding the last line read by ACCEPT.
+    ///
+    /// ACCEPT reads one line from `input_reader` and stores it here (trimmed of
+    /// trailing newline characters).  GETDEC then consumes the buffer via `take()`
+    /// and parses the stored string as a signed decimal integer.
+    pub input_buffer: Option<String>,
+    /// Source of user input.
+    ///
+    /// Defaults to stdin (wrapped in a `BufReader`) when the VM is created via
+    /// `new()`.  Tests can replace this field directly with any `Box<dyn BufRead>`
+    /// implementation (e.g. `std::io::Cursor`) to mock user input without
+    /// touching stdin.
+    ///
+    /// The field is not included in the `Debug` output because `dyn BufRead` does
+    /// not implement `Debug`.
+    pub input_reader: Box<dyn BufRead>,
 }
 
 impl VM {
     /// Create a new VM with empty header table, dictionary, and stacks.
+    ///
+    /// User input is read from stdin by default.  To redirect input (e.g. in
+    /// tests), replace the `input_reader` field after construction:
+    ///
+    /// ```no_run
+    /// use std::io::Cursor;
+    /// use tbx::vm::VM;
+    ///
+    /// let mut vm = VM::new();
+    /// vm.input_reader = Box::new(Cursor::new("42\n"));
+    /// ```
     pub fn new() -> Self {
         Self {
             headers: Vec::new(),
@@ -180,6 +207,8 @@ impl VM {
             compile_state: None,
             compile_stack: Vec::new(),
             pending_use_path: None,
+            input_buffer: None,
+            input_reader: Box::new(BufReader::new(std::io::stdin())),
         }
     }
 
@@ -868,6 +897,36 @@ impl VM {
             .enumerate()
             .find(|(_, e)| pred(&e.kind))
             .map(|(i, _)| Xt(i))
+    }
+}
+
+impl std::fmt::Debug for VM {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VM")
+            .field("headers", &self.headers)
+            .field("dictionary", &self.dictionary)
+            .field("string_pool", &self.string_pool)
+            .field("data_stack", &self.data_stack)
+            .field("return_stack", &self.return_stack)
+            .field("pc", &self.pc)
+            .field("bp", &self.bp)
+            .field("dp_sys", &self.dp_sys)
+            .field("dp_lib", &self.dp_lib)
+            .field("dp_user", &self.dp_user)
+            .field("hdr_sys", &self.hdr_sys)
+            .field("hdr_lib", &self.hdr_lib)
+            .field("hdr_user", &self.hdr_user)
+            .field("dp", &self.dp)
+            .field("latest", &self.latest)
+            .field("output_buffer", &self.output_buffer)
+            .field("is_compiling", &self.is_compiling)
+            .field("token_stream", &self.token_stream)
+            .field("compile_state", &self.compile_state)
+            .field("compile_stack", &self.compile_stack)
+            .field("pending_use_path", &self.pending_use_path)
+            .field("input_buffer", &self.input_buffer)
+            .field("input_reader", &"<dyn BufRead>")
+            .finish()
     }
 }
 


### PR DESCRIPTION
## 概要

issue #394「ユーザーとの対話機能の実装」のうち、ACCEPT と GETDEC プリミティブを実装します。
GETKEY は複雑度が高いため別issueとし、今回はスコープ外です。

## 変更内容

- `src/vm.rs`: VM に `input_buffer: Option<String>` と `input_reader: Box<dyn BufRead>` フィールドを追加。`VM::new()` はデフォルトで stdin を保持する
- `src/error.rs`: `TbxError::InputBufferEmpty` および `TbxError::ParseIntError` エラーバリアントを追加
- `src/primitives.rs`: `accept_prim` と `getdec_prim` を実装し、`register_all` で登録

### ACCEPT の設計

- シグネチャ: `ACCEPT  ( -- )`
- `vm.input_reader.read_line()` で1行読み取り、`vm.input_buffer` に格納する（スタックには積まない）
- 既存の `output_buffer` と対称的な設計

### GETDEC の設計

- シグネチャ: `GETDEC  ( -- n )`
- `vm.input_buffer.take()` で文字列を取り出し、`trim().parse::<i64>()` で整数にパース
- バッファが空なら `TbxError::InputBufferEmpty`、パース失敗なら `TbxError::ParseIntError`

### テスト

- `vm.input_reader = Box::new(Cursor::new("42\n"))` のようにフィールドを直接差し替えてモック
- stdin 非依存でユニットテスト可能

Closes #394
