### PR TITLE
大文字小文字非依存のワード呼び出しを検証するテストを追加する

### DIFF
--- a/lib/tests/test_case_insensitive.tbx
+++ b/lib/tests/test_case_insensitive.tbx
@@ -1,0 +1,63 @@
+REM lib/tests/test_case_insensitive.tbx — TBX tests for case-insensitive word/variable names
+USE "lib/tests/helper.tbx"
+
+REM --- Scenario 1: define in lowercase, call in lowercase ---
+REM This was the primary bug: lowercase-defined words could not be called.
+
+DEF hello
+  RETURN 1
+END
+ASSERT hello() = 1
+
+REM --- Scenario 2: define in lowercase, call in UPPERCASE ---
+
+ASSERT HELLO() = 1
+
+REM --- Scenario 3: define in UPPERCASE, call in lowercase ---
+REM Regression guard: this worked before the fix and must continue to work.
+
+DEF GREET
+  RETURN 2
+END
+ASSERT greet() = 2
+
+REM --- Scenario 4: define in MixedCase, call with different mixed patterns ---
+
+DEF MyWord
+  RETURN 3
+END
+ASSERT MYWORD() = 3
+ASSERT myword() = 3
+ASSERT MyWoRd() = 3
+
+REM --- Scenario 5: parameter names are case-insensitive ---
+REM Parameters are registered in uppercase internally; the body must resolve
+REM them regardless of the case used in the DEF signature.
+
+DEF addone(x)
+  RETURN x + 1
+END
+ASSERT addone(9) = 10
+ASSERT ADDONE(9) = 10
+
+REM --- Scenario 6: VAR names are case-insensitive ---
+REM Define a VAR in lowercase, read and write it with UPPERCASE references.
+
+DEF count_up
+  VAR n
+  SET &N, 0
+  SET &N, N + 1
+  SET &N, N + 1
+  RETURN N
+END
+ASSERT count_up() = 2
+ASSERT COUNT_UP() = 2
+
+REM --- Scenario 7: mixed-case VAR name, accessed with all-uppercase ---
+
+DEF mixedvar
+  VAR myCount
+  SET &MYCOUNT, 10
+  RETURN mycount + 5
+END
+ASSERT mixedvar() = 15


### PR DESCRIPTION
## 概要

issue #404 で修正されたワード名・変数名の大文字小文字非依存動作を検証する統合テストが存在しなかったため、`lib/tests/test_case_insensitive.tbx` を新規作成する。

## 変更内容

- `lib/tests/test_case_insensitive.tbx` を新規追加（Rustコードへの変更なし）
  - シナリオ1: 小文字で定義 → 小文字で呼び出し（修正前に失敗していた主要バグの確認）
  - シナリオ2: 小文字で定義 → 大文字で呼び出し（修正前に失敗していた）
  - シナリオ3: 大文字で定義 → 小文字で呼び出し（修正前から成功していた動作の回帰確認）
  - シナリオ4: 混在ケースで定義 → 異なる混在パターンで呼び出し（`MyWord` → `MYWORD`・`myword`・`MyWoRd`）
  - シナリオ5: 小文字パラメータ名を持つワードの動作確認（`def addone(x)` で定義し `ADDONE(9)` で呼び出し）
  - シナリオ6: 小文字 VAR 名を大文字で参照（`VAR n` → `SET &N`・`RETURN N`）
  - シナリオ7: 混在 VAR 名を異なるケースで参照（`VAR myCount` → `SET &MYCOUNT`・`RETURN mycount`）

Closes #406
