### PR TITLE
# コメント記号を実装する

### DIFF
--- a/lib/tests/test_hash_comment.tbx
+++ b/lib/tests/test_hash_comment.tbx
@@ -1,0 +1,26 @@
+# lib/tests/test_hash_comment.tbx — TBX tests for '#' hash comment syntax
+USE "lib/tests/helper.tbx"
+
+# --- Hash comment at start of line does not affect execution ---
+
+DEF ADD_TWO(A, B)
+  # This is a comment inside a word definition
+  RETURN A + B
+END
+ASSERT ADD_TWO(3, 4) = 7
+
+# --- Inline hash comment after a statement ---
+
+DEF INLINE_COMMENT_TEST
+  VAR X
+  SET &X, 10 # set X to 10
+  RETURN X   # return it
+END
+ASSERT INLINE_COMMENT_TEST() = 10
+
+# --- Multiple consecutive comment lines ---
+
+# line one comment
+# line two comment
+# line three comment
+ASSERT ADD_TWO(1, 2) = 3

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -593,6 +593,21 @@ impl<'a> Lexer<'a> {
                 }
             }
             '!' => self.op1_with_end("!", start_pos, start_off, end_off),
+            '#' => {
+                // Hash comment: skip the rest of the line, then emit Newline.
+                while !matches!(self.peek_char(), None | Some('\n') | Some('\r')) {
+                    self.advance();
+                }
+                // Consume the actual newline character(s) so the next token starts on the next line.
+                if self.peek_char() == Some('\r') {
+                    self.advance();
+                }
+                if self.peek_char() == Some('\n') {
+                    self.advance();
+                }
+                let end_off2 = self.peek_offset();
+                self.emit_newline(start_pos, start_off, end_off2 - start_off)
+            }
             c => {
                 let end_off2 = self.peek_offset();
                 SpannedToken {
@@ -1057,6 +1072,52 @@ mod tests {
             vec![
                 Token::LineNum(10),
                 Token::Ident("REM".to_string()),
+                Token::Newline,
+                Token::Eof,
+            ]
+        );
+    }
+
+    // --- # hash comment ---
+
+    #[test]
+    fn test_hash_comment_skips_to_newline() {
+        // A '#' comment line followed by code on the next line.
+        let toks = tokens("# this is a comment\nPUTDEC 1");
+        assert_eq!(
+            toks,
+            vec![
+                Token::Newline,
+                Token::Ident("PUTDEC".to_string()),
+                Token::IntLit(1),
+                Token::Eof,
+            ]
+        );
+    }
+
+    #[test]
+    fn test_hash_comment_at_end_of_input() {
+        // '#' comment with no trailing newline: emits Newline then Eof.
+        let toks = tokens("# no newline at end");
+        assert_eq!(toks, vec![Token::Newline, Token::Eof,]);
+    }
+
+    #[test]
+    fn test_hash_comment_after_linenum() {
+        // Line number followed by a '#' comment.
+        let toks = tokens("10 # comment after linenum");
+        assert_eq!(toks, vec![Token::LineNum(10), Token::Newline, Token::Eof,]);
+    }
+
+    #[test]
+    fn test_hash_comment_inline() {
+        // Code followed by a '#' inline comment.
+        let toks = tokens("PUTDEC 42 # inline comment");
+        assert_eq!(
+            toks,
+            vec![
+                Token::Ident("PUTDEC".to_string()),
+                Token::IntLit(42),
                 Token::Newline,
                 Token::Eof,
             ]


### PR DESCRIPTION
## 概要

`REM` に加えて `#` を行コメント開始記号として使えるようにする。シングルクォート `'` を将来のCHARリテラル `'A'` に使いたいため、行コメントのデファクトである `#` を代替として採用する。

## 変更内容

- `src/lexer.rs`: `scan_operator()` に `'#'` アームを追加。`#` を検出した時点で行末まで読み飛ばし、`Token::Newline` を返す（フラグ不要の1段階方式）
- `src/lexer.rs`: `#` コメントのユニットテストを4件追加（行頭・入力末尾・行番号後・インライン）
- `lib/tests/test_hash_comment.tbx`: 統合テスト用 `.tbx` ファイルを追加

Closes #413
