### PR TITLE
ACCEPT のデッドロックと出力バッファ未フラッシュを修正する

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -156,6 +156,11 @@ pub enum TbxError {
         /// Human-readable description of the I/O error.
         reason: String,
     },
+    /// An I/O error occurred while writing to the output destination.
+    OutputIoError {
+        /// Human-readable description of the I/O error.
+        reason: String,
+    },
 }
 
 impl std::fmt::Display for TbxError {
@@ -261,6 +266,9 @@ impl std::fmt::Display for TbxError {
             }
             TbxError::InputIoError { reason } => {
                 write!(f, "ACCEPT: I/O error reading input: {reason}")
+            }
+            TbxError::OutputIoError { reason } => {
+                write!(f, "ACCEPT: I/O error flushing output: {reason}")
             }
         }
     }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1,6 +1,7 @@
 //! Outer interpreter: tokenizes source text and executes statements via the inner interpreter.
 
 use std::collections::{HashSet, VecDeque};
+use std::io::BufRead;
 use std::path::PathBuf;
 
 use crate::cell::{Cell, ReturnFrame, Xt};
@@ -563,6 +564,28 @@ impl Interpreter {
     /// Take the current output buffer contents, leaving it empty.
     pub fn take_output(&mut self) -> String {
         self.vm.take_output()
+    }
+
+    /// Read one line from the VM's input reader.
+    ///
+    /// Returns `Ok(Some(line))` with the line stripped of trailing newline
+    /// characters, `Ok(None)` on EOF, or an `Err` on I/O failure.
+    ///
+    /// This method is used by `main::run_stdin()` so that the outer read loop
+    /// draws from the same `BufReader` as `ACCEPT`, avoiding the deadlock that
+    /// would occur if two separate `StdinLock` acquisitions competed on the
+    /// same thread.
+    pub fn read_input_line(&mut self) -> std::io::Result<Option<String>> {
+        let mut line = String::new();
+        match self.vm.input_reader.read_line(&mut line) {
+            Ok(0) => Ok(None),
+            Ok(_) => Ok(Some(
+                line.trim_end_matches('\n')
+                    .trim_end_matches('\r')
+                    .to_string(),
+            )),
+            Err(e) => Err(e),
+        }
     }
 
     /// Override the maximum USE nesting depth (test-only).

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::io::{self, BufRead, Write};
+use std::io::{self, Write};
 use tbx::error::TbxError;
 use tbx::interpreter::{Interpreter, InterpreterError};
 
@@ -54,31 +54,31 @@ fn run_file(path: &str) -> std::process::ExitCode {
 
 fn run_stdin() -> std::process::ExitCode {
     let mut interp = Interpreter::new();
-    let stdin = io::stdin();
-
-    for line_result in stdin.lock().lines() {
-        let line = match line_result {
-            Ok(l) => l,
+    // Read from the VM's own input_reader instead of acquiring a separate
+    // StdinLock.  This avoids the deadlock that occurs when ACCEPT tries to
+    // re-lock stdin while the outer loop already holds the lock.
+    loop {
+        match interp.read_input_line() {
+            Ok(None) => break,
+            Ok(Some(line)) => match interp.exec_line(&line) {
+                Ok(()) => {
+                    let out = interp.take_output();
+                    print!("{out}");
+                    let _ = io::stdout().flush();
+                }
+                Err(err) if matches!(err.kind, TbxError::Halted) => {
+                    let out = interp.take_output();
+                    print!("{out}");
+                    let _ = io::stdout().flush();
+                    return std::process::ExitCode::SUCCESS;
+                }
+                Err(err) => {
+                    print_error(&err);
+                    return std::process::ExitCode::FAILURE;
+                }
+            },
             Err(e) => {
                 eprintln!("Error: reading stdin: {}", e);
-                return std::process::ExitCode::FAILURE;
-            }
-        };
-
-        match interp.exec_line(&line) {
-            Ok(()) => {
-                let out = interp.take_output();
-                print!("{out}");
-                let _ = io::stdout().flush();
-            }
-            Err(err) if matches!(err.kind, TbxError::Halted) => {
-                let out = interp.take_output();
-                print!("{out}");
-                let _ = io::stdout().flush();
-                return std::process::ExitCode::SUCCESS;
-            }
-            Err(err) => {
-                print_error(&err);
                 return std::process::ExitCode::FAILURE;
             }
         }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1538,6 +1538,21 @@ fn use_prim(vm: &mut VM) -> Result<(), TbxError> {
 /// Each call overwrites any previously buffered input.
 /// Stack signature: `( -- )`
 pub fn accept_prim(vm: &mut VM) -> Result<(), TbxError> {
+    // Flush any pending output before blocking on user input, so that prompt
+    // strings written with PUTSTR are visible before the interpreter waits.
+    if !vm.output_buffer.is_empty() {
+        let pending = std::mem::take(&mut vm.output_buffer);
+        vm.output_writer
+            .write_all(pending.as_bytes())
+            .map_err(|e| TbxError::InputIoError {
+                reason: e.to_string(),
+            })?;
+        vm.output_writer
+            .flush()
+            .map_err(|e| TbxError::InputIoError {
+                reason: e.to_string(),
+            })?;
+    }
     let mut line = String::new();
     vm.input_reader
         .read_line(&mut line)

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1544,12 +1544,12 @@ pub fn accept_prim(vm: &mut VM) -> Result<(), TbxError> {
         let pending = std::mem::take(&mut vm.output_buffer);
         vm.output_writer
             .write_all(pending.as_bytes())
-            .map_err(|e| TbxError::InputIoError {
+            .map_err(|e| TbxError::OutputIoError {
                 reason: e.to_string(),
             })?;
         vm.output_writer
             .flush()
-            .map_err(|e| TbxError::InputIoError {
+            .map_err(|e| TbxError::OutputIoError {
                 reason: e.to_string(),
             })?;
     }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -5,7 +5,7 @@ use crate::error::TbxError;
 use crate::lexer::SpannedToken;
 use std::collections::HashMap;
 use std::collections::VecDeque;
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, Write};
 
 /// State maintained during compilation of a new word definition (DEF..END).
 #[derive(Debug)]
@@ -169,6 +169,16 @@ pub struct VM {
     /// The field is not included in the `Debug` output because `dyn BufRead` does
     /// not implement `Debug`.
     pub input_reader: Box<dyn BufRead>,
+    /// Destination for immediate output flushed by ACCEPT before blocking.
+    ///
+    /// Defaults to stdout when the VM is created via `new()`.  The ACCEPT
+    /// primitive flushes `output_buffer` through this writer before blocking
+    /// on user input, so that any prompt printed with PUTSTR is visible before
+    /// the interpreter waits for a line.
+    ///
+    /// The field is not included in the `Debug` output because `dyn Write` does
+    /// not implement `Debug`.
+    pub output_writer: Box<dyn Write + Send>,
 }
 
 impl VM {
@@ -209,6 +219,7 @@ impl VM {
             pending_use_path: None,
             input_buffer: None,
             input_reader: Box::new(BufReader::new(std::io::stdin())),
+            output_writer: Box::new(std::io::stdout()),
         }
     }
 
@@ -926,6 +937,7 @@ impl std::fmt::Debug for VM {
             .field("pending_use_path", &self.pending_use_path)
             .field("input_buffer", &self.input_buffer)
             .field("input_reader", &"<dyn BufRead>")
+            .field("output_writer", &"<dyn Write>")
             .finish()
     }
 }


### PR DESCRIPTION
## 概要

stdinモード（ファイル引数なし起動）で `ACCEPT` 命令を含むコードを実行すると処理がハングする問題を修正する。
デッドロック（`StdinLock` の二重取得）とプロンプト未表示（出力バッファ未フラッシュ）の2つの根本原因を解消する。

## 変更内容

- `vm.rs`: `output_writer` フィールド（`Box<dyn Write + Send>`、デフォルト: stdout）を追加
- `primitives.rs`: `accept_prim` がユーザー入力をブロックする前に `output_buffer` を `output_writer` へフラッシュするよう変更
- `interpreter.rs`: `read_input_line()` メソッドを追加し、VM の `input_reader` から読む外部向け API を提供
- `main.rs`: `run_stdin()` を `stdin.lock().lines()` ループから `read_input_line()` ベースに変更し、`StdinLock` の再取得によるデッドロックを解消

Closes #408
