### PR TITLE
fix: ELSIF/ELSEのインタープリットモードテストコメントを現行動作に合わせて修正する

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -3871,10 +3871,8 @@ TRYROT";
     #[test]
     fn test_elsif_outside_def_is_error() {
         // ELSIF at top level (interpret mode) must return an error.
-        // The ELSIF body executes APPEND JUMP_ALWAYS and APPEND 0 first (APPEND does
-        // not check is_compiling), then fails at CS_POP which detects is_compiling=false
-        // and returns InvalidExpression.  Note: the two APPEND calls write to the
-        // dictionary before the error is raised.
+        // ELSIF starts with CS_CLOSE_TAG "IF", which checks is_compiling and returns
+        // InvalidExpression immediately — no APPEND calls are made.
         let mut interp = Interpreter::new();
         let result = interp.exec_line("ELSIF 1 > 0", 1);
         assert!(
@@ -3886,10 +3884,8 @@ TRYROT";
     #[test]
     fn test_else_outside_def_is_error() {
         // ELSE at top level (interpret mode) must return an error.
-        // The ELSE body executes APPEND JUMP_ALWAYS and APPEND 0 first (APPEND does
-        // not check is_compiling), then fails at CS_POP which detects is_compiling=false
-        // and returns InvalidExpression.  Note: the two APPEND calls write to the
-        // dictionary before the error is raised.
+        // ELSE starts with CS_CLOSE_TAG "IF", which checks is_compiling and returns
+        // InvalidExpression immediately — no APPEND calls are made.
         let mut interp = Interpreter::new();
         let result = interp.exec_line("ELSE", 1);
         assert!(


### PR DESCRIPTION
## 概要

- `test_elsif_outside_def_is_error` と `test_else_outside_def_is_error` のコメントを現行の動作に合わせて更新する

## 背景

issue #360 で報告されたとおり、`ELSIF`/`ELSE` はもともとインタープリットモードで呼ばれると `APPEND JUMP_ALWAYS` + `APPEND 0` が辞書に書き込んだ後で `CS_POP` がエラーを返すという副作用があった。

コミット `1322a21` でこれが修正され、`ELSIF`/`ELSE` の先頭に `CS_CLOSE_TAG "IF"` が追加された。`CS_CLOSE_TAG` は `is_compiling` をチェックするため、現在はインタープリットモードで呼ばれると `APPEND` に到達する前に即座にエラーを返す。

しかしテストのコメントは修正前の古い動作（「APPEND が辞書に書き込んでから CS_POP でエラー」）を説明したままになっていた。

## 変更内容

`src/interpreter.rs` の2つのテストコメントを現行の動作に合わせて更新した：

- 旧: 「APPEND JUMP_ALWAYS と APPEND 0 が先に実行され副作用が発生、その後 CS_POP でエラー」
- 新: 「CS_CLOSE_TAG "IF" が is_compiling をチェックして即座にエラーを返す、APPEND は呼ばれない」

## Test plan

- [x] `cargo test` が全テスト通過することを確認
- [x] `cargo clippy --all-targets -- -D warnings` が警告ゼロであることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)