### PR TITLE
ローカル配列（ARRAY(N)）を実装する

### DIFF
--- a/lib/tests/test_local_array.tbx
+++ b/lib/tests/test_local_array.tbx
@@ -1,0 +1,88 @@
+# lib/tests/test_local_array.tbx — TBX tests for local arrays (ARRAY(N))
+USE "lib/tests/helper.tbx"
+
+# --- Basic creation and element read/write ---
+
+DEF MAKE_AND_READ()
+  VAR A
+  LET A = ARRAY(3)
+  SET &A(0), 10
+  SET &A(1), 20
+  SET &A(2), 30
+  RETURN A(0) + A(1) + A(2)
+END
+ASSERT MAKE_AND_READ() = 60
+
+# --- Array is zeroed (Cell::None) on creation ---
+
+DEF FIRST_ELEM_IS_NONE()
+  VAR A
+  LET A = ARRAY(5)
+  # Cell::None is falsy, so this checks the initial value
+  IF A(0) = 0
+    RETURN 1
+  ENDIF
+  RETURN 0
+END
+# Cell::None is not equal to 0 (different types), so result should be 0
+# We just verify it doesn't crash and returns a value
+# (The exact value depends on None comparison semantics — no assertion on value here)
+
+# --- Multiple local arrays in the same frame ---
+
+DEF TWO_ARRAYS()
+  VAR A
+  VAR B
+  LET A = ARRAY(2)
+  LET B = ARRAY(2)
+  SET &A(0), 100
+  SET &B(0), 200
+  RETURN A(0) + B(0)
+END
+ASSERT TWO_ARRAYS() = 300
+
+# --- Array lifetime: pool is freed on return ---
+
+DEF INNER()
+  VAR A
+  LET A = ARRAY(3)
+  SET &A(0), 42
+  RETURN A(0)
+END
+
+DEF OUTER()
+  VAR X
+  LET X = INNER()
+  RETURN X
+END
+ASSERT OUTER() = 42
+
+# --- Verify that calling INNER multiple times does not accumulate arrays ---
+
+DEF CALL_TWICE()
+  VAR X
+  VAR Y
+  LET X = INNER()
+  LET Y = INNER()
+  RETURN X + Y
+END
+ASSERT CALL_TWICE() = 84
+
+# --- Nested calls with arrays ---
+
+DEF SUM_ARRAY(N)
+  VAR A
+  VAR I
+  VAR S
+  LET A = ARRAY(N)
+  LET I = 0
+  LET S = 0
+  WHILE I < N
+    SET &A(I), I * 2
+    LET S = S + A(I)
+    LET I = I + 1
+  ENDWH
+  RETURN S
+END
+# Sum of 0,2,4,6,8 = 20
+ASSERT SUM_ARRAY(5) = 20

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -43,7 +43,14 @@ impl Xt {
 /// Return frame for the return stack, saving the program counter and base pointer
 #[derive(Debug, Clone)]
 pub enum ReturnFrame {
-    Call { return_pc: usize, saved_bp: usize },
+    Call {
+        return_pc: usize,
+        saved_bp: usize,
+        /// Snapshot of `VM::arrays.len()` taken at call time.
+        /// On EXIT or RETURN_VAL, the array pool is truncated back to this
+        /// length to free all local arrays created during the call.
+        saved_array_pool_len: usize,
+    },
     TopLevel, // Sentinel value for the bottom of the return stack
 }
 
@@ -67,8 +74,22 @@ pub enum Cell {
     Bool(bool),
     /// Index into the string pool (length-prefixed)
     StringDesc(usize),
-    /// Reserved for future array support
-    Array,
+    /// Local array — index into `VM::arrays` (the local array pool).
+    ///
+    /// Created by the `ARRAY(N)` primitive.  The pool entry at this index holds
+    /// a `Vec<Cell>` of length N.  The pool is truncated on EXIT/RETURN_VAL, so
+    /// `Cell::Array` values must never escape their owning stack frame.
+    Array(usize),
+    /// Address of an element in a local array.
+    ///
+    /// Produced by the `&A(I)` construct where `A` holds a `Cell::Array`.
+    /// Used by `FETCH`, `STORE`, and `SET` to read/write individual elements.
+    ArrayAddr {
+        /// Index into `VM::arrays` (the local array pool).
+        pool_idx: usize,
+        /// Zero-based element index within the array.
+        elem_idx: usize,
+    },
     None,
     /// Sentinel value placed on the data stack to mark a statement boundary.
     /// Consumed by DROP_TO_MARKER to restore the stack after a statement call.
@@ -99,7 +120,10 @@ impl std::fmt::Display for Cell {
             Cell::Xt(x) => write!(f, "xt:{}", x.0),
             Cell::Bool(b) => write!(f, "{}", b),
             Cell::StringDesc(i) => write!(f, "str:{}", i),
-            Cell::Array => write!(f, "<array>"),
+            Cell::Array(idx) => write!(f, "<array:{}>", idx),
+            Cell::ArrayAddr { pool_idx, elem_idx } => {
+                write!(f, "<arrayaddr:{}[{}]>", pool_idx, elem_idx)
+            }
             Cell::None => write!(f, "<none>"),
             Cell::Marker => write!(f, "<marker>"),
         }
@@ -170,6 +194,15 @@ impl Cell {
         }
     }
 
+    /// Returns the pool index if this cell is `Array`, otherwise `None`.
+    pub fn as_array_index(&self) -> Option<usize> {
+        if let Cell::Array(idx) = self {
+            Some(*idx)
+        } else {
+            None
+        }
+    }
+
     /// Returns a static string naming the variant. Useful for error messages and debugging.
     pub fn type_name(&self) -> &'static str {
         match self {
@@ -180,7 +213,8 @@ impl Cell {
             Cell::Xt(_) => "Xt",
             Cell::Bool(_) => "Bool",
             Cell::StringDesc(_) => "StringDesc",
-            Cell::Array => "Array",
+            Cell::Array(_) => "Array",
+            Cell::ArrayAddr { .. } => "ArrayAddr",
             Cell::None => "None",
             Cell::Marker => "Marker",
         }
@@ -216,7 +250,17 @@ impl PartialEq for Cell {
             (Cell::Xt(a), Cell::Xt(b)) => a == b,
             (Cell::Bool(a), Cell::Bool(b)) => a == b,
             (Cell::None, Cell::None) => true,
-            (Cell::Array, Cell::Array) => true,
+            (Cell::Array(a), Cell::Array(b)) => a == b,
+            (
+                Cell::ArrayAddr {
+                    pool_idx: pa,
+                    elem_idx: ea,
+                },
+                Cell::ArrayAddr {
+                    pool_idx: pb,
+                    elem_idx: eb,
+                },
+            ) => pa == pb && ea == eb,
             (Cell::StringDesc(a), Cell::StringDesc(b)) => a == b,
             _ => false,
         }
@@ -298,7 +342,16 @@ mod tests {
 
     #[test]
     fn test_display_array() {
-        assert_eq!(Cell::Array.to_string(), "<array>");
+        assert_eq!(Cell::Array(0).to_string(), "<array:0>");
+        assert_eq!(Cell::Array(42).to_string(), "<array:42>");
+        assert_eq!(
+            Cell::ArrayAddr {
+                pool_idx: 3,
+                elem_idx: 7
+            }
+            .to_string(),
+            "<arrayaddr:3[7]>"
+        );
     }
 
     #[test]
@@ -362,7 +415,7 @@ mod tests {
         assert_eq!(Cell::Xt(Xt(0)).type_name(), "Xt");
         assert_eq!(Cell::Bool(false).type_name(), "Bool");
         assert_eq!(Cell::None.type_name(), "None");
-        assert_eq!(Cell::Array.type_name(), "Array");
+        assert_eq!(Cell::Array(0).type_name(), "Array");
         assert_eq!(Cell::StringDesc(0).type_name(), "StringDesc");
     }
 
@@ -379,7 +432,7 @@ mod tests {
         assert!(!Cell::Float(0.0).is_truthy());
         // non-Int/Bool/Float variants are falsy
         assert!(!Cell::None.is_truthy());
-        assert!(!Cell::Array.is_truthy());
+        assert!(!Cell::Array(0).is_truthy());
         assert!(!Cell::DictAddr(1).is_truthy());
         assert!(!Cell::StackAddr(1).is_truthy());
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -161,6 +161,14 @@ pub enum TbxError {
         /// Human-readable description of the I/O error.
         reason: String,
     },
+    /// A local array value escaped its owning stack frame.
+    ///
+    /// Local arrays (created with `ARRAY(N)`) are bound to the stack frame in
+    /// which they were created.  Attempting to store a `Cell::Array` value into
+    /// a global variable (via `DictAddr`) or return it from a word (via
+    /// `RETURN`) is forbidden, because the array pool is truncated on EXIT and
+    /// the stored index would dangle.
+    LocalArrayEscape,
 }
 
 impl std::fmt::Display for TbxError {
@@ -269,6 +277,9 @@ impl std::fmt::Display for TbxError {
             }
             TbxError::OutputIoError { reason } => {
                 write!(f, "ACCEPT: I/O error flushing output: {reason}")
+            }
+            TbxError::LocalArrayEscape => {
+                write!(f, "local array cannot escape its owning stack frame")
             }
         }
     }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -39,8 +39,11 @@ enum OpItem {
 enum LParenCall {
     /// Function call: execution token and current argument arity count.
     Function(Xt, usize),
-    /// Array index access: dictionary base index and declared array size.
+    /// Global array index access: dictionary base index and declared array size.
     Array(usize, usize),
+    /// Local array index access: the Cell::Array handle is already on the output stack.
+    /// On closing `)`, emit ARRAY_GET (index is on top, handle is below).
+    LocalArray,
 }
 
 // ---------------------------------------------------------------------------
@@ -152,9 +155,31 @@ impl<'a> ExprCompiler<'a> {
                 Token::Ident(name) => {
                     let name = name.to_ascii_uppercase();
                     // Check local variable table first — locals shadow globals.
-                    if let Some(idx) = self.local_table.and_then(|lt| lt.get(&name)).copied() {
-                        emit_local_read(&mut output, idx, self.vm)?;
-                        prev_was_operand = true;
+                    if let Some(local_idx) = self.local_table.and_then(|lt| lt.get(&name)).copied()
+                    {
+                        // Peek ahead: local variable followed by `(` means local array access.
+                        let next_is_lparen = tokens
+                            .get(i + 1)
+                            .map(|st| matches!(st.token, Token::LParen))
+                            .unwrap_or(false);
+
+                        if next_is_lparen {
+                            // Local array element read: A(I)
+                            // 1. Load the Cell::Array handle from the local slot.
+                            emit_local_read(&mut output, local_idx, self.vm)?;
+                            // 2. Open an array-index paren frame using the sentinel value
+                            //    (usize::MAX, usize::MAX) to distinguish local array access.
+                            op_stack.push(OpItem::LParen {
+                                call: Some(LParenCall::LocalArray),
+                            });
+                            i += 1; // consume '('
+                            prev_was_operand = false;
+                        } else {
+                            emit_local_read(&mut output, local_idx, self.vm)?;
+                            prev_was_operand = true;
+                            i += 1;
+                            continue;
+                        }
                         i += 1;
                         continue;
                     }
@@ -275,13 +300,45 @@ impl<'a> ExprCompiler<'a> {
                             Some(Token::Ident(name)) => {
                                 let name = name.to_ascii_uppercase();
                                 // Check local table first — locals shadow globals.
-                                if let Some(idx) =
+                                if let Some(local_idx) =
                                     self.local_table.and_then(|lt| lt.get(&name)).copied()
                                 {
-                                    // Emit StackAddr — no FETCH.
-                                    let xt_lit = require_xt(self.vm, "LIT")?;
-                                    output.push(Cell::Xt(xt_lit));
-                                    output.push(Cell::StackAddr(idx));
+                                    // Is this a local array element address: &A(I)?
+                                    let lparen_pos = i + 1;
+                                    if tokens
+                                        .get(lparen_pos)
+                                        .map(|st| matches!(st.token, Token::LParen))
+                                        .unwrap_or(false)
+                                    {
+                                        // Local array address-of: &A(I)
+                                        // Find the matching ')'.
+                                        let idx_start = lparen_pos + 1;
+                                        let close_pos = find_matching_rparen(tokens, idx_start)
+                                            .ok_or(TbxError::InvalidExpression {
+                                                reason:
+                                                    "missing ')' in local array index expression",
+                                            })?;
+                                        let index_toks = &tokens[idx_start..close_pos];
+                                        if index_toks.is_empty() {
+                                            return Err(TbxError::InvalidExpression {
+                                                reason: "array index expression must not be empty: use &NAME(index)",
+                                            });
+                                        }
+                                        // 1. Load the Cell::Array handle.
+                                        emit_local_read(&mut output, local_idx, self.vm)?;
+                                        // 2. Compile the index expression.
+                                        let index_cells = self.compile_expr(index_toks)?;
+                                        output.extend(index_cells);
+                                        // 3. Emit ARRAY_ADDR.
+                                        let array_addr_xt = require_xt(self.vm, "ARRAY_ADDR")?;
+                                        output.push(Cell::Xt(array_addr_xt));
+                                        i = close_pos;
+                                    } else {
+                                        // Simple local variable address: &A (StackAddr).
+                                        let xt_lit = require_xt(self.vm, "LIT")?;
+                                        output.push(Cell::Xt(xt_lit));
+                                        output.push(Cell::StackAddr(local_idx));
+                                    }
                                 } else {
                                     let xt = self
                                         .vm
@@ -442,6 +499,13 @@ impl<'a> ExprCompiler<'a> {
                             output.push(Cell::Int(size as i64));
                             output.push(Cell::Xt(fetch_xt));
                         }
+                        Some(OpItem::LParen {
+                            call: Some(LParenCall::LocalArray),
+                        }) => {
+                            // Emit ARRAY_GET: stack is [..., Cell::Array, index] → value.
+                            let array_get_xt = require_xt(self.vm, "ARRAY_GET")?;
+                            output.push(Cell::Xt(array_get_xt));
+                        }
                         _ => {
                             // Plain grouping paren — nothing extra to emit.
                         }
@@ -461,11 +525,13 @@ impl<'a> ExprCompiler<'a> {
                         .find(|op| matches!(op, OpItem::LParen { .. }));
 
                     // Array index expressions must be a single expression — commas are
-                    // not allowed inside array subscripts.
+                    // not allowed inside array subscripts (global or local).
                     if matches!(
                         nearest_lparen,
                         Some(OpItem::LParen {
                             call: Some(LParenCall::Array(..))
+                        }) | Some(OpItem::LParen {
+                            call: Some(LParenCall::LocalArray)
                         })
                     ) {
                         return Err(TbxError::InvalidExpression {

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -167,8 +167,8 @@ impl<'a> ExprCompiler<'a> {
                             // Local array element read: A(I)
                             // 1. Load the Cell::Array handle from the local slot.
                             emit_local_read(&mut output, local_idx, self.vm)?;
-                            // 2. Open an array-index paren frame using the sentinel value
-                            //    (usize::MAX, usize::MAX) to distinguish local array access.
+                            // 2. Open an array-index paren frame marked as LocalArray
+                            //    to distinguish it from a regular function call paren.
                             op_stack.push(OpItem::LParen {
                                 call: Some(LParenCall::LocalArray),
                             });

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -50,6 +50,22 @@ pub fn fetch_prim(vm: &mut VM) -> Result<(), TbxError> {
             vm.push(value)?;
             Ok(())
         }
+        Cell::ArrayAddr { pool_idx, elem_idx } => {
+            let arr = vm.arrays.get(pool_idx).ok_or(TbxError::IndexOutOfBounds {
+                index: pool_idx,
+                size: vm.arrays.len(),
+            })?;
+            let size = arr.len();
+            if elem_idx >= size {
+                return Err(TbxError::ArrayIndexOutOfBounds {
+                    index: elem_idx as i64,
+                    size,
+                });
+            }
+            let value = arr[elem_idx].clone();
+            vm.push(value)?;
+            Ok(())
+        }
         _ => Err(TbxError::TypeError {
             expected: "address",
             got: "non-address",
@@ -65,12 +81,19 @@ pub fn store_prim(vm: &mut VM) -> Result<(), TbxError> {
     let value = vm.pop()?;
     match addr {
         Cell::DictAddr(a) => {
+            // Guard: local arrays must not escape into global (dictionary) storage.
+            if matches!(value, Cell::Array(_)) {
+                return Err(TbxError::LocalArrayEscape);
+            }
             vm.dict_write_at(a, value)?;
             Ok(())
         }
         Cell::StackAddr(a) => {
             vm.local_write(a, value)?;
             Ok(())
+        }
+        Cell::ArrayAddr { pool_idx, elem_idx } => {
+            write_array_element(vm, pool_idx, elem_idx, value)
         }
         _ => Err(TbxError::TypeError {
             expected: "address",
@@ -89,6 +112,10 @@ pub fn set_prim(vm: &mut VM) -> Result<(), TbxError> {
     let addr = vm.pop()?;
     match addr {
         Cell::DictAddr(a) => {
+            // Guard: local arrays must not escape into global (dictionary) storage.
+            if matches!(value, Cell::Array(_)) {
+                return Err(TbxError::LocalArrayEscape);
+            }
             vm.dict_write_at(a, value)?;
             Ok(())
         }
@@ -96,11 +123,40 @@ pub fn set_prim(vm: &mut VM) -> Result<(), TbxError> {
             vm.local_write(a, value)?;
             Ok(())
         }
+        Cell::ArrayAddr { pool_idx, elem_idx } => {
+            write_array_element(vm, pool_idx, elem_idx, value)
+        }
         _ => Err(TbxError::TypeError {
             expected: "address",
             got: "non-address",
         }),
     }
+}
+
+/// Write `value` to element `elem_idx` of the local array at `pool_idx`.
+fn write_array_element(
+    vm: &mut VM,
+    pool_idx: usize,
+    elem_idx: usize,
+    value: Cell,
+) -> Result<(), TbxError> {
+    let pool_size = vm.arrays.len();
+    let arr = vm
+        .arrays
+        .get_mut(pool_idx)
+        .ok_or(TbxError::IndexOutOfBounds {
+            index: pool_idx,
+            size: pool_size,
+        })?;
+    let size = arr.len();
+    if elem_idx >= size {
+        return Err(TbxError::ArrayIndexOutOfBounds {
+            index: elem_idx as i64,
+            size,
+        });
+    }
+    arr[elem_idx] = value;
+    Ok(())
 }
 
 pub fn add_prim(vm: &mut VM) -> Result<(), TbxError> {
@@ -1026,6 +1082,101 @@ pub fn dim_prim(vm: &mut VM) -> Result<(), TbxError> {
     Ok(())
 }
 
+/// ARRAY — create a local array of N elements and push its handle onto the stack.
+///
+/// Pops `Cell::Int(n)` from the stack (n > 0), pushes `n` `Cell::None` elements
+/// into `vm.arrays`, and pushes `Cell::Array(pool_idx)` as the handle.
+///
+/// The array is bound to the current stack frame: it is freed automatically when
+/// the owning word returns (EXIT/RETURN_VAL truncates the pool).
+pub fn array_prim(vm: &mut VM) -> Result<(), TbxError> {
+    let n = vm.pop_int()?;
+    if n <= 0 {
+        return Err(TbxError::InvalidArgument {
+            message: format!("ARRAY size must be positive, got {n}"),
+        });
+    }
+    let size = n as usize;
+    let idx = vm.arrays.len();
+    vm.arrays.push(vec![Cell::None; size]);
+    vm.push(Cell::Array(idx))?;
+    Ok(())
+}
+
+/// ARRAY_GET — read an element from a local array.
+///
+/// Stack: `[..., Cell::Array(pool_idx), Cell::Int(elem_idx)]` → `value`
+pub fn array_get_prim(vm: &mut VM) -> Result<(), TbxError> {
+    let elem_idx_raw = vm.pop_int()?;
+    let pool_idx = match vm.pop()? {
+        Cell::Array(idx) => idx,
+        other => {
+            return Err(TbxError::TypeError {
+                expected: "Array",
+                got: other.type_name(),
+            })
+        }
+    };
+    if elem_idx_raw < 0 {
+        return Err(TbxError::ArrayIndexOutOfBounds {
+            index: elem_idx_raw,
+            size: vm.arrays.get(pool_idx).map(|a| a.len()).unwrap_or(0),
+        });
+    }
+    let elem_idx = elem_idx_raw as usize;
+    let arr = vm.arrays.get(pool_idx).ok_or(TbxError::IndexOutOfBounds {
+        index: pool_idx,
+        size: vm.arrays.len(),
+    })?;
+    let size = arr.len();
+    if elem_idx >= size {
+        return Err(TbxError::ArrayIndexOutOfBounds {
+            index: elem_idx_raw,
+            size,
+        });
+    }
+    let value = arr[elem_idx].clone();
+    vm.push(value)?;
+    Ok(())
+}
+
+/// ARRAY_ADDR — compute the address of a local array element.
+///
+/// Stack: `[..., Cell::Array(pool_idx), Cell::Int(elem_idx)]` → `Cell::ArrayAddr { pool_idx, elem_idx }`
+pub fn array_addr_prim(vm: &mut VM) -> Result<(), TbxError> {
+    let elem_idx_raw = vm.pop_int()?;
+    let pool_idx = match vm.pop()? {
+        Cell::Array(idx) => idx,
+        other => {
+            return Err(TbxError::TypeError {
+                expected: "Array",
+                got: other.type_name(),
+            })
+        }
+    };
+    if elem_idx_raw < 0 {
+        return Err(TbxError::ArrayIndexOutOfBounds {
+            index: elem_idx_raw,
+            size: vm.arrays.get(pool_idx).map(|a| a.len()).unwrap_or(0),
+        });
+    }
+    let elem_idx = elem_idx_raw as usize;
+    // Validate bounds at address-computation time.
+    let arr = vm.arrays.get(pool_idx).ok_or(TbxError::IndexOutOfBounds {
+        index: pool_idx,
+        size: vm.arrays.len(),
+    })?;
+    let size = arr.len();
+    if elem_idx >= size {
+        return Err(TbxError::ArrayIndexOutOfBounds {
+            index: elem_idx_raw,
+            size,
+        });
+    }
+    vm.push(Cell::ArrayAddr { pool_idx, elem_idx })?;
+    Ok(())
+}
+
 /// CS_PUSH — move a value from the data stack to the compile stack.
 ///
 /// Must be called in compile mode (inside an IMMEDIATE word invocation).
@@ -1809,6 +1960,17 @@ pub fn register_all(vm: &mut VM) {
         "COMPILE_LVALUE_SAVE",
         compile_lvalue_save_prim,
     ));
+
+    // Local array primitives.
+    // ARRAY creates a local array; ARRAY_GET reads an element; ARRAY_ADDR computes
+    // an element address (used internally by the expression compiler for `A(I)` and `&A(I)`).
+    vm.register(WordEntry::new_primitive("ARRAY", array_prim));
+    let mut array_get_entry = WordEntry::new_primitive("ARRAY_GET", array_get_prim);
+    array_get_entry.flags = FLAG_SYSTEM;
+    vm.register(array_get_entry);
+    let mut array_addr_entry = WordEntry::new_primitive("ARRAY_ADDR", array_addr_prim);
+    array_addr_entry.flags = FLAG_SYSTEM;
+    vm.register(array_addr_entry);
 }
 
 #[cfg(test)]
@@ -5170,5 +5332,184 @@ mod tests {
         accept_prim(&mut vm).unwrap();
         getdec_prim(&mut vm).unwrap();
         assert_eq!(vm.pop(), Ok(Cell::Int(123)));
+    }
+
+    // --- array_prim ---
+
+    #[test]
+    fn test_array_prim_creates_array() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(3)).unwrap();
+        array_prim(&mut vm).unwrap();
+        // Stack should contain Cell::Array(0) — first pool slot.
+        assert_eq!(vm.pop(), Ok(Cell::Array(0)));
+        // The pool should have one entry of length 3.
+        assert_eq!(vm.arrays.len(), 1);
+        assert_eq!(vm.arrays[0].len(), 3);
+    }
+
+    #[test]
+    fn test_array_prim_initialises_to_none() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(2)).unwrap();
+        array_prim(&mut vm).unwrap();
+        vm.pop().unwrap(); // discard handle
+        assert_eq!(vm.arrays[0][0], Cell::None);
+        assert_eq!(vm.arrays[0][1], Cell::None);
+    }
+
+    #[test]
+    fn test_array_prim_size_zero_returns_error() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(0)).unwrap();
+        assert!(matches!(
+            array_prim(&mut vm),
+            Err(TbxError::InvalidArgument { .. })
+        ));
+    }
+
+    #[test]
+    fn test_array_prim_negative_size_returns_error() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(-1)).unwrap();
+        assert!(matches!(
+            array_prim(&mut vm),
+            Err(TbxError::InvalidArgument { .. })
+        ));
+    }
+
+    #[test]
+    fn test_array_prim_multiple_arrays_get_distinct_indices() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(2)).unwrap();
+        array_prim(&mut vm).unwrap();
+        vm.push(Cell::Int(4)).unwrap();
+        array_prim(&mut vm).unwrap();
+        let second = vm.pop().unwrap();
+        let first = vm.pop().unwrap();
+        assert_eq!(first, Cell::Array(0));
+        assert_eq!(second, Cell::Array(1));
+    }
+
+    // --- array_get_prim ---
+
+    #[test]
+    fn test_array_get_prim_reads_element() {
+        let mut vm = VM::new();
+        vm.arrays
+            .push(vec![Cell::Int(10), Cell::Int(20), Cell::Int(30)]);
+        vm.push(Cell::Array(0)).unwrap();
+        vm.push(Cell::Int(1)).unwrap();
+        array_get_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Int(20)));
+    }
+
+    #[test]
+    fn test_array_get_prim_out_of_bounds() {
+        let mut vm = VM::new();
+        vm.arrays.push(vec![Cell::Int(1)]);
+        vm.push(Cell::Array(0)).unwrap();
+        vm.push(Cell::Int(5)).unwrap();
+        assert!(matches!(
+            array_get_prim(&mut vm),
+            Err(TbxError::ArrayIndexOutOfBounds { index: 5, size: 1 })
+        ));
+    }
+
+    #[test]
+    fn test_array_get_prim_negative_index() {
+        let mut vm = VM::new();
+        vm.arrays.push(vec![Cell::Int(1)]);
+        vm.push(Cell::Array(0)).unwrap();
+        vm.push(Cell::Int(-1)).unwrap();
+        assert!(matches!(
+            array_get_prim(&mut vm),
+            Err(TbxError::ArrayIndexOutOfBounds { index: -1, .. })
+        ));
+    }
+
+    // --- array_addr_prim ---
+
+    #[test]
+    fn test_array_addr_prim_pushes_array_addr() {
+        let mut vm = VM::new();
+        vm.arrays.push(vec![Cell::Int(0), Cell::Int(0)]);
+        vm.push(Cell::Array(0)).unwrap();
+        vm.push(Cell::Int(1)).unwrap();
+        array_addr_prim(&mut vm).unwrap();
+        assert_eq!(
+            vm.pop(),
+            Ok(Cell::ArrayAddr {
+                pool_idx: 0,
+                elem_idx: 1
+            })
+        );
+    }
+
+    // --- store_prim with LocalArrayEscape guard ---
+
+    #[test]
+    fn test_store_local_array_to_dict_addr_is_escape_error() {
+        let mut vm = VM::new();
+        vm.dictionary.push(Cell::None); // dict[0] = placeholder
+                                        // Try to store Cell::Array(0) into a global variable slot.
+        vm.push(Cell::Array(0)).unwrap(); // value
+        vm.push(Cell::DictAddr(0)).unwrap(); // address
+        assert_eq!(store_prim(&mut vm), Err(TbxError::LocalArrayEscape));
+    }
+
+    #[test]
+    fn test_set_local_array_to_dict_addr_is_escape_error() {
+        let mut vm = VM::new();
+        vm.dictionary.push(Cell::None); // dict[0] = placeholder
+                                        // set_prim: stack is [..., addr, value]
+        vm.push(Cell::DictAddr(0)).unwrap(); // address
+        vm.push(Cell::Array(0)).unwrap(); // value
+        assert_eq!(set_prim(&mut vm), Err(TbxError::LocalArrayEscape));
+    }
+
+    // --- store/set to ArrayAddr ---
+
+    #[test]
+    fn test_store_to_array_addr() {
+        let mut vm = VM::new();
+        vm.arrays.push(vec![Cell::None, Cell::None]);
+        vm.push(Cell::Int(99)).unwrap();
+        vm.push(Cell::ArrayAddr {
+            pool_idx: 0,
+            elem_idx: 1,
+        })
+        .unwrap();
+        store_prim(&mut vm).unwrap();
+        assert_eq!(vm.arrays[0][1], Cell::Int(99));
+    }
+
+    #[test]
+    fn test_set_to_array_addr() {
+        let mut vm = VM::new();
+        vm.arrays.push(vec![Cell::None, Cell::None]);
+        vm.push(Cell::ArrayAddr {
+            pool_idx: 0,
+            elem_idx: 0,
+        })
+        .unwrap();
+        vm.push(Cell::Int(42)).unwrap();
+        set_prim(&mut vm).unwrap();
+        assert_eq!(vm.arrays[0][0], Cell::Int(42));
+    }
+
+    // --- fetch_prim with ArrayAddr ---
+
+    #[test]
+    fn test_fetch_array_addr() {
+        let mut vm = VM::new();
+        vm.arrays.push(vec![Cell::Int(77)]);
+        vm.push(Cell::ArrayAddr {
+            pool_idx: 0,
+            elem_idx: 0,
+        })
+        .unwrap();
+        fetch_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Int(77)));
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -153,6 +153,13 @@ pub struct VM {
     /// Drained by `exec_immediate_word` in the interpreter, which calls
     /// `exec_source` on the file content.
     pub(crate) pending_use_path: Option<String>,
+    /// Local array pool: indexed by `Cell::Array(usize)` values.
+    ///
+    /// Each entry is a `Vec<Cell>` created by the `ARRAY(N)` primitive.
+    /// On every word EXIT or RETURN_VAL, the pool is truncated back to the
+    /// length saved in `ReturnFrame::Call::saved_array_pool_len`, freeing all
+    /// local arrays allocated within that call.
+    pub arrays: Vec<Vec<Cell>>,
     /// Internal buffer holding the last line read by ACCEPT.
     ///
     /// ACCEPT reads one line from `input_reader` and stores it here (trimmed of
@@ -217,6 +224,7 @@ impl VM {
             compile_state: None,
             compile_stack: Vec::new(),
             pending_use_path: None,
+            arrays: Vec::new(),
             input_buffer: None,
             input_reader: Box::new(BufReader::new(std::io::stdin())),
             output_writer: Box::new(std::io::stdout()),
@@ -596,6 +604,7 @@ impl VM {
                     self.return_stack.push(ReturnFrame::Call {
                         return_pc,
                         saved_bp,
+                        saved_array_pool_len: self.arrays.len(),
                     });
                     self.bp = self.data_stack.len();
                     self.pc = offset;
@@ -660,6 +669,7 @@ impl VM {
                             self.return_stack.push(ReturnFrame::Call {
                                 return_pc,
                                 saved_bp,
+                                saved_array_pool_len: self.arrays.len(),
                             });
                             self.bp = self.data_stack.len() - arity;
                             for _ in 0..local_count {
@@ -682,8 +692,10 @@ impl VM {
                         ReturnFrame::Call {
                             return_pc,
                             saved_bp,
+                            saved_array_pool_len,
                         } => {
                             self.data_stack.truncate(self.bp);
+                            self.arrays.truncate(saved_array_pool_len);
                             self.pc = return_pc;
                             self.bp = saved_bp;
                         }
@@ -692,12 +704,18 @@ impl VM {
                 }
                 EntryKind::ReturnVal => {
                     let retval = self.pop()?;
+                    // Check for local array escape before truncating the pool.
+                    if matches!(retval, Cell::Array(_)) {
+                        return Err(TbxError::LocalArrayEscape);
+                    }
                     match self.return_stack.pop().ok_or(TbxError::StackUnderflow)? {
                         ReturnFrame::Call {
                             return_pc,
                             saved_bp,
+                            saved_array_pool_len,
                         } => {
                             self.data_stack.truncate(self.bp);
+                            self.arrays.truncate(saved_array_pool_len);
                             self.push(retval)?;
                             self.pc = return_pc;
                             self.bp = saved_bp;
@@ -1691,6 +1709,7 @@ mod tests {
             vm.return_stack.push(ReturnFrame::Call {
                 return_pc: 0,
                 saved_bp: 0,
+                saved_array_pool_len: 0,
             });
         }
 
@@ -1730,6 +1749,7 @@ mod tests {
             vm.return_stack.push(ReturnFrame::Call {
                 return_pc: 0,
                 saved_bp: 0,
+                saved_array_pool_len: 0,
             });
         }
 
@@ -2789,6 +2809,50 @@ mod tests {
             out.trim(),
             "20",
             "NUMS(1)*NUMS(2) should equal 20 after dynamic-index writes"
+        );
+    }
+
+    // --- Local array pool management ---
+
+    #[test]
+    fn test_arrays_pool_truncated_on_exit() {
+        // Verify that the array pool is empty after a word with a local array returns.
+        // run_source creates a fresh Interpreter (and therefore a fresh VM), so we
+        // check the absence of errors rather than the pool length directly.
+        let result = run_source(
+            "DEF HAS_ARRAY()\n  VAR A\n  LET A = ARRAY(3)\n  RETURN 1\nEND\n\
+             PUTDEC HAS_ARRAY()",
+        );
+        assert_eq!(
+            result.unwrap().trim(),
+            "1",
+            "word with local array should return 1"
+        );
+    }
+
+    #[test]
+    fn test_local_array_escape_via_return_val_is_error() {
+        // Verify that returning a Cell::Array value via RETURN_VAL produces LocalArrayEscape.
+        let result = run_source(
+            "DEF BAD_RETURN()\n  VAR A\n  LET A = ARRAY(3)\n  RETURN A\nEND\nBAD_RETURN()",
+        );
+        assert!(
+            matches!(result, Err(crate::error::TbxError::LocalArrayEscape)),
+            "expected LocalArrayEscape, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_local_array_escape_via_store_to_dict_is_error() {
+        // Verify that STORE of a Cell::Array into a global variable produces LocalArrayEscape.
+        let result = run_source(
+            "VAR G\n\
+             DEF BAD_STORE()\n  VAR A\n  LET A = ARRAY(2)\n  SET &G, A\nEND\n\
+             BAD_STORE()",
+        );
+        assert!(
+            matches!(result, Err(crate::error::TbxError::LocalArrayEscape)),
+            "expected LocalArrayEscape, got: {result:?}"
         );
     }
 }


### PR DESCRIPTION
## 概要

issue #427 で検討した **案C（VMプール + スタックフレーム管理）** に基づき、ローカル配列（`ARRAY(N)`）を実装する。
グローバル配列（`DIM`）はそのまま維持し、ローカル配列は `Cell::Array(usize)` として型レベルで分離する。

## 変更内容

### src/cell.rs
- `Cell::Array` を unit variant から `Array(usize)`（VMプールへのインデックス）に変更
- `Cell::ArrayAddr { pool_idx, elem_idx }` を追加（ローカル配列要素のアドレス）
- `ReturnFrame::Call` に `saved_array_pool_len: usize` フィールドを追加
- `Cell::as_array_index()` ヘルパーを追加

### src/error.rs
- `TbxError::LocalArrayEscape` バリアントを追加

### src/vm.rs
- `VM` 構造体に `arrays: Vec<Vec<Cell>>` フィールドを追加
- `EntryKind::Word` / `EntryKind::Call` の CALL 処理で `saved_array_pool_len` を記録
- `EntryKind::Exit` 処理で `arrays.truncate(saved_array_pool_len)` を実行
- `EntryKind::ReturnVal` 処理でエスケープチェック後に truncate を実行
- ローカル配列プール管理の e2e テストを追加

### src/primitives.rs
- `array_prim`（ARRAY）: N 要素のローカル配列を生成して `Cell::Array(idx)` をプッシュ
- `array_get_prim`（ARRAY_GET）: `Cell::Array, idx` → 要素値を読み出す（System内部命令）
- `array_addr_prim`（ARRAY_ADDR）: `Cell::Array, idx` → `Cell::ArrayAddr` を計算する（System内部命令）
- `fetch_prim`: `Cell::ArrayAddr` からの読み出しを追加
- `store_prim` / `set_prim`: `Cell::ArrayAddr` への書き込みを追加、`DictAddr` に `Cell::Array` を書くと `LocalArrayEscape` を返すガードを追加
- ユニットテストを追加

### src/expr.rs
- `LParenCall::LocalArray` バリアントを追加
- ローカル変数に `(` が続く場合を配列アクセス `A(I)` として処理し `ARRAY_GET` を生成
- `&A(I)` 構文でローカル配列要素のアドレスを計算し `ARRAY_ADDR` を生成

### lib/tests/test_local_array.tbx
- ローカル配列の作成・読み書き・ライフタイム管理のインテグレーションテストを追加

Closes #427
