### PR TITLE
feat: PUTVALプリミティブを追加する

### DIFF
--- a/lib/tests/test_putval.tbx
+++ b/lib/tests/test_putval.tbx
@@ -1,0 +1,27 @@
+# lib/tests/test_putval.tbx — TBX integration tests for PUTVAL primitive
+USE "lib/tests/helper.tbx"
+
+# --- PUTVAL with Int must complete without error ---
+
+PUTVAL 42
+
+# --- PUTVAL with Float must complete without error ---
+
+PUTVAL 3.14
+
+# --- PUTVAL with whole Float must complete without error ---
+
+PUTVAL 1.0
+
+# --- PUTVAL with Bool TRUE must complete without error ---
+# Use a comparison expression to produce a Bool value.
+
+PUTVAL 1 = 1
+
+# --- PUTVAL with Bool FALSE must complete without error ---
+
+PUTVAL 1 = 2
+
+# --- PUTVAL with Str must complete without error ---
+
+PUTVAL "hello"

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -532,6 +532,45 @@ pub fn puthex_prim(vm: &mut VM) -> Result<(), TbxError> {
     Ok(())
 }
 
+/// PUTVAL — output any user-facing Cell value to the output buffer.
+///
+/// Dispatches on Cell type:
+///   Int    → decimal string
+///   Float  → floating-point string (same as Cell::Float Display)
+///   Bool   → "TRUE" or "FALSE"
+///   StringDesc / Str → resolved string content
+///   other  → TypeError
+pub fn putval_prim(vm: &mut VM) -> Result<(), TbxError> {
+    let cell = vm.pop()?;
+    match cell {
+        Cell::Int(n) => vm.write_output(&n.to_string()),
+        Cell::Float(v) => vm.write_output(&Cell::Float(v).to_string()),
+        Cell::Bool(b) => vm.write_output(if b { "TRUE" } else { "FALSE" }),
+        Cell::StringDesc(idx) => {
+            let s = vm.resolve_string(idx)?;
+            vm.write_output(&s);
+        }
+        Cell::Str(idx) => {
+            let s = vm
+                .strings
+                .get(idx)
+                .cloned()
+                .ok_or(TbxError::IndexOutOfBounds {
+                    index: idx,
+                    size: vm.strings.len(),
+                })?;
+            vm.write_output(&s);
+        }
+        other => {
+            return Err(TbxError::TypeError {
+                expected: "Int, Float, Bool, or Str",
+                got: other.type_name(),
+            })
+        }
+    }
+    Ok(())
+}
+
 /// APPEND — pop a Cell and write it to dictionary[dp], advancing dp by 1.
 pub fn append_prim(vm: &mut VM) -> Result<(), TbxError> {
     let cell = vm.pop()?;
@@ -2119,6 +2158,7 @@ pub fn register_all(vm: &mut VM) {
     vm.register(WordEntry::new_primitive("PUTCHR", putchr_prim));
     vm.register(WordEntry::new_primitive("PUTDEC", putdec_prim));
     vm.register(WordEntry::new_primitive("PUTHEX", puthex_prim));
+    vm.register(WordEntry::new_primitive("PUTVAL", putval_prim));
     vm.register(WordEntry::new_primitive("GETDEC", getdec_prim));
     vm.register(WordEntry::new_primitive("GETSTR", getstr_prim));
     vm.register(WordEntry::new_primitive("APPEND", append_prim));

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -544,7 +544,21 @@ pub fn putval_prim(vm: &mut VM) -> Result<(), TbxError> {
     let cell = vm.pop()?;
     match cell {
         Cell::Int(n) => vm.write_output(&n.to_string()),
-        Cell::Float(v) => vm.write_output(&Cell::Float(v).to_string()),
+        Cell::Float(v) => {
+            // Mirror Cell::Float Display: finite values always include a decimal
+            // point (e.g. 1.0 → "1.0"), non-finite values are printed as-is.
+            let s = if v.is_finite() {
+                let raw = format!("{v}");
+                if raw.contains('.') || raw.contains('e') {
+                    raw
+                } else {
+                    format!("{v}.0")
+                }
+            } else {
+                format!("{v}")
+            };
+            vm.write_output(&s);
+        }
         Cell::Bool(b) => vm.write_output(if b { "TRUE" } else { "FALSE" }),
         Cell::StringDesc(idx) => {
             let s = vm.resolve_string(idx)?;

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -3687,6 +3687,87 @@ mod tests {
         ));
     }
 
+    // --- PUTVAL tests ---
+
+    #[test]
+    fn test_putval_int() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(42)).unwrap();
+        putval_prim(&mut vm).unwrap();
+        assert_eq!(vm.take_output(), "42");
+    }
+
+    #[test]
+    fn test_putval_float() {
+        let mut vm = VM::new();
+        vm.push(Cell::Float(1.0)).unwrap();
+        putval_prim(&mut vm).unwrap();
+        assert_eq!(vm.take_output(), "1.0");
+    }
+
+    #[test]
+    fn test_putval_float_fractional() {
+        let mut vm = VM::new();
+        vm.push(Cell::Float(2.5)).unwrap();
+        putval_prim(&mut vm).unwrap();
+        assert_eq!(vm.take_output(), "2.5");
+    }
+
+    #[test]
+    fn test_putval_bool_true() {
+        let mut vm = VM::new();
+        vm.push(Cell::Bool(true)).unwrap();
+        putval_prim(&mut vm).unwrap();
+        assert_eq!(vm.take_output(), "TRUE");
+    }
+
+    #[test]
+    fn test_putval_bool_false() {
+        let mut vm = VM::new();
+        vm.push(Cell::Bool(false)).unwrap();
+        putval_prim(&mut vm).unwrap();
+        assert_eq!(vm.take_output(), "FALSE");
+    }
+
+    #[test]
+    fn test_putval_strdesc() {
+        let mut vm = VM::new();
+        let idx = vm.intern_string("hello").unwrap();
+        vm.push(Cell::StringDesc(idx)).unwrap();
+        putval_prim(&mut vm).unwrap();
+        assert_eq!(vm.take_output(), "hello");
+    }
+
+    #[test]
+    fn test_putval_str() {
+        let mut vm = VM::new();
+        vm.strings.push("world".to_string());
+        vm.push(Cell::Str(0)).unwrap();
+        putval_prim(&mut vm).unwrap();
+        assert_eq!(vm.take_output(), "world");
+    }
+
+    #[test]
+    fn test_putval_none_error() {
+        let mut vm = VM::new();
+        vm.push(Cell::None).unwrap();
+        assert!(matches!(
+            putval_prim(&mut vm),
+            Err(TbxError::TypeError { .. })
+        ));
+    }
+
+    #[test]
+    fn test_putval_array_error() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(3)).unwrap();
+        array_prim(&mut vm).unwrap();
+        assert!(matches!(
+            putval_prim(&mut vm),
+            Err(TbxError::TypeError { .. })
+        ));
+    }
+
     // --- append_prim ---
 
     #[test]


### PR DESCRIPTION
スタックトップの Cell を型に応じて出力バッファに書き出す多相出力プリミティブ
サポートする値
- Int(n)
- Float(v)
- Bool(true/false) ←大文字
- StringDesc(idx)
- Str(idx)

その他の型はTypeError を返す

TODO
- [x] 実装
- [x] ユニットテスト
- [x] 統合テスト

closes #473