### PR TITLE
fix: compile_program_segment でエラー行番号を正しく報告するように修正

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1011,7 +1011,6 @@ impl Interpreter {
             Token::Ident(name) => name.clone(),
             _ => return Ok(()), // not an identifier — skip
         };
-        let stmt_pos_line = stmt_tok.pos.line;
         let stmt_pos_col = stmt_tok.pos.col;
         idx += 1;
 
@@ -1031,7 +1030,7 @@ impl Interpreter {
                 return self.exec_immediate_word(
                     xt,
                     &tokens[idx..],
-                    stmt_pos_line,
+                    absolute_line,
                     stmt_pos_col,
                     source_line,
                 );
@@ -1043,7 +1042,7 @@ impl Interpreter {
             let result = self.write_stmt_to_dict(
                 &stmt_name,
                 &tokens[idx..],
-                stmt_pos_line,
+                absolute_line,
                 stmt_pos_col,
                 source_line,
             );
@@ -1058,7 +1057,7 @@ impl Interpreter {
         if let Err(e) = self.write_stmt_to_dict(
             &stmt_name,
             &tokens[idx..],
-            stmt_pos_line,
+            absolute_line,
             stmt_pos_col,
             source_line,
         ) {
@@ -3807,6 +3806,33 @@ TRYROT";
             result.is_err(),
             "ELSE at top level should return an error (no compile mode)"
         );
+    }
+
+    #[test]
+    fn test_compile_error_line_number() {
+        // Compile a program with an error on the second line.
+        // It should report line 2.
+        let mut interp = Interpreter::new();
+        // Use a new line in the source to ensure absolute_line works.
+        let src = "VAR X\nUNKNOWN_WORD";
+        let result = interp.exec_source(src);
+        match result {
+            Err(e) if e.line == 1 => {} // FIXME: Should be 2
+            other => panic!("expected error at line 1 (current behavior), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_compile_error_line_number_in_def() {
+        // Compile a DEF with an error inside.
+        let mut interp = Interpreter::new();
+        // The error is inside the DEF body.
+        let src = "DEF TEST\n  UNKNOWN_WORD\nEND";
+        let result = interp.exec_source(src);
+        match result {
+            Err(e) if e.line == 1 => {} // FIXME: Should be 2
+            other => panic!("expected error at line 1 (current behavior), got {other:?}"),
+        }
     }
 
     // --- Control-structure mismatch detection (issue #358) ---

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -3810,28 +3810,25 @@ TRYROT";
 
     #[test]
     fn test_compile_error_line_number() {
-        // Compile a program with an error on the second line.
-        // It should report line 2.
+        // compile_program must report the absolute line number of the error.
         let mut interp = Interpreter::new();
-        // Use a new line in the source to ensure absolute_line works.
         let src = "VAR X\nUNKNOWN_WORD";
-        let result = interp.exec_source(src);
+        let result = interp.compile_program(src);
         match result {
-            Err(e) if e.line == 1 => {} // FIXME: Should be 2
-            other => panic!("expected error at line 1 (current behavior), got {other:?}"),
+            Err(e) if e.line == 2 => {}
+            other => panic!("expected error at line 2, got {other:?}"),
         }
     }
 
     #[test]
     fn test_compile_error_line_number_in_def() {
-        // Compile a DEF with an error inside.
+        // compile_program must report the absolute line number even inside DEF bodies.
         let mut interp = Interpreter::new();
-        // The error is inside the DEF body.
         let src = "DEF TEST\n  UNKNOWN_WORD\nEND";
-        let result = interp.exec_source(src);
+        let result = interp.compile_program(src);
         match result {
-            Err(e) if e.line == 1 => {} // FIXME: Should be 2
-            other => panic!("expected error at line 1 (current behavior), got {other:?}"),
+            Err(e) if e.line == 2 => {}
+            other => panic!("expected error at line 2, got {other:?}"),
         }
     }
 


### PR DESCRIPTION
Issue #329 の対応。compile_program_segment 内で絶対行番号を使用し、コンパイルエラー時に正しい行番号が報告されるように修正しました。