### PR TITLE
配列インデックスを1オリジンに統一する

### DIFF
--- a/blueprint-language.md
+++ b/blueprint-language.md
@@ -596,15 +596,16 @@ CALL実行時にコンパイル時確定のローカル変数スロット数を 
 DEF MYWORD
   VAR A
   LET A = ARRAY(5)    ' create an array of 5 elements
-  SET &A(0), 42       ' write to element 0
-  PUTDEC A(1)         ' read element 1
-  PUTDEC &A(2)        ' get address of element 2
+  SET &A(1), 42       ' write to element 1 (1-based index)
+  PUTDEC A(2)         ' read element 2
+  PUTDEC &A(3)        ' get address of element 3
 END
 ```
 
 - `ARRAY(N)` — N 要素の配列を VM の配列プール（`VM::arrays`）に確保し、`Cell::Array(pool_idx)` をスタックに積む。N は正の整数でなければならない
-- `A(I)` — 配列変数 A の I 番目要素を読み出す（`FETCH` 経由）
-- `&A(I)` — 配列変数 A の I 番目要素のアドレス（`Cell::ArrayAddr { pool_idx, elem_idx }`）を返す。`STORE` / `SET` で書き込める
+- `A(I)` — 配列変数 A の I 番目要素を読み出す（`FETCH` 経由）。インデックスは **1 オリジン**（有効範囲: `1..=N`）。インデックス 0 以下は `ArrayIndexOutOfBounds` エラー
+- `&A(I)` — 配列変数 A の I 番目要素のアドレス（`Cell::ArrayAddr { pool_idx, elem_idx }`）を返す。`STORE` / `SET` で書き込める。インデックスは 1 オリジン
+- 内部実装では Rust の `Vec`（`vm.arrays`）を 0 オリジンで管理し、ユーザーインデックス `I` を `I - 1` に変換してアクセスする
 - **スコープとライフタイム**: 配列には「フレームローカル配列」と「グローバル配列」の2種類がある（Issue #454）
 
 ##### 配列のスコープ・ライフタイム

--- a/lib/tests/test_array.tbx
+++ b/lib/tests/test_array.tbx
@@ -6,10 +6,10 @@ USE "lib/tests/helper.tbx"
 DEF MAKE_AND_READ()
   VAR A
   LET A = ARRAY(3)
-  SET &A(0), 10
-  SET &A(1), 20
-  SET &A(2), 30
-  RETURN A(0) + A(1) + A(2)
+  SET &A(1), 10
+  SET &A(2), 20
+  SET &A(3), 30
+  RETURN A(1) + A(2) + A(3)
 END
 ASSERT MAKE_AND_READ() = 60
 
@@ -19,7 +19,7 @@ DEF FIRST_ELEM_IS_NONE()
   VAR A
   LET A = ARRAY(5)
   # Cell::None is falsy, so this checks the initial value
-  IF A(0) = 0
+  IF A(1) = 0
     RETURN 1
   ENDIF
   RETURN 0
@@ -35,9 +35,9 @@ DEF TWO_ARRAYS()
   VAR B
   LET A = ARRAY(2)
   LET B = ARRAY(2)
-  SET &A(0), 100
-  SET &B(0), 200
-  RETURN A(0) + B(0)
+  SET &A(1), 100
+  SET &B(1), 200
+  RETURN A(1) + B(1)
 END
 ASSERT TWO_ARRAYS() = 300
 
@@ -46,8 +46,8 @@ ASSERT TWO_ARRAYS() = 300
 DEF INNER()
   VAR A
   LET A = ARRAY(3)
-  SET &A(0), 42
-  RETURN A(0)
+  SET &A(1), 42
+  RETURN A(1)
 END
 
 DEF OUTER()
@@ -75,10 +75,10 @@ DEF SUM_ARRAY(N)
   VAR I
   VAR S
   LET A = ARRAY(N)
-  LET I = 0
+  LET I = 1
   LET S = 0
-  WHILE I < N
-    SET &A(I), I * 2
+  WHILE I <= N
+    SET &A(I), (I - 1) * 2
     LET S = S + A(I)
     LET I = I + 1
   ENDWH

--- a/lib/tests/test_array_len.tbx
+++ b/lib/tests/test_array_len.tbx
@@ -17,20 +17,20 @@ DEF LEN_ONE()
 END
 ASSERT LEN_ONE() = 1
 
-# Use ARRAY_LEN in a WHILE loop condition
+# Use ARRAY_LEN in a WHILE loop condition (1-based indices)
 DEF SUM_WITH_LEN(N)
   VAR A
   VAR I
   VAR S
   LET A = ARRAY(N)
-  LET I = 0
+  LET I = 1
   LET S = 0
-  WHILE I < N
-    SET &A(I), I + 1
+  WHILE I <= N
+    SET &A(I), I
     LET I = I + 1
   ENDWH
-  LET I = 0
-  WHILE I < ARRAY_LEN(A)
+  LET I = 1
+  WHILE I <= ARRAY_LEN(A)
     LET S = S + A(I)
     LET I = I + 1
   ENDWH

--- a/lib/tests/test_to_array.tbx
+++ b/lib/tests/test_to_array.tbx
@@ -6,18 +6,18 @@ USE "lib/tests/helper.tbx"
 DEF TO_ARRAY_SUM()
   VAR A
   LET A = TO_ARRAY(1, 2, 3)
-  RETURN A(0) + A(1) + A(2)
+  RETURN A(1) + A(2) + A(3)
 END
 ASSERT TO_ARRAY_SUM() = 6
 
-# --- TO_ARRAY: element order is preserved (first arg -> index 0) ---
+# --- TO_ARRAY: element order is preserved (first arg -> index 1) ---
 
 DEF TO_ARRAY_ORDER()
   VAR A
   LET A = TO_ARRAY(10, 20, 30)
-  IF A(0) = 10
-    IF A(1) = 20
-      IF A(2) = 30
+  IF A(1) = 10
+    IF A(2) = 20
+      IF A(3) = 30
         RETURN 1
       ENDIF
     ENDIF
@@ -40,7 +40,7 @@ ASSERT TO_ARRAY_EMPTY() = 99
 DEF TO_ARRAY_ONE()
   VAR A
   LET A = TO_ARRAY(42)
-  RETURN A(0)
+  RETURN A(1)
 END
 ASSERT TO_ARRAY_ONE() = 42
 
@@ -49,8 +49,8 @@ ASSERT TO_ARRAY_ONE() = 42
 DEF TO_ARRAY_MUTATE()
   VAR A
   LET A = TO_ARRAY(1, 2, 3)
-  SET &A(1), 99
-  RETURN A(0) + A(1) + A(2)
+  SET &A(2), 99
+  RETURN A(1) + A(2) + A(3)
 END
 ASSERT TO_ARRAY_MUTATE() = 103
 
@@ -93,9 +93,9 @@ ASSERT FROM_ARRAY_EMPTY_STMT() = 2
 DEF ROUNDTRIP()
   VAR A
   LET A = TO_ARRAY(100, 200, 300)
-  IF A(0) = 100
-    IF A(1) = 200
-      IF A(2) = 300
+  IF A(1) = 100
+    IF A(2) = 200
+      IF A(3) = 300
         RETURN 1
       ENDIF
     ENDIF

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1441,6 +1441,9 @@ pub fn array_prim(vm: &mut VM) -> Result<(), TbxError> {
 /// ARRAY_GET — read an element from an array.
 ///
 /// Stack: `[..., Cell::Array(pool_idx), Cell::Int(elem_idx)]` → `value`
+///
+/// Array indices are 1-based from the user's perspective: valid range is `1..=N`.
+/// The index is translated to 0-based internally before accessing the Vec.
 pub fn array_get_prim(vm: &mut VM) -> Result<(), TbxError> {
     let elem_idx_raw = vm.pop_int()?;
     let pool_idx = match vm.pop()? {
@@ -1452,18 +1455,20 @@ pub fn array_get_prim(vm: &mut VM) -> Result<(), TbxError> {
             })
         }
     };
-    if elem_idx_raw < 0 {
-        return Err(TbxError::ArrayIndexOutOfBounds {
-            index: elem_idx_raw,
-            size: vm.arrays.get(pool_idx).map(|a| a.len()).unwrap_or(0),
-        });
-    }
-    let elem_idx = elem_idx_raw as usize;
     let arr = vm.arrays.get(pool_idx).ok_or(TbxError::IndexOutOfBounds {
         index: pool_idx,
         size: vm.arrays.len(),
     })?;
     let size = arr.len();
+    // Translate 1-based user index to 0-based internal index.
+    // Index 0 or negative is out of bounds.
+    if elem_idx_raw < 1 {
+        return Err(TbxError::ArrayIndexOutOfBounds {
+            index: elem_idx_raw,
+            size,
+        });
+    }
+    let elem_idx = (elem_idx_raw - 1) as usize;
     if elem_idx >= size {
         return Err(TbxError::ArrayIndexOutOfBounds {
             index: elem_idx_raw,
@@ -1478,6 +1483,9 @@ pub fn array_get_prim(vm: &mut VM) -> Result<(), TbxError> {
 /// ARRAY_ADDR — compute the address of an array element.
 ///
 /// Stack: `[..., Cell::Array(pool_idx), Cell::Int(elem_idx)]` → `Cell::ArrayAddr { pool_idx, elem_idx }`
+///
+/// Array indices are 1-based from the user's perspective: valid range is `1..=N`.
+/// The index is translated to 0-based internally before storing in `Cell::ArrayAddr`.
 pub fn array_addr_prim(vm: &mut VM) -> Result<(), TbxError> {
     let elem_idx_raw = vm.pop_int()?;
     let pool_idx = match vm.pop()? {
@@ -1489,19 +1497,21 @@ pub fn array_addr_prim(vm: &mut VM) -> Result<(), TbxError> {
             })
         }
     };
-    if elem_idx_raw < 0 {
-        return Err(TbxError::ArrayIndexOutOfBounds {
-            index: elem_idx_raw,
-            size: vm.arrays.get(pool_idx).map(|a| a.len()).unwrap_or(0),
-        });
-    }
-    let elem_idx = elem_idx_raw as usize;
     // Validate bounds at address-computation time.
     let arr = vm.arrays.get(pool_idx).ok_or(TbxError::IndexOutOfBounds {
         index: pool_idx,
         size: vm.arrays.len(),
     })?;
     let size = arr.len();
+    // Translate 1-based user index to 0-based internal index.
+    // Index 0 or negative is out of bounds.
+    if elem_idx_raw < 1 {
+        return Err(TbxError::ArrayIndexOutOfBounds {
+            index: elem_idx_raw,
+            size,
+        });
+    }
+    let elem_idx = (elem_idx_raw - 1) as usize;
     if elem_idx >= size {
         return Err(TbxError::ArrayIndexOutOfBounds {
             index: elem_idx_raw,
@@ -6252,11 +6262,24 @@ mod tests {
 
     #[test]
     fn test_array_get_prim_reads_element() {
+        // User index 1 maps to internal index 0.
         let mut vm = VM::new();
         vm.arrays
             .push(vec![Cell::Int(10), Cell::Int(20), Cell::Int(30)]);
         vm.push(Cell::Array(0)).unwrap();
         vm.push(Cell::Int(1)).unwrap();
+        array_get_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Int(10)));
+    }
+
+    #[test]
+    fn test_array_get_prim_reads_second_element() {
+        // User index 2 maps to internal index 1.
+        let mut vm = VM::new();
+        vm.arrays
+            .push(vec![Cell::Int(10), Cell::Int(20), Cell::Int(30)]);
+        vm.push(Cell::Array(0)).unwrap();
+        vm.push(Cell::Int(2)).unwrap();
         array_get_prim(&mut vm).unwrap();
         assert_eq!(vm.pop(), Ok(Cell::Int(20)));
     }
@@ -6270,6 +6293,19 @@ mod tests {
         assert!(matches!(
             array_get_prim(&mut vm),
             Err(TbxError::ArrayIndexOutOfBounds { index: 5, size: 1 })
+        ));
+    }
+
+    #[test]
+    fn test_array_get_prim_zero_index_is_out_of_bounds() {
+        // Index 0 is invalid in 1-based indexing.
+        let mut vm = VM::new();
+        vm.arrays.push(vec![Cell::Int(1)]);
+        vm.push(Cell::Array(0)).unwrap();
+        vm.push(Cell::Int(0)).unwrap();
+        assert!(matches!(
+            array_get_prim(&mut vm),
+            Err(TbxError::ArrayIndexOutOfBounds { index: 0, .. })
         ));
     }
 
@@ -6289,6 +6325,7 @@ mod tests {
 
     #[test]
     fn test_array_addr_prim_pushes_array_addr() {
+        // User index 1 maps to internal elem_idx 0.
         let mut vm = VM::new();
         vm.arrays.push(vec![Cell::Int(0), Cell::Int(0)]);
         vm.push(Cell::Array(0)).unwrap();
@@ -6298,9 +6335,22 @@ mod tests {
             vm.pop(),
             Ok(Cell::ArrayAddr {
                 pool_idx: 0,
-                elem_idx: 1
+                elem_idx: 0
             })
         );
+    }
+
+    #[test]
+    fn test_array_addr_prim_zero_index_is_out_of_bounds() {
+        // Index 0 is invalid in 1-based indexing.
+        let mut vm = VM::new();
+        vm.arrays.push(vec![Cell::Int(0), Cell::Int(0)]);
+        vm.push(Cell::Array(0)).unwrap();
+        vm.push(Cell::Int(0)).unwrap();
+        assert!(matches!(
+            array_addr_prim(&mut vm),
+            Err(TbxError::ArrayIndexOutOfBounds { index: 0, .. })
+        ));
     }
 
     // --- store_prim with ArrayFrameEscape guard ---

--- a/tests/tbx_lib_tests.rs
+++ b/tests/tbx_lib_tests.rs
@@ -64,3 +64,22 @@ fn test_sqrt_negative_int_is_error() {
         .expect_err("sqrt of negative should fail");
     assert!(err.to_string().contains("sqrt of negative"), "{err}");
 }
+
+#[test]
+fn test_array_index_zero_is_out_of_bounds() {
+    use std::path::PathBuf;
+    let base = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut interp = Interpreter::new();
+    interp
+        .set_base_dir(base)
+        .expect("CARGO_MANIFEST_DIR is always absolute");
+    // Array indices are 1-based; index 0 must return ArrayIndexOutOfBounds.
+    let src = "DEF T()\n  VAR A\n  LET A = ARRAY(3)\n  RETURN A(0)\nEND\nT()\n";
+    let err = interp
+        .exec_source(src)
+        .expect_err("index 0 should be out of bounds");
+    assert!(
+        err.to_string().contains("array index out of bounds"),
+        "expected 'array index out of bounds', got: {err}"
+    );
+}


### PR DESCRIPTION
## 概要

配列アクセス `A(I)` のインデックスを 0 オリジンから **1 オリジン**に統一する。
`FOR &I, N` で `I=1..N` のループと `A(I)` の組み合わせが自然に動作するようになる。

## 変更内容

- `src/primitives.rs`: `array_get_prim` / `array_addr_prim` でユーザーインデックスを `I - 1` に変換。インデックス 0 以下は `ArrayIndexOutOfBounds` エラー。内部の `Vec`（`vm.arrays`）は 0 オリジンのまま
- `lib/tests/test_array.tbx`: 全インデックスを +1 シフト。`SUM_ARRAY` のループを `I=1`/`I<=N` に変更
- `lib/tests/test_to_array.tbx`: 全インデックスを +1 シフト
- `lib/tests/test_array_len.tbx`: ループを 1 オリジンに変更
- `tests/tbx_lib_tests.rs`: インデックス 0 アクセスが `ArrayIndexOutOfBounds` を返すことを確認するテストを追加
- `blueprint-language.md`: 配列インデックスが 1 オリジンである旨の仕様記述を更新

## テスト

- `cargo test` — 全テストパス
- `cargo clippy --all-targets -- -D warnings` — 警告なし
- `cargo fmt --check` — パス

Closes #479
