### PR TITLE
Token::Errorをサイレント無視せずInvalidExpressionとして伝播させる

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -512,7 +512,16 @@ impl<'a> ExprCompiler<'a> {
                 // -------------------------------------------------------
                 Token::Newline | Token::Eof | Token::Semicolon => break,
 
-                // Ignore all other tokens (LineNum, Error, …).
+                // Propagate lexer errors rather than silently ignoring them.
+                // Silently skipping Token::Error would compile incomplete
+                // expressions and cause confusing runtime failures.
+                Token::Error(_) => {
+                    return Err(TbxError::InvalidExpression {
+                        reason: "lexer error in expression (e.g. unterminated string literal)",
+                    });
+                }
+
+                // Ignore all other tokens (LineNum, …).
                 _ => {}
             }
 
@@ -1572,6 +1581,38 @@ mod tests {
         assert!(
             matches!(err, TbxError::InvalidExpression { .. }),
             "&NUMS() with no index should produce InvalidExpression, got {err:?}"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Test: Token::Error propagates as InvalidExpression
+    // ------------------------------------------------------------------
+
+    /// An unterminated string literal produces Token::Error from the lexer.
+    /// compile_expr must propagate that as TbxError::InvalidExpression rather
+    /// than silently ignoring it (which would leave the argument list empty and
+    /// cause confusing runtime type errors).
+    #[test]
+    fn test_token_error_propagates_as_invalid_expression() {
+        use crate::lexer::Position;
+        let mut vm = make_vm();
+
+        // Build a token slice that contains Token::Error directly, mimicking
+        // what the lexer emits for an unterminated string literal.
+        let error_token = SpannedToken {
+            token: Token::Error("unterminated string literal".to_string()),
+            pos: Position { line: 1, col: 1 },
+            source_offset: 0,
+            source_len: 1,
+        };
+        let tokens = vec![error_token];
+
+        let err = ExprCompiler::new(&mut vm)
+            .compile_expr(&tokens)
+            .unwrap_err();
+        assert!(
+            matches!(err, TbxError::InvalidExpression { .. }),
+            "Token::Error should produce InvalidExpression, got {err:?}"
         );
     }
 }

--- a/tests/tbx_lib_tests.rs
+++ b/tests/tbx_lib_tests.rs
@@ -22,3 +22,27 @@ fn run_tbx_test(path: &PathBuf, base_dir: &Path) -> Result<(), String> {
 // Individual #[test] functions for each lib/tests/test_*.tbx file are generated
 // by build.rs and included here.
 include!(concat!(env!("OUT_DIR"), "/tbx_lib_tests_generated.rs"));
+
+// ---------------------------------------------------------------------------
+// Error-path integration tests: verify that invalid TBX programs are rejected
+// at compile time rather than producing silent runtime failures.
+// ---------------------------------------------------------------------------
+
+/// A DEF…END block containing an unterminated string literal must fail at
+/// compile time with `InvalidExpression`, not silently compile and then crash
+/// at runtime with a `TypeError`.
+#[test]
+fn test_unterminated_string_in_def_is_compile_error() {
+    use tbx::interpreter::Interpreter;
+    let mut interp = Interpreter::new();
+    // The closing `"` is intentionally omitted to produce Token::Error.
+    let src = "DEF BAD_WORD\n  PUTSTR \"unterminated\nEND\n";
+    let err = interp
+        .exec_source(src)
+        .expect_err("expected a compile-time error for unterminated string literal");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("invalid expression"),
+        "expected 'invalid expression' in error message, got: {msg}"
+    );
+}


### PR DESCRIPTION
## 概要

`compile_expr` 関数が `Token::Error`（レクサーエラー）をサイレントに無視していたため、未終端文字列リテラル等のレクサーエラーを含む式がエラーなしにコンパイルされ、実行時に `TypeError` が発生するバグを修正する。

## 変更内容

- `src/expr.rs`: `compile_expr` の `_ => {}` デフォルト分岐の前に `Token::Error(_)` ブランチを追加し、`TbxError::InvalidExpression` を返すように修正
- `src/expr.rs`: `Token::Error` が適切に `InvalidExpression` として伝播されることを確認するユニットテストを追加

## 備考

`examples/scratch.tbx` はこのバグの再現ファイルだが、`.gitignore` に含まれているためPRには含めない。ローカルで修正済み（line 8の右二重引用符 U+201D を ASCII `"` に置換）。

Closes #409
