### PR TITLE
LOOKUPプリミティブを追加してxxx_XT定数ワードを置き換える

### DIFF
--- a/lib/basic.tbx
+++ b/lib/basic.tbx
@@ -156,7 +156,7 @@ REM  Works for both local variables (StackAddr) and global variables (DictAddr).
 REM  COMPILE_LVALUE reads the variable name from the token stream and emits LIT addr.
 REM  SKIP_EQ validates and consumes the '=' token.
 REM  COMPILE_EXPR compiles the right-hand side expression.
-REM  APPEND ASSIGN_XT emits the SET instruction.
+REM  APPEND LOOKUP("SET") emits the SET instruction.
 REM
 REM  Usage (inside DEF body only):
 REM    LET I = 10
@@ -166,7 +166,7 @@ DEF LET
   COMPILE_LVALUE
   SKIP_EQ
   COMPILE_EXPR
-  APPEND ASSIGN_XT
+  APPEND LOOKUP("SET")
 END
 IMMEDIATE LET
 
@@ -212,14 +212,14 @@ DEF FOR
   SKIP_COMMA
   REM Emit: LIT 1, SET  ->  var = 1 (fixed start)
   LITERAL 1
-  APPEND ASSIGN_XT
+  APPEND LOOKUP("SET")
   REM Record loop-condition start address A on the compile stack.
   CS_PUSH HERE
   REM Emit condition: LIT addr, FETCH, <end_expr>, LE
   LITERAL VAR_ADDR
-  APPEND FETCH_XT
+  APPEND LOOKUP("FETCH")
   COMPILE_EXPR
-  APPEND LE_XT
+  APPEND LOOKUP("LE")
   REM Emit JUMP_FALSE placeholder (patched by NEXT to D).
   APPEND JUMP_FALSE
   CS_PUSH HERE
@@ -242,10 +242,10 @@ DEF NEXT
   REM Emit increment code: LIT addr, LIT addr, FETCH, LIT 1, ADD, SET  ->  var += 1
   LITERAL VAR_ADDR
   LITERAL VAR_ADDR
-  APPEND FETCH_XT
+  APPEND LOOKUP("FETCH")
   LITERAL 1
-  APPEND ADD_XT
-  APPEND ASSIGN_XT
+  APPEND LOOKUP("ADD")
+  APPEND LOOKUP("SET")
   REM Emit JUMP_ALWAYS back to A (loop-condition start).
   APPEND JUMP_ALWAYS
   APPEND CS_POP

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1481,6 +1481,14 @@ fn skip_eq_prim(vm: &mut VM) -> Result<(), TbxError> {
     }
 }
 
+/// LOOKUP — pop a string from the stack, look up the named word, and push its Xt.
+fn lookup_prim(vm: &mut VM) -> Result<(), TbxError> {
+    let idx = vm.pop_string_desc()?;
+    let name = vm.resolve_string(idx)?;
+    let xt = vm.lookup(&name).ok_or(TbxError::UndefinedSymbol { name })?;
+    vm.push(Cell::Xt(xt))
+}
+
 /// USE — load and execute a TBX source file at compile time.
 ///
 /// Syntax: `USE "path/to/file.tbx"`
@@ -1775,13 +1783,9 @@ pub fn register_all(vm: &mut VM) {
     ));
     vm.register(WordEntry::new_primitive("SKIP_EQ", skip_eq_prim));
 
-    // ASSIGN_XT: constant holding the Xt of the SET primitive.
-    // Allows TBX compile words to emit a SET instruction via `APPEND ASSIGN_XT`,
-    // analogous to JUMP_FALSE/JUMP_TRUE/JUMP_ALWAYS for branch instructions.
-    let set_xt = vm
-        .lookup("SET")
-        .expect("SET primitive must be registered before ASSIGN_XT");
-    vm.register(WordEntry::new_constant("ASSIGN_XT", Cell::Xt(set_xt)));
+    // LOOKUP: look up a word by name string and push its Xt.
+    // Replaces the xxx_XT constant pattern: `APPEND LOOKUP("SET")` instead of `APPEND ASSIGN_XT`.
+    vm.register(WordEntry::new_primitive("LOOKUP", lookup_prim));
 
     // FOR/NEXT compile-helper primitives.
     // These are used inside IMMEDIATE word bodies (FOR, NEXT) defined in basic.tbx.
@@ -1790,23 +1794,6 @@ pub fn register_all(vm: &mut VM) {
         "COMPILE_LVALUE_SAVE",
         compile_lvalue_save_prim,
     ));
-
-    // Runtime Xt constants for arithmetic/comparison instructions used by FOR/NEXT.
-    // Analogous to ASSIGN_XT (SET) and JUMP_FALSE/JUMP_ALWAYS for control flow.
-    let fetch_xt = vm
-        .lookup("FETCH")
-        .expect("FETCH primitive must be registered before FETCH_XT");
-    vm.register(WordEntry::new_constant("FETCH_XT", Cell::Xt(fetch_xt)));
-
-    let add_xt = vm
-        .lookup("ADD")
-        .expect("ADD primitive must be registered before ADD_XT");
-    vm.register(WordEntry::new_constant("ADD_XT", Cell::Xt(add_xt)));
-
-    let le_xt = vm
-        .lookup("LE")
-        .expect("LE primitive must be registered before LE_XT");
-    vm.register(WordEntry::new_constant("LE_XT", Cell::Xt(le_xt)));
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## 概要

`lib/basic.tbx` で使用していた `ASSIGN_XT`/`FETCH_XT`/`ADD_XT`/`LE_XT` の4つの Xt 定数ワードを廃止し、汎用の `LOOKUP` プリミティブ一つに統合する。

## 変更内容

- `src/primitives.rs`: `lookup_prim` 関数を追加し `LOOKUP` ワードとして登録
  - スタックから文字列を受け取り、同名ワードの `Xt` をスタックに返す
  - `ASSIGN_XT`/`FETCH_XT`/`ADD_XT`/`LE_XT` の定数登録を削除
- `lib/basic.tbx`: `APPEND ASSIGN_XT` → `APPEND LOOKUP("SET")` 等に置換 (LET, FOR, NEXT)

## 動作の違いについて

| 観点 | 旧: xxx_XT 定数 | 新: LOOKUP("xxx") |
|------|----------------|-------------------|
| Xt 解決タイミング | VM 起動時 | IMMEDIATE ワード実行時（TBX コンパイル時） |
| シャドウイング | 起動時の定義固定 | 最新の定義を返す |

`SET`/`FETCH`/`ADD`/`LE` はシステムプリミティブで再定義されないため、現在の用途では動作は同一。
