### PR TITLE
可変引数（Variadic Arguments）機能を追加する

### DIFF
--- a/lib/tests/test_variadic.tbx
+++ b/lib/tests/test_variadic.tbx
@@ -1,0 +1,105 @@
+# lib/tests/test_variadic.tbx — TBX tests for variadic arguments (DEF WORD(...))
+USE "lib/tests/helper.tbx"
+
+# --- VA_COUNT: all-variadic word returns correct argument count ---
+
+DEF VA_ONLY(...)
+  RETURN VA_COUNT()
+END
+
+ASSERT VA_ONLY(10) = 1
+ASSERT VA_ONLY(10, 20) = 2
+ASSERT VA_ONLY(10, 20, 30) = 3
+
+# --- VA_COUNT with zero variadic arguments (only fixed params supplied) ---
+
+DEF FIXED_PLUS_VA(A, ...)
+  RETURN VA_COUNT()
+END
+
+ASSERT FIXED_PLUS_VA(1) = 1
+ASSERT FIXED_PLUS_VA(1, 2) = 2
+ASSERT FIXED_PLUS_VA(1, 2, 3) = 3
+
+# --- Fixed parameter is accessible by name ---
+
+DEF FIRST_PLUS_VA(A, ...)
+  RETURN A + VA_COUNT()
+END
+
+ASSERT FIRST_PLUS_VA(10) = 11
+ASSERT FIRST_PLUS_VA(10, 20) = 12
+
+# --- ARG_ADDR: access arguments by index ---
+
+DEF GET_ARG(INDEX, ...)
+  VAR ADDR
+  LET ADDR = ARG_ADDR(INDEX)
+  RETURN FETCH(ADDR)
+END
+
+ASSERT GET_ARG(0, 99) = 0
+ASSERT GET_ARG(1, 99) = 99
+ASSERT GET_ARG(1, 10, 20, 30) = 10
+
+# --- Sum of all variadic arguments using VA_COUNT + ARG_ADDR ---
+
+DEF SUM(...)
+  VAR I
+  VAR S
+  VAR N
+  LET I = 0
+  LET S = 0
+  LET N = VA_COUNT()
+  WHILE I < N
+    LET S = S + FETCH(ARG_ADDR(I))
+    LET I = I + 1
+  ENDWH
+  RETURN S
+END
+
+ASSERT SUM(1) = 1
+ASSERT SUM(1, 2) = 3
+ASSERT SUM(1, 2, 3) = 6
+ASSERT SUM(10, 20, 30, 40) = 100
+
+# --- Sum with one fixed parameter plus variadic ---
+# START is the initial accumulator; variadic args are added on top.
+# ARG_ADDR(0) = START, ARG_ADDR(1..N-1) = variadic args.
+# Loop from I=1 (first variadic arg) to N-1.
+
+DEF SUM_FROM(START, ...)
+  VAR I
+  VAR S
+  VAR N
+  LET I = 1
+  LET S = START
+  LET N = VA_COUNT()
+  WHILE I < N
+    LET S = S + FETCH(ARG_ADDR(I))
+    LET I = I + 1
+  ENDWH
+  RETURN S
+END
+
+ASSERT SUM_FROM(100, 1, 2, 3) = 106
+ASSERT SUM_FROM(0, 5, 10) = 15
+
+# --- DEF WORD() (no params, non-variadic) still works ---
+
+DEF NO_PARAMS()
+  RETURN 42
+END
+
+ASSERT NO_PARAMS() = 42
+
+# --- Variadic word called recursively ---
+
+DEF VA_RECURSE(N, ...)
+  IF N = 0
+    RETURN 0
+  ENDIF
+  RETURN N + VA_RECURSE(N - 1)
+END
+
+ASSERT VA_RECURSE(5) = 15

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -57,14 +57,6 @@ pub enum ReturnFrame {
         /// dispatch without a CALL instruction), which should not occur for
         /// variadic words.
         actual_arity: usize,
-        /// The number of formal (fixed) parameters declared in the callee's DEF header.
-        /// Stored for informational purposes; not used by `resolve_local_idx` directly
-        /// (which relies on `VARIADIC_LOCAL_BASE` for disambiguation instead).
-        formal_arity: usize,
-        /// True if the callee is a variadic word (`DEF WORD(X, ...)`).
-        /// Stored for informational purposes; `resolve_local_idx` identifies VAR-local
-        /// indices by checking `local_idx >= VARIADIC_LOCAL_BASE` rather than this flag.
-        is_variadic: bool,
     },
     TopLevel, // Sentinel value for the bottom of the return stack
 }

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -58,13 +58,12 @@ pub enum ReturnFrame {
         /// variadic words.
         actual_arity: usize,
         /// The number of formal (fixed) parameters declared in the callee's DEF header.
-        /// Used together with `is_variadic` and `actual_arity` to correctly resolve
-        /// `StackAddr` indices for VAR-declared local variables in variadic words.
-        /// For non-variadic words this is equal to `actual_arity`.
+        /// Stored for informational purposes; not used by `resolve_local_idx` directly
+        /// (which relies on `VARIADIC_LOCAL_BASE` for disambiguation instead).
         formal_arity: usize,
         /// True if the callee is a variadic word (`DEF WORD(X, ...)`).
-        /// When true, local variables (with `StackAddr` index >= `formal_arity`) are
-        /// located at `bp + actual_arity + (idx - formal_arity)` rather than `bp + idx`.
+        /// Stored for informational purposes; `resolve_local_idx` identifies VAR-local
+        /// indices by checking `local_idx >= VARIADIC_LOCAL_BASE` rather than this flag.
         is_variadic: bool,
     },
     TopLevel, // Sentinel value for the bottom of the return stack

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -50,6 +50,22 @@ pub enum ReturnFrame {
         /// On EXIT or RETURN_VAL, the array pool is truncated back to this
         /// length to free all local arrays created during the call.
         saved_array_pool_len: usize,
+        /// The actual number of arguments passed to this call.
+        /// Used by the `VA_COUNT` primitive to report how many arguments the
+        /// caller supplied (including both fixed and variadic arguments).
+        /// Set to 0 when a word is dispatched via `EntryKind::Word` (direct
+        /// dispatch without a CALL instruction), which should not occur for
+        /// variadic words.
+        actual_arity: usize,
+        /// The number of formal (fixed) parameters declared in the callee's DEF header.
+        /// Used together with `is_variadic` and `actual_arity` to correctly resolve
+        /// `StackAddr` indices for VAR-declared local variables in variadic words.
+        /// For non-variadic words this is equal to `actual_arity`.
+        formal_arity: usize,
+        /// True if the callee is a variadic word (`DEF WORD(X, ...)`).
+        /// When true, local variables (with `StackAddr` index >= `formal_arity`) are
+        /// located at `bp + actual_arity + (idx - formal_arity)` rather than `bp + idx`.
+        is_variadic: bool,
     },
     TopLevel, // Sentinel value for the bottom of the return stack
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -9,3 +9,18 @@ pub const MAX_DATA_STACK_DEPTH: usize = 65_536;
 /// Maximum depth of the return stack.
 /// Exceeding this limit raises `TbxError::ReturnStackOverflow`.
 pub const MAX_RETURN_STACK_DEPTH: usize = 4_096;
+
+/// Base index offset for VAR-declared local variables in variadic words.
+///
+/// In variadic words, the number of actual arguments is not known at compile time,
+/// so `StackAddr` indices for VAR locals cannot be placed directly after formal
+/// parameters (as they are in non-variadic words).  Instead, their indices are
+/// encoded as `VARIADIC_LOCAL_BASE + local_slot_index`, which places them in a
+/// distinct range well above any realistic argument count.
+///
+/// `VM::resolve_local_idx` detects indices in `[VARIADIC_LOCAL_BASE, ..)` and maps
+/// them to `bp + actual_arity + (index - VARIADIC_LOCAL_BASE)` at runtime.
+///
+/// `ARG_ADDR` indices are always in `[0, actual_arity)` and are never in this range,
+/// so the two namespaces are completely disjoint.
+pub const VARIADIC_LOCAL_BASE: usize = 0x4000_0000;

--- a/src/dict.rs
+++ b/src/dict.rs
@@ -192,6 +192,21 @@ impl WordEntry {
     pub fn is_immediate(&self) -> bool {
         self.flags & FLAG_IMMEDIATE != 0
     }
+
+    /// Checks that `got` arguments satisfy the variadic arity requirement.
+    ///
+    /// For non-variadic words this is a no-op. For variadic words, `got` must be
+    /// at least `self.arity` (the fixed-parameter count before `...`).
+    pub fn check_variadic_arity(&self, got: usize) -> Result<(), crate::error::TbxError> {
+        if self.is_variadic && got < self.arity {
+            return Err(crate::error::TbxError::WrongNumberOfArguments {
+                name: self.name.clone(),
+                expected_min: self.arity,
+                got,
+            });
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/src/dict.rs
+++ b/src/dict.rs
@@ -111,6 +111,10 @@ pub struct WordEntry {
     /// Set to 0 at registration time and patched to the final count when END is compiled.
     /// Used by callers to emit the correct `local_count` operand in CALL instructions.
     pub local_count: usize,
+    /// True if this word was declared with a variadic parameter list (`DEF WORD(X, ...)`).
+    /// When true, `arity` holds the number of fixed (named) parameters before `...`.
+    /// Callers must pass at least `arity` arguments; extra arguments become variadic.
+    pub is_variadic: bool,
     /// Index of the previous entry in `VM::headers` (linked list for search).
     ///
     /// **Do not set this field directly.** It is automatically managed by
@@ -127,6 +131,7 @@ impl WordEntry {
             kind: EntryKind::Primitive(f),
             arity: 0,
             local_count: 0,
+            is_variadic: false,
             prev: None,
         }
     }
@@ -139,6 +144,7 @@ impl WordEntry {
             kind: EntryKind::Word(offset),
             arity: 0,
             local_count: 0,
+            is_variadic: false,
             prev: None,
         }
     }
@@ -151,6 +157,7 @@ impl WordEntry {
             kind: EntryKind::Variable(idx),
             arity: 0,
             local_count: 0,
+            is_variadic: false,
             prev: None,
         }
     }
@@ -163,6 +170,7 @@ impl WordEntry {
             kind: EntryKind::Constant(value),
             arity: 0,
             local_count: 0,
+            is_variadic: false,
             prev: None,
         }
     }
@@ -175,6 +183,7 @@ impl WordEntry {
             kind: EntryKind::Array { base, size },
             arity: 0,
             local_count: 0,
+            is_variadic: false,
             prev: None,
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -169,6 +169,16 @@ pub enum TbxError {
     /// `RETURN`) is forbidden, because the array pool is truncated on EXIT and
     /// the stored index would dangle.
     LocalArrayEscape,
+
+    /// A variadic word was called with fewer arguments than its fixed parameter count.
+    ///
+    /// `name` is the word name, `expected_min` is the number of fixed parameters
+    /// declared before `...`, and `got` is the actual number of arguments supplied.
+    WrongNumberOfArguments {
+        name: String,
+        expected_min: usize,
+        got: usize,
+    },
 }
 
 impl std::fmt::Display for TbxError {
@@ -280,6 +290,16 @@ impl std::fmt::Display for TbxError {
             }
             TbxError::LocalArrayEscape => {
                 write!(f, "local array cannot escape its owning stack frame")
+            }
+            TbxError::WrongNumberOfArguments {
+                name,
+                expected_min,
+                got,
+            } => {
+                write!(
+                    f,
+                    "wrong number of arguments: '{name}' expects at least {expected_min}, got {got}"
+                )
             }
         }
     }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -680,6 +680,19 @@ fn emit_call_by_kind(
     self_hdr_idx: Option<usize>,
     patch_offsets: &mut Vec<usize>,
 ) -> Result<(), TbxError> {
+    // For variadic words, verify that at least the fixed parameter count is supplied.
+    // Non-variadic words are not checked to avoid breaking existing behaviour.
+    {
+        let entry = &vm.headers[xt.index()];
+        if entry.is_variadic && arity < entry.arity {
+            return Err(TbxError::WrongNumberOfArguments {
+                name: entry.name.clone(),
+                expected_min: entry.arity,
+                got: arity,
+            });
+        }
+    }
+
     // Match by reference: `vm` is immutable here so no borrow conflict arises.
     match &vm.headers[xt.index()].kind {
         EntryKind::Word(_) => {
@@ -1455,6 +1468,7 @@ mod tests {
             kind: EntryKind::Lit,
             arity: 0,
             local_count: 0,
+            is_variadic: false,
             prev: None,
         });
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -680,18 +680,7 @@ fn emit_call_by_kind(
     self_hdr_idx: Option<usize>,
     patch_offsets: &mut Vec<usize>,
 ) -> Result<(), TbxError> {
-    // For variadic words, verify that at least the fixed parameter count is supplied.
-    // Non-variadic words are not checked to avoid breaking existing behaviour.
-    {
-        let entry = &vm.headers[xt.index()];
-        if entry.is_variadic && arity < entry.arity {
-            return Err(TbxError::WrongNumberOfArguments {
-                name: entry.name.clone(),
-                expected_min: entry.arity,
-                got: arity,
-            });
-        }
-    }
+    vm.headers[xt.index()].check_variadic_arity(arity)?;
 
     // Match by reference: `vm` is immutable here so no borrow conflict arises.
     match &vm.headers[xt.index()].kind {

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -468,6 +468,19 @@ impl Interpreter {
         // Determine arity from top-level comma count.
         let arity = count_top_level_arity(arg_tokens).map_err(&make_err)?;
 
+        // For variadic words, verify that at least the fixed parameter count is supplied.
+        // Non-variadic words are not checked here to avoid breaking existing behaviour.
+        {
+            let entry = &self.vm.headers[stmt_xt.index()];
+            if entry.is_variadic && arity < entry.arity {
+                return Err(make_err(TbxError::WrongNumberOfArguments {
+                    name: entry.name.clone(),
+                    expected_min: entry.arity,
+                    got: arity,
+                }));
+            }
+        }
+
         // Check whether the statement is a compiled word (needs CALL with arity/locals)
         // or a primitive/other (called directly by placing Xt in the code stream).
         let stmt_is_word = matches!(

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -468,18 +468,9 @@ impl Interpreter {
         // Determine arity from top-level comma count.
         let arity = count_top_level_arity(arg_tokens).map_err(&make_err)?;
 
-        // For variadic words, verify that at least the fixed parameter count is supplied.
-        // Non-variadic words are not checked here to avoid breaking existing behaviour.
-        {
-            let entry = &self.vm.headers[stmt_xt.index()];
-            if entry.is_variadic && arity < entry.arity {
-                return Err(make_err(TbxError::WrongNumberOfArguments {
-                    name: entry.name.clone(),
-                    expected_min: entry.arity,
-                    got: arity,
-                }));
-            }
-        }
+        self.vm.headers[stmt_xt.index()]
+            .check_variadic_arity(arity)
+            .map_err(&make_err)?;
 
         // Check whether the statement is a compiled word (needs CALL with arity/locals)
         // or a primitive/other (called directly by placing Xt in the code stream).

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -26,6 +26,10 @@ pub enum Token {
     /// Operator string: `+` `-` `*` `/` `%` `=` `<>` `<` `>` `<=` `>=` `|` `||` `&&`.
     /// Maps to TOK_OP.
     Op(String),
+    /// Ellipsis `...`. Used in `DEF WORD(X, ...)` to mark a variadic parameter list.
+    /// Only valid inside a `DEF` parameter list; `kind_code()` returns `None`
+    /// because this token is never exposed through the `TOKEN` primitive.
+    Ellipsis,
     /// Comma `,`. Acts as a low-priority binary operator (argument separator).
     /// Maps to TOK_OP.
     Comma,
@@ -62,6 +66,8 @@ impl Token {
             }
             Token::Semicolon => Some(TOK_DELIM),
             Token::StringLit(_) => Some(TOK_STR),
+            // Ellipsis is a DEF-parsing-only token; never exposed via TOKEN primitive.
+            Token::Ellipsis => None,
             Token::LineNum(_) | Token::Newline | Token::Eof | Token::Error(_) => None,
         }
     }
@@ -593,6 +599,40 @@ impl<'a> Lexer<'a> {
                 }
             }
             '!' => self.op1_with_end("!", start_pos, start_off, end_off),
+            '.' => {
+                // Only `...` (three dots) is a valid token starting with '.'.
+                // Single '.' or '..' are not valid operators in TBX.
+                if self.peek_char() == Some('.') {
+                    self.advance(); // consume second '.'
+                    if self.peek_char() == Some('.') {
+                        self.advance(); // consume third '.'
+                        let end_off3 = self.peek_offset();
+                        SpannedToken {
+                            token: Token::Ellipsis,
+                            pos: start_pos,
+                            source_offset: start_off,
+                            source_len: end_off3 - start_off,
+                        }
+                    } else {
+                        // '..' is not a valid token.
+                        let end_off2 = self.peek_offset();
+                        SpannedToken {
+                            token: Token::Error("unexpected token: '..'".to_string()),
+                            pos: start_pos,
+                            source_offset: start_off,
+                            source_len: end_off2 - start_off,
+                        }
+                    }
+                } else {
+                    // Single '.' is not a valid operator.
+                    SpannedToken {
+                        token: Token::Error("unexpected character: '.'".to_string()),
+                        pos: start_pos,
+                        source_offset: start_off,
+                        source_len: end_off - start_off,
+                    }
+                }
+            }
             '#' => {
                 // Hash comment: skip the rest of the line, then emit Newline.
                 while !matches!(self.peek_char(), None | Some('\n') | Some('\r')) {

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -567,22 +567,25 @@ pub fn def_prim(vm: &mut VM) -> Result<(), TbxError> {
         }
     };
 
-    // Parse optional parameter list: DEF WORD(X, Y, ...)
+    // Parse optional parameter list: DEF WORD(X, Y, ...) or DEF WORD(...)
     //
-    // DFA with 4 states:
+    // DFA with 5 states:
     //   LParenOrEnd      — after word name: expect '(' or EOL
-    //   FirstParamOrEnd  — right after '(': expect ident or ')'  (comma here = leading-comma error)
-    //   CommaOrRParen    — after registering a param: expect ',' or ')'  (ident here = missing-comma error)
-    //   NextParam        — after ',': next must be ident  (')' = trailing-comma error)
+    //   FirstParamOrEnd  — right after '(': expect ident, '...', or ')'
+    //   CommaOrRParen    — after registering a param: expect ',' or ')'
+    //   NextParam        — after ',': next must be ident or '...'  (')' = trailing-comma error)
+    //   AfterEllipsis    — after '...': only ')' is valid
     enum DefParseState {
         LParenOrEnd,
         FirstParamOrEnd,
         CommaOrRParen,
         NextParam,
+        AfterEllipsis,
     }
 
     let mut local_table: HashMap<String, usize> = HashMap::new();
     let mut arity: usize = 0;
+    let mut is_variadic: bool = false;
     let mut state = DefParseState::LParenOrEnd;
 
     loop {
@@ -607,9 +610,14 @@ pub fn def_prim(vm: &mut VM) -> Result<(), TbxError> {
                     arity += 1;
                     state = DefParseState::CommaOrRParen;
                 }
+                (DefParseState::FirstParamOrEnd, crate::lexer::Token::Ellipsis) => {
+                    // DEF WORD(...) — variadic with zero fixed parameters.
+                    is_variadic = true;
+                    state = DefParseState::AfterEllipsis;
+                }
                 (DefParseState::FirstParamOrEnd, _) => {
                     return Err(TbxError::InvalidExpression {
-                        reason: "expected identifier or ')' after '('",
+                        reason: "expected identifier, '...', or ')' after '('",
                     });
                 }
 
@@ -638,6 +646,11 @@ pub fn def_prim(vm: &mut VM) -> Result<(), TbxError> {
                     arity += 1;
                     state = DefParseState::CommaOrRParen;
                 }
+                (DefParseState::NextParam, crate::lexer::Token::Ellipsis) => {
+                    // DEF WORD(X, ...) — variadic with one or more fixed parameters.
+                    is_variadic = true;
+                    state = DefParseState::AfterEllipsis;
+                }
                 (DefParseState::NextParam, crate::lexer::Token::RParen) => {
                     return Err(TbxError::InvalidExpression {
                         reason: "trailing comma before ')' is not allowed",
@@ -645,7 +658,17 @@ pub fn def_prim(vm: &mut VM) -> Result<(), TbxError> {
                 }
                 (DefParseState::NextParam, _) => {
                     return Err(TbxError::InvalidExpression {
-                        reason: "expected identifier after ',' in parameter list",
+                        reason: "expected identifier or '...' after ',' in parameter list",
+                    });
+                }
+
+                // --- AfterEllipsis: after '...' — only ')' is valid ---
+                (DefParseState::AfterEllipsis, crate::lexer::Token::RParen) => {
+                    break; // '...' followed by ')': valid variadic end.
+                }
+                (DefParseState::AfterEllipsis, _) => {
+                    return Err(TbxError::InvalidExpression {
+                        reason: "expected ')' after '...' in parameter list",
                     });
                 }
             },
@@ -680,8 +703,58 @@ pub fn def_prim(vm: &mut VM) -> Result<(), TbxError> {
         saved_latest,
         local_table,
         arity,
+        is_variadic,
     ));
 
+    Ok(())
+}
+
+/// VA_COUNT ( -- n ) — return the total number of arguments passed to the current call.
+///
+/// Returns `actual_arity` from the innermost `ReturnFrame::Call` on the return stack.
+/// This includes both fixed (named) parameters and any variadic arguments.
+/// Useful in variadic words defined with `DEF WORD(X, ...)` to determine how many
+/// arguments were actually passed.
+pub fn va_count_prim(vm: &mut VM) -> Result<(), TbxError> {
+    use crate::cell::ReturnFrame;
+    let actual_arity = match vm.return_stack.last() {
+        Some(ReturnFrame::Call { actual_arity, .. }) => *actual_arity,
+        Some(ReturnFrame::TopLevel) | None => {
+            return Err(TbxError::InvalidReturn);
+        }
+    };
+    vm.push(Cell::Int(actual_arity as i64))?;
+    Ok(())
+}
+
+/// ARG_ADDR ( index -- addr ) — return the StackAddr for the argument at the given index.
+///
+/// Pops `index` (zero-based) from the stack, validates it against `actual_arity` from
+/// the current return frame, and pushes `Cell::StackAddr(index)`.  The caller can then
+/// use `FETCH` or `STORE` to read or write the argument value at `data_stack[bp + index]`.
+///
+/// Argument indices are always in `[0, actual_arity)` and are well below
+/// `VARIADIC_LOCAL_BASE`, so `resolve_local_idx` maps them directly to `bp + index`.
+///
+/// Returns `TbxError::IndexOutOfBounds` if `index >= actual_arity`.
+pub fn arg_addr_prim(vm: &mut VM) -> Result<(), TbxError> {
+    use crate::cell::ReturnFrame;
+    let actual_arity = match vm.return_stack.last() {
+        Some(ReturnFrame::Call { actual_arity, .. }) => *actual_arity,
+        Some(ReturnFrame::TopLevel) | None => {
+            return Err(TbxError::InvalidReturn);
+        }
+    };
+    let index_raw = vm.pop_int()?;
+    if index_raw < 0 || index_raw as usize >= actual_arity {
+        return Err(TbxError::IndexOutOfBounds {
+            index: index_raw.max(0) as usize,
+            size: actual_arity,
+        });
+    }
+    // Argument indices are in [0, actual_arity) which is always < VARIADIC_LOCAL_BASE,
+    // so resolve_local_idx maps StackAddr(index) directly to bp + index. No adjustment needed.
+    vm.push(Cell::StackAddr(index_raw as usize))?;
     Ok(())
 }
 
@@ -738,11 +811,12 @@ pub fn end_prim(vm: &mut VM) -> Result<(), TbxError> {
             return Err(e);
         }
     }
-    // Update word header: confirm arity, local_count, unsmudge.
+    // Update word header: confirm arity, local_count, is_variadic, unsmudge.
     let word_hdr_idx = state.word_hdr_idx();
     if word_hdr_idx < vm.headers.len() {
         vm.headers[word_hdr_idx].arity = state.arity;
         vm.headers[word_hdr_idx].local_count = state.local_count;
+        vm.headers[word_hdr_idx].is_variadic = state.is_variadic;
         vm.headers[word_hdr_idx].flags &= !crate::dict::FLAG_HIDDEN;
     }
 
@@ -772,7 +846,14 @@ pub fn var_prim(vm: &mut VM) -> Result<(), TbxError> {
             .ok_or(TbxError::InvalidExpression {
                 reason: "VAR in compile mode but no compile_state",
             })?;
-        let idx = state.arity + state.local_count;
+        // For variadic words, use the VARIADIC_LOCAL_BASE offset so that local-variable
+        // StackAddr indices are in a disjoint range from argument indices.
+        // This allows ARG_ADDR to return raw argument indices without ambiguity.
+        let idx = if state.is_variadic {
+            crate::constants::VARIADIC_LOCAL_BASE + state.local_count
+        } else {
+            state.arity + state.local_count
+        };
         state.local_table.insert(name, idx);
         state.local_count += 1;
     } else {
@@ -1784,6 +1865,7 @@ pub fn register_all(vm: &mut VM) {
         kind: EntryKind::Call,
         arity: 0,
         local_count: 0,
+        is_variadic: false,
         prev: None,
     });
     vm.register(WordEntry {
@@ -1792,6 +1874,7 @@ pub fn register_all(vm: &mut VM) {
         kind: EntryKind::Exit,
         arity: 0,
         local_count: 0,
+        is_variadic: false,
         prev: None,
     });
     vm.register(WordEntry {
@@ -1800,6 +1883,7 @@ pub fn register_all(vm: &mut VM) {
         kind: EntryKind::ReturnVal,
         arity: 0,
         local_count: 0,
+        is_variadic: false,
         prev: None,
     });
     vm.register(WordEntry {
@@ -1808,6 +1892,7 @@ pub fn register_all(vm: &mut VM) {
         kind: EntryKind::DropToMarker,
         arity: 0,
         local_count: 0,
+        is_variadic: false,
         prev: None,
     });
     vm.register(WordEntry {
@@ -1816,6 +1901,7 @@ pub fn register_all(vm: &mut VM) {
         kind: EntryKind::Goto,
         arity: 0,
         local_count: 0,
+        is_variadic: false,
         prev: None,
     });
     vm.register(WordEntry {
@@ -1824,6 +1910,7 @@ pub fn register_all(vm: &mut VM) {
         kind: EntryKind::BranchIfFalse,
         arity: 0,
         local_count: 0,
+        is_variadic: false,
         prev: None,
     });
     vm.register(WordEntry {
@@ -1832,6 +1919,7 @@ pub fn register_all(vm: &mut VM) {
         kind: EntryKind::BranchIfTrue,
         arity: 0,
         local_count: 0,
+        is_variadic: false,
         prev: None,
     });
     let mut lit_marker_entry = WordEntry::new_primitive("LIT_MARKER", lit_marker_prim);
@@ -1843,6 +1931,7 @@ pub fn register_all(vm: &mut VM) {
         kind: EntryKind::Lit,
         arity: 0,
         local_count: 0,
+        is_variadic: false,
         prev: None,
     });
     // LITERAL: compile-time primitive that emits `LIT <value>` to the dictionary.
@@ -1891,6 +1980,7 @@ pub fn register_all(vm: &mut VM) {
         kind: EntryKind::Offset,
         arity: 0,
         local_count: 0,
+        is_variadic: false,
         prev: None,
     });
     // DIM: IMMEDIATE so the outer interpreter feeds the token stream before calling it.
@@ -1971,6 +2061,12 @@ pub fn register_all(vm: &mut VM) {
     let mut array_addr_entry = WordEntry::new_primitive("ARRAY_ADDR", array_addr_prim);
     array_addr_entry.flags = FLAG_SYSTEM;
     vm.register(array_addr_entry);
+
+    // Variadic argument primitives.
+    // VA_COUNT returns the total argument count of the current call.
+    // ARG_ADDR converts an argument index to a StackAddr for FETCH/STORE.
+    vm.register(WordEntry::new_primitive("VA_COUNT", va_count_prim));
+    vm.register(WordEntry::new_primitive("ARG_ADDR", arg_addr_prim));
 }
 
 #[cfg(test)]

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -465,11 +465,6 @@ impl VM {
         Ok(())
     }
 
-    /// Read a local variable from the data stack at `bp + local_idx`.
-    ///
-    /// # Errors
-    ///
-    /// Returns `Err(TbxError::IndexOutOfBounds)` if `bp + local_idx` is out of range.
     /// Translate a `StackAddr` index to an absolute `data_stack` index.
     ///
     /// Two index ranges are recognised:

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -653,8 +653,6 @@ impl VM {
                         saved_bp,
                         saved_array_pool_len: self.arrays.len(),
                         actual_arity: 0,
-                        formal_arity: 0,
-                        is_variadic: false,
                     });
                     self.bp = self.data_stack.len();
                     self.pc = offset;
@@ -716,22 +714,11 @@ impl VM {
                                     limit: MAX_RETURN_STACK_DEPTH,
                                 });
                             }
-                            let (formal_arity, callee_is_variadic) = {
-                                let h = self.headers.get(target_xt.index()).ok_or(
-                                    TbxError::IndexOutOfBounds {
-                                        index: target_xt.index(),
-                                        size: self.headers.len(),
-                                    },
-                                )?;
-                                (h.arity, h.is_variadic)
-                            };
                             self.return_stack.push(ReturnFrame::Call {
                                 return_pc,
                                 saved_bp,
                                 saved_array_pool_len: self.arrays.len(),
                                 actual_arity: arity,
-                                formal_arity,
-                                is_variadic: callee_is_variadic,
                             });
                             self.bp = self.data_stack.len() - arity;
                             for _ in 0..local_count {
@@ -756,8 +743,6 @@ impl VM {
                             saved_bp,
                             saved_array_pool_len,
                             actual_arity: _,
-                            formal_arity: _,
-                            is_variadic: _,
                         } => {
                             self.data_stack.truncate(self.bp);
                             self.arrays.truncate(saved_array_pool_len);
@@ -779,8 +764,6 @@ impl VM {
                             saved_bp,
                             saved_array_pool_len,
                             actual_arity: _,
-                            formal_arity: _,
-                            is_variadic: _,
                         } => {
                             self.data_stack.truncate(self.bp);
                             self.arrays.truncate(saved_array_pool_len);
@@ -1779,8 +1762,6 @@ mod tests {
                 saved_bp: 0,
                 saved_array_pool_len: 0,
                 actual_arity: 0,
-                formal_arity: 0,
-                is_variadic: false,
             });
         }
 
@@ -1822,8 +1803,6 @@ mod tests {
                 saved_bp: 0,
                 saved_array_pool_len: 0,
                 actual_arity: 0,
-                formal_arity: 0,
-                is_variadic: false,
             });
         }
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -26,6 +26,9 @@ pub struct CompileState {
     pub(crate) arity: usize,
     /// Number of VAR-declared local variables encountered so far.
     pub(crate) local_count: usize,
+    /// True if the word being compiled has a variadic parameter list (`DEF WORD(X, ...)`).
+    /// Set during DEF parsing when `...` is encountered.
+    pub(crate) is_variadic: bool,
     /// Source line number (1-based) where this DEF block started.
     /// Set by `compile_program` after the DEF IMMEDIATE word executes.
     /// Used to report accurate positions in unclosed-DEF errors.
@@ -52,6 +55,7 @@ impl CompileState {
         saved_latest: Option<Xt>,
         local_table: HashMap<String, usize>,
         arity: usize,
+        is_variadic: bool,
     ) -> Self {
         Self {
             word_name,
@@ -61,6 +65,7 @@ impl CompileState {
             local_table,
             arity,
             local_count: 0,
+            is_variadic,
             start_line: 0,
             call_patch_list: Vec::new(),
             label_table: HashMap::new(),
@@ -465,30 +470,63 @@ impl VM {
     /// # Errors
     ///
     /// Returns `Err(TbxError::IndexOutOfBounds)` if `bp + local_idx` is out of range.
+    /// Translate a `StackAddr` index to an absolute `data_stack` index.
+    ///
+    /// Two index ranges are recognised:
+    ///
+    /// - `[0, VARIADIC_LOCAL_BASE)` — argument indices and, in non-variadic words,
+    ///   VAR-local indices.  All map directly to `bp + local_idx`.
+    ///
+    /// - `[VARIADIC_LOCAL_BASE, ..)` — VAR-declared local variables in variadic words.
+    ///   The actual stack slot is `bp + actual_arity + (local_idx - VARIADIC_LOCAL_BASE)`.
+    ///   `actual_arity` is read from the innermost `ReturnFrame::Call`.
+    ///
+    /// Using a high-base offset ensures that argument indices (from `ARG_ADDR`) and
+    /// VAR indices in variadic words occupy completely disjoint ranges.
+    ///
+    /// Returns `None` if the computed index would overflow `usize`.
+    fn resolve_local_idx(&self, local_idx: usize) -> Option<usize> {
+        use crate::constants::VARIADIC_LOCAL_BASE;
+        if local_idx >= VARIADIC_LOCAL_BASE {
+            // VAR-declared local in a variadic word.
+            let slot = local_idx - VARIADIC_LOCAL_BASE;
+            let actual_arity = match self.return_stack.last() {
+                Some(ReturnFrame::Call { actual_arity, .. }) => *actual_arity,
+                _ => 0,
+            };
+            self.bp
+                .checked_add(actual_arity)
+                .and_then(|x| x.checked_add(slot))
+        } else {
+            self.bp.checked_add(local_idx)
+        }
+    }
+
     pub fn local_read(&self, local_idx: usize) -> Result<Cell, TbxError> {
-        let idx = self
-            .bp
-            .checked_add(local_idx)
+        let resolved = self
+            .resolve_local_idx(local_idx)
             .ok_or(TbxError::IndexOutOfBounds {
                 index: usize::MAX,
                 size: self.data_stack.len(),
             })?;
         let size = self.data_stack.len();
         self.data_stack
-            .get(idx)
+            .get(resolved)
             .cloned()
-            .ok_or(TbxError::IndexOutOfBounds { index: idx, size })
+            .ok_or(TbxError::IndexOutOfBounds {
+                index: resolved,
+                size,
+            })
     }
 
-    /// Write a local variable to the data stack at `bp + local_idx`.
+    /// Write a local variable to the data stack at the resolved index for `local_idx`.
     ///
     /// # Errors
     ///
-    /// Returns `Err(TbxError::IndexOutOfBounds)` if `bp + local_idx` is out of range.
+    /// Returns `Err(TbxError::IndexOutOfBounds)` if the resolved index is out of range or overflows.
     pub fn local_write(&mut self, local_idx: usize, cell: Cell) -> Result<(), TbxError> {
-        let idx = self
-            .bp
-            .checked_add(local_idx)
+        let resolved = self
+            .resolve_local_idx(local_idx)
             .ok_or(TbxError::IndexOutOfBounds {
                 index: usize::MAX,
                 size: self.data_stack.len(),
@@ -496,8 +534,11 @@ impl VM {
         let size = self.data_stack.len();
         *self
             .data_stack
-            .get_mut(idx)
-            .ok_or(TbxError::IndexOutOfBounds { index: idx, size })? = cell;
+            .get_mut(resolved)
+            .ok_or(TbxError::IndexOutOfBounds {
+                index: resolved,
+                size,
+            })? = cell;
         Ok(())
     }
 
@@ -601,10 +642,15 @@ impl VM {
                             limit: MAX_RETURN_STACK_DEPTH,
                         });
                     }
+                    // Direct dispatch (no CALL instruction): actual_arity is unknown.
+                    // Variadic words should always be called via CALL, not this path.
                     self.return_stack.push(ReturnFrame::Call {
                         return_pc,
                         saved_bp,
                         saved_array_pool_len: self.arrays.len(),
+                        actual_arity: 0,
+                        formal_arity: 0,
+                        is_variadic: false,
                     });
                     self.bp = self.data_stack.len();
                     self.pc = offset;
@@ -666,10 +712,22 @@ impl VM {
                                     limit: MAX_RETURN_STACK_DEPTH,
                                 });
                             }
+                            let (formal_arity, callee_is_variadic) = {
+                                let h = self.headers.get(target_xt.index()).ok_or(
+                                    TbxError::IndexOutOfBounds {
+                                        index: target_xt.index(),
+                                        size: self.headers.len(),
+                                    },
+                                )?;
+                                (h.arity, h.is_variadic)
+                            };
                             self.return_stack.push(ReturnFrame::Call {
                                 return_pc,
                                 saved_bp,
                                 saved_array_pool_len: self.arrays.len(),
+                                actual_arity: arity,
+                                formal_arity,
+                                is_variadic: callee_is_variadic,
                             });
                             self.bp = self.data_stack.len() - arity;
                             for _ in 0..local_count {
@@ -693,6 +751,9 @@ impl VM {
                             return_pc,
                             saved_bp,
                             saved_array_pool_len,
+                            actual_arity: _,
+                            formal_arity: _,
+                            is_variadic: _,
                         } => {
                             self.data_stack.truncate(self.bp);
                             self.arrays.truncate(saved_array_pool_len);
@@ -713,6 +774,9 @@ impl VM {
                             return_pc,
                             saved_bp,
                             saved_array_pool_len,
+                            actual_arity: _,
+                            formal_arity: _,
+                            is_variadic: _,
                         } => {
                             self.data_stack.truncate(self.bp);
                             self.arrays.truncate(saved_array_pool_len);
@@ -1710,6 +1774,9 @@ mod tests {
                 return_pc: 0,
                 saved_bp: 0,
                 saved_array_pool_len: 0,
+                actual_arity: 0,
+                formal_arity: 0,
+                is_variadic: false,
             });
         }
 
@@ -1750,6 +1817,9 @@ mod tests {
                 return_pc: 0,
                 saved_bp: 0,
                 saved_array_pool_len: 0,
+                actual_arity: 0,
+                formal_arity: 0,
+                is_variadic: false,
             });
         }
 
@@ -2090,6 +2160,7 @@ mod tests {
                 kind,
                 arity: 0,
                 local_count: 0,
+                is_variadic: false,
                 prev: None,
             });
             vm.dict_write(Cell::Xt(call_xt)).unwrap();

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -497,6 +497,15 @@ impl VM {
         }
     }
 
+    /// Read a local variable from the data stack by its `StackAddr` index.
+    ///
+    /// Delegates address resolution to `resolve_local_idx`, which handles both
+    /// ordinary (non-variadic) and variadic-word local slots.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(TbxError::IndexOutOfBounds)` if the resolved index is out of range
+    /// or if the `bp + local_idx` addition would overflow.
     pub fn local_read(&self, local_idx: usize) -> Result<Cell, TbxError> {
         let resolved = self
             .resolve_local_idx(local_idx)


### PR DESCRIPTION
## 概要

TBX言語に可変引数（Variadic Arguments）機能を追加する。`DEF WORD(...)` 構文で可変長引数を受け取るワードを定義でき、`VA_COUNT()` で引数個数を、`ARG_ADDR(I)` でI番目の引数のアドレスを取得できる。

## 変更内容

- `src/lexer.rs`: `Token::Ellipsis` を追加し `DEF WORD(...)` 構文を解析可能にする
- `src/dict.rs`: `WordEntry` に `is_variadic: bool` フィールドを追加する
- `src/error.rs`: `TbxError::WrongNumberOfArguments` を追加する
- `src/cell.rs`: `ReturnFrame::Call` に `actual_arity` / `formal_arity` / `is_variadic` を追加する
- `src/constants.rs`: `VARIADIC_LOCAL_BASE` 定数を導入し VAR インデックスと ARG_ADDR インデックスの名前空間を分離する
- `src/vm.rs`: `resolve_local_idx` メソッドを追加し、variadic ワードでの VAR アクセスを実現する
- `src/primitives.rs`: `DefParseState` DFA を拡張し、`VA_COUNT` / `ARG_ADDR` プリミティブを実装・登録する
- `src/interpreter.rs`, `src/expr.rs`: variadic ワードの呼び出し時アリティ下限チェックを追加する
- `lib/tests/test_variadic.tbx`: 結合テストを追加する

Closes #429
