### PR TITLE
Lexerから文脈依存な行番号判定を撤廃しStatementReaderに移管する

### DIFF
--- a/blueprint-compiler.md
+++ b/blueprint-compiler.md
@@ -111,6 +111,20 @@ DEF 開始時に両構造体を生成し、END 完了後に破棄する。行番
 2. ラベル `N` が出現したとき、現在の `DP` を `label_table[N]` として登録し、`patch_list` 内の `N` に対応するすべてのオフセットに正しいアドレスを書き戻す（バックパッチ）。
 3. END 完了後に `patch_list` に未解決エントリが残っていた場合はコンパイルエラーとする。
 
+**Lexer と StatementReader の責務分離（行番号ラベル判定）**
+
+> Issue #534「Lexerから文脈依存な行番号判定を撤廃し、LineNum判定をStatementReaderへ移管する」に基づく設計方針
+
+行頭の整数を「行番号ラベル」として扱うかどうかの判断は、Lexer ではなく `StatementReader` が行う。
+
+* **Lexer は文脈フリー**: 整数リテラルは出現位置によらず常に `Token::IntLit(n)` を生成する。Lexer が「いま行頭か」「いま括弧の中か」を意識する必要はなく、`Token::LineNum` バリアントは存在しない。同様に、行頭にフロート（`1.5` 等）が現れても通常の `Token::FloatLit` を返す。
+* **StatementReader が論理ステートメントの先頭を知る**: `StatementReader` は `paren_depth` と論理ステートメント境界を管理しているので、`paren_depth == 0` の論理ステートメントの先頭にある `Token::IntLit(n)` を行番号ラベルと解釈し、`LogicalStatement.label: Option<i64>` に格納したうえでその整数を `tokens` から除く。
+* **括弧内の継続行は通常の整数/フロート**: `SET &A, TO_ARRAY(\n10, 20,\n30, 40\n)` のように複数行にまたがる論理ステートメントの継続行先頭の数値は、`paren_depth > 0` のため StatementReader はラベル化しない。Lexer が出した `IntLit` / `FloatLit` がそのまま式コンパイラに渡される。
+* **Interpreter 側の扱い**: `Interpreter::prepare_logical_statement` は `stmt.label` を見て、DEF コンパイル中（`compile_state.is_some()`）の場合のみ `register_label` を呼んでブランチターゲットとして登録する。DEF の外では label は黙って捨てられる（実行時には無効ではない、単に何もしない）。
+* **REPL/`exec_line` 経路**: `parse_line_into_segments` も同じルールに従う。先頭セグメントの先頭トークンが `Token::IntLit(n)` なら行番号ラベルとして扱い、DEF コンパイル中であれば `register_label` を呼んでから `IntLit` トークンを除く。
+
+この分離により、Lexer は単純なトークナイザに保たれ、行番号判定の責務は論理ステートメントを構築する層に集中する。
+
 ---
 
 ## コンパイルスタックプリミティブ

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -534,7 +534,7 @@ impl<'a> ExprCompiler<'a> {
                     });
                 }
 
-                // Ignore all other tokens (LineNum, …).
+                // Ignore all other tokens.
                 _ => {}
             }
 
@@ -792,17 +792,8 @@ mod tests {
     use crate::lexer::Lexer;
 
     /// Tokenise `src`, stopping before `Newline` / `Eof`.
-    ///
-    /// A dummy identifier prefix is prepended so that the lexer's
-    /// `at_line_start` flag is cleared before the first real token.
-    /// This prevents leading integer literals from being classified as
-    /// `LineNum` tokens.
     fn lex(src: &str) -> Vec<SpannedToken> {
-        // The `_S ` prefix forces `at_line_start` to false before any token in
-        // `src` is scanned. The leading identifier token is discarded.
-        let prefixed = format!("_S {src}");
-        let mut lx = Lexer::new(&prefixed);
-        lx.next_token(); // discard the dummy "_S" identifier
+        let mut lx = Lexer::new(src);
         let mut out = Vec::new();
         loop {
             let st = lx.next_token();

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -202,10 +202,12 @@ impl Interpreter {
 
     /// Tokenizes `source_line` and splits it into non-empty statement segments.
     ///
-    /// Segments are delimited by semicolons.  A leading `LineNum` token on the
-    /// first segment is stripped; if the interpreter is currently inside a DEF
-    /// body, it is also registered as a branch-target label.  Empty segments
-    /// (e.g. a trailing semicolon) are omitted from the result.
+    /// Segments are delimited by semicolons.  A leading integer literal on the
+    /// first segment is treated as a line-number label: if the interpreter is
+    /// currently inside a DEF body, it is registered as a branch-target label,
+    /// then stripped from the segment.  Outside a DEF body, the leading integer
+    /// is silently discarded.  Empty segments (e.g. a trailing semicolon) are
+    /// omitted from the result.
     ///
     /// Returns a tuple of `(tokens, boundaries)` where each boundary `(start, end)`
     /// is a half-open index range into `tokens`.
@@ -248,11 +250,14 @@ impl Interpreter {
         for (seg_start_orig, seg_end) in raw_boundaries {
             let mut seg_start = seg_start_orig;
 
-            // Only the first segment may begin with a line number.
+            // Only the first segment may begin with a line-number label.
+            // The lexer is context-free (issue #534), so the leading integer
+            // arrives here as `Token::IntLit`; recognising it as a label is
+            // the interpreter's job.
             if first_segment {
                 first_segment = false;
                 if seg_start < seg_end {
-                    if let Token::LineNum(n) = tokens[seg_start].token {
+                    if let Token::IntLit(n) = tokens[seg_start].token {
                         if self.vm.compile_state.is_some() {
                             // Inside a DEF body: register as a branch-target label.
                             let ln_line = tokens[seg_start].pos.line;
@@ -292,8 +297,9 @@ impl Interpreter {
 
     /// Executes a single statement segment (a slice of tokens with no Semicolons).
     ///
-    /// `tokens` must be non-empty and must not contain `Token::LineNum` at index 0
-    /// (the caller is responsible for stripping it on the first segment).
+    /// `tokens` must be non-empty.  Any leading line-number label has already
+    /// been stripped by the caller (`parse_line_into_segments` or
+    /// `prepare_logical_statement`).
     ///
     /// `absolute_line` is the 1-based line number of this segment in the full source being
     /// processed.  The token positions produced by `parse_line_into_segments` are always
@@ -417,30 +423,30 @@ impl Interpreter {
         run_result.map_err(make_err)
     }
 
-    /// Strip a leading `LineNum` token and, if inside a DEF body, register it as a label.
+    /// Register the statement's line-number label (if any) inside a DEF body
+    /// and return the statement when there are still tokens to execute.
     ///
-    /// Returns `Ok(Some(stmt))` when the statement still has tokens after the line-number
-    /// is consumed, `Ok(None)` when the statement was a bare line-number (nothing left to
-    /// execute), or `Err` when label registration fails (compile state is rolled back by
-    /// `register_label`'s caller before returning).
+    /// `StatementReader` already strips a leading line-number label from the
+    /// token list and stores it in `stmt.label`. This method only needs to
+    /// register that label as a branch target when compiling a word.
+    ///
+    /// Returns `Ok(Some(stmt))` when the statement has tokens to execute,
+    /// `Ok(None)` when the statement was a bare line-number label (nothing
+    /// left to execute), or `Err` when label registration fails (compile
+    /// state is rolled back before returning).
     fn prepare_logical_statement(
         &mut self,
-        mut stmt: LogicalStatement,
+        stmt: LogicalStatement,
     ) -> Result<Option<LogicalStatement>, InterpreterError> {
-        if stmt.tokens.is_empty() {
-            return Ok(None);
-        }
-
-        if let Token::LineNum(n) = stmt.tokens[0].token {
+        if let Some(n) = stmt.label {
             if self.vm.compile_state.is_some() {
-                let ln_line = stmt.tokens[0].pos.line;
-                let ln_col = stmt.tokens[0].pos.col;
+                let ln_line = stmt.start_line;
+                let ln_col = stmt.start_col;
                 self.register_label(n, &stmt.source_excerpt, ln_line, ln_col)
                     .inspect_err(|_e| {
                         self.vm.rollback_def();
                     })?;
             }
-            stmt.tokens.remove(0);
         }
 
         if stmt.tokens.is_empty() {

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -42,9 +42,6 @@ pub enum Token {
     LParen,
     /// Right parenthesis `)`. Maps to TOK_OP.
     RParen,
-    /// Integer label at the start of a line (before any identifier).
-    /// Used by GOTO/BIF/BIT as jump targets. Outer-interpreter-only.
-    LineNum(i64),
     /// Line terminator (newline or end of statement). Outer-interpreter-only.
     Newline,
     /// End of input. Outer-interpreter-only.
@@ -56,7 +53,7 @@ pub enum Token {
 impl Token {
     /// Returns the TOKEN kind code for use by the TBX `TOKEN` primitive.
     ///
-    /// Returns `None` for outer-interpreter-only tokens (`Newline`, `Eof`, `Error`, `LineNum`).
+    /// Returns `None` for outer-interpreter-only tokens (`Newline`, `Eof`, `Error`).
     pub fn kind_code(&self) -> Option<i64> {
         match self {
             Token::Ident(_) => Some(TOK_ID),
@@ -68,7 +65,7 @@ impl Token {
             Token::StringLit(_) => Some(TOK_STR),
             // Ellipsis is a DEF-parsing-only token; never exposed via TOKEN primitive.
             Token::Ellipsis => None,
-            Token::LineNum(_) | Token::Newline | Token::Eof | Token::Error(_) => None,
+            Token::Newline | Token::Eof | Token::Error(_) => None,
         }
     }
 }
@@ -120,9 +117,6 @@ pub struct Lexer<'a> {
     line: usize,
     /// Current column number (1-based, character index).
     col: usize,
-    /// True at the start of each line (before any non-whitespace token on that line).
-    /// When true, an integer token is classified as `LineNum` rather than `IntLit`.
-    at_line_start: bool,
     /// Set to true after emitting `Ident("REM")`.
     /// The next call to `next_token_inner()` will skip to end-of-line and return `Newline`.
     rem_pending: bool,
@@ -138,7 +132,6 @@ impl<'a> Lexer<'a> {
             chars: source.char_indices().peekable(),
             line: 1,
             col: 1,
-            at_line_start: true,
             rem_pending: false,
             peeked: None,
         }
@@ -272,9 +265,8 @@ impl<'a> Lexer<'a> {
         self.emit_newline(start_pos, start_off, raw_len)
     }
 
-    /// Build a `Newline` token and reset `at_line_start`.
+    /// Build a `Newline` token.
     fn emit_newline(&mut self, pos: Position, offset: usize, len: usize) -> SpannedToken {
-        self.at_line_start = true;
         SpannedToken {
             token: Token::Newline,
             pos,
@@ -283,11 +275,13 @@ impl<'a> Lexer<'a> {
         }
     }
 
-    /// Scan an integer or float literal, or a line-number label.
+    /// Scan an integer or float literal.
+    ///
+    /// The lexer is context-free: integers are always emitted as `Token::IntLit`,
+    /// regardless of whether they appear at the start of a line. The decision to
+    /// treat a leading integer as a line-number label is made by `StatementReader`
+    /// (which knows logical-statement boundaries and parenthesis depth).
     fn scan_number(&mut self, start_pos: Position, start_off: usize) -> SpannedToken {
-        let is_line_num = self.at_line_start;
-        self.at_line_start = false;
-
         // Consume digit sequence.
         while matches!(self.peek_char(), Some(c) if c.is_ascii_digit()) {
             self.advance();
@@ -322,37 +316,6 @@ impl<'a> Lexer<'a> {
         let end_off = self.peek_offset();
         let raw = &self.source[start_off..end_off];
         let raw_len = end_off - start_off;
-
-        // A float at line-start is not a valid line number label.
-        if is_line_num && is_float {
-            return SpannedToken {
-                token: Token::Error(format!("invalid line number: {raw}")),
-                pos: start_pos,
-                source_offset: start_off,
-                source_len: raw_len,
-            };
-        }
-
-        if is_line_num {
-            match raw.parse::<i64>() {
-                Ok(n) => {
-                    return SpannedToken {
-                        token: Token::LineNum(n),
-                        pos: start_pos,
-                        source_offset: start_off,
-                        source_len: raw_len,
-                    }
-                }
-                Err(_) => {
-                    return SpannedToken {
-                        token: Token::Error(format!("integer literal out of range: {raw}")),
-                        pos: start_pos,
-                        source_offset: start_off,
-                        source_len: raw_len,
-                    }
-                }
-            }
-        }
 
         if is_float {
             match raw.parse::<f64>() {
@@ -389,7 +352,6 @@ impl<'a> Lexer<'a> {
 
     /// Scan an identifier.  If the identifier is `REM`, set `rem_pending`.
     fn scan_ident(&mut self, start_pos: Position, start_off: usize) -> SpannedToken {
-        self.at_line_start = false;
         while matches!(self.peek_char(), Some(c) if c.is_alphanumeric() || c == '_') {
             self.advance();
         }
@@ -414,7 +376,6 @@ impl<'a> Lexer<'a> {
     /// The opening `"` must already be the next character.
     /// Returns `Token::Error` if the string is unterminated.
     fn scan_string(&mut self, start_pos: Position, start_off: usize) -> SpannedToken {
-        self.at_line_start = false;
         self.advance(); // consume opening '"'
 
         let mut value = String::new();
@@ -489,8 +450,6 @@ impl<'a> Lexer<'a> {
 
     /// Scan an operator or punctuation character.
     fn scan_operator(&mut self, start_pos: Position, start_off: usize) -> SpannedToken {
-        self.at_line_start = false;
-
         // Helper macro to build SpannedToken after consuming n chars.
         // (Not a real macro — we build inline.)
 
@@ -715,14 +674,13 @@ pub(crate) fn last_top_level_comma(
 /// Parse a label number from a token slice.
 ///
 /// Skips leading `Newline`/`Eof` tokens and returns the integer value of the
-/// first meaningful token if it is an `IntLit` or `LineNum`.
+/// first meaningful token if it is an `IntLit`.
 pub(crate) fn parse_label_number(tokens: &[SpannedToken]) -> Option<i64> {
     let tok = tokens
         .iter()
         .find(|st| !matches!(st.token, Token::Newline | Token::Eof))?;
     match &tok.token {
         Token::IntLit(n) => Some(*n),
-        Token::LineNum(n) => Some(*n),
         _ => None,
     }
 }
@@ -820,7 +778,6 @@ mod tests {
         assert_eq!(Token::Newline.kind_code(), None);
         assert_eq!(Token::Eof.kind_code(), None);
         assert_eq!(Token::Error("x".to_string()).kind_code(), None);
-        assert_eq!(Token::LineNum(10).kind_code(), None);
     }
 
     // --- identifier ---
@@ -1017,14 +974,16 @@ mod tests {
         assert_eq!(tokens("()"), vec![Token::LParen, Token::RParen, Token::Eof]);
     }
 
-    // --- LineNum vs IntLit ---
+    // --- integer literal: lexer is context-free ---
 
     #[test]
-    fn test_linenum_at_line_start() {
+    fn test_intlit_at_line_start() {
+        // Integer at the start of a line is still emitted as IntLit;
+        // StatementReader is responsible for promoting it to a line-number label.
         assert_eq!(
             tokens("10 PUTDEC 42"),
             vec![
-                Token::LineNum(10),
+                Token::IntLit(10),
                 Token::Ident("PUTDEC".to_string()),
                 Token::IntLit(42),
                 Token::Eof,
@@ -1034,7 +993,7 @@ mod tests {
 
     #[test]
     fn test_intlit_not_at_line_start() {
-        // The first token on the line is an identifier, so the number after it is IntLit.
+        // Non-leading integer is unchanged: still IntLit.
         assert_eq!(
             tokens("PUTDEC 42"),
             vec![
@@ -1046,8 +1005,8 @@ mod tests {
     }
 
     #[test]
-    fn test_linenum_at_second_line() {
-        // After a Newline, at_line_start resets, so `99` on the second line is also LineNum.
+    fn test_intlit_at_second_line() {
+        // The first integer on a second physical line is also a plain IntLit.
         let toks = tokens("PUTDEC 1\n99 PUTDEC 2");
         assert_eq!(
             toks,
@@ -1055,7 +1014,7 @@ mod tests {
                 Token::Ident("PUTDEC".to_string()),
                 Token::IntLit(1),
                 Token::Newline,
-                Token::LineNum(99),
+                Token::IntLit(99),
                 Token::Ident("PUTDEC".to_string()),
                 Token::IntLit(2),
                 Token::Eof,
@@ -1064,13 +1023,13 @@ mod tests {
     }
 
     #[test]
-    fn test_linenum_with_leading_spaces() {
-        // Leading spaces do not break at_line_start.
+    fn test_intlit_with_leading_spaces() {
+        // Leading spaces do not change tokenization.
         let toks = tokens("  10  PUTDEC");
         assert_eq!(
             toks,
             vec![
-                Token::LineNum(10),
+                Token::IntLit(10),
                 Token::Ident("PUTDEC".to_string()),
                 Token::Eof,
             ]
@@ -1110,7 +1069,7 @@ mod tests {
         assert_eq!(
             toks,
             vec![
-                Token::LineNum(10),
+                Token::IntLit(10),
                 Token::Ident("REM".to_string()),
                 Token::Newline,
                 Token::Eof,
@@ -1146,7 +1105,7 @@ mod tests {
     fn test_hash_comment_after_linenum() {
         // Line number followed by a '#' comment.
         let toks = tokens("10 # comment after linenum");
-        assert_eq!(toks, vec![Token::LineNum(10), Token::Newline, Token::Eof,]);
+        assert_eq!(toks, vec![Token::IntLit(10), Token::Newline, Token::Eof,]);
     }
 
     #[test]
@@ -1342,7 +1301,8 @@ mod tests {
     }
 
     #[test]
-    fn test_linenum_overflow_yields_error() {
+    fn test_intlit_overflow_at_line_start_yields_error() {
+        // Even at the start of a line an oversized integer yields a lexer error.
         let toks = tokens("99999999999999999999 PRINT");
         assert!(
             matches!(toks[0], Token::Error(_)),
@@ -1351,15 +1311,20 @@ mod tests {
         );
     }
 
-    // --- float at line-start → Error ---
+    // --- float at line-start: emitted as a plain FloatLit ---
 
     #[test]
-    fn test_float_at_line_start_yields_error() {
+    fn test_float_at_line_start_is_floatlit() {
+        // The lexer is context-free: a float at the start of a line is still
+        // a FloatLit. Treating it as a label is the StatementReader's job.
         let toks = tokens("1.25 X");
-        assert!(
-            matches!(toks[0], Token::Error(_)),
-            "expected Error, got {:?}",
-            toks[0]
+        assert_eq!(
+            toks,
+            vec![
+                Token::FloatLit(1.25),
+                Token::Ident("X".to_string()),
+                Token::Eof,
+            ]
         );
     }
 

--- a/src/statement_reader.rs
+++ b/src/statement_reader.rs
@@ -12,6 +12,12 @@ pub struct LogicalStatement {
     pub end_line: usize,
     pub source_excerpt: String,
     pub terminator: StatementTerminator,
+    /// Line-number label parsed off the head of this statement, if any.
+    ///
+    /// `StatementReader` strips a leading `Token::IntLit` at `paren_depth == 0`
+    /// from `tokens` and stores its value here. The interpreter uses this for
+    /// GOTO/BIF/BIT label registration during DEF compilation.
+    pub label: Option<i64>,
 }
 
 /// Error produced while reading logical statements.
@@ -53,24 +59,14 @@ impl<'a> StatementReader<'a> {
         let mut start_col = 0usize;
         let mut end_line = 0usize;
         let mut source_excerpt = String::new();
+        let mut label: Option<i64> = None;
+        let mut label_seen = false;
 
         loop {
-            let mut st = self.lexer.next_token();
+            let st = self.lexer.next_token();
 
             match st.token.clone() {
                 Token::Error(message) => {
-                    if paren_depth > 0 && recover_continuation_number(self.lexer.source(), &mut st)
-                    {
-                        end_line = st.pos.line;
-                        if tokens.is_empty() {
-                            start_line = st.pos.line;
-                            start_col = st.pos.col;
-                            source_excerpt =
-                                line_text_for_offset(self.lexer.source(), st.source_offset);
-                        }
-                        tokens.push(st);
-                        continue;
-                    }
                     return Err(TbxError::InvalidExpression {
                         reason: lexer_error_reason(&message),
                     }
@@ -78,7 +74,7 @@ impl<'a> StatementReader<'a> {
                 }
                 Token::Newline => {
                     if paren_depth == 0 {
-                        if tokens.is_empty() {
+                        if tokens.is_empty() && label.is_none() {
                             continue;
                         }
                         return Ok(Some(LogicalStatement {
@@ -88,6 +84,7 @@ impl<'a> StatementReader<'a> {
                             end_line,
                             source_excerpt,
                             terminator: StatementTerminator::Newline,
+                            label,
                         }));
                     }
                     continue;
@@ -99,7 +96,7 @@ impl<'a> StatementReader<'a> {
                         }
                         .into_reader_error(&st, self.lexer.source()));
                     }
-                    if tokens.is_empty() {
+                    if tokens.is_empty() && label.is_none() {
                         continue;
                     }
                     return Ok(Some(LogicalStatement {
@@ -109,6 +106,7 @@ impl<'a> StatementReader<'a> {
                         end_line,
                         source_excerpt,
                         terminator: StatementTerminator::Semicolon,
+                        label,
                     }));
                 }
                 Token::Eof => {
@@ -119,7 +117,7 @@ impl<'a> StatementReader<'a> {
                         }
                         .into_reader_error_at(error_pos, self.lexer.source()));
                     }
-                    if tokens.is_empty() {
+                    if tokens.is_empty() && label.is_none() {
                         return Ok(None);
                     }
                     return Ok(Some(LogicalStatement {
@@ -129,6 +127,7 @@ impl<'a> StatementReader<'a> {
                         end_line,
                         source_excerpt,
                         terminator: StatementTerminator::Eof,
+                        label,
                     }));
                 }
                 Token::RParen => {
@@ -145,13 +144,25 @@ impl<'a> StatementReader<'a> {
                     paren_depth += 1;
                     open_parens.push(st.pos.clone());
                 }
-                Token::LineNum(n) if paren_depth > 0 => {
-                    st.token = Token::IntLit(n);
-                }
                 _ => {}
             }
 
-            if tokens.is_empty() {
+            // At paren_depth == 0, the very first meaningful token of a logical
+            // statement is treated as a line-number label if it is an integer.
+            // The label is stripped from `tokens` and stored on the statement.
+            if !label_seen && paren_depth == 0 && tokens.is_empty() {
+                label_seen = true;
+                if let Token::IntLit(n) = st.token {
+                    label = Some(n);
+                    start_line = st.pos.line;
+                    start_col = st.pos.col;
+                    source_excerpt = line_text_for_offset(self.lexer.source(), st.source_offset);
+                    end_line = st.pos.line;
+                    continue;
+                }
+            }
+
+            if tokens.is_empty() && label.is_none() {
                 start_line = st.pos.line;
                 start_col = st.pos.col;
                 source_excerpt = line_text_for_offset(self.lexer.source(), st.source_offset);
@@ -204,30 +215,11 @@ fn line_text_for_line(source: &str, line: usize) -> String {
         .to_string()
 }
 
-fn recover_continuation_number(source: &str, st: &mut SpannedToken) -> bool {
-    let Token::Error(message) = &st.token else {
-        return false;
-    };
-    if !message.starts_with("invalid line number: ") {
-        return false;
-    }
-
-    let raw = &source[st.source_offset..st.source_offset + st.source_len];
-    match raw.parse::<f64>() {
-        Ok(value) => {
-            st.token = Token::FloatLit(value);
-            true
-        }
-        Err(_) => false,
-    }
-}
-
 fn lexer_error_reason(message: &str) -> &'static str {
     match message {
         "unterminated string literal" => "unterminated string literal",
         "unterminated string literal after escape" => "unterminated string literal after escape",
         "unexpected token: '..'" => "unexpected token: '..'",
-        _ if message.starts_with("invalid line number: ") => "invalid line number",
         _ if message.starts_with("integer literal out of range: ") => {
             "integer literal out of range"
         }
@@ -307,21 +299,14 @@ mod tests {
     }
 
     #[test]
-    fn test_line_num_inside_parens_is_normalized_to_int_lit() {
+    fn test_int_inside_parens_stays_int_lit() {
         let statements = collect_statements("SET &A, TO_ARRAY(\n10, 20,\n30, 40\n)\n").unwrap();
         assert!(
             statements[0]
                 .tokens
                 .iter()
                 .any(|st| matches!(st.token, Token::IntLit(30))),
-            "expected continuation-line number token to be normalized to IntLit"
-        );
-        assert!(
-            statements[0]
-                .tokens
-                .iter()
-                .all(|st| !matches!(st.token, Token::LineNum(30))),
-            "continuation-line number token must not remain LineNum"
+            "expected continuation-line integer token to be IntLit"
         );
     }
 
@@ -395,5 +380,83 @@ mod tests {
                 reason: "unterminated string literal"
             }
         ));
+    }
+
+    #[test]
+    fn test_leading_int_at_paren_depth_zero_is_extracted_as_label() {
+        // A leading integer at the start of a logical statement is recognized
+        // as a line-number label and stripped from `tokens`.
+        let statements = collect_statements("10 PUTDEC 42").unwrap();
+        assert_eq!(statements.len(), 1);
+        assert_eq!(statements[0].label, Some(10));
+        // The leading `10` must NOT remain in the token list.
+        assert!(matches!(
+            statements[0].tokens.first().map(|st| &st.token),
+            Some(Token::Ident(name)) if name == "PUTDEC"
+        ));
+    }
+
+    #[test]
+    fn test_no_leading_int_means_label_is_none() {
+        let statements = collect_statements("PUTDEC 42").unwrap();
+        assert_eq!(statements.len(), 1);
+        assert_eq!(statements[0].label, None);
+    }
+
+    #[test]
+    fn test_bare_label_line_yields_statement_with_no_tokens() {
+        // `10` alone on a line still produces a statement so that the
+        // interpreter can register the label inside a DEF body.
+        let statements = collect_statements("10\n").unwrap();
+        assert_eq!(statements.len(), 1);
+        assert_eq!(statements[0].label, Some(10));
+        assert!(statements[0].tokens.is_empty());
+    }
+
+    #[test]
+    fn test_int_after_first_token_is_not_a_label() {
+        // The integer 99 here is the second meaningful token of the statement
+        // and must remain a regular IntLit (no label).
+        let statements = collect_statements("PUTDEC 99").unwrap();
+        assert_eq!(statements.len(), 1);
+        assert_eq!(statements[0].label, None);
+        assert!(matches!(
+            statements[0].tokens.last().map(|st| &st.token),
+            Some(Token::IntLit(99))
+        ));
+    }
+
+    #[test]
+    fn test_continuation_line_integer_is_not_a_label() {
+        // A multi-line parenthesized statement: the `30` on the second
+        // continuation line must stay a plain IntLit, not a label.
+        let statements = collect_statements("SET &A, TO_ARRAY(\n10, 20,\n30, 40\n)\n").unwrap();
+        assert_eq!(statements.len(), 1);
+        assert_eq!(statements[0].label, None);
+    }
+
+    #[test]
+    fn test_continuation_line_float_is_floatlit() {
+        // After issue #534, floats at the start of a continuation line are
+        // emitted by the lexer as plain FloatLit tokens (no recovery needed).
+        let statements = collect_statements("SET &A, TO_ARRAY(\n1.5, 2.5,\n3.5, 4.5\n)\n").unwrap();
+        assert!(
+            statements[0]
+                .tokens
+                .iter()
+                .any(|st| matches!(st.token, Token::FloatLit(value) if value == 1.5)),
+            "expected continuation-line float to be FloatLit"
+        );
+    }
+
+    #[test]
+    fn test_label_with_trailing_semicolon() {
+        // `10; PUTDEC 1` → first statement has label 10 with empty tokens,
+        // second statement has no label and `PUTDEC 1` tokens.
+        let statements = collect_statements("10; PUTDEC 1").unwrap();
+        assert_eq!(statements.len(), 2);
+        assert_eq!(statements[0].label, Some(10));
+        assert!(statements[0].tokens.is_empty());
+        assert_eq!(statements[1].label, None);
     }
 }


### PR DESCRIPTION
## 概要

Lexer から文脈依存な行番号判定（`at_line_start` フラグによる `Token::LineNum` 生成）を撤廃し、行番号ラベル判定の責務を `StatementReader` に集約しました。Lexer は純粋な文脈フリー・トークナイザになり、`StatementReader` が `paren_depth` と論理ステートメント境界という既知の文脈に基づいてラベルを判定します。

## 背景

旧設計では Lexer が「いま行頭か」を `at_line_start` フラグで追跡し、行頭の整数を `Token::LineNum` として特殊化していました。しかし複数行にまたがる論理ステートメント（`SET &A, TO_ARRAY(\n10, 20,\n)` など）では継続行先頭の数値もラベル判定されてしまうため、`StatementReader` 側で `LineNum → IntLit` に書き戻すハック（`statement_reader.rs:148-150`）と、行頭フロート（`1.5` 等）が出した `Token::Error` を `FloatLit` に回収する `recover_continuation_number` 関数が必要になっていました。

## 主な変更点

### `src/lexer.rs`

- `Token::LineNum(i64)` バリアントを削除
- `at_line_start: bool` フィールドおよびそれを更新する全コードを削除
- `scan_number` の `is_line_num` 分岐を削除し、整数は常に `Token::IntLit`、行頭フロートは通常の `Token::FloatLit` を返すよう変更
- `Token::kind_code()` の `LineNum` 分岐を削除
- `parse_label_number` ヘルパは GOTO/BIF/BIT のラベル引数解析でなお必要なので残し、`LineNum` 参照のみ削除
- 関連テストを `IntLit` ベースに書き換え（行頭フロート→FloatLit、行頭オーバーフローはエラー継続）

### `src/statement_reader.rs`

- `LogicalStatement` に `label: Option<i64>` フィールドを追加（**案A**）
- `paren_depth == 0` の論理ステートメント先頭にある `Token::IntLit(n)` を行番号ラベルとして取り出し、`tokens` からは除く
- `LineNum(n) if paren_depth > 0` の上書き処理を削除
- `recover_continuation_number` 関数を削除
- 新規テスト追加（先頭IntLit抽出、継続行のIntLit/FloatLit、ラベルのみのライン、`10; PUTDEC 1` のようにラベル + セミコロン区切り など）

### `src/interpreter.rs`

- `exec_logical_statement` から呼ばれる `prepare_logical_statement` を `stmt.label` を見るよう変更
- `parse_line_into_segments`（`exec_line` / REPL 経路）も `Token::IntLit` ベースで先頭セグメントのラベルを判定するよう更新
- 関連doc-commentの修正

### `src/expr.rs`

- `LineNum` を生成するために `_S ` プレフィックスを差し込んでいたテストヘルパ（`lex` 関数）を簡素化

### `blueprint-compiler.md`

- 「Lexer は文脈フリー、行番号ラベル判定は StatementReader の責務」という設計方針を新セクションとして追記

## テスト計画

- [x] `cargo build` が通る
- [x] `cargo test` が通る（unit 864 + 統合 32 + サニタイズ 10 = 906 個すべてpass）
- [x] `cargo clippy --all-targets -- -D warnings` が警告なしで通る
- [x] `cargo fmt --check` が通る
- [x] `examples/asciiart1.tbx`（GOTOを含む）が正しく動作する
- [x] `examples/hello.tbx` が正しく動作する

## 完了条件

- [x] `Token::LineNum` バリアントが削除されている
- [x] Lexer から `at_line_start` フィールドが削除されている
- [x] `StatementReader` の `recover_continuation_number` が削除されている
- [x] `LineNum(n) if paren_depth > 0` の上書き処理が削除されている
- [x] 既存テスト（行番号ラベル付きジャンプ、複数行 `TO_ARRAY`、継続行のフロートなど）がすべて通る
- [x] `cargo test` / `cargo clippy` が通る
- [x] `blueprint-compiler.md` が更新されている

Closes #534
