### PR TITLE
exec_sourceをStatementReaderベースへ移行

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -10,6 +10,7 @@ use crate::error::TbxError;
 use crate::expr::ExprCompiler;
 use crate::init_vm;
 use crate::lexer::{Lexer, SpannedToken, Token};
+use crate::statement_reader::{LogicalStatement, StatementReader};
 use crate::vm::VM;
 
 /// Maximum allowed nesting depth for USE statements.
@@ -416,6 +417,34 @@ impl Interpreter {
         run_result.map_err(make_err)
     }
 
+    /// Executes one logical statement produced by `StatementReader`.
+    fn exec_logical_statement(
+        &mut self,
+        mut stmt: LogicalStatement,
+    ) -> Result<(), InterpreterError> {
+        if stmt.tokens.is_empty() {
+            return Ok(());
+        }
+
+        if let Token::LineNum(n) = stmt.tokens[0].token {
+            if self.vm.compile_state.is_some() {
+                let ln_line = stmt.tokens[0].pos.line;
+                let ln_col = stmt.tokens[0].pos.col;
+                self.register_label(n, &stmt.source_excerpt, ln_line, ln_col)
+                    .inspect_err(|_e| {
+                        self.vm.rollback_def();
+                    })?;
+            }
+            stmt.tokens.remove(0);
+        }
+
+        if stmt.tokens.is_empty() {
+            return Ok(());
+        }
+
+        self.exec_segment(&stmt.tokens, &stmt.source_excerpt, stmt.start_line)
+    }
+
     /// Write a single statement and its arguments to the dictionary.
     ///
     /// Emits: `LIT_MARKER [arg_cells] (CALL stmt arity local_count | stmt) DROP_TO_MARKER`
@@ -584,13 +613,25 @@ impl Interpreter {
 
     /// Execute a multi-line source string.
     ///
-    /// Splits `src` by newlines and calls `exec_line` for each.
+    /// Reads logical statements from the source and executes each one.
     /// Stops on the first error (including `TbxError::Halted`, which the inner
     /// interpreter returns for the `HALT` statement).
     pub fn exec_source(&mut self, src: &str) -> Result<(), InterpreterError> {
-        for (line_idx, line) in src.lines().enumerate() {
-            let line_num = line_idx + 1; // 1-based line number
-            match self.exec_line(line, line_num) {
+        let mut reader = StatementReader::new(src);
+        loop {
+            let stmt = match reader.next_statement() {
+                Ok(Some(stmt)) => stmt,
+                Ok(None) => break,
+                Err(e) => {
+                    return Err(InterpreterError::new(
+                        e.line,
+                        e.col,
+                        &e.source_excerpt,
+                        e.kind,
+                    ));
+                }
+            };
+            match self.exec_logical_statement(stmt) {
                 Ok(()) => {}
                 Err(e) if matches!(e.kind, TbxError::Halted) => return Ok(()),
                 Err(e) => return Err(e),
@@ -1313,6 +1354,112 @@ SET &A, TO_ARRAY(10, 20)
 PUTDEC A(2)";
         interp.exec_source(src).unwrap();
         assert_eq!(interp.take_output(), "20");
+    }
+
+    #[test]
+    fn test_exec_source_multiline_to_array() {
+        let mut interp = Interpreter::new();
+        let src = "\
+VAR A
+SET &A, TO_ARRAY(
+  10, 20,
+  30, 40
+)
+PUTDEC ARRAY_LEN(A)
+PUTSTR \":\"
+PUTDEC A(3)";
+        interp.exec_source(src).unwrap();
+        assert_eq!(interp.take_output(), "4:30");
+    }
+
+    #[test]
+    fn test_exec_source_multiline_str_concat() {
+        let mut interp = Interpreter::new();
+        let src = "\
+VAR S
+SET &S, STR_CONCAT(
+  \"foo\",
+  \"bar\"
+)
+PUTSTR S";
+        interp.exec_source(src).unwrap();
+        assert_eq!(interp.take_output(), "foobar");
+    }
+
+    #[test]
+    fn test_exec_source_multiline_nested_call() {
+        let mut interp = Interpreter::new();
+        let src = "\
+PUTDEC ADD(
+  1,
+  MUL(
+    2,
+    3
+  )
+)";
+        interp.exec_source(src).unwrap();
+        assert_eq!(interp.take_output(), "7");
+    }
+
+    #[test]
+    fn test_exec_source_multiline_expr_inside_def() {
+        let mut interp = Interpreter::new();
+        let src = "\
+DEF SHOW
+  PUTDEC ADD(
+    1,
+    2
+  )
+END
+SHOW";
+        interp.exec_source(src).unwrap();
+        assert_eq!(interp.take_output(), "3");
+    }
+
+    #[test]
+    fn test_exec_source_line_number_label_inside_def() {
+        let mut interp = Interpreter::new();
+        let src = "\
+DEF SHOW(X)
+  BIT X = 0, 10
+  PUTDEC 1
+  10 PUTDEC 2
+END
+SHOW 0";
+        interp.exec_source(src).unwrap();
+        assert_eq!(interp.take_output(), "2");
+    }
+
+    #[test]
+    fn test_exec_source_semicolon_and_rem_compatibility() {
+        let mut interp = Interpreter::new();
+        interp
+            .exec_source("PUTDEC 1; REM x; PUTDEC 2\nPUTDEC 3")
+            .unwrap();
+        assert_eq!(interp.take_output(), "13");
+    }
+
+    #[test]
+    fn test_exec_line_unclosed_paren_still_errors() {
+        let mut interp = Interpreter::new();
+        let result = interp.exec_line("PUTDEC ADD(", 1);
+        assert!(result.is_err(), "exec_line must remain single-line");
+    }
+
+    #[test]
+    fn test_exec_source_unclosed_paren_reports_open_paren_position() {
+        let mut interp = Interpreter::new();
+        let err = interp
+            .exec_source("PUTDEC ADD(\n  1\n")
+            .expect_err("unclosed paren should be an error");
+        assert_eq!(err.line, 1);
+        assert_eq!(err.col, 11);
+        assert!(matches!(
+            err.kind,
+            TbxError::InvalidExpression {
+                reason: "unmatched '(' in statement"
+            }
+        ));
     }
 
     #[test]

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -623,6 +623,9 @@ impl Interpreter {
                 Ok(Some(stmt)) => stmt,
                 Ok(None) => break,
                 Err(e) => {
+                    if self.vm.compile_state.is_some() {
+                        self.vm.rollback_def();
+                    }
                     return Err(InterpreterError::new(
                         e.line,
                         e.col,
@@ -1460,6 +1463,18 @@ SHOW 0";
                 reason: "unmatched '(' in statement"
             }
         ));
+    }
+
+    #[test]
+    fn test_exec_source_reader_error_inside_def_rolls_back() {
+        let mut interp = Interpreter::new();
+        let result = interp.exec_source("DEF BAD\n  PUTDEC ADD(\n");
+        assert!(result.is_err(), "unclosed paren inside DEF should fail");
+
+        interp
+            .exec_source("PUTDEC 7")
+            .expect("interpreter should be reusable after reader error rollback");
+        assert_eq!(interp.take_output(), "7");
     }
 
     #[test]

--- a/src/statement_reader.rs
+++ b/src/statement_reader.rs
@@ -14,6 +14,15 @@ pub struct LogicalStatement {
     pub terminator: StatementTerminator,
 }
 
+/// Error produced while reading logical statements.
+#[derive(Debug, Clone, PartialEq)]
+pub struct StatementReaderError {
+    pub line: usize,
+    pub col: usize,
+    pub source_excerpt: String,
+    pub kind: TbxError,
+}
+
 /// The delimiter that ended a logical statement.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StatementTerminator {
@@ -36,7 +45,7 @@ impl<'a> StatementReader<'a> {
     }
 
     /// Return the next non-empty logical statement, or `None` at EOF.
-    pub fn next_statement(&mut self) -> Result<Option<LogicalStatement>, TbxError> {
+    pub fn next_statement(&mut self) -> Result<Option<LogicalStatement>, StatementReaderError> {
         let mut tokens = Vec::new();
         let mut paren_depth = 0usize;
         let mut open_parens: Vec<Position> = Vec::new();
@@ -64,7 +73,8 @@ impl<'a> StatementReader<'a> {
                     }
                     return Err(TbxError::InvalidExpression {
                         reason: lexer_error_reason(&message),
-                    });
+                    }
+                    .into_reader_error(&st, self.lexer.source()));
                 }
                 Token::Newline => {
                     if paren_depth == 0 {
@@ -86,7 +96,8 @@ impl<'a> StatementReader<'a> {
                     if paren_depth > 0 {
                         return Err(TbxError::InvalidExpression {
                             reason: "semicolon is not allowed inside parentheses",
-                        });
+                        }
+                        .into_reader_error(&st, self.lexer.source()));
                     }
                     if tokens.is_empty() {
                         continue;
@@ -102,9 +113,11 @@ impl<'a> StatementReader<'a> {
                 }
                 Token::Eof => {
                     if paren_depth > 0 {
+                        let error_pos = open_parens.last().unwrap_or(&st.pos);
                         return Err(TbxError::InvalidExpression {
                             reason: "unmatched '(' in statement",
-                        });
+                        }
+                        .into_reader_error_at(error_pos, self.lexer.source()));
                     }
                     if tokens.is_empty() {
                         return Ok(None);
@@ -122,7 +135,8 @@ impl<'a> StatementReader<'a> {
                     if paren_depth == 0 {
                         return Err(TbxError::InvalidExpression {
                             reason: "unmatched ')' in statement",
-                        });
+                        }
+                        .into_reader_error(&st, self.lexer.source()));
                     }
                     paren_depth -= 1;
                     open_parens.pop();
@@ -148,12 +162,46 @@ impl<'a> StatementReader<'a> {
     }
 }
 
+trait IntoStatementReaderError {
+    fn into_reader_error(self, st: &SpannedToken, source: &str) -> StatementReaderError;
+    fn into_reader_error_at(self, pos: &Position, source: &str) -> StatementReaderError;
+}
+
+impl IntoStatementReaderError for TbxError {
+    fn into_reader_error(self, st: &SpannedToken, source: &str) -> StatementReaderError {
+        StatementReaderError {
+            line: st.pos.line,
+            col: st.pos.col,
+            source_excerpt: line_text_for_offset(source, st.source_offset),
+            kind: self,
+        }
+    }
+
+    fn into_reader_error_at(self, pos: &Position, source: &str) -> StatementReaderError {
+        StatementReaderError {
+            line: pos.line,
+            col: pos.col,
+            source_excerpt: line_text_for_line(source, pos.line),
+            kind: self,
+        }
+    }
+}
+
 fn line_text_for_offset(source: &str, offset: usize) -> String {
     let start = source[..offset].rfind('\n').map_or(0, |idx| idx + 1);
     let end = source[offset..]
         .find('\n')
         .map_or(source.len(), |idx| offset + idx);
     source[start..end].trim_end_matches('\r').to_string()
+}
+
+fn line_text_for_line(source: &str, line: usize) -> String {
+    source
+        .lines()
+        .nth(line.saturating_sub(1))
+        .unwrap_or("")
+        .trim_end_matches('\r')
+        .to_string()
 }
 
 fn recover_continuation_number(source: &str, st: &mut SpannedToken) -> bool {
@@ -193,7 +241,7 @@ fn lexer_error_reason(message: &str) -> &'static str {
 mod tests {
     use super::*;
 
-    fn collect_statements(src: &str) -> Result<Vec<LogicalStatement>, TbxError> {
+    fn collect_statements(src: &str) -> Result<Vec<LogicalStatement>, StatementReaderError> {
         let mut reader = StatementReader::new(src);
         let mut statements = Vec::new();
         while let Some(stmt) = reader.next_statement()? {
@@ -292,25 +340,27 @@ mod tests {
     #[test]
     fn test_semicolon_inside_parens_is_error() {
         let err = collect_statements("SET &A, TO_ARRAY(1; 2)").unwrap_err();
-        assert!(matches!(err, TbxError::InvalidExpression { .. }));
+        assert!(matches!(err.kind, TbxError::InvalidExpression { .. }));
     }
 
     #[test]
     fn test_unmatched_open_paren_is_error() {
         let err = collect_statements("SET &A, TO_ARRAY(1, 2").unwrap_err();
         assert!(matches!(
-            err,
+            err.kind,
             TbxError::InvalidExpression {
                 reason: "unmatched '(' in statement"
             }
         ));
+        assert_eq!(err.line, 1);
+        assert_eq!(err.col, 17);
     }
 
     #[test]
     fn test_unmatched_close_paren_is_error() {
         let err = collect_statements("PUTDEC 1)").unwrap_err();
         assert!(matches!(
-            err,
+            err.kind,
             TbxError::InvalidExpression {
                 reason: "unmatched ')' in statement"
             }
@@ -340,7 +390,7 @@ mod tests {
     fn test_lexer_error_reason_is_preserved_for_unterminated_string() {
         let err = collect_statements("PUTSTR \"unterminated\n").unwrap_err();
         assert!(matches!(
-            err,
+            err.kind,
             TbxError::InvalidExpression {
                 reason: "unterminated string literal"
             }


### PR DESCRIPTION
## 概要

Refs #519

`exec_source()` を `StatementReader` ベースへ移行し、通常のソース実行で括弧内複数行式を扱えるようにしました。

この PR では `compile_program()` はまだ移行していません。`exec_line()` は従来通り単一行 API として維持しています。

## 変更内容

- `exec_source()` を `src.lines()` ループから `StatementReader::next_statement()` へ移行
- `LogicalStatement` 実行用の helper を追加し、先頭 `LineNum` の剥がしと DEF 内ラベル登録を維持
- `StatementReaderError` を追加し、reader 由来の構文エラーを位置情報付きで `InterpreterError` へ変換
- 複数行 `TO_ARRAY(...)` / `STR_CONCAT(...)` / nested call / DEF 本体内式の回帰テストを追加
- セミコロン、`REM`、`exec_line()` の単一行契約、未閉じ括弧エラー位置のテストを追加

## 確認

- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo fmt --check`
