### PR TITLE
ACCEPT を辞書から削除し GETDEC の内部処理として統合する

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -144,8 +144,6 @@ pub enum TbxError {
     InvalidArgument {
         message: String,
     },
-    /// GETDEC was called but the input buffer was empty (ACCEPT had not been called first).
-    InputBufferEmpty,
     /// GETDEC could not parse the input buffer as a signed decimal integer.
     ParseIntError {
         /// The string that failed to parse.
@@ -284,9 +282,6 @@ impl std::fmt::Display for TbxError {
             }
             TbxError::InvalidArgument { message } => {
                 write!(f, "invalid argument: {message}")
-            }
-            TbxError::InputBufferEmpty => {
-                write!(f, "GETDEC: input buffer is empty; call ACCEPT first")
             }
             TbxError::ParseIntError { input } => {
                 write!(f, "GETDEC: cannot parse {:?} as a decimal integer", input)

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1954,13 +1954,11 @@ fn use_prim(vm: &mut VM) -> Result<(), TbxError> {
     Ok(())
 }
 
-/// Read one line from the VM's input source and store it in the input buffer.
+/// Read one line from the VM's input source and return it as a `String`.
 ///
 /// Internal helper used by `getdec_prim`. Reads until a newline (or EOF) and
-/// strips the trailing newline characters. Each call overwrites any previously
-/// buffered input.
-/// Stack signature: `( -- )`
-fn accept_prim(vm: &mut VM) -> Result<(), TbxError> {
+/// strips the trailing newline characters.
+fn accept_prim(vm: &mut VM) -> Result<String, TbxError> {
     // Flush any pending output before blocking on user input, so that prompt
     // strings written with PUTSTR are visible before the interpreter waits.
     if !vm.output_buffer.is_empty() {
@@ -1987,8 +1985,7 @@ fn accept_prim(vm: &mut VM) -> Result<(), TbxError> {
         .trim_end_matches('\n')
         .trim_end_matches('\r')
         .to_string();
-    vm.input_buffer = Some(trimmed);
-    Ok(())
+    Ok(trimmed)
 }
 
 /// GETDEC — read one line from the input and push its integer value onto the data stack.
@@ -2002,8 +1999,7 @@ fn accept_prim(vm: &mut VM) -> Result<(), TbxError> {
 ///
 /// Stack signature: `( -- n )`
 pub fn getdec_prim(vm: &mut VM) -> Result<(), TbxError> {
-    accept_prim(vm)?;
-    let s = vm.input_buffer.take().ok_or(TbxError::InputBufferEmpty)?;
+    let s = accept_prim(vm)?;
     let n = s
         .trim()
         .parse::<i64>()
@@ -5694,12 +5690,12 @@ mod tests {
     // --- accept_prim ---
 
     #[test]
-    fn test_accept_stores_line_in_input_buffer() {
+    fn test_accept_reads_line() {
         use std::io::Cursor;
         let mut vm = VM::new();
         vm.input_reader = Box::new(Cursor::new("hello\n"));
-        accept_prim(&mut vm).unwrap();
-        assert_eq!(vm.input_buffer, Some("hello".to_string()));
+        let result = accept_prim(&mut vm).unwrap();
+        assert_eq!(result, "hello".to_string());
     }
 
     #[test]
@@ -5707,18 +5703,8 @@ mod tests {
         use std::io::Cursor;
         let mut vm = VM::new();
         vm.input_reader = Box::new(Cursor::new("world\r\n"));
-        accept_prim(&mut vm).unwrap();
-        assert_eq!(vm.input_buffer, Some("world".to_string()));
-    }
-
-    #[test]
-    fn test_accept_overwrites_previous_buffer() {
-        use std::io::Cursor;
-        let mut vm = VM::new();
-        vm.input_buffer = Some("old value".to_string());
-        vm.input_reader = Box::new(Cursor::new("new value\n"));
-        accept_prim(&mut vm).unwrap();
-        assert_eq!(vm.input_buffer, Some("new value".to_string()));
+        let result = accept_prim(&mut vm).unwrap();
+        assert_eq!(result, "world".to_string());
     }
 
     #[test]
@@ -5727,7 +5713,7 @@ mod tests {
         let mut vm = VM::new();
         vm.input_reader = Box::new(Cursor::new("42\n"));
         accept_prim(&mut vm).unwrap();
-        // Stack must remain empty — ACCEPT is ( -- ).
+        // Stack must remain empty — accept_prim only reads; it does not push.
         assert_eq!(vm.data_stack.len(), 0);
     }
 
@@ -5736,8 +5722,8 @@ mod tests {
         use std::io::Cursor;
         let mut vm = VM::new();
         vm.input_reader = Box::new(Cursor::new("\n"));
-        accept_prim(&mut vm).unwrap();
-        assert_eq!(vm.input_buffer, Some("".to_string()));
+        let result = accept_prim(&mut vm).unwrap();
+        assert_eq!(result, "".to_string());
     }
 
     // --- getdec_prim ---
@@ -5770,12 +5756,12 @@ mod tests {
     }
 
     #[test]
-    fn test_getdec_consumes_buffer() {
+    fn test_getdec_does_not_use_input_buffer() {
         use std::io::Cursor;
         let mut vm = VM::new();
         vm.input_reader = Box::new(Cursor::new("10\n"));
         getdec_prim(&mut vm).unwrap();
-        // input_buffer must be None after take().
+        // getdec_prim reads directly via accept_prim; input_buffer is not used.
         assert_eq!(vm.input_buffer, None);
     }
 

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1954,12 +1954,13 @@ fn use_prim(vm: &mut VM) -> Result<(), TbxError> {
     Ok(())
 }
 
-/// ACCEPT — read one line from the VM's input source and store it in the input buffer.
+/// Read one line from the VM's input source and store it in the input buffer.
 ///
-/// Reads until a newline (or EOF) and strips the trailing newline characters.
-/// Each call overwrites any previously buffered input.
+/// Internal helper used by `getdec_prim`. Reads until a newline (or EOF) and
+/// strips the trailing newline characters. Each call overwrites any previously
+/// buffered input.
 /// Stack signature: `( -- )`
-pub fn accept_prim(vm: &mut VM) -> Result<(), TbxError> {
+fn accept_prim(vm: &mut VM) -> Result<(), TbxError> {
     // Flush any pending output before blocking on user input, so that prompt
     // strings written with PUTSTR are visible before the interpreter waits.
     if !vm.output_buffer.is_empty() {
@@ -1990,17 +1991,18 @@ pub fn accept_prim(vm: &mut VM) -> Result<(), TbxError> {
     Ok(())
 }
 
-/// GETDEC — consume the input buffer and push its integer value onto the data stack.
+/// GETDEC — read one line from the input and push its integer value onto the data stack.
 ///
-/// Parses the string stored by the most recent ACCEPT call as a signed decimal integer
-/// (leading/trailing whitespace is ignored) and pushes the result as `Cell::Int`.
+/// Calls `accept_prim` internally to read a line, then parses the result as a signed
+/// decimal integer (leading/trailing whitespace is ignored) and pushes it as `Cell::Int`.
+/// No prior `ACCEPT` call is needed.
 ///
-/// Returns `TbxError::InputBufferEmpty` if ACCEPT has not been called since the last
-/// GETDEC (or since VM creation), and `TbxError::ParseIntError` if the string cannot
-/// be parsed as a signed decimal integer.
+/// Returns `TbxError::ParseIntError` if the input cannot be parsed as a signed decimal
+/// integer (including when the input is empty or EOF).
 ///
 /// Stack signature: `( -- n )`
 pub fn getdec_prim(vm: &mut VM) -> Result<(), TbxError> {
+    accept_prim(vm)?;
     let s = vm.input_buffer.take().ok_or(TbxError::InputBufferEmpty)?;
     let n = s
         .trim()
@@ -2045,7 +2047,6 @@ pub fn register_all(vm: &mut VM) {
     vm.register(WordEntry::new_primitive("PUTCHR", putchr_prim));
     vm.register(WordEntry::new_primitive("PUTDEC", putdec_prim));
     vm.register(WordEntry::new_primitive("PUTHEX", puthex_prim));
-    vm.register(WordEntry::new_primitive("ACCEPT", accept_prim));
     vm.register(WordEntry::new_primitive("GETDEC", getdec_prim));
     vm.register(WordEntry::new_primitive("APPEND", append_prim));
     vm.register(WordEntry::new_primitive("ALLOT", allot_prim));
@@ -5743,32 +5744,36 @@ mod tests {
 
     #[test]
     fn test_getdec_pushes_integer() {
+        use std::io::Cursor;
         let mut vm = VM::new();
-        vm.input_buffer = Some("42".to_string());
+        vm.input_reader = Box::new(Cursor::new("42\n"));
         getdec_prim(&mut vm).unwrap();
         assert_eq!(vm.pop(), Ok(Cell::Int(42)));
     }
 
     #[test]
     fn test_getdec_negative_integer() {
+        use std::io::Cursor;
         let mut vm = VM::new();
-        vm.input_buffer = Some("-7".to_string());
+        vm.input_reader = Box::new(Cursor::new("-7\n"));
         getdec_prim(&mut vm).unwrap();
         assert_eq!(vm.pop(), Ok(Cell::Int(-7)));
     }
 
     #[test]
     fn test_getdec_trims_whitespace() {
+        use std::io::Cursor;
         let mut vm = VM::new();
-        vm.input_buffer = Some("  100  ".to_string());
+        vm.input_reader = Box::new(Cursor::new("  100  \n"));
         getdec_prim(&mut vm).unwrap();
         assert_eq!(vm.pop(), Ok(Cell::Int(100)));
     }
 
     #[test]
     fn test_getdec_consumes_buffer() {
+        use std::io::Cursor;
         let mut vm = VM::new();
-        vm.input_buffer = Some("10".to_string());
+        vm.input_reader = Box::new(Cursor::new("10\n"));
         getdec_prim(&mut vm).unwrap();
         // input_buffer must be None after take().
         assert_eq!(vm.input_buffer, None);
@@ -5776,16 +5781,23 @@ mod tests {
 
     #[test]
     fn test_getdec_empty_buffer_returns_error() {
+        use std::io::Cursor;
         let mut vm = VM::new();
-        // input_buffer is None by default.
+        // EOF (empty reader) yields an empty string, which fails to parse as integer.
+        vm.input_reader = Box::new(Cursor::new(""));
         let result = getdec_prim(&mut vm);
-        assert_eq!(result, Err(TbxError::InputBufferEmpty));
+        assert!(
+            matches!(result, Err(TbxError::ParseIntError { .. })),
+            "expected ParseIntError for empty input, got: {:?}",
+            result
+        );
     }
 
     #[test]
     fn test_getdec_non_integer_returns_error() {
+        use std::io::Cursor;
         let mut vm = VM::new();
-        vm.input_buffer = Some("abc".to_string());
+        vm.input_reader = Box::new(Cursor::new("abc\n"));
         let result = getdec_prim(&mut vm);
         assert!(
             matches!(result, Err(TbxError::ParseIntError { .. })),
@@ -5795,11 +5807,11 @@ mod tests {
     }
 
     #[test]
-    fn test_accept_then_getdec_sequence() {
+    fn test_getdec_reads_from_reader_directly() {
         use std::io::Cursor;
+        // Verify that getdec_prim works without a prior accept_prim call.
         let mut vm = VM::new();
         vm.input_reader = Box::new(Cursor::new("123\n"));
-        accept_prim(&mut vm).unwrap();
         getdec_prim(&mut vm).unwrap();
         assert_eq!(vm.pop(), Ok(Cell::Int(123)));
     }


### PR DESCRIPTION
## Summary

- `accept_prim` を `pub` から非公開（モジュール内部のみ）に変更
- `getdec_prim` 内で `accept_prim` を呼び出すよう変更し、呼び出し側で `ACCEPT` を明示的に実行する必要をなくした
- `register_all` から `ACCEPT` の辞書登録を削除（`ACCEPT` はユーザー向け辞書ワードとして公開されなくなった）
- `getdec_prim` のテストを `input_buffer` 直接セット方式から `Cursor` を使う形に書き直し
- `test_getdec_empty_buffer_returns_error` を EOF 時の `ParseIntError` 検証に差し替え
- `test_accept_then_getdec_sequence` を `accept_prim` 手動呼び出しなしで `getdec_prim` のみで完結するテストに書き直し

Closes #462

## Test plan

- [x] `cargo build` — ビルド成功
- [x] `cargo test` — 710テスト全て通過
- [x] `cargo clippy --all-targets -- -D warnings` — 警告なし
- [x] `cargo fmt --check` — フォーマット問題なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)