### PR TITLE
implement SQRT primitive

### DIFF
--- a/lib/tests/test_sqrt.tbx
+++ b/lib/tests/test_sqrt.tbx
@@ -1,0 +1,7 @@
+# lib/tests/test_sqrt.tbx — TBX integration tests for SQRT
+USE "lib/tests/helper.tbx"
+
+ASSERT SQRT(0) = 0.0
+ASSERT SQRT(0.0) = 0.0
+ASSERT SQRT(2) = 1.4142135623730951
+ASSERT SQRT(1.23) = 1.1090536506409416

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -263,12 +263,20 @@ pub fn mod_prim(vm: &mut VM) -> Result<(), TbxError> {
     Ok(())
 }
 
+/// SQRT — compute the square root of a number. Pushes a Float result.
+/// Accepts Int or Float. Negative values and NaN/Infinity produce an error.
+/// Negative zero (-0.0) is normalized to positive zero (0.0).
 pub fn sqrt_prim(vm: &mut VM) -> Result<(), TbxError> {
     let num = vm.pop_number()?;
     match num {
         Cell::Int(i) if i < 0 => {
             return Err(TbxError::InvalidArgument {
                 message: format!("sqrt of negative number: {i}"),
+            });
+        }
+        Cell::Float(f) if f.is_nan() || !f.is_finite() => {
+            return Err(TbxError::InvalidArgument {
+                message: format!("sqrt of invalid number: {f}"),
             });
         }
         Cell::Float(f) if f < 0.0 => {
@@ -281,6 +289,8 @@ pub fn sqrt_prim(vm: &mut VM) -> Result<(), TbxError> {
             vm.push(Cell::Float(result))?;
         }
         Cell::Float(f) => {
+            // Normalize -0.0 to 0.0 for consistency with zero handling elsewhere.
+            let f = if f == 0.0 { 0.0 } else { f };
             let result = f.sqrt();
             vm.push(Cell::Float(result))?;
         }
@@ -2934,13 +2944,8 @@ mod tests {
         let mut vm = VM::new();
         vm.push(Cell::Int(7)).unwrap();
         sqrt_prim(&mut vm).unwrap();
-        let result = match vm.pop().unwrap() {
-            Cell::Float(f) => f,
-            _ => 0.0,
-        };
         let expected = (7.0f64).sqrt();
-        let diff = (result - expected).abs();
-        assert!(diff < f64::EPSILON);
+        assert_eq!(vm.pop(), Ok(Cell::Float(expected)));
     }
 
     #[test]
@@ -2949,13 +2954,8 @@ mod tests {
         let mut vm = VM::new();
         vm.push(Cell::Float(float_num)).unwrap();
         sqrt_prim(&mut vm).unwrap();
-        let result = match vm.pop().unwrap() {
-            Cell::Float(f) => f,
-            _ => 0.0,
-        };
-        let expected = (float_num).sqrt();
-        let diff = (result - expected).abs();
-        assert!(diff < f64::EPSILON);
+        let expected = float_num.sqrt();
+        assert_eq!(vm.pop(), Ok(Cell::Float(expected)));
     }
 
     #[test]
@@ -2976,6 +2976,43 @@ mod tests {
             sqrt_prim(&mut vm),
             Err(TbxError::InvalidArgument { .. })
         ));
+    }
+
+    #[test]
+    fn test_sqrt_nan() {
+        let mut vm = VM::new();
+        vm.push(Cell::Float(f64::NAN)).unwrap();
+        assert!(matches!(
+            sqrt_prim(&mut vm),
+            Err(TbxError::InvalidArgument { .. })
+        ));
+    }
+
+    #[test]
+    fn test_sqrt_infinity() {
+        let mut vm = VM::new();
+        vm.push(Cell::Float(f64::INFINITY)).unwrap();
+        assert!(matches!(
+            sqrt_prim(&mut vm),
+            Err(TbxError::InvalidArgument { .. })
+        ));
+    }
+
+    #[test]
+    fn test_sqrt_negative_zero() {
+        // -0.0 should be normalized to +0.0, yielding 0.0
+        let mut vm = VM::new();
+        vm.push(Cell::Float(-0.0f64)).unwrap();
+        sqrt_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Float(0.0)));
+    }
+
+    #[test]
+    fn test_sqrt_type_error() {
+        // Non-numeric type should produce a type error
+        let mut vm = VM::new();
+        vm.push(Cell::Bool(true)).unwrap();
+        assert!(sqrt_prim(&mut vm).is_err());
     }
 
     // --- EQ / NEQ tests ---

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -263,6 +263,32 @@ pub fn mod_prim(vm: &mut VM) -> Result<(), TbxError> {
     Ok(())
 }
 
+pub fn sqrt_prim(vm: &mut VM) -> Result<(), TbxError> {
+    let num = vm.pop_number()?;
+    match num {
+        Cell::Int(i) if i < 0 => {
+            return Err(TbxError::InvalidArgument {
+                message: format!("sqrt of negative number: {i}"),
+            });
+        }
+        Cell::Float(f) if f < 0.0 => {
+            return Err(TbxError::InvalidArgument {
+                message: format!("sqrt of negative number: {f}"),
+            });
+        }
+        Cell::Int(i) => {
+            let result = (i as f64).sqrt();
+            vm.push(Cell::Float(result))?;
+        }
+        Cell::Float(f) => {
+            let result = f.sqrt();
+            vm.push(Cell::Float(result))?;
+        }
+        _ => unreachable!("pop_number guarantees Int or Float"),
+    }
+    Ok(())
+}
+
 /// EQ — equality comparison. Pushes Bool(true) if the two top values are equal.
 /// Int/Float mixed pairs are compared by promoting Int to Float.
 pub fn eq_prim(vm: &mut VM) -> Result<(), TbxError> {
@@ -2149,6 +2175,7 @@ pub fn register_all(vm: &mut VM) {
     vm.register(WordEntry::new_primitive("MUL", mul_prim));
     vm.register(WordEntry::new_primitive("DIV", div_prim));
     vm.register(WordEntry::new_primitive("MOD", mod_prim));
+    vm.register(WordEntry::new_primitive("SQRT", sqrt_prim));
     vm.register(WordEntry::new_primitive("EQ", eq_prim));
     vm.register(WordEntry::new_primitive("NEQ", neq_prim));
     vm.register(WordEntry::new_primitive("LT", lt_prim));
@@ -2898,6 +2925,57 @@ mod tests {
         vm.push(Cell::Int(i64::MIN)).unwrap();
         vm.push(Cell::Int(-1)).unwrap();
         assert_eq!(mod_prim(&mut vm), Err(TbxError::IntegerOverflow));
+    }
+
+    // --- SQRT tests ---
+
+    #[test]
+    fn test_sqrt_int() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(7)).unwrap();
+        sqrt_prim(&mut vm).unwrap();
+        let result = match vm.pop().unwrap() {
+            Cell::Float(f) => f,
+            _ => 0.0,
+        };
+        let expected = (7.0f64).sqrt();
+        let diff = (result - expected).abs();
+        assert!(diff < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_sqrt_float() {
+        let float_num = 1.23f64;
+        let mut vm = VM::new();
+        vm.push(Cell::Float(float_num)).unwrap();
+        sqrt_prim(&mut vm).unwrap();
+        let result = match vm.pop().unwrap() {
+            Cell::Float(f) => f,
+            _ => 0.0,
+        };
+        let expected = (float_num).sqrt();
+        let diff = (result - expected).abs();
+        assert!(diff < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_sqrt_negative_int() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(-7)).unwrap();
+        assert!(matches!(
+            sqrt_prim(&mut vm),
+            Err(TbxError::InvalidArgument { .. })
+        ));
+    }
+
+    #[test]
+    fn test_sqrt_negative_float() {
+        let mut vm = VM::new();
+        vm.push(Cell::Float(-7.0)).unwrap();
+        assert!(matches!(
+            sqrt_prim(&mut vm),
+            Err(TbxError::InvalidArgument { .. })
+        ));
     }
 
     // --- EQ / NEQ tests ---

--- a/tests/tbx_lib_tests.rs
+++ b/tests/tbx_lib_tests.rs
@@ -46,3 +46,21 @@ fn test_unterminated_string_in_def_is_compile_error() {
         "expected 'invalid expression' in error message, got: {msg}"
     );
 }
+
+#[test]
+fn test_sqrt_negative_float_is_error() {
+    let mut interp = Interpreter::new();
+    let err = interp
+        .exec_source("SQRT -1.0\n")
+        .expect_err("sqrt of negative should fail");
+    assert!(err.to_string().contains("sqrt of negative"), "{err}");
+}
+
+#[test]
+fn test_sqrt_negative_int_is_error() {
+    let mut interp = Interpreter::new();
+    let err = interp
+        .exec_source("SQRT -1\n")
+        .expect_err("sqrt of negative should fail");
+    assert!(err.to_string().contains("sqrt of negative"), "{err}");
+}


### PR DESCRIPTION
引数がInt → Floatにキャストして計算、Floatを返す
引数がFloat → Floatを返す
引数がマイナス → TbxError::InvalidArgumentエラー

closes #477 