### PR TITLE
FOR/NEXT文を実装する

### DIFF
--- a/lib/basic.tbx
+++ b/lib/basic.tbx
@@ -169,3 +169,115 @@ DEF LET
   APPEND ASSIGN_XT
 END
 IMMEDIATE LET
+
+REM FOR &varref, start, end, step ... NEXT
+REM
+REM  Implements a counted loop: the loop variable is initialised to start, and the
+REM  body repeats while var <= end; after each iteration var is incremented by step.
+REM  Only positive step values are supported (step > 0 is assumed).
+REM
+REM  The start, end, and step expressions are all compiled eagerly during FOR
+REM  processing.  end and step are saved as CompiledCells on the compile stack and
+REM  emitted in the correct order.  A forward JUMP_ALWAYS skips the step code on
+REM  the first iteration.
+REM
+REM  Compile stack after FOR:
+REM    [S, BIF_placeholder, Tag("FOR")]
+REM    S               = DictAddr of step-code start (back-jump target for NEXT)
+REM    BIF_placeholder = DictAddr of the JUMP_FALSE operand cell (patched by NEXT)
+REM    Tag("FOR")      = scope tag (tag-last layout)
+REM
+REM  Generated instruction sequence:
+REM    LIT addr_of_var
+REM    <start_expr>
+REM    SET                      -- var = start
+REM    JUMP_ALWAYS A            -- skip step code on first entry
+REM  S:
+REM    LIT addr_of_var          -- step update code
+REM    FETCH
+REM    <step_expr>
+REM    ADD                      -- var + step
+REM    LIT addr_of_var
+REM    SET                      -- var = var + step
+REM  A:
+REM    LIT addr_of_var
+REM    FETCH                    -- push current var value
+REM    <end_expr>
+REM    LE                       -- var <= end ?
+REM    BIF D                    -- exit loop if false
+REM    <body>
+REM    JUMP_ALWAYS S            -- back-jump to step update
+REM  D:
+
+DEF FOR
+  REM Step 1: Read &var, emit LIT addr, and save var_addr in a local variable.
+  REM  COMPILE_LVALUE_SAVE emits LIT addr_of_var and pushes addr onto compile stack.
+  REM  We pop it immediately into a local variable for easy reuse without CS juggling.
+  VAR VAR_ADDR
+  COMPILE_LVALUE_SAVE
+  SET &VAR_ADDR, CS_POP
+  REM Step 2: Consume the comma after &var.
+  SKIP_COMMA
+  REM Step 3: Compile start expression and emit SET (var = start).
+  COMPILE_EXPR_UNTIL_COMMA
+  APPEND ASSIGN_XT
+  REM Step 4: Save end and step as CompiledCells (not emitted yet).
+  REM  SAVE_EXPR_UNTIL_COMMA compiles "end," and saves cells on compile stack.
+  SAVE_EXPR_UNTIL_COMMA
+  REM  COMPILE_EXPR_SAVE compiles the last argument "step" (no trailing comma).
+  COMPILE_EXPR_SAVE
+  REM  Compile stack: [end_cells, step_cells]
+  REM Step 5: Emit JUMP_ALWAYS to skip step code on the first iteration.
+  APPEND JUMP_ALWAYS
+  VAR SKIP_STEP_ADDR
+  SET &SKIP_STEP_ADDR, HERE
+  APPEND 0
+  REM Step 6: Record step-code start address S on the compile stack.
+  CS_PUSH HERE
+  REM  Compile stack: [end_cells, step_cells, S]
+  REM Step 7: Emit step update code: LIT addr, LIT addr, FETCH, <step>, ADD, SET.
+  REM  Stack convention: SET expects (addr, value) — addr pushed first, then value.
+  REM  CS_SWAP brings step_cells just above S to become the new top.
+  CS_SWAP
+  REM  Compile stack: [end_cells, S, step_cells]
+  LITERAL VAR_ADDR
+  LITERAL VAR_ADDR
+  APPEND FETCH_XT
+  EMIT_COMPILED_CELLS
+  REM  Compile stack: [end_cells, S]
+  APPEND ADD_XT
+  APPEND ASSIGN_XT
+  REM Step 8: Patch the JUMP_ALWAYS placeholder to here (= loop condition start A).
+  PATCH_ADDR SKIP_STEP_ADDR
+  REM Step 9: Emit condition code: LIT addr, FETCH, <end>, LE, BIF placeholder.
+  REM  CS_SWAP exposes end_cells at the top.
+  CS_SWAP
+  REM  Compile stack: [S, end_cells]
+  LITERAL VAR_ADDR
+  APPEND FETCH_XT
+  EMIT_COMPILED_CELLS
+  REM  Compile stack: [S]
+  APPEND LE_XT
+  APPEND JUMP_FALSE
+  CS_PUSH HERE
+  APPEND 0
+  REM  Compile stack: [S, BIF_placeholder]
+  REM Step 10: Push scope tag last (tag-last layout).
+  CS_OPEN_TAG "FOR"
+END
+IMMEDIATE FOR
+
+DEF NEXT
+  REM Validate and pop the "FOR" scope tag.
+  CS_CLOSE_TAG "FOR"
+  REM  Compile stack: [S, BIF_placeholder]
+  VAR BIF_ADDR
+  SET &BIF_ADDR, CS_POP
+  REM  Compile stack: [S]
+  REM Back-jump to step-update code at S.
+  APPEND JUMP_ALWAYS
+  APPEND CS_POP
+  REM Patch the BIF placeholder with the current dictionary pointer (= D, loop exit).
+  PATCH_ADDR BIF_ADDR
+END
+IMMEDIATE NEXT

--- a/lib/tests/test_for_next.tbx
+++ b/lib/tests/test_for_next.tbx
@@ -1,0 +1,83 @@
+REM lib/tests/test_for_next.tbx — TBX tests for FOR/NEXT control structures
+USE "lib/tests/helper.tbx"
+
+REM --- Basic counting loop: sum 1..10 step 1 ---
+
+DEF SUM_1_TO_10
+  VAR I
+  VAR S
+  SET &S, 0
+  FOR &I, 1, 10, 1
+    SET &S, S + I
+  NEXT
+  RETURN S
+END
+ASSERT SUM_1_TO_10() = 55
+
+REM --- Step 2: sum of odd numbers 1, 3, 5, 7, 9 = 25 ---
+
+DEF SUM_ODD_1_TO_10
+  VAR I
+  VAR S
+  SET &S, 0
+  FOR &I, 1, 9, 2
+    SET &S, S + I
+  NEXT
+  RETURN S
+END
+ASSERT SUM_ODD_1_TO_10() = 25
+
+REM --- Loop that does not execute: start > end ---
+
+DEF ZERO_ITERATIONS
+  VAR I
+  VAR C
+  SET &C, 0
+  FOR &I, 5, 1, 1
+    SET &C, C + 1
+  NEXT
+  RETURN C
+END
+ASSERT ZERO_ITERATIONS() = 0
+
+REM --- Single iteration: start = end ---
+
+DEF ONE_ITERATION
+  VAR I
+  VAR C
+  SET &C, 0
+  FOR &I, 3, 3, 1
+    SET &C, C + 1
+  NEXT
+  RETURN C
+END
+ASSERT ONE_ITERATION() = 1
+
+REM --- Nested FOR loops: multiplication table entry 3 * 4 = 12 ---
+
+DEF NESTED_FOR
+  VAR I
+  VAR J
+  VAR S
+  SET &S, 0
+  FOR &I, 1, 3, 1
+    FOR &J, 1, 4, 1
+      SET &S, S + 1
+    NEXT
+  NEXT
+  RETURN S
+END
+ASSERT NESTED_FOR() = 12
+
+REM --- FOR with IF inside: count even numbers in 2..10 step 2 ---
+
+DEF COUNT_EVEN
+  VAR I
+  VAR C
+  SET &C, 0
+  FOR &I, 2, 10, 2
+    SET &C, C + 1
+  NEXT
+  RETURN C
+END
+ASSERT COUNT_EVEN() = 5

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -13,8 +13,9 @@ pub enum CompileEntry {
     Cell(Cell),
     /// A string tag that marks an open control-structure scope.
     Tag(String),
-    /// A saved sequence of compiled cells to be emitted later.
-    CompiledCells(Vec<Cell>),
+    /// A saved sequence of compiled cells to be emitted later, with self-recursive
+    /// call-patch offsets relative to the start of the cell sequence.
+    CompiledCells(Vec<Cell>, Vec<usize>),
 }
 
 impl std::fmt::Display for CompileEntry {
@@ -22,7 +23,7 @@ impl std::fmt::Display for CompileEntry {
         match self {
             CompileEntry::Cell(c) => write!(f, "Cell({})", c),
             CompileEntry::Tag(s) => write!(f, "Tag(\"{}\")", s),
-            CompileEntry::CompiledCells(cells) => {
+            CompileEntry::CompiledCells(cells, _) => {
                 write!(f, "CompiledCells(len={})", cells.len())
             }
         }

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -5,12 +5,16 @@
 /// `Tag` holds a string label that identifies an open control-structure scope
 /// (e.g. `"IF"` or `"WHILE"`); it is pushed by CS_OPEN_TAG and validated/popped
 /// by CS_CLOSE_TAG.
+/// `CompiledCells` holds a sequence of compiled cells that have been saved for later
+/// emission into the dictionary (e.g. the step expression compiled by FOR).
 #[derive(Debug, Clone, PartialEq)]
 pub enum CompileEntry {
     /// A regular runtime cell stored on the compile stack.
     Cell(Cell),
     /// A string tag that marks an open control-structure scope.
     Tag(String),
+    /// A saved sequence of compiled cells to be emitted later.
+    CompiledCells(Vec<Cell>),
 }
 
 impl std::fmt::Display for CompileEntry {
@@ -18,6 +22,9 @@ impl std::fmt::Display for CompileEntry {
         match self {
             CompileEntry::Cell(c) => write!(f, "Cell({})", c),
             CompileEntry::Tag(s) => write!(f, "Tag(\"{}\")", s),
+            CompileEntry::CompiledCells(cells) => {
+                write!(f, "CompiledCells(len={})", cells.len())
+            }
         }
     }
 }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1065,6 +1065,14 @@ fn cs_pop_prim(vm: &mut VM) -> Result<(), TbxError> {
                 got: "Tag",
             })
         }
+        CompileEntry::CompiledCells(cells) => {
+            // Restore and signal a type error: CS_POP cannot pop CompiledCells.
+            vm.compile_stack.push(CompileEntry::CompiledCells(cells));
+            Err(TbxError::TypeError {
+                expected: "Cell",
+                got: "CompiledCells",
+            })
+        }
     }
 }
 
@@ -1196,6 +1204,11 @@ fn cs_close_tag_prim(vm: &mut VM) -> Result<(), TbxError> {
             vm.compile_stack.push(CompileEntry::Cell(c));
             Err(TbxError::NoOpenTag { expected })
         }
+        Some(CompileEntry::CompiledCells(cells)) => {
+            // Restore and report no matching open tag.
+            vm.compile_stack.push(CompileEntry::CompiledCells(cells));
+            Err(TbxError::NoOpenTag { expected })
+        }
     }
 }
 
@@ -1284,6 +1297,339 @@ fn compile_expr_prim(vm: &mut VM) -> Result<(), TbxError> {
             state.call_patch_list.push(base_dp + offset);
         }
     }
+    Ok(())
+}
+
+/// COMPILE_EXPR_UNTIL_COMMA — compile a partial expression up to the first top-level comma.
+///
+/// Scans the token stream for the first comma that is not nested inside parentheses.
+/// Compiles the tokens before the comma as an expression and writes the result to the
+/// dictionary. The comma token itself is consumed. Remaining tokens (after the comma)
+/// stay in the token stream for subsequent compilation steps.
+///
+/// Returns `InvalidExpression` if:
+/// - called outside compile mode,
+/// - the token stream is absent or empty, or
+/// - no top-level comma is found.
+fn compile_expr_until_comma_prim(vm: &mut VM) -> Result<(), TbxError> {
+    if !vm.is_compiling {
+        return Err(TbxError::InvalidExpression {
+            reason: "COMPILE_EXPR_UNTIL_COMMA outside compile mode",
+        });
+    }
+
+    // Find the first top-level comma (depth == 0) in the token stream.
+    let split_pos = {
+        let stream = vm.token_stream.as_ref().ok_or(TbxError::TokenStreamEmpty)?;
+        if stream.is_empty() {
+            return Err(TbxError::TokenStreamEmpty);
+        }
+        let mut depth: usize = 0;
+        let mut found: Option<usize> = None;
+        for (i, st) in stream.iter().enumerate() {
+            match &st.token {
+                Token::LParen => depth += 1,
+                Token::RParen => depth = depth.saturating_sub(1),
+                Token::Comma if depth == 0 => {
+                    found = Some(i);
+                    break;
+                }
+                _ => {}
+            }
+        }
+        found.ok_or(TbxError::InvalidExpression {
+            reason: "COMPILE_EXPR_UNTIL_COMMA: no top-level comma found",
+        })?
+    };
+
+    // Drain the tokens before the comma.
+    let stream = vm.token_stream.as_mut().ok_or(TbxError::TokenStreamEmpty)?;
+    let expr_tokens: Vec<crate::lexer::SpannedToken> = stream.drain(..split_pos).collect();
+    // Consume the comma token itself.
+    stream.pop_front();
+
+    if expr_tokens.is_empty() {
+        return Err(TbxError::InvalidExpression {
+            reason: "COMPILE_EXPR_UNTIL_COMMA: empty expression before comma",
+        });
+    }
+
+    // Compile the extracted tokens using the current local variable table.
+    // Use the take-compile-restore pattern to satisfy the borrow checker.
+    let self_word = vm.compile_state.as_ref().map(|s| s.word_name.clone());
+    let self_hdr_idx = vm.compile_state.as_ref().map(|s| s.word_hdr_idx());
+    let local_table = vm
+        .compile_state
+        .as_mut()
+        .map(|s| std::mem::take(&mut s.local_table));
+    let compile_result: Result<(Vec<Cell>, Vec<usize>), TbxError> = {
+        let local_table_ref = local_table.as_ref();
+        let mut compiler =
+            crate::expr::ExprCompiler::with_context(vm, local_table_ref, self_word, self_hdr_idx);
+        compiler.compile_expr(&expr_tokens).map(|cells| {
+            let offsets = std::mem::take(&mut compiler.patch_offsets);
+            (cells, offsets)
+        })
+    };
+    // Restore local_table regardless of success or failure.
+    if let (Some(state), Some(lt)) = (vm.compile_state.as_mut(), local_table) {
+        state.local_table = lt;
+    }
+    let (cells, patch_offsets) = compile_result?;
+    // Write compiled cells to the dictionary.
+    let base_dp = vm.dp;
+    for cell in &cells {
+        vm.dict_write(cell.clone())?;
+    }
+    // Register patch offsets (adjust by base_dp to get absolute dictionary positions).
+    if let Some(state) = vm.compile_state.as_mut() {
+        for offset in patch_offsets {
+            state.call_patch_list.push(base_dp + offset);
+        }
+    }
+    Ok(())
+}
+
+/// SAVE_EXPR_UNTIL_COMMA — compile a partial expression up to the first top-level comma
+/// and push the resulting cell sequence onto the compile stack as `CompileEntry::CompiledCells`.
+///
+/// Behaves like `COMPILE_EXPR_UNTIL_COMMA` except that it does NOT write the compiled cells
+/// to the dictionary; instead it saves them for later emission via `EMIT_COMPILED_CELLS`.
+///
+/// Used by FOR to save the end expression before emitting the step code.
+fn save_expr_until_comma_prim(vm: &mut VM) -> Result<(), TbxError> {
+    if !vm.is_compiling {
+        return Err(TbxError::InvalidExpression {
+            reason: "SAVE_EXPR_UNTIL_COMMA outside compile mode",
+        });
+    }
+
+    // Find the first top-level comma.
+    let split_pos = {
+        let stream = vm.token_stream.as_ref().ok_or(TbxError::TokenStreamEmpty)?;
+        if stream.is_empty() {
+            return Err(TbxError::TokenStreamEmpty);
+        }
+        let mut depth: usize = 0;
+        let mut found: Option<usize> = None;
+        for (i, st) in stream.iter().enumerate() {
+            match &st.token {
+                Token::LParen => depth += 1,
+                Token::RParen => depth = depth.saturating_sub(1),
+                Token::Comma if depth == 0 => {
+                    found = Some(i);
+                    break;
+                }
+                _ => {}
+            }
+        }
+        found.ok_or(TbxError::InvalidExpression {
+            reason: "SAVE_EXPR_UNTIL_COMMA: no top-level comma found",
+        })?
+    };
+
+    // Drain the tokens before the comma and consume the comma itself.
+    let stream = vm.token_stream.as_mut().ok_or(TbxError::TokenStreamEmpty)?;
+    let expr_tokens: Vec<crate::lexer::SpannedToken> = stream.drain(..split_pos).collect();
+    stream.pop_front();
+
+    if expr_tokens.is_empty() {
+        return Err(TbxError::InvalidExpression {
+            reason: "SAVE_EXPR_UNTIL_COMMA: empty expression before comma",
+        });
+    }
+
+    // Compile the tokens.
+    let self_word = vm.compile_state.as_ref().map(|s| s.word_name.clone());
+    let self_hdr_idx = vm.compile_state.as_ref().map(|s| s.word_hdr_idx());
+    let local_table = vm
+        .compile_state
+        .as_mut()
+        .map(|s| std::mem::take(&mut s.local_table));
+    let compile_result: Result<Vec<Cell>, TbxError> = {
+        let local_table_ref = local_table.as_ref();
+        let mut compiler =
+            crate::expr::ExprCompiler::with_context(vm, local_table_ref, self_word, self_hdr_idx);
+        compiler.compile_expr(&expr_tokens)
+    };
+    if let (Some(state), Some(lt)) = (vm.compile_state.as_mut(), local_table) {
+        state.local_table = lt;
+    }
+    let cells = compile_result?;
+    // Save onto compile stack without writing to dictionary.
+    vm.compile_stack.push(CompileEntry::CompiledCells(cells));
+    Ok(())
+}
+
+/// COMPILE_EXPR_SAVE — compile the remaining tokens in the token stream as an expression
+/// and push the resulting cell sequence onto the compile stack as `CompileEntry::CompiledCells`.
+///
+/// Unlike `COMPILE_EXPR`, this primitive does NOT write the compiled cells to the dictionary.
+/// The saved cells can be emitted later by `EMIT_COMPILED_CELLS`.
+///
+/// Used by FOR to save the step expression (which must be compiled while the token stream is
+/// still set) for deferred emission by NEXT.
+fn compile_expr_save_prim(vm: &mut VM) -> Result<(), TbxError> {
+    if !vm.is_compiling {
+        return Err(TbxError::InvalidExpression {
+            reason: "COMPILE_EXPR_SAVE outside compile mode",
+        });
+    }
+    // Drain all remaining tokens from the stream.
+    let tokens: Vec<crate::lexer::SpannedToken> = match vm.token_stream.as_mut() {
+        Some(stream) => stream.drain(..).collect(),
+        None => return Err(TbxError::TokenStreamEmpty),
+    };
+    if tokens.is_empty() {
+        return Err(TbxError::TokenStreamEmpty);
+    }
+    // Compile using take-compile-restore pattern.
+    let self_word = vm.compile_state.as_ref().map(|s| s.word_name.clone());
+    let self_hdr_idx = vm.compile_state.as_ref().map(|s| s.word_hdr_idx());
+    let local_table = vm
+        .compile_state
+        .as_mut()
+        .map(|s| std::mem::take(&mut s.local_table));
+    let compile_result: Result<Vec<Cell>, TbxError> = {
+        let local_table_ref = local_table.as_ref();
+        let mut compiler =
+            crate::expr::ExprCompiler::with_context(vm, local_table_ref, self_word, self_hdr_idx);
+        compiler.compile_expr(&tokens)
+    };
+    if let (Some(state), Some(lt)) = (vm.compile_state.as_mut(), local_table) {
+        state.local_table = lt;
+    }
+    let cells = compile_result?;
+    // Push compiled cells onto the compile stack (not into the dictionary).
+    vm.compile_stack.push(CompileEntry::CompiledCells(cells));
+    Ok(())
+}
+
+/// EMIT_COMPILED_CELLS — pop a `CompileEntry::CompiledCells` from the compile stack
+/// and write all cells to the dictionary.
+///
+/// This is the deferred-emission counterpart to `COMPILE_EXPR_SAVE`.
+fn emit_compiled_cells_prim(vm: &mut VM) -> Result<(), TbxError> {
+    if !vm.is_compiling {
+        return Err(TbxError::InvalidExpression {
+            reason: "EMIT_COMPILED_CELLS outside compile mode",
+        });
+    }
+    let entry = vm.compile_stack.pop().ok_or(TbxError::StackUnderflow)?;
+    let cells = match entry {
+        CompileEntry::CompiledCells(c) => c,
+        other => {
+            // Restore to avoid losing the entry on error.
+            vm.compile_stack.push(other);
+            return Err(TbxError::TypeError {
+                expected: "CompiledCells",
+                got: "non-CompiledCells compile stack entry",
+            });
+        }
+    };
+    for cell in cells {
+        vm.dict_write(cell)?;
+    }
+    Ok(())
+}
+
+/// SKIP_COMMA — read the next token from the token stream and validate it is `,`.
+///
+/// Used by FOR to consume the comma separator between the loop variable reference
+/// and the start expression.
+///
+/// Must be called in compile mode. Returns `InvalidExpression` if the token is
+/// not `Token::Comma`.
+fn skip_comma_prim(vm: &mut VM) -> Result<(), TbxError> {
+    if !vm.is_compiling {
+        return Err(TbxError::InvalidExpression {
+            reason: "SKIP_COMMA outside compile mode",
+        });
+    }
+
+    let tok = vm.next_token()?;
+    match tok.token {
+        Token::Comma => Ok(()),
+        _ => Err(TbxError::InvalidExpression {
+            reason: "SKIP_COMMA: expected ','",
+        }),
+    }
+}
+
+/// COMPILE_LVALUE_SAVE — emit `LIT addr` to the dictionary and push addr onto the compile stack.
+///
+/// Combines the behaviour of `COMPILE_LVALUE` with a compile-stack push so that the
+/// loop variable address is preserved across statement boundaries for use by FOR/NEXT.
+///
+/// Unlike pushing to the data stack (which would be discarded by `DROP_TO_MARKER` at
+/// the end of each statement), the compile stack persists between statements inside an
+/// IMMEDIATE word body.
+fn compile_lvalue_save_prim(vm: &mut VM) -> Result<(), TbxError> {
+    if !vm.is_compiling {
+        return Err(TbxError::InvalidExpression {
+            reason: "COMPILE_LVALUE_SAVE outside compile mode",
+        });
+    }
+
+    // Consume the leading `&` (address-of operator) before the variable name.
+    let amp_tok = vm.next_token()?;
+    if !matches!(amp_tok.token, Token::Ampersand) {
+        return Err(TbxError::InvalidExpression {
+            reason: "COMPILE_LVALUE_SAVE: expected '&' before variable name",
+        });
+    }
+
+    let tok = vm.next_token()?;
+    let name = match tok.token {
+        Token::Ident(n) => n.to_ascii_uppercase(),
+        _ => {
+            return Err(TbxError::InvalidExpression {
+                reason: "COMPILE_LVALUE_SAVE: expected variable name",
+            })
+        }
+    };
+
+    // Resolve address: local table first, then global dictionary.
+    // Use the take→use→restore pattern to satisfy the borrow checker.
+    let addr_cell = {
+        let local_table = vm
+            .compile_state
+            .as_mut()
+            .map(|s| std::mem::take(&mut s.local_table));
+
+        let result: Result<Cell, TbxError> =
+            if let Some(idx) = local_table.as_ref().and_then(|lt| lt.get(&name)).copied() {
+                Ok(Cell::StackAddr(idx))
+            } else {
+                match vm.lookup(&name) {
+                    None => Err(TbxError::UndefinedSymbol { name }),
+                    Some(xt) => match &vm.headers[xt.index()].kind {
+                        EntryKind::Variable(addr) => Ok(Cell::DictAddr(*addr)),
+                        _ => Err(TbxError::TypeError {
+                            expected: "variable",
+                            got: "non-variable",
+                        }),
+                    },
+                }
+            };
+
+        if let (Some(state), Some(lt)) = (vm.compile_state.as_mut(), local_table) {
+            state.local_table = lt;
+        }
+        result?
+    };
+
+    // Emit LIT <addr> to the dictionary.
+    let lit_xt =
+        vm.find_by_kind(|k| matches!(k, EntryKind::Lit))
+            .ok_or(TbxError::UndefinedSymbol {
+                name: "LIT".to_string(),
+            })?;
+    vm.dict_write(Cell::Xt(lit_xt))?;
+    vm.dict_write(addr_cell.clone())?;
+
+    // Push addr onto the compile stack so it survives statement boundaries.
+    vm.compile_stack.push(CompileEntry::Cell(addr_cell));
     Ok(())
 }
 
@@ -1571,13 +1917,12 @@ pub fn register_all(vm: &mut VM) {
         local_count: 0,
         prev: None,
     });
-    // LITERAL: system-internal compile-time primitive.
+    // LITERAL: compile-time primitive that emits `LIT <value>` to the dictionary.
     // Not IMMEDIATE — it must not be caught by the interpreter's IMMEDIATE dispatch,
     // because it reads its argument from the data stack (not from the token stream).
-    // FLAG_SYSTEM prevents it from being called as a user statement word.
-    let mut literal_entry = WordEntry::new_primitive("LITERAL", literal_prim);
-    literal_entry.flags = FLAG_SYSTEM;
-    vm.register(literal_entry);
+    // No FLAG_SYSTEM — LITERAL is part of the IMMEDIATE-word authoring API, callable
+    // as a statement inside DEF bodies (e.g. `LITERAL CS_POP`), just like CS_PUSH/CS_POP.
+    vm.register(WordEntry::new_primitive("LITERAL", literal_prim));
     // HEADER: IMMEDIATE so the outer interpreter feeds the token stream before calling it.
     // Also FLAG_SYSTEM to mark it as a system word consistent with other compile-time words.
     let mut header_entry = WordEntry::new_primitive("HEADER", header_prim);
@@ -1683,6 +2028,47 @@ pub fn register_all(vm: &mut VM) {
         .lookup("SET")
         .expect("SET primitive must be registered before ASSIGN_XT");
     vm.register(WordEntry::new_constant("ASSIGN_XT", Cell::Xt(set_xt)));
+
+    // FOR/NEXT compile-helper primitives.
+    // These are used inside IMMEDIATE word bodies (FOR, NEXT) defined in basic.tbx.
+    vm.register(WordEntry::new_primitive(
+        "COMPILE_EXPR_UNTIL_COMMA",
+        compile_expr_until_comma_prim,
+    ));
+    vm.register(WordEntry::new_primitive("SKIP_COMMA", skip_comma_prim));
+    vm.register(WordEntry::new_primitive(
+        "COMPILE_LVALUE_SAVE",
+        compile_lvalue_save_prim,
+    ));
+    vm.register(WordEntry::new_primitive(
+        "COMPILE_EXPR_SAVE",
+        compile_expr_save_prim,
+    ));
+    vm.register(WordEntry::new_primitive(
+        "SAVE_EXPR_UNTIL_COMMA",
+        save_expr_until_comma_prim,
+    ));
+    vm.register(WordEntry::new_primitive(
+        "EMIT_COMPILED_CELLS",
+        emit_compiled_cells_prim,
+    ));
+
+    // Runtime Xt constants for arithmetic/comparison instructions used by FOR/NEXT.
+    // Analogous to ASSIGN_XT (SET) and JUMP_FALSE/JUMP_ALWAYS for control flow.
+    let fetch_xt = vm
+        .lookup("FETCH")
+        .expect("FETCH primitive must be registered before FETCH_XT");
+    vm.register(WordEntry::new_constant("FETCH_XT", Cell::Xt(fetch_xt)));
+
+    let add_xt = vm
+        .lookup("ADD")
+        .expect("ADD primitive must be registered before ADD_XT");
+    vm.register(WordEntry::new_constant("ADD_XT", Cell::Xt(add_xt)));
+
+    let le_xt = vm
+        .lookup("LE")
+        .expect("LE primitive must be registered before LE_XT");
+    vm.register(WordEntry::new_constant("LE_XT", Cell::Xt(le_xt)));
 }
 
 #[cfg(test)]

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1537,13 +1537,13 @@ fn emit_compiled_cells_prim(vm: &mut VM) -> Result<(), TbxError> {
             });
         }
     };
-    let base_bp = vm.dp;
+    let base_dp = vm.dp;
     for cell in cells {
         vm.dict_write(cell)?;
     }
     if let Some(state) = &mut vm.compile_state {
         for offset in offsets {
-            state.call_patch_list.push(base_bp + offset);
+            state.call_patch_list.push(base_dp + offset);
         }
     }
     Ok(())

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1065,9 +1065,10 @@ fn cs_pop_prim(vm: &mut VM) -> Result<(), TbxError> {
                 got: "Tag",
             })
         }
-        CompileEntry::CompiledCells(cells) => {
+        CompileEntry::CompiledCells(cells, offsets) => {
             // Restore and signal a type error: CS_POP cannot pop CompiledCells.
-            vm.compile_stack.push(CompileEntry::CompiledCells(cells));
+            vm.compile_stack
+                .push(CompileEntry::CompiledCells(cells, offsets));
             Err(TbxError::TypeError {
                 expected: "Cell",
                 got: "CompiledCells",
@@ -1204,9 +1205,10 @@ fn cs_close_tag_prim(vm: &mut VM) -> Result<(), TbxError> {
             vm.compile_stack.push(CompileEntry::Cell(c));
             Err(TbxError::NoOpenTag { expected })
         }
-        Some(CompileEntry::CompiledCells(cells)) => {
+        Some(CompileEntry::CompiledCells(cells, offsets)) => {
             // Restore and report no matching open tag.
-            vm.compile_stack.push(CompileEntry::CompiledCells(cells));
+            vm.compile_stack
+                .push(CompileEntry::CompiledCells(cells, offsets));
             Err(TbxError::NoOpenTag { expected })
         }
     }
@@ -1446,18 +1448,22 @@ fn save_expr_until_comma_prim(vm: &mut VM) -> Result<(), TbxError> {
         .compile_state
         .as_mut()
         .map(|s| std::mem::take(&mut s.local_table));
-    let compile_result: Result<Vec<Cell>, TbxError> = {
+    let compile_result: Result<(Vec<Cell>, Vec<usize>), TbxError> = {
         let local_table_ref = local_table.as_ref();
         let mut compiler =
             crate::expr::ExprCompiler::with_context(vm, local_table_ref, self_word, self_hdr_idx);
-        compiler.compile_expr(&expr_tokens)
+        compiler.compile_expr(&expr_tokens).map(|cells| {
+            let offsets = std::mem::take(&mut compiler.patch_offsets);
+            (cells, offsets)
+        })
     };
     if let (Some(state), Some(lt)) = (vm.compile_state.as_mut(), local_table) {
         state.local_table = lt;
     }
-    let cells = compile_result?;
+    let (cells, patch_offsets) = compile_result?;
     // Save onto compile stack without writing to dictionary.
-    vm.compile_stack.push(CompileEntry::CompiledCells(cells));
+    vm.compile_stack
+        .push(CompileEntry::CompiledCells(cells, patch_offsets));
     Ok(())
 }
 
@@ -1490,18 +1496,22 @@ fn compile_expr_save_prim(vm: &mut VM) -> Result<(), TbxError> {
         .compile_state
         .as_mut()
         .map(|s| std::mem::take(&mut s.local_table));
-    let compile_result: Result<Vec<Cell>, TbxError> = {
+    let compile_result: Result<(Vec<Cell>, Vec<usize>), TbxError> = {
         let local_table_ref = local_table.as_ref();
         let mut compiler =
             crate::expr::ExprCompiler::with_context(vm, local_table_ref, self_word, self_hdr_idx);
-        compiler.compile_expr(&tokens)
+        compiler.compile_expr(&tokens).map(|cells| {
+            let offsets = std::mem::take(&mut compiler.patch_offsets);
+            (cells, offsets)
+        })
     };
     if let (Some(state), Some(lt)) = (vm.compile_state.as_mut(), local_table) {
         state.local_table = lt;
     }
-    let cells = compile_result?;
+    let (cells, patch_offsets) = compile_result?;
     // Push compiled cells onto the compile stack (not into the dictionary).
-    vm.compile_stack.push(CompileEntry::CompiledCells(cells));
+    vm.compile_stack
+        .push(CompileEntry::CompiledCells(cells, patch_offsets));
     Ok(())
 }
 
@@ -1516,8 +1526,8 @@ fn emit_compiled_cells_prim(vm: &mut VM) -> Result<(), TbxError> {
         });
     }
     let entry = vm.compile_stack.pop().ok_or(TbxError::StackUnderflow)?;
-    let cells = match entry {
-        CompileEntry::CompiledCells(c) => c,
+    let (cells, offsets) = match entry {
+        CompileEntry::CompiledCells(cells, offsets) => (cells, offsets),
         other => {
             // Restore to avoid losing the entry on error.
             vm.compile_stack.push(other);
@@ -1527,8 +1537,14 @@ fn emit_compiled_cells_prim(vm: &mut VM) -> Result<(), TbxError> {
             });
         }
     };
+    let base_bp = vm.dp;
     for cell in cells {
         vm.dict_write(cell)?;
+    }
+    if let Some(state) = &mut vm.compile_state {
+        for offset in offsets {
+            state.call_patch_list.push(base_bp + offset);
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
## 概要

`FOR &I, start, end, step ... NEXT` 構文を `lib/basic.tbx` のコンパイルワードとして実装する。
IF/WHILE/DO と同じ「標準ライブラリ層でコンパイルワードを定義する」設計方針に従う。

## 変更内容

### `src/cell.rs`
- `CompileEntry::CompiledCells(Vec<Cell>)` を追加。コンパイル済みセル列をコンパイルスタックに保存するために使用する（FORの end/step 式の遅延 emit）

### `src/primitives.rs`
- `COMPILE_EXPR_UNTIL_COMMA`: カンマまでの部分式をコンパイルして辞書に書き込む
- `SAVE_EXPR_UNTIL_COMMA`: カンマまでの部分式をコンパイルして `CompiledCells` としてCSに保存する（辞書には書かない）
- `COMPILE_EXPR_SAVE`: トークンストリームの残り全体をコンパイルして `CompiledCells` としてCSに保存する
- `EMIT_COMPILED_CELLS`: CSの `CompiledCells` エントリを辞書に書き込む
- `SKIP_COMMA`: トークンストリームからカンマを読み捨てる
- `COMPILE_LVALUE_SAVE`: `COMPILE_LVALUE` と同様に `LIT addr` を emit しつつ、アドレスを CS にも積む
- `FETCH_XT` / `ADD_XT` / `LE_XT`: APPEND と組み合わせて命令を emit するための Xt 定数
- `LITERAL` の `FLAG_SYSTEM` を取り除き、IMMEDIATE ワードボディからステートメントとして呼び出せるようにする

### `lib/basic.tbx`
- `FOR` / `NEXT` コンパイルワードを追加。生成する命令列は以下の通り:
  ```
  LIT addr, start, SET
  JUMP_ALWAYS A        -- skip step code on first entry
  S:
  LIT addr, LIT addr, FETCH, step, ADD, SET  -- step update
  A:
  LIT addr, FETCH, end, LE
  BIF D
  [body]
  JUMP_ALWAYS S
  D:
  ```

### `lib/tests/test_for_next.tbx`
- FOR/NEXT の統合テストを追加（基本カウント、ステップ2、0回反復、1回反復、ネスト、IF内使用）

## 設計上の注意点

- **ステップ正のみ対応**: `I <= end` を終了条件とする。負ステップ対応は別 issue で対応する。
- **LITERAL の FLAG_SYSTEM 変更**: `LITERAL CS_POP` のパターン（IMMEDIATE ワード内でコンパイルスタック値を辞書に emit）を成立させるために必要。`CS_PUSH` / `CS_POP` と同様の扱いにした。

Closes #382
