### PR TITLE
トップレベルのグローバル配列添字を修正

### DIFF
--- a/lib/tests/test_to_array.tbx
+++ b/lib/tests/test_to_array.tbx
@@ -54,6 +54,14 @@ DEF TO_ARRAY_MUTATE()
 END
 ASSERT TO_ARRAY_MUTATE() = 103
 
+# --- Top-level global array variable supports A(I) / &A(I) ---
+
+VAR TOP_ARR
+SET &TOP_ARR, TO_ARRAY(10, 20)
+ASSERT TOP_ARR(2) = 20
+SET &TOP_ARR(2), 123
+ASSERT TOP_ARR(2) = 123
+
 # --- FROM_ARRAY: single-element array (expression context) ---
 # With exactly one element, FROM_ARRAY pushes one value, which behaves
 # like a normal expression returning that single value.

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -208,6 +208,23 @@ impl<'a> ExprCompiler<'a> {
                             .map(|st| matches!(st.token, Token::RParen))
                             .unwrap_or(false);
 
+                        if !next_is_rparen {
+                            if let EntryKind::Variable(addr) = &self.vm.headers[xt.index()].kind {
+                                let lparen_pos = i + 1;
+                                let (index_toks, close_pos) =
+                                    parse_array_index_tokens(tokens, lparen_pos)?;
+                                emit_var_read(&mut output, *addr, self.vm)?;
+                                let index_cells = self.compile_expr(index_toks)?;
+                                output.extend(index_cells);
+                                let array_get_xt = require_xt(self.vm, "ARRAY_GET")?;
+                                output.push(Cell::Xt(array_get_xt));
+                                i = close_pos;
+                                prev_was_operand = true;
+                                i += 1;
+                                continue;
+                            }
+                        }
+
                         if next_is_rparen {
                             // Zero-argument call: emit based on entry kind.
                             emit_call_by_kind(
@@ -283,18 +300,8 @@ impl<'a> ExprCompiler<'a> {
                                         .unwrap_or(false)
                                     {
                                         // Array address-of: &A(I)
-                                        // Find the matching ')'.
-                                        let idx_start = lparen_pos + 1;
-                                        let close_pos = find_matching_rparen(tokens, idx_start)
-                                            .ok_or(TbxError::InvalidExpression {
-                                                reason: "missing ')' in array index expression",
-                                            })?;
-                                        let index_toks = &tokens[idx_start..close_pos];
-                                        if index_toks.is_empty() {
-                                            return Err(TbxError::InvalidExpression {
-                                                reason: "array index expression must not be empty: use &NAME(index)",
-                                            });
-                                        }
+                                        let (index_toks, close_pos) =
+                                            parse_array_index_tokens(tokens, lparen_pos)?;
                                         // 1. Load the Cell::Array handle.
                                         emit_local_read(&mut output, local_idx, self.vm)?;
                                         // 2. Compile the index expression.
@@ -319,10 +326,27 @@ impl<'a> ExprCompiler<'a> {
                                         })?;
                                     match &self.vm.headers[xt.index()].kind {
                                         EntryKind::Variable(addr) => {
-                                            // Emit address only — no FETCH.
-                                            let xt_lit = require_xt(self.vm, "LIT")?;
-                                            output.push(Cell::Xt(xt_lit));
-                                            output.push(Cell::DictAddr(*addr));
+                                            let lparen_pos = i + 1;
+                                            if tokens
+                                                .get(lparen_pos)
+                                                .map(|st| matches!(st.token, Token::LParen))
+                                                .unwrap_or(false)
+                                            {
+                                                let (index_toks, close_pos) =
+                                                    parse_array_index_tokens(tokens, lparen_pos)?;
+                                                emit_var_read(&mut output, *addr, self.vm)?;
+                                                let index_cells = self.compile_expr(index_toks)?;
+                                                output.extend(index_cells);
+                                                let array_addr_xt =
+                                                    require_xt(self.vm, "ARRAY_ADDR")?;
+                                                output.push(Cell::Xt(array_addr_xt));
+                                                i = close_pos;
+                                            } else {
+                                                // Emit address only — no FETCH.
+                                                let xt_lit = require_xt(self.vm, "LIT")?;
+                                                output.push(Cell::Xt(xt_lit));
+                                                output.push(Cell::DictAddr(*addr));
+                                            }
                                         }
                                         _ => {
                                             return Err(TbxError::TypeError {
@@ -553,6 +577,25 @@ fn find_matching_rparen(tokens: &[SpannedToken], start: usize) -> Option<usize> 
         }
     }
     None
+}
+
+/// Return the tokens inside `(` `)` of an array index expression and the
+/// position of the matching closing parenthesis.
+fn parse_array_index_tokens(
+    tokens: &[SpannedToken],
+    lparen_pos: usize,
+) -> Result<(&[SpannedToken], usize), TbxError> {
+    let idx_start = lparen_pos + 1;
+    let close_pos = find_matching_rparen(tokens, idx_start).ok_or(TbxError::InvalidExpression {
+        reason: "missing ')' in array index expression",
+    })?;
+    let index_toks = &tokens[idx_start..close_pos];
+    if index_toks.is_empty() {
+        return Err(TbxError::InvalidExpression {
+            reason: "array index expression must not be empty: use NAME(index)",
+        });
+    }
+    Ok((index_toks, close_pos))
 }
 
 /// Emit `Xt(LIT)` followed by `value` onto `output`.
@@ -882,6 +925,58 @@ mod tests {
         assert_eq!(result.len(), 2);
         assert_eq!(result[0], Cell::Xt(lit_xt));
         assert_eq!(result[1], Cell::DictAddr(0));
+    }
+
+    #[test]
+    fn test_global_array_element_read() {
+        let mut vm = make_vm();
+        vm.dict_write(Cell::Int(0)).unwrap();
+        vm.register(WordEntry::new_variable("A", 0));
+
+        let tokens = lex("A(2)");
+        let result = ExprCompiler::new(&mut vm).compile_expr(&tokens).unwrap();
+
+        let lit_xt = vm.lookup("LIT").unwrap();
+        let fetch_xt = vm.lookup("FETCH").unwrap();
+        let array_get_xt = vm.lookup("ARRAY_GET").unwrap();
+
+        assert_eq!(
+            result,
+            vec![
+                Cell::Xt(lit_xt),
+                Cell::DictAddr(0),
+                Cell::Xt(fetch_xt),
+                Cell::Xt(lit_xt),
+                Cell::Int(2),
+                Cell::Xt(array_get_xt),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_address_of_global_array_element() {
+        let mut vm = make_vm();
+        vm.dict_write(Cell::Int(0)).unwrap();
+        vm.register(WordEntry::new_variable("A", 0));
+
+        let tokens = lex("&A(2)");
+        let result = ExprCompiler::new(&mut vm).compile_expr(&tokens).unwrap();
+
+        let lit_xt = vm.lookup("LIT").unwrap();
+        let fetch_xt = vm.lookup("FETCH").unwrap();
+        let array_addr_xt = vm.lookup("ARRAY_ADDR").unwrap();
+
+        assert_eq!(
+            result,
+            vec![
+                Cell::Xt(lit_xt),
+                Cell::DictAddr(0),
+                Cell::Xt(fetch_xt),
+                Cell::Xt(lit_xt),
+                Cell::Int(2),
+                Cell::Xt(array_addr_xt),
+            ]
+        );
     }
 
     // ------------------------------------------------------------------

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1293,6 +1293,29 @@ mod tests {
     }
 
     #[test]
+    fn test_exec_source_top_level_global_array_element_set() {
+        let mut interp = Interpreter::new();
+        let src = "\
+VAR A
+SET &A, TO_ARRAY(10, 20)
+SET &A(2), 123
+PUTDEC A(2)";
+        interp.exec_source(src).unwrap();
+        assert_eq!(interp.take_output(), "123");
+    }
+
+    #[test]
+    fn test_exec_source_top_level_global_array_element_read() {
+        let mut interp = Interpreter::new();
+        let src = "\
+VAR A
+SET &A, TO_ARRAY(10, 20)
+PUTDEC A(2)";
+        interp.exec_source(src).unwrap();
+        assert_eq!(interp.take_output(), "20");
+    }
+
+    #[test]
     fn test_exec_undefined_symbol() {
         let mut interp = Interpreter::new();
         let result = interp.exec_line("NOSUCHWORD 1", 1);


### PR DESCRIPTION
## 概要

Refs #494

トップレベルでグローバル配列変数に対する `A(I)` / `&A(I)` が正しく解釈されず、`SET &A(2), ...` や `PUTDEC A(2)` が失敗する問題を修正しました。

## 変更内容

- `src/expr.rs` でグローバル `VARIABLE` に対する `A(I)` を `emit_var_read(...)` + `ARRAY_GET` としてコンパイル
- `src/expr.rs` でグローバル `VARIABLE` に対する `&A(I)` を `emit_var_read(...)` + `ARRAY_ADDR` としてコンパイル
- 配列添字の `(` `)` 解析を `parse_array_index_tokens(...)` に共通化
- 既存の `V()` の意味論は維持し、空の配列添字としては扱わないように調整
- `expr` ユニットテスト、`exec_source` 回帰テスト、`lib/tests/test_to_array.tbx` のトップレベル統合テストを追加

## 確認

- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo fmt --check`
