### PR TITLE
時刻成分プリミティブを MINUTE/SECOND に改名する

### DIFF
--- a/lib/basic.tbx
+++ b/lib/basic.tbx
@@ -284,5 +284,5 @@ END
 
 # return Time array (Hour, Minute, Second) in JST
 DEF HMS(T)
-  RETURN TO_ARRAY((HOUR(T) + 9) % 24, MIN(T), INT(SEC(T)))
+  RETURN TO_ARRAY((HOUR(T) + 9) % 24, MINUTE(T), INT(SECOND(T)))
 END

--- a/lib/tests/test_time.tbx
+++ b/lib/tests/test_time.tbx
@@ -1,4 +1,4 @@
-# lib/tests/test_time.tbx — TBX integration tests for UNIXTIME / HOUR / MIN / SEC / HMS
+# lib/tests/test_time.tbx — TBX integration tests for UNIXTIME / HOUR / MINUTE / SECOND / HMS
 USE "lib/tests/helper.tbx"
 
 # --- UNIXTIME ---
@@ -8,26 +8,25 @@ VAR T
 SET &T, UNIXTIME()
 ASSERT T > 0
 
-# --- HOUR / MIN / SEC with a known fixed timestamp ---
+# --- HOUR / MINUTE / SECOND with a known fixed timestamp ---
 #
 # Unix timestamp 1_700_000_000 is 2023-11-14 22:13:20 UTC.
 #   HOUR  = (1700000000 / 3600) % 24 = 22
-#   MIN   = (1700000000 / 60)   % 60 = 13
-#   SEC   = (1700000000 % 60)        = 20.0
+#   MINUTE = (1700000000 / 60)   % 60 = 13
+#   SECOND = (1700000000 % 60)        = 20.0
 
 VAR TS
 SET &TS, 1700000000.0
 
 ASSERT HOUR(TS) = 22
-ASSERT MIN(TS) = 13
-ASSERT SEC(TS) = 20.0
+ASSERT MINUTE(TS) = 13
+ASSERT SECOND(TS) = 20.0
 
-# SEC must preserve the fractional part.
+# SECOND must preserve the fractional part.
 # 1700000000.75 -> seconds = 20 + 0.75 = 20.75
-ASSERT SEC(1700000000.75) = 20.75
+ASSERT SECOND(1700000000.75) = 20.75
 
 # INT arguments must be accepted (promoted to Float internally).
 ASSERT HOUR(1700000000) = 22
-ASSERT MIN(1700000000) = 13
-ASSERT SEC(1700000000) = 20.0
-
+ASSERT MINUTE(1700000000) = 13
+ASSERT SECOND(1700000000) = 20.0

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -2233,13 +2233,13 @@ pub fn hour_prim(vm: &mut VM) -> Result<(), TbxError> {
     vm.push(Cell::Int(h))
 }
 
-/// MIN — extract the UTC minute (0–59) from a Unix timestamp.
+/// MINUTE — extract the UTC minute (0–59) from a Unix timestamp.
 ///
 /// Accepts both `Float` and `Int`; promotes `Int` to `f64` for the computation.
 /// Returns `InvalidArgument` if `t` is negative.
 ///
 /// Stack signature: `( t:Float -- m:Int )`
-pub fn min_prim(vm: &mut VM) -> Result<(), TbxError> {
+pub fn minute_prim(vm: &mut VM) -> Result<(), TbxError> {
     let t = match vm.pop_number()? {
         Cell::Float(f) => f,
         Cell::Int(i) => i as f64,
@@ -2247,21 +2247,21 @@ pub fn min_prim(vm: &mut VM) -> Result<(), TbxError> {
     };
     if t < 0.0 {
         return Err(TbxError::InvalidArgument {
-            message: "MIN requires a non-negative timestamp".to_string(),
+            message: "MINUTE requires a non-negative timestamp".to_string(),
         });
     }
     let m = (t as i64 / 60) % 60;
     vm.push(Cell::Int(m))
 }
 
-/// SEC — extract the UTC second (0.000–59.999) from a Unix timestamp.
+/// SECOND — extract the UTC second (0.000–59.999) from a Unix timestamp.
 ///
 /// Returns a `Float` that preserves the sub-second fractional part of `t`.
 /// Accepts both `Float` and `Int`; promotes `Int` to `f64` for the computation.
 /// Returns `InvalidArgument` if `t` is negative.
 ///
 /// Stack signature: `( t:Float -- s:Float )`
-pub fn sec_prim(vm: &mut VM) -> Result<(), TbxError> {
+pub fn second_prim(vm: &mut VM) -> Result<(), TbxError> {
     let t = match vm.pop_number()? {
         Cell::Float(f) => f,
         Cell::Int(i) => i as f64,
@@ -2269,7 +2269,7 @@ pub fn sec_prim(vm: &mut VM) -> Result<(), TbxError> {
     };
     if t < 0.0 {
         return Err(TbxError::InvalidArgument {
-            message: "SEC requires a non-negative timestamp".to_string(),
+            message: "SECOND requires a non-negative timestamp".to_string(),
         });
     }
     let s = (t as i64 % 60) as f64 + t.fract();
@@ -2534,11 +2534,11 @@ pub fn register_all(vm: &mut VM) {
 
     // Time primitives.
     // UNIXTIME returns the current Unix timestamp as a Float (seconds since epoch).
-    // HOUR / MIN / SEC extract UTC hour, minute, and second from a timestamp.
+    // HOUR / MINUTE / SECOND extract UTC hour, minute, and second from a timestamp.
     vm.register(WordEntry::new_primitive("UNIXTIME", unixtime_prim));
     vm.register(WordEntry::new_primitive("HOUR", hour_prim));
-    vm.register(WordEntry::new_primitive("MIN", min_prim));
-    vm.register(WordEntry::new_primitive("SEC", sec_prim));
+    vm.register(WordEntry::new_primitive("MINUTE", minute_prim));
+    vm.register(WordEntry::new_primitive("SECOND", second_prim));
 }
 
 #[cfg(test)]
@@ -6943,49 +6943,52 @@ mod tests {
         ));
     }
 
-    // --- min_prim ---
+    // --- minute_prim ---
 
     // 1_700_000_000 = 28333333 minutes + 20 s  →  (28333333) % 60 = 13
     #[test]
-    fn test_min_known_timestamp() {
+    fn test_minute_known_timestamp() {
         let mut vm = VM::new();
         vm.push(Cell::Float(1_700_000_000.0)).unwrap();
-        min_prim(&mut vm).unwrap();
+        minute_prim(&mut vm).unwrap();
         assert_eq!(vm.pop(), Ok(Cell::Int(13)));
     }
 
     #[test]
-    fn test_min_accepts_int() {
+    fn test_minute_accepts_int() {
         let mut vm = VM::new();
         vm.push(Cell::Int(1_700_000_000)).unwrap();
-        min_prim(&mut vm).unwrap();
+        minute_prim(&mut vm).unwrap();
         assert_eq!(vm.pop(), Ok(Cell::Int(13)));
     }
 
     #[test]
-    fn test_min_type_error() {
+    fn test_minute_type_error() {
         let mut vm = VM::new();
         vm.push(Cell::Bool(false)).unwrap();
-        assert!(matches!(min_prim(&mut vm), Err(TbxError::TypeError { .. })));
+        assert!(matches!(
+            minute_prim(&mut vm),
+            Err(TbxError::TypeError { .. })
+        ));
     }
 
-    // --- sec_prim ---
+    // --- second_prim ---
 
     // 1_700_000_000 % 60 = 20, fract = 0.0  →  20.0
     #[test]
-    fn test_sec_known_timestamp() {
+    fn test_second_known_timestamp() {
         let mut vm = VM::new();
         vm.push(Cell::Float(1_700_000_000.0)).unwrap();
-        sec_prim(&mut vm).unwrap();
+        second_prim(&mut vm).unwrap();
         assert_eq!(vm.pop(), Ok(Cell::Float(20.0)));
     }
 
     #[test]
-    fn test_sec_preserves_fractional_part() {
+    fn test_second_preserves_fractional_part() {
         // 1_700_000_000.75 → integer part 1_700_000_000 → seconds = 20, fract = 0.75
         let mut vm = VM::new();
         vm.push(Cell::Float(1_700_000_000.75)).unwrap();
-        sec_prim(&mut vm).unwrap();
+        second_prim(&mut vm).unwrap();
         match vm.pop().unwrap() {
             Cell::Float(f) => {
                 assert!((f - 20.75).abs() < 1e-9, "expected ≈20.75, got {f}");
@@ -6995,17 +6998,20 @@ mod tests {
     }
 
     #[test]
-    fn test_sec_accepts_int() {
+    fn test_second_accepts_int() {
         let mut vm = VM::new();
         vm.push(Cell::Int(1_700_000_000)).unwrap();
-        sec_prim(&mut vm).unwrap();
+        second_prim(&mut vm).unwrap();
         assert_eq!(vm.pop(), Ok(Cell::Float(20.0)));
     }
 
     #[test]
-    fn test_sec_type_error() {
+    fn test_second_type_error() {
         let mut vm = VM::new();
         vm.push(Cell::Str(0)).unwrap();
-        assert!(matches!(sec_prim(&mut vm), Err(TbxError::TypeError { .. })));
+        assert!(matches!(
+            second_prim(&mut vm),
+            Err(TbxError::TypeError { .. })
+        ));
     }
 }

--- a/tests/tbx_lib_tests.rs
+++ b/tests/tbx_lib_tests.rs
@@ -78,11 +78,11 @@ fn test_hour_negative_timestamp_is_error() {
 }
 
 #[test]
-fn test_min_negative_timestamp_is_error() {
+fn test_minute_negative_timestamp_is_error() {
     let mut interp = Interpreter::new();
     let err = interp
-        .exec_source("MIN -1.0\n")
-        .expect_err("MIN with negative timestamp should fail");
+        .exec_source("MINUTE -1.0\n")
+        .expect_err("MINUTE with negative timestamp should fail");
     assert!(
         err.to_string().contains("non-negative"),
         "expected 'non-negative' in error message, got: {err}"
@@ -90,11 +90,11 @@ fn test_min_negative_timestamp_is_error() {
 }
 
 #[test]
-fn test_sec_negative_timestamp_is_error() {
+fn test_second_negative_timestamp_is_error() {
     let mut interp = Interpreter::new();
     let err = interp
-        .exec_source("SEC -1.0\n")
-        .expect_err("SEC with negative timestamp should fail");
+        .exec_source("SECOND -1.0\n")
+        .expect_err("SECOND with negative timestamp should fail");
     assert!(
         err.to_string().contains("non-negative"),
         "expected 'non-negative' in error message, got: {err}"


### PR DESCRIPTION
## 概要

Refs #496

時刻成分プリミティブの命名を `HOUR` / `MINUTE` / `SECOND` に統一しました。
`MIN` は今後の最小値関数向けに空け、`SEC` は略称をやめて `SECOND` へリネームしています。

## 変更内容

- `src/primitives.rs` で `MIN` / `SEC` を `MINUTE` / `SECOND` にリネーム
- 登録名、doc comment、エラーメッセージ、内部テスト名を新名称へ更新
- `lib/basic.tbx` の `HMS` 実装を `MINUTE` / `SECOND` 呼び出しへ更新
- `lib/tests/test_time.tbx` と `tests/tbx_lib_tests.rs` の時刻プリミティブ関連テストを更新

## 確認

- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo fmt --check`
