### PR TITLE
STR_REPLACE_FIRSTプリミティブを追加

### DIFF
--- a/lib/tests/test_string_ops.tbx
+++ b/lib/tests/test_string_ops.tbx
@@ -1,5 +1,5 @@
 # lib/tests/test_string_ops.tbx
-# TBX tests for STR_INDEXOF, STR_SLICE, STR_TRIM, STR_UPPER, and STR_LOWER.
+# TBX tests for STR_INDEXOF, STR_SLICE, STR_TRIM, STR_UPPER, STR_LOWER, and STR_REPLACE_FIRST.
 USE "lib/tests/helper.tbx"
 
 ASSERT STR_INDEXOF("hello world", "world") = 7
@@ -23,3 +23,7 @@ ASSERT STR_EQ(STR_UPPER("abc"), "ABC")
 ASSERT STR_EQ(STR_UPPER("straße"), "STRASSE")
 ASSERT STR_EQ(STR_LOWER("ABC"), "abc")
 ASSERT STR_EQ(STR_LOWER("ÄÖÜ"), "äöü")
+
+ASSERT STR_EQ(STR_REPLACE_FIRST("abcabc", "ab", "X"), "Xcabc")
+ASSERT STR_EQ(STR_REPLACE_FIRST("abc", "z", "X"), "abc")
+ASSERT STR_EQ(STR_REPLACE_FIRST("あいうあい", "あい", "x"), "xうあい")

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -625,6 +625,38 @@ pub fn str_lower_prim(vm: &mut VM) -> Result<(), TbxError> {
     Ok(())
 }
 
+/// STR_REPLACE_FIRST — replace the first occurrence of a substring.
+///
+/// Stack: `[..., s: Str|StringDesc, needle: Str|StringDesc, replacement: Str|StringDesc]`
+///   → `Cell::Str(new)`
+pub fn str_replace_first_prim(vm: &mut VM) -> Result<(), TbxError> {
+    let replacement_cell = vm.pop()?;
+    let needle_cell = vm.pop()?;
+    let s_cell = vm.pop()?;
+    let replacement = resolve_str_cell(vm, &replacement_cell)?;
+    let needle = resolve_str_cell(vm, &needle_cell)?;
+    let s = resolve_str_cell(vm, &s_cell)?;
+
+    if needle.is_empty() {
+        return Err(TbxError::InvalidArgument {
+            message: "STR_REPLACE_FIRST needle must not be empty".to_string(),
+        });
+    }
+
+    let result = if let Some(idx) = s.find(&needle) {
+        let (prefix, rest) = s.split_at(idx);
+        let suffix = &rest[needle.len()..];
+        prefix.to_string() + &replacement + suffix
+    } else {
+        s
+    };
+
+    let idx = vm.strings.len();
+    vm.strings.push(result);
+    vm.push(Cell::Str(idx))?;
+    Ok(())
+}
+
 /// Helper: resolve a `Cell::Str` or `Cell::StringDesc` to a `String`.
 fn resolve_str_cell(vm: &VM, cell: &Cell) -> Result<String, TbxError> {
     match cell {
@@ -2404,8 +2436,8 @@ pub fn register_all(vm: &mut VM) {
     // Runtime string primitives.
     // STR converts any value to a string; STR_CONCAT concatenates two strings;
     // STR_LEN returns the character count; STR_EQ compares by content;
-    // STR_INDEXOF, STR_SLICE, STR_TRIM, STR_UPPER, and STR_LOWER provide
-    // core string manipulation.
+    // STR_INDEXOF, STR_SLICE, STR_TRIM, STR_UPPER, STR_LOWER, and
+    // STR_REPLACE_FIRST provide core string manipulation.
     vm.register(WordEntry::new_primitive("STR", str_prim));
     vm.register(WordEntry::new_primitive("STR_CONCAT", str_concat_prim));
     vm.register(WordEntry::new_primitive("STR_LEN", str_len_prim));
@@ -2415,6 +2447,10 @@ pub fn register_all(vm: &mut VM) {
     vm.register(WordEntry::new_primitive("STR_TRIM", str_trim_prim));
     vm.register(WordEntry::new_primitive("STR_UPPER", str_upper_prim));
     vm.register(WordEntry::new_primitive("STR_LOWER", str_lower_prim));
+    vm.register(WordEntry::new_primitive(
+        "STR_REPLACE_FIRST",
+        str_replace_first_prim,
+    ));
     vm.register(WordEntry::new_primitive("PUTCHR", putchr_prim));
     vm.register(WordEntry::new_primitive("PUTDEC", putdec_prim));
     vm.register(WordEntry::new_primitive("PUTHEX", puthex_prim));
@@ -4131,6 +4167,79 @@ mod tests {
         str_lower_prim(&mut vm).unwrap();
         assert_eq!(vm.pop().unwrap(), Cell::Str(1));
         assert_eq!(vm.strings[1], "mix");
+    }
+
+    // --- str_replace_first_prim tests ---
+
+    #[test]
+    fn test_str_replace_first_replaces_only_first_match() {
+        let mut vm = VM::new();
+        let source_idx = vm.intern_string("abcabc").unwrap();
+        let needle_idx = vm.intern_string("ab").unwrap();
+        let replacement_idx = vm.intern_string("X").unwrap();
+        vm.push(Cell::StringDesc(source_idx)).unwrap();
+        vm.push(Cell::StringDesc(needle_idx)).unwrap();
+        vm.push(Cell::StringDesc(replacement_idx)).unwrap();
+        str_replace_first_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop().unwrap(), Cell::Str(0));
+        assert_eq!(vm.strings[0], "Xcabc");
+    }
+
+    #[test]
+    fn test_str_replace_first_returns_copy_when_not_found() {
+        let mut vm = VM::new();
+        let source_idx = vm.intern_string("abc").unwrap();
+        let needle_idx = vm.intern_string("z").unwrap();
+        let replacement_idx = vm.intern_string("X").unwrap();
+        vm.push(Cell::StringDesc(source_idx)).unwrap();
+        vm.push(Cell::StringDesc(needle_idx)).unwrap();
+        vm.push(Cell::StringDesc(replacement_idx)).unwrap();
+        str_replace_first_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop().unwrap(), Cell::Str(0));
+        assert_eq!(vm.strings[0], "abc");
+    }
+
+    #[test]
+    fn test_str_replace_first_accepts_runtime_string() {
+        let mut vm = VM::new();
+        let needle_idx = vm.intern_string("ab").unwrap();
+        let replacement_idx = vm.intern_string("X").unwrap();
+        vm.strings.push("abcabc".to_string());
+        vm.push(Cell::Str(0)).unwrap();
+        vm.push(Cell::StringDesc(needle_idx)).unwrap();
+        vm.push(Cell::StringDesc(replacement_idx)).unwrap();
+        str_replace_first_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop().unwrap(), Cell::Str(1));
+        assert_eq!(vm.strings[1], "Xcabc");
+    }
+
+    #[test]
+    fn test_str_replace_first_handles_unicode() {
+        let mut vm = VM::new();
+        let source_idx = vm.intern_string("あいうあい").unwrap();
+        let needle_idx = vm.intern_string("あい").unwrap();
+        let replacement_idx = vm.intern_string("x").unwrap();
+        vm.push(Cell::StringDesc(source_idx)).unwrap();
+        vm.push(Cell::StringDesc(needle_idx)).unwrap();
+        vm.push(Cell::StringDesc(replacement_idx)).unwrap();
+        str_replace_first_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop().unwrap(), Cell::Str(0));
+        assert_eq!(vm.strings[0], "xうあい");
+    }
+
+    #[test]
+    fn test_str_replace_first_empty_needle_is_invalid_argument() {
+        let mut vm = VM::new();
+        let source_idx = vm.intern_string("abc").unwrap();
+        let needle_idx = vm.intern_string("").unwrap();
+        let replacement_idx = vm.intern_string("X").unwrap();
+        vm.push(Cell::StringDesc(source_idx)).unwrap();
+        vm.push(Cell::StringDesc(needle_idx)).unwrap();
+        vm.push(Cell::StringDesc(replacement_idx)).unwrap();
+        assert!(matches!(
+            str_replace_first_prim(&mut vm),
+            Err(TbxError::InvalidArgument { .. })
+        ));
     }
 
     // --- StringFrameEscape tests ---


### PR DESCRIPTION
## 概要

Refs #501

`STR_REPLACE_FIRST` プリミティブを追加しました。

## 変更内容

- `src/primitives.rs` に `str_replace_first_prim` を追加
- `register_all()` に `STR_REPLACE_FIRST` を登録
- Rust unit test に first replace / not found / Unicode / runtime string / empty needle のケースを追加
- `lib/tests/test_string_ops.tbx` に統合テストを追加

## 仕様

- `STR_REPLACE_FIRST(s, needle, replacement)` は最初に見つかった 1 件だけ置換します
- 入力は `Str | StringDesc`、返り値は新しい `Str` です
- 一致が見つからない場合は、元と同内容の新しい `Str` を返します
- `needle = ""` は `InvalidArgument` とします

## 確認

- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo fmt --check`
