### PR TITLE
PUTDECでFloat値を印字できるよう修正する

### DIFF
--- a/lib/tests/test_putdec_float.tbx
+++ b/lib/tests/test_putdec_float.tbx
@@ -1,0 +1,10 @@
+# lib/tests/test_putdec_float.tbx — TBX tests for PUTDEC with Float values
+#
+# PUTDEC must accept Float values without raising a type error.
+# These statements verify that PUTDEC does not abort execution when
+# given Float arguments (output correctness is covered by unit tests in
+# src/primitives.rs).
+
+PUTDEC 1.0
+PUTDEC 2.5
+PUTDEC -2.5

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -383,10 +383,11 @@ pub fn putchr_prim(vm: &mut VM) -> Result<(), TbxError> {
     Ok(())
 }
 
-/// PUTDEC — output the integer value on the stack as a signed decimal number (no newline).
+/// PUTDEC — output the numeric value on the stack as a signed decimal number (no newline).
+/// Accepts both `Int` and `Float` values.
 pub fn putdec_prim(vm: &mut VM) -> Result<(), TbxError> {
-    let n = vm.pop_int()?;
-    vm.write_output(&n.to_string());
+    let cell = vm.pop_number()?;
+    vm.write_output(&cell.to_string());
     Ok(())
 }
 
@@ -3207,9 +3208,25 @@ mod tests {
     }
 
     #[test]
+    fn test_putdec_float() {
+        let mut vm = VM::new();
+        vm.push(Cell::Float(1.0)).unwrap();
+        putdec_prim(&mut vm).unwrap();
+        assert_eq!(vm.take_output(), "1.0");
+    }
+
+    #[test]
+    fn test_putdec_float_fractional() {
+        let mut vm = VM::new();
+        vm.push(Cell::Float(2.5)).unwrap();
+        putdec_prim(&mut vm).unwrap();
+        assert_eq!(vm.take_output(), "2.5");
+    }
+
+    #[test]
     fn test_putdec_type_error() {
         let mut vm = VM::new();
-        vm.push(Cell::Float(3.5)).unwrap();
+        vm.push(Cell::Bool(true)).unwrap();
         assert!(matches!(
             putdec_prim(&mut vm),
             Err(TbxError::TypeError { .. })


### PR DESCRIPTION
## 概要

`PUTDEC` プリミティブが `Float` 値を受け付けずにタイプエラーを返していた問題を修正する。
`pop_int()` の代わりに `pop_number()` を使うことで、`Int` と `Float` の両方を10進表記で印字できるようにする。

## 変更内容

- `src/primitives.rs` — `putdec_prim` を `pop_int()` から `pop_number()` を使う実装に変更
- `src/primitives.rs` — `Float` 用のユニットテストを追加（`1.0`、`2.5` の2ケース）
- `src/primitives.rs` — `test_putdec_type_error` を `Float` → `Bool` に変更（Float は今後エラーにならないため）
- `lib/tests/test_putdec_float.tbx` — Float 引数でのインテグレーションテストを追加

Closes #441
