### PR TITLE
乱数生成プリミティブ RND / RANDOMIZE / SHUFFLE を実装する

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,17 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
@@ -143,6 +154,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,6 +195,36 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "rustix"
@@ -252,6 +302,7 @@ dependencies = [
 name = "tbx"
 version = "0.1.0"
 dependencies = [
+ "rand",
  "tempfile",
 ]
 
@@ -262,7 +313,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -279,6 +330,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -439,6 +496,26 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,8 @@ path = "src/lib.rs"
 name = "tbx"
 path = "src/main.rs"
 
+[dependencies]
+rand = { version = "0.8", features = ["small_rng"] }
+
 [dev-dependencies]
 tempfile = "3"

--- a/lib/tests/test_rnd.tbx
+++ b/lib/tests/test_rnd.tbx
@@ -1,0 +1,37 @@
+# lib/tests/test_rnd.tbx — TBX integration tests for RND / RANDOMIZE / SHUFFLE
+USE "lib/tests/helper.tbx"
+
+# --- RND(1) must always return 1 ---
+
+ASSERT RND(1) = 1
+
+# --- RND(6) result must be in [1, 6] ---
+
+VAR X
+SET &X, RND(6)
+ASSERT X >= 1
+ASSERT X <= 6
+
+# --- RANDOMIZE must complete without error ---
+
+RANDOMIZE
+
+# --- SHUFFLE must preserve the number of elements ---
+
+DEF SHUFFLE_PRESERVES_LEN()
+  VAR A
+  LET A = TO_ARRAY(1, 2, 3, 4, 5)
+  SHUFFLE A
+  RETURN ARRAY_LEN(A)
+END
+ASSERT SHUFFLE_PRESERVES_LEN() = 5
+
+# --- SHUFFLE used as a function expression returns the same array handle ---
+
+DEF SHUFFLE_RETURNS_ARRAY()
+  VAR A
+  LET A = TO_ARRAY(10, 20, 30)
+  LET A = SHUFFLE(A)
+  RETURN ARRAY_LEN(A)
+END
+ASSERT SHUFFLE_RETURNS_ARRAY() = 3

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -2025,6 +2025,64 @@ pub fn getstr_prim(vm: &mut VM) -> Result<(), TbxError> {
     vm.push(Cell::Str(idx))
 }
 
+/// RND — generate a random integer in the range [1, n].
+///
+/// Pops `Cell::Int(n)` from the stack (n > 0) and pushes a random integer in [1, n].
+///
+/// Stack signature: `( n:Int -- result:Int )`
+pub fn rnd_prim(vm: &mut VM) -> Result<(), TbxError> {
+    use rand::Rng;
+    let n = vm.pop_int()?;
+    if n <= 0 {
+        return Err(TbxError::InvalidArgument {
+            message: format!("RND requires a positive integer, got {n}"),
+        });
+    }
+    let result = vm.rng.gen_range(1..=n);
+    vm.push(Cell::Int(result))
+}
+
+/// RANDOMIZE — re-seed the RNG from OS entropy.
+///
+/// Replaces the VM's RNG with a new `SmallRng` seeded from the operating system's
+/// entropy source, breaking any previously deterministic sequence.
+///
+/// Stack signature: `( -- )`
+pub fn randomize_prim(vm: &mut VM) -> Result<(), TbxError> {
+    use rand::SeedableRng;
+    vm.rng = rand::rngs::SmallRng::from_entropy();
+    Ok(())
+}
+
+/// SHUFFLE — randomly permute the elements of an array in place.
+///
+/// Pops `Cell::Array(pool_idx)` from the stack, shuffles the array's elements
+/// using the VM's RNG, and pushes the same `Cell::Array(pool_idx)` back.
+///
+/// Stack signature: `( arr:Array -- arr:Array )`
+pub fn shuffle_prim(vm: &mut VM) -> Result<(), TbxError> {
+    use rand::seq::SliceRandom;
+    let pool_idx = match vm.pop()? {
+        Cell::Array(idx) => idx,
+        other => {
+            return Err(TbxError::TypeError {
+                expected: "Array",
+                got: other.type_name(),
+            })
+        }
+    };
+    let arrays_len = vm.arrays.len();
+    let arr = vm
+        .arrays
+        .get_mut(pool_idx)
+        .ok_or(TbxError::IndexOutOfBounds {
+            index: pool_idx,
+            size: arrays_len,
+        })?;
+    arr.shuffle(&mut vm.rng);
+    vm.push(Cell::Array(pool_idx))
+}
+
 /// Register all stack primitives into the VM's dictionary.
 pub fn register_all(vm: &mut VM) {
     vm.register(WordEntry::new_primitive("DROP", drop_prim));
@@ -2271,6 +2329,13 @@ pub fn register_all(vm: &mut VM) {
     // ARG_ADDR converts an argument index to a StackAddr for FETCH/STORE.
     vm.register(WordEntry::new_primitive("VA_COUNT", va_count_prim));
     vm.register(WordEntry::new_primitive("ARG_ADDR", arg_addr_prim));
+
+    // Random number primitives.
+    // RND(n) returns a random integer in [1, n]; RANDOMIZE re-seeds the RNG from OS entropy;
+    // SHUFFLE permutes an array in place and returns the same array handle.
+    vm.register(WordEntry::new_primitive("RND", rnd_prim));
+    vm.register(WordEntry::new_primitive("RANDOMIZE", randomize_prim));
+    vm.register(WordEntry::new_primitive("SHUFFLE", shuffle_prim));
 }
 
 #[cfg(test)]
@@ -6270,6 +6335,161 @@ mod tests {
         vm.push(Cell::Int(42)).unwrap();
         assert!(matches!(
             array_len_prim(&mut vm),
+            Err(TbxError::TypeError {
+                expected: "Array",
+                ..
+            })
+        ));
+    }
+
+    // --- rnd_prim ---
+
+    #[test]
+    fn test_rnd_prim_range() {
+        // RND(n) must always return a value in [1, n].
+        use rand::SeedableRng;
+        let mut vm = VM::new();
+        vm.rng = rand::rngs::SmallRng::seed_from_u64(42);
+        for _ in 0..100 {
+            vm.push(Cell::Int(6)).unwrap();
+            rnd_prim(&mut vm).unwrap();
+            let result = vm.pop_int().unwrap();
+            assert!((1..=6).contains(&result), "RND(6) out of range: {result}");
+        }
+    }
+
+    #[test]
+    fn test_rnd_prim_one() {
+        // RND(1) must always return 1.
+        use rand::SeedableRng;
+        let mut vm = VM::new();
+        vm.rng = rand::rngs::SmallRng::seed_from_u64(0);
+        for _ in 0..10 {
+            vm.push(Cell::Int(1)).unwrap();
+            rnd_prim(&mut vm).unwrap();
+            assert_eq!(vm.pop(), Ok(Cell::Int(1)));
+        }
+    }
+
+    #[test]
+    fn test_rnd_prim_zero_error() {
+        // RND(0) must return InvalidArgument.
+        let mut vm = VM::new();
+        vm.push(Cell::Int(0)).unwrap();
+        assert!(matches!(
+            rnd_prim(&mut vm),
+            Err(TbxError::InvalidArgument { .. })
+        ));
+    }
+
+    #[test]
+    fn test_rnd_prim_negative_error() {
+        // RND(-1) must return InvalidArgument.
+        let mut vm = VM::new();
+        vm.push(Cell::Int(-1)).unwrap();
+        assert!(matches!(
+            rnd_prim(&mut vm),
+            Err(TbxError::InvalidArgument { .. })
+        ));
+    }
+
+    // --- randomize_prim ---
+
+    #[test]
+    fn test_randomize_prim_no_error() {
+        // RANDOMIZE must complete without error and leave the stack unchanged.
+        let mut vm = VM::new();
+        randomize_prim(&mut vm).unwrap();
+        assert_eq!(vm.data_stack.len(), 0);
+    }
+
+    // --- shuffle_prim ---
+
+    #[test]
+    fn test_shuffle_prim_preserves_elements() {
+        // SHUFFLE must not add or remove elements from the array.
+        use rand::SeedableRng;
+        let mut vm = VM::new();
+        vm.rng = rand::rngs::SmallRng::seed_from_u64(123);
+        vm.arrays.push(vec![
+            Cell::Int(1),
+            Cell::Int(2),
+            Cell::Int(3),
+            Cell::Int(4),
+            Cell::Int(5),
+        ]);
+        vm.push(Cell::Array(0)).unwrap();
+        shuffle_prim(&mut vm).unwrap();
+        // The returned value must be Cell::Array(0).
+        assert_eq!(vm.pop(), Ok(Cell::Array(0)));
+        // All original elements must still be present (order may differ).
+        let mut values: Vec<i64> = vm.arrays[0]
+            .iter()
+            .map(|c| match c {
+                Cell::Int(n) => *n,
+                _ => panic!("unexpected cell type"),
+            })
+            .collect();
+        values.sort_unstable();
+        assert_eq!(values, vec![1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn test_shuffle_prim_deterministic() {
+        // With a fixed seed, SHUFFLE must produce the same permutation every time.
+        use rand::SeedableRng;
+        let mut vm = VM::new();
+        vm.rng = rand::rngs::SmallRng::seed_from_u64(42);
+        vm.arrays
+            .push(vec![Cell::Int(1), Cell::Int(2), Cell::Int(3)]);
+        vm.push(Cell::Array(0)).unwrap();
+        shuffle_prim(&mut vm).unwrap();
+        vm.pop().unwrap();
+        let first_run: Vec<i64> = vm.arrays[0]
+            .iter()
+            .map(|c| match c {
+                Cell::Int(n) => *n,
+                _ => panic!("unexpected cell type"),
+            })
+            .collect();
+
+        // Reset and run again with the same seed.
+        let mut vm2 = VM::new();
+        vm2.rng = rand::rngs::SmallRng::seed_from_u64(42);
+        vm2.arrays
+            .push(vec![Cell::Int(1), Cell::Int(2), Cell::Int(3)]);
+        vm2.push(Cell::Array(0)).unwrap();
+        shuffle_prim(&mut vm2).unwrap();
+        vm2.pop().unwrap();
+        let second_run: Vec<i64> = vm2.arrays[0]
+            .iter()
+            .map(|c| match c {
+                Cell::Int(n) => *n,
+                _ => panic!("unexpected cell type"),
+            })
+            .collect();
+
+        assert_eq!(first_run, second_run);
+    }
+
+    #[test]
+    fn test_shuffle_prim_empty_array() {
+        // SHUFFLE on an empty array must not error.
+        let mut vm = VM::new();
+        vm.arrays.push(vec![]);
+        vm.push(Cell::Array(0)).unwrap();
+        shuffle_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Array(0)));
+        assert_eq!(vm.arrays[0].len(), 0);
+    }
+
+    #[test]
+    fn test_shuffle_prim_type_error() {
+        // SHUFFLE on a non-Array cell must return TypeError.
+        let mut vm = VM::new();
+        vm.push(Cell::Int(42)).unwrap();
+        assert!(matches!(
+            shuffle_prim(&mut vm),
             Err(TbxError::TypeError {
                 expected: "Array",
                 ..

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -3,6 +3,7 @@ use crate::constants::{MAX_DATA_STACK_DEPTH, MAX_DICTIONARY_CELLS, MAX_RETURN_ST
 use crate::dict::{EntryKind, WordEntry};
 use crate::error::TbxError;
 use crate::lexer::SpannedToken;
+use rand::SeedableRng;
 use std::collections::HashMap;
 use std::collections::VecDeque;
 use std::io::{BufRead, BufReader, Write};
@@ -217,6 +218,13 @@ pub struct VM {
     /// The field is not included in the `Debug` output because `dyn Write` does
     /// not implement `Debug`.
     pub output_writer: Box<dyn Write + Send>,
+    /// Random number generator state.
+    ///
+    /// Uses `SmallRng` (non-cryptographic, fast) for game and simulation use cases.
+    /// Initialized from OS entropy in `new()`.  Can be reseeded with a fixed seed
+    /// for deterministic testing via `SmallRng::seed_from_u64(seed)`.
+    /// Re-seeded from OS entropy by the RANDOMIZE primitive.
+    pub rng: rand::rngs::SmallRng,
 }
 
 impl VM {
@@ -262,6 +270,7 @@ impl VM {
             input_buffer: None,
             input_reader: Box::new(BufReader::new(std::io::stdin())),
             output_writer: Box::new(std::io::stdout()),
+            rng: rand::rngs::SmallRng::from_entropy(),
         }
     }
 


### PR DESCRIPTION
## 概要

issue #469 の仕様に基づき、乱数生成プリミティブ `RND` / `RANDOMIZE` / `SHUFFLE` を実装する。
`rand` クレート（SmallRng）を使用し、RNG 状態を VM に持たせることで、テスト時のシード固定も可能にする。

## 変更内容

- `Cargo.toml`: `rand = { version = "0.8", features = ["small_rng"] }` を追加
- `src/vm.rs`: `VM` 構造体に `rng: rand::rngs::SmallRng` フィールドを追加し、`VM::new()` で OS エントロピーから初期化
- `src/primitives.rs`:
  - `rnd_prim`: `RND(n)` — [1, n] の範囲のランダムな整数を返す。n ≤ 0 は `InvalidArgument`
  - `randomize_prim`: `RANDOMIZE` — OS エントロピーで RNG を再シード
  - `shuffle_prim`: `SHUFFLE(arr)` — 配列要素をインプレースで並び替え、同じ配列ハンドルを返す。非 Array 型は `TypeError`
  - 各プリミティブを `register_all` に登録
  - 各プリミティブの単体テスト（範囲検証・型エラー・固定シードによる決定的テスト等）を追加
- `lib/tests/test_rnd.tbx`: TBX 統合テストを追加

Closes #469
