### PR TITLE
INT プリミティブを追加する（Float→Int のtrunc変換）

### DIFF
--- a/examples/asciiart2.tbx
+++ b/examples/asciiart2.tbx
@@ -9,6 +9,13 @@ DEF charCode(i)
   ENDIF
 END
 
+# https://gist.github.com/eparadis/d4a242c8cc149f3583c303efa80532c4?permalink_comment_id=2861310#gistcomment-2861310
+# Add some ANSI color to your drawing, if you terminal supports it, with these changes to the original listing:
+# 130 PRINT CHR$(27);CHR$(91);CHR$(51);CHR$(N-INT(N/6)*6+49);CHR$(109);
+DEF setColor(N)
+  PUTCHR(27); PUTCHR(91); PUTCHR(51); PUTCHR(N-INT(N/6)*6+49); PUTCHR(109);
+END
+
 DEF PlotMandel(X, Y)
   VAR CA,CB,A,B,I,T, isInside, iterate
 

--- a/lib/tests/test_int.tbx
+++ b/lib/tests/test_int.tbx
@@ -1,0 +1,14 @@
+# lib/tests/test_int.tbx — TBX tests for INT primitive (Float-to-Int truncation)
+USE "lib/tests/helper.tbx"
+
+# --- Positive Float: INT(3.7) => 3 ---
+ASSERT INT(3.7) = 3
+
+# --- Negative Float: INT(-3.7) => -3 (truncation toward zero, not floor) ---
+ASSERT INT(-3.7) = -3
+
+# --- Whole Float: INT(3.0) => 3 ---
+ASSERT INT(3.0) = 3
+
+# --- Int identity: INT(5) => 5 ---
+ASSERT INT(5) = 5

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -484,6 +484,30 @@ pub fn negate_prim(vm: &mut VM) -> Result<(), TbxError> {
     Ok(())
 }
 
+/// INT — truncate a numeric value toward zero and return it as `Cell::Int`.
+///
+/// - `Cell::Float(v)` → `Cell::Int(v.trunc() as i64)` (truncation toward zero)
+/// - `Cell::Int(n)` → `Cell::Int(n)` (identity)
+/// - any other type → `TbxError::TypeError`
+pub fn int_prim(vm: &mut VM) -> Result<(), TbxError> {
+    let val = vm.pop()?;
+    match val {
+        Cell::Float(v) => {
+            vm.push(Cell::Int(v.trunc() as i64))?;
+        }
+        Cell::Int(n) => {
+            vm.push(Cell::Int(n))?;
+        }
+        other => {
+            return Err(TbxError::TypeError {
+                expected: "Int or Float",
+                got: other.type_name(),
+            });
+        }
+    }
+    Ok(())
+}
+
 /// LITERAL — compile a literal value into the dictionary as LIT + value (2 cells).
 pub fn literal_prim(vm: &mut VM) -> Result<(), TbxError> {
     let value = vm.pop()?;
@@ -1930,6 +1954,7 @@ pub fn register_all(vm: &mut VM) {
     vm.register(WordEntry::new_primitive("BAND", band_prim));
     vm.register(WordEntry::new_primitive("BOR", bor_prim));
     vm.register(WordEntry::new_primitive("NEGATE", negate_prim));
+    vm.register(WordEntry::new_primitive("INT", int_prim));
     vm.register(WordEntry::new_primitive("PUTSTR", putstr_prim));
     vm.register(WordEntry::new_primitive("PUTCHR", putchr_prim));
     vm.register(WordEntry::new_primitive("PUTDEC", putdec_prim));
@@ -5945,5 +5970,57 @@ mod tests {
         assert_eq!(vm.pop(), Ok(Cell::Int(300)));
         assert_eq!(vm.pop(), Ok(Cell::Int(200)));
         assert_eq!(vm.pop(), Ok(Cell::Int(100)));
+    }
+
+    // --- int_prim ---
+
+    #[test]
+    fn test_int_prim_positive_float_truncates() {
+        // INT(3.7) => 3 (truncation toward zero)
+        let mut vm = VM::new();
+        vm.push(Cell::Float(3.7)).unwrap();
+        int_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Int(3)));
+    }
+
+    #[test]
+    fn test_int_prim_negative_float_truncates_toward_zero() {
+        // INT(-3.7) => -3 (truncation toward zero, not floor)
+        let mut vm = VM::new();
+        vm.push(Cell::Float(-3.7)).unwrap();
+        int_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Int(-3)));
+    }
+
+    #[test]
+    fn test_int_prim_whole_float_returns_int() {
+        // INT(3.0) => 3
+        let mut vm = VM::new();
+        vm.push(Cell::Float(3.0)).unwrap();
+        int_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Int(3)));
+    }
+
+    #[test]
+    fn test_int_prim_int_identity() {
+        // INT(5) => 5 (identity for Cell::Int)
+        let mut vm = VM::new();
+        vm.push(Cell::Int(5)).unwrap();
+        int_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Int(5)));
+    }
+
+    #[test]
+    fn test_int_prim_type_error() {
+        // INT on a non-numeric type must return TypeError.
+        let mut vm = VM::new();
+        vm.push(Cell::Bool(true)).unwrap();
+        assert!(matches!(
+            int_prim(&mut vm),
+            Err(TbxError::TypeError {
+                expected: "Int or Float",
+                ..
+            })
+        ));
     }
 }


### PR DESCRIPTION
## 概要

Float 値をゼロ方向に切り捨てて Int に変換するプリミティブ `INT(n)` を追加する。
`f64::trunc() as i64` による変換で、`INT(-3.7)` は `-3` を返す。

## 変更内容

- `src/primitives.rs` — `int_prim` 関数を追加し、`register_all` で `INT` として登録
- `src/primitives.rs` — `int_prim` のユニットテストを追加（正の Float、負の Float、整数 Float、Int 恒等変換、TypeError の5ケース）
- `lib/tests/test_int.tbx` — 統合テストを追加（4ケース）

Closes #442
