### PR TITLE
TO_ARRAY / FROM_ARRAY プリミティブを追加し可変長プリミティブ呼び出し規約を実装する

### DIFF
--- a/lib/tests/test_to_array.tbx
+++ b/lib/tests/test_to_array.tbx
@@ -1,0 +1,105 @@
+# lib/tests/test_to_array.tbx — TBX tests for TO_ARRAY and FROM_ARRAY primitives
+USE "lib/tests/helper.tbx"
+
+# --- TO_ARRAY: basic creation and element access ---
+
+DEF TO_ARRAY_SUM()
+  VAR A
+  LET A = TO_ARRAY(1, 2, 3)
+  RETURN A(0) + A(1) + A(2)
+END
+ASSERT TO_ARRAY_SUM() = 6
+
+# --- TO_ARRAY: element order is preserved (first arg -> index 0) ---
+
+DEF TO_ARRAY_ORDER()
+  VAR A
+  LET A = TO_ARRAY(10, 20, 30)
+  IF A(0) = 10
+    IF A(1) = 20
+      IF A(2) = 30
+        RETURN 1
+      ENDIF
+    ENDIF
+  ENDIF
+  RETURN 0
+END
+ASSERT TO_ARRAY_ORDER() = 1
+
+# --- TO_ARRAY: empty array (zero arguments) does not crash ---
+
+DEF TO_ARRAY_EMPTY()
+  VAR A
+  LET A = TO_ARRAY()
+  RETURN 99
+END
+ASSERT TO_ARRAY_EMPTY() = 99
+
+# --- TO_ARRAY: single element ---
+
+DEF TO_ARRAY_ONE()
+  VAR A
+  LET A = TO_ARRAY(42)
+  RETURN A(0)
+END
+ASSERT TO_ARRAY_ONE() = 42
+
+# --- TO_ARRAY: elements can be mutated via SET ---
+
+DEF TO_ARRAY_MUTATE()
+  VAR A
+  LET A = TO_ARRAY(1, 2, 3)
+  SET &A(1), 99
+  RETURN A(0) + A(1) + A(2)
+END
+ASSERT TO_ARRAY_MUTATE() = 103
+
+# --- FROM_ARRAY: single-element array (expression context) ---
+# With exactly one element, FROM_ARRAY pushes one value, which behaves
+# like a normal expression returning that single value.
+
+DEF FROM_ARRAY_ONE()
+  VAR ARR
+  VAR V
+  LET ARR = TO_ARRAY(42)
+  LET V = FROM_ARRAY(ARR)
+  RETURN V
+END
+ASSERT FROM_ARRAY_ONE() = 42
+
+# --- FROM_ARRAY: statement call does not crash (elements are discarded
+#     by DROP_TO_MARKER, which is the expected behaviour for statement use) ---
+
+DEF FROM_ARRAY_STMT_NO_CRASH()
+  VAR ARR
+  LET ARR = TO_ARRAY(5, 10, 15)
+  FROM_ARRAY ARR
+  RETURN 1
+END
+ASSERT FROM_ARRAY_STMT_NO_CRASH() = 1
+
+# --- FROM_ARRAY: empty array as statement does not crash ---
+
+DEF FROM_ARRAY_EMPTY_STMT()
+  VAR ARR
+  LET ARR = TO_ARRAY()
+  FROM_ARRAY ARR
+  RETURN 2
+END
+ASSERT FROM_ARRAY_EMPTY_STMT() = 2
+
+# --- Round-trip: TO_ARRAY -> element read -> matches original values ---
+
+DEF ROUNDTRIP()
+  VAR A
+  LET A = TO_ARRAY(100, 200, 300)
+  IF A(0) = 100
+    IF A(1) = 200
+      IF A(2) = 300
+        RETURN 1
+      ENDIF
+    ENDIF
+  ENDIF
+  RETURN 0
+END
+ASSERT ROUNDTRIP() = 1

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -699,6 +699,14 @@ fn emit_call_by_kind(
                 output.push(Cell::Int(local_count as i64));
             }
         }
+        EntryKind::Primitive(_) if vm.headers[xt.index()].is_variadic => {
+            // Variadic primitive: push arity as Int before the Xt so the
+            // primitive can pop it and know how many arguments to consume.
+            let lit_xt = require_xt(vm, "LIT")?;
+            output.push(Cell::Xt(lit_xt));
+            output.push(Cell::Int(arity as i64));
+            output.push(Cell::Xt(xt));
+        }
         EntryKind::Primitive(_) | EntryKind::Variable(_) | EntryKind::Constant(_) => {
             output.push(Cell::Xt(xt));
         }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -670,7 +670,8 @@ fn emit_local_read(output: &mut Vec<Cell>, idx: usize, vm: &VM) -> Result<(), Tb
 /// - `EntryKind::Word`: emits `Xt(CALL)`, `Xt(xt)`, `Int(arity)`, `Int(local_count)`
 ///   - When `xt.index() == self_hdr_idx` (self-recursive call), emits `Int(0)` as a
 ///     placeholder and records the offset in `patch_offsets` for later back-patching.
-/// - `EntryKind::Primitive` / `Variable` / `Constant`: emits `Xt(xt)` directly
+/// - `EntryKind::Primitive` (variadic): emits `Xt(LIT)`, `Int(arity)`, `Xt(xt)`
+/// - `EntryKind::Primitive` (fixed) / `Variable` / `Constant`: emits `Xt(xt)` directly
 /// - Any internal kind (Lit, Call, Exit, ReturnVal, DropToMarker): returns `InvalidExpression`
 fn emit_call_by_kind(
     output: &mut Vec<Cell>,

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -543,6 +543,19 @@ impl Interpreter {
                     .map_err(&make_err)?;
             }
         } else {
+            // For a variadic primitive used as a statement, emit LIT + Int(arity)
+            // before the Xt so the primitive can pop the arity from the stack.
+            let is_variadic_prim = matches!(
+                self.vm.headers[stmt_xt.index()].kind,
+                crate::dict::EntryKind::Primitive(_)
+            ) && self.vm.headers[stmt_xt.index()].is_variadic;
+            if is_variadic_prim {
+                let lit_xt = self.lookup_required("LIT", err_line, err_col, source_line)?;
+                self.vm.dict_write(Cell::Xt(lit_xt)).map_err(&make_err)?;
+                self.vm
+                    .dict_write(Cell::Int(arity as i64))
+                    .map_err(&make_err)?;
+            }
             self.vm.dict_write(Cell::Xt(stmt_xt)).map_err(&make_err)?;
         }
         self.vm

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1188,6 +1188,68 @@ pub fn dim_prim(vm: &mut VM) -> Result<(), TbxError> {
     Ok(())
 }
 
+/// TO_ARRAY — collect n values from the stack into a local array.
+///
+/// The compiler emits `LIT Int(n)` before the Xt for variadic primitives, so the
+/// arity is on top of the stack when this function runs.
+///
+/// Stack before call: `[arg0, arg1, ..., arg(n-1), Int(n)]`
+/// Stack after call:  `[Cell::Array(pool_idx)]`
+///
+/// The returned `Cell::Array` is bound to the current frame and must not escape.
+/// TO_ARRAY with zero arguments (`TO_ARRAY()`) produces an empty array.
+pub fn to_array_prim(vm: &mut VM) -> Result<(), TbxError> {
+    // Pop the arity pushed by the compiler.
+    let n = vm.pop_int()?;
+    if n < 0 {
+        return Err(TbxError::InvalidArgument {
+            message: format!("TO_ARRAY arity must be non-negative, got {n}"),
+        });
+    }
+    let count = n as usize;
+    // Pop `count` values in reverse order, then reverse to restore original order.
+    let mut elems: Vec<Cell> = Vec::with_capacity(count);
+    for _ in 0..count {
+        elems.push(vm.pop()?);
+    }
+    elems.reverse();
+    let pool_idx = vm.arrays.len();
+    vm.arrays.push(elems);
+    vm.push(Cell::Array(pool_idx))?;
+    Ok(())
+}
+
+/// FROM_ARRAY — expand a local array onto the stack.
+///
+/// Pops `Cell::Array(pool_idx)` from the stack and pushes every element of the
+/// array onto the stack in order (index 0 first).
+///
+/// Stack before call: `[Cell::Array(pool_idx)]`
+/// Stack after call:  `[elem0, elem1, ..., elem(n-1)]`
+pub fn from_array_prim(vm: &mut VM) -> Result<(), TbxError> {
+    let pool_idx = match vm.pop()? {
+        Cell::Array(idx) => idx,
+        other => {
+            return Err(TbxError::TypeError {
+                expected: "Array",
+                got: other.type_name(),
+            })
+        }
+    };
+    let elems = vm
+        .arrays
+        .get(pool_idx)
+        .ok_or(TbxError::IndexOutOfBounds {
+            index: pool_idx,
+            size: vm.arrays.len(),
+        })?
+        .clone();
+    for elem in elems {
+        vm.push(elem)?;
+    }
+    Ok(())
+}
+
 /// ARRAY — create a local array of N elements and push its handle onto the stack.
 ///
 /// Pops `Cell::Int(n)` from the stack (n > 0), pushes `n` `Cell::None` elements
@@ -2079,6 +2141,12 @@ pub fn register_all(vm: &mut VM) {
     // Local array primitives.
     // ARRAY creates a local array; ARRAY_GET reads an element; ARRAY_ADDR computes
     // an element address (used internally by the expression compiler for `A(I)` and `&A(I)`).
+    // TO_ARRAY packs stack values into a new local array; FROM_ARRAY expands one onto the stack.
+    let mut to_array_entry = WordEntry::new_primitive("TO_ARRAY", to_array_prim);
+    to_array_entry.is_variadic = true;
+    // arity stays 0: TO_ARRAY accepts zero or more arguments.
+    vm.register(to_array_entry);
+    vm.register(WordEntry::new_primitive("FROM_ARRAY", from_array_prim));
     vm.register(WordEntry::new_primitive("ARRAY", array_prim));
     let mut array_get_entry = WordEntry::new_primitive("ARRAY_GET", array_get_prim);
     array_get_entry.flags = FLAG_SYSTEM;
@@ -5743,5 +5811,139 @@ mod tests {
         .unwrap();
         fetch_prim(&mut vm).unwrap();
         assert_eq!(vm.pop(), Ok(Cell::Int(77)));
+    }
+
+    // --- to_array_prim ---
+
+    #[test]
+    fn test_to_array_prim_basic() {
+        // Stack: [1, 2, 3, Int(3)] → Cell::Array(0) with elems [1, 2, 3]
+        let mut vm = VM::new();
+        vm.push(Cell::Int(1)).unwrap();
+        vm.push(Cell::Int(2)).unwrap();
+        vm.push(Cell::Int(3)).unwrap();
+        vm.push(Cell::Int(3)).unwrap(); // arity
+        to_array_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Array(0)));
+        assert_eq!(vm.arrays[0], vec![Cell::Int(1), Cell::Int(2), Cell::Int(3)]);
+    }
+
+    #[test]
+    fn test_to_array_prim_empty() {
+        // Stack: [Int(0)] → Cell::Array(0) with empty vec
+        let mut vm = VM::new();
+        vm.push(Cell::Int(0)).unwrap(); // arity = 0
+        to_array_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Array(0)));
+        assert!(vm.arrays[0].is_empty());
+    }
+
+    #[test]
+    fn test_to_array_prim_single_element() {
+        // Stack: [Int(42), Int(1)] → Cell::Array(0) with elems [42]
+        let mut vm = VM::new();
+        vm.push(Cell::Int(42)).unwrap();
+        vm.push(Cell::Int(1)).unwrap(); // arity
+        to_array_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Array(0)));
+        assert_eq!(vm.arrays[0], vec![Cell::Int(42)]);
+    }
+
+    #[test]
+    fn test_to_array_prim_preserves_order() {
+        // Ensure push order: first arg (10) → index 0, last arg (30) → index 2.
+        let mut vm = VM::new();
+        vm.push(Cell::Int(10)).unwrap();
+        vm.push(Cell::Int(20)).unwrap();
+        vm.push(Cell::Int(30)).unwrap();
+        vm.push(Cell::Int(3)).unwrap(); // arity
+        to_array_prim(&mut vm).unwrap();
+        let _ = vm.pop().unwrap(); // discard Cell::Array handle
+        assert_eq!(vm.arrays[0][0], Cell::Int(10));
+        assert_eq!(vm.arrays[0][1], Cell::Int(20));
+        assert_eq!(vm.arrays[0][2], Cell::Int(30));
+    }
+
+    #[test]
+    fn test_to_array_prim_negative_arity_returns_error() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(-1)).unwrap(); // negative arity
+        assert!(matches!(
+            to_array_prim(&mut vm),
+            Err(TbxError::InvalidArgument { .. })
+        ));
+    }
+
+    #[test]
+    fn test_to_array_prim_multiple_calls_get_distinct_pool_indices() {
+        let mut vm = VM::new();
+        // First call: TO_ARRAY(1) → Array(0)
+        vm.push(Cell::Int(1)).unwrap();
+        vm.push(Cell::Int(1)).unwrap();
+        to_array_prim(&mut vm).unwrap();
+        // Second call: TO_ARRAY(2) → Array(1)
+        vm.push(Cell::Int(2)).unwrap();
+        vm.push(Cell::Int(1)).unwrap();
+        to_array_prim(&mut vm).unwrap();
+        let second = vm.pop().unwrap();
+        let first = vm.pop().unwrap();
+        assert_eq!(first, Cell::Array(0));
+        assert_eq!(second, Cell::Array(1));
+    }
+
+    // --- from_array_prim ---
+
+    #[test]
+    fn test_from_array_prim_pushes_elements_in_order() {
+        // Array [7, 8, 9]: FROM_ARRAY should push 7, 8, 9 (7 first, 9 last/top).
+        let mut vm = VM::new();
+        vm.arrays
+            .push(vec![Cell::Int(7), Cell::Int(8), Cell::Int(9)]);
+        vm.push(Cell::Array(0)).unwrap();
+        from_array_prim(&mut vm).unwrap();
+        // Stack should now be [7, 8, 9] (top = 9).
+        assert_eq!(vm.pop(), Ok(Cell::Int(9)));
+        assert_eq!(vm.pop(), Ok(Cell::Int(8)));
+        assert_eq!(vm.pop(), Ok(Cell::Int(7)));
+    }
+
+    #[test]
+    fn test_from_array_prim_empty_array_pushes_nothing() {
+        let mut vm = VM::new();
+        vm.arrays.push(vec![]);
+        let stack_depth_before = vm.data_stack.len();
+        vm.push(Cell::Array(0)).unwrap();
+        from_array_prim(&mut vm).unwrap();
+        // Stack depth must be equal to before (the handle was consumed, nothing added).
+        assert_eq!(vm.data_stack.len(), stack_depth_before);
+    }
+
+    #[test]
+    fn test_from_array_prim_type_error_on_non_array() {
+        // Passing an Int where Array is expected must return TypeError.
+        let mut vm = VM::new();
+        vm.push(Cell::Int(42)).unwrap();
+        assert!(matches!(
+            from_array_prim(&mut vm),
+            Err(TbxError::TypeError {
+                expected: "Array",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn test_from_array_prim_to_array_roundtrip() {
+        // TO_ARRAY then FROM_ARRAY must restore the original elements.
+        let mut vm = VM::new();
+        vm.push(Cell::Int(100)).unwrap();
+        vm.push(Cell::Int(200)).unwrap();
+        vm.push(Cell::Int(300)).unwrap();
+        vm.push(Cell::Int(3)).unwrap(); // arity
+        to_array_prim(&mut vm).unwrap(); // → Cell::Array(0) on stack
+        from_array_prim(&mut vm).unwrap(); // consume Array, push 100, 200, 300
+        assert_eq!(vm.pop(), Ok(Cell::Int(300)));
+        assert_eq!(vm.pop(), Ok(Cell::Int(200)));
+        assert_eq!(vm.pop(), Ok(Cell::Int(100)));
     }
 }


### PR DESCRIPTION
## 概要

`TO_ARRAY` と `FROM_ARRAY` の2つのプリミティブを追加し、可変長プリミティブの呼び出し規約（arity push 方式）をコンパイラに実装する。

## 変更内容

- `src/expr.rs` — `emit_call_by_kind` に `is_variadic && Primitive` の分岐を追加し、コンパイラが `LIT Int(arity) Xt(xt)` を emit するようにした
- `src/interpreter.rs` — `write_stmt_to_dict` の else ブランチで可変長プリミティブが statement として呼ばれる場合にも `LIT + Int(arity)` を emit するようにした
- `src/primitives.rs` — `to_array_prim`（スタックの値を集めて `Cell::Array` を生成）と `from_array_prim`（`Cell::Array` を展開してスタックに積む）を実装し `register_all` に登録した。`TO_ARRAY` は `is_variadic: true`、`FROM_ARRAY` は固定アリティ 1
- `lib/tests/test_to_array.tbx` — 統合テストを追加（基本生成・要素順序・空配列・単一要素・要素変更・FROM_ARRAY ラウンドトリップなど）
- `src/primitives.rs` のユニットテストを追加（`to_array_prim` 6件・`from_array_prim` 4件）

Closes #438
