### PR TITLE
実行時エラー時の呼出履歴を表示

### DIFF
--- a/src/cell.rs
+++ b/src/cell.rs
@@ -44,6 +44,9 @@ impl Xt {
 #[derive(Debug, Clone)]
 pub enum ReturnFrame {
     Call {
+        /// Execution token of the compiled word currently running in this frame.
+        /// Used for stack trace display on runtime errors.
+        callee_xt: Xt,
         return_pc: usize,
         saved_bp: usize,
         /// Snapshot of `VM::arrays.len()` taken at call time.

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -395,7 +395,7 @@ impl Interpreter {
                 stmt_pos_col,
                 source_excerpt,
                 e,
-                call_stack.unwrap_or_default(),
+                call_stack.expect("call_stack must be Some when run_result is Err"),
             )),
         }
     }
@@ -760,11 +760,21 @@ impl Interpreter {
         let saved_return_stack_len = self.vm.return_stack.len();
         let saved_bp = self.vm.bp;
 
-        let mut active_immediate_word_frame: Option<StackTraceFrame> = None;
+        // Frame to inject into the call stack if a runtime error occurs during
+        // dispatch.  Only set after we have committed to executing the word —
+        // pre-execution rejections (e.g. arity > 0) leave this None so the
+        // resulting error reports an empty call stack.
+        let mut pending_synthetic_frame: Option<StackTraceFrame> = None;
         let run_result = match kind {
             // Native primitive: call the function pointer directly (avoids
             // temporary-buffer issues when the primitive writes to the dictionary).
-            crate::dict::EntryKind::Primitive(f) => f(&mut self.vm),
+            crate::dict::EntryKind::Primitive(f) => {
+                pending_synthetic_frame = Some(StackTraceFrame {
+                    word_name: immediate_word_name.clone(),
+                    actual_arity: 0,
+                });
+                f(&mut self.vm)
+            }
             // User-defined word: run via vm.run(), passing the body start address.
             // Guard: words with formal parameters (arity > 0) still require a
             // CALL frame and are rejected.  Words with only VAR locals
@@ -799,7 +809,7 @@ impl Interpreter {
                     if let Some(e) = push_err {
                         Err(e)
                     } else {
-                        active_immediate_word_frame = Some(StackTraceFrame {
+                        pending_synthetic_frame = Some(StackTraceFrame {
                             word_name: immediate_word_name,
                             actual_arity: 0,
                         });
@@ -827,7 +837,7 @@ impl Interpreter {
         // On error, rollback compile state and stacks.
         let call_stack = if run_result.is_err() {
             let mut frames = self.vm.stack_trace_frames();
-            if let Some(frame) = active_immediate_word_frame {
+            if let Some(frame) = pending_synthetic_frame {
                 let insert_pos = frames
                     .iter()
                     .position(|existing| existing.word_name == "<top-level>")
@@ -856,7 +866,7 @@ impl Interpreter {
                     stmt_pos_col,
                     source_excerpt,
                     e,
-                    call_stack.unwrap_or_default(),
+                    call_stack.expect("call_stack must be Some when run_result is Err"),
                 ));
             }
         }
@@ -2677,6 +2687,21 @@ IPARAM 42";
         assert_eq!(err.call_stack[0].word_name, "BAD");
         assert_eq!(err.call_stack[0].actual_arity, 0);
         assert_eq!(err.call_stack[1].word_name, "<top-level>");
+    }
+
+    #[test]
+    fn test_immediate_primitive_runtime_error_captures_primitive_frame() {
+        // END is an IMMEDIATE primitive; calling it outside of DEF returns a
+        // runtime error from end_prim.  The primitive's name must appear in the
+        // call stack so the error message points at the offending word.
+        // (IMMEDIATE primitives are dispatched without entering vm.run(), so
+        // the captured stack contains only the synthetic primitive frame.)
+        let mut interp = Interpreter::new();
+        let result = interp.exec_source("END");
+        let err = result.expect_err("expected runtime error from IMMEDIATE primitive");
+        assert_eq!(err.call_stack.len(), 1);
+        assert_eq!(err.call_stack[0].word_name, "END");
+        assert_eq!(err.call_stack[0].actual_arity, 0);
     }
 
     #[test]

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -11,7 +11,7 @@ use crate::expr::ExprCompiler;
 use crate::init_vm;
 use crate::lexer::{Position, SpannedToken, Token};
 use crate::statement_reader::{LogicalStatement, StatementReader};
-use crate::vm::VM;
+use crate::vm::{StackTraceFrame, VM};
 
 #[cfg(test)]
 use crate::lexer::Lexer;
@@ -35,6 +35,7 @@ pub struct InterpreterError {
     pub col: usize,
     pub source_excerpt: String,
     pub kind: TbxError,
+    pub call_stack: Vec<StackTraceFrame>,
 }
 
 impl InterpreterError {
@@ -45,6 +46,24 @@ impl InterpreterError {
             col,
             source_excerpt: source_excerpt.to_string(),
             kind,
+            call_stack: Vec::new(),
+        }
+    }
+
+    /// Construct a new `InterpreterError` with a captured runtime call stack.
+    fn with_call_stack(
+        line: usize,
+        col: usize,
+        source_excerpt: &str,
+        kind: TbxError,
+        call_stack: Vec<StackTraceFrame>,
+    ) -> Self {
+        InterpreterError {
+            line,
+            col,
+            source_excerpt: source_excerpt.to_string(),
+            kind,
+            call_stack,
         }
     }
 }
@@ -357,13 +376,28 @@ impl Interpreter {
 
         // On error, restore stacks and bp to their pre-run state so that
         // subsequent exec_line calls start from a clean VM state.
+        let call_stack = if run_result.is_err() {
+            Some(self.vm.stack_trace_frames())
+        } else {
+            None
+        };
+
         if run_result.is_err() {
             self.vm.data_stack.truncate(saved_data_stack_len);
             self.vm.return_stack.truncate(saved_return_stack_len);
             self.vm.bp = saved_bp;
         }
 
-        run_result.map_err(make_err)
+        match run_result {
+            Ok(()) => Ok(()),
+            Err(e) => Err(InterpreterError::with_call_stack(
+                absolute_line,
+                stmt_pos_col,
+                source_excerpt,
+                e,
+                call_stack.unwrap_or_default(),
+            )),
+        }
     }
 
     /// Register the statement's line-number label (if any) inside a DEF body
@@ -785,6 +819,12 @@ impl Interpreter {
         self.vm.token_stream = None;
 
         // On error, rollback compile state and stacks.
+        let call_stack = if run_result.is_err() {
+            Some(self.vm.stack_trace_frames())
+        } else {
+            None
+        };
+
         if run_result.is_err() {
             self.vm.rollback_def();
             self.vm.data_stack.truncate(saved_data_stack_len);
@@ -794,7 +834,18 @@ impl Interpreter {
             self.vm.pending_use_path = None;
         }
 
-        run_result.map_err(make_err)?;
+        match run_result {
+            Ok(()) => {}
+            Err(e) => {
+                return Err(InterpreterError::with_call_stack(
+                    stmt_pos_line,
+                    stmt_pos_col,
+                    source_excerpt,
+                    e,
+                    call_stack.unwrap_or_default(),
+                ));
+            }
+        }
 
         // If use_prim stored a path, read the file and execute it now.
         if let Some(path) = self.vm.pending_use_path.take() {
@@ -1066,10 +1117,13 @@ impl Interpreter {
                     main_len,
                     &stmt_positions,
                 );
+                let call_stack = self.vm.stack_trace_frames();
                 self.vm.data_stack.truncate(saved_data_stack_len);
                 self.vm.return_stack.truncate(saved_return_stack_len);
                 self.vm.bp = saved_bp;
-                Err(InterpreterError::new(line, col, &source, e))
+                Err(InterpreterError::with_call_stack(
+                    line, col, &source, e, call_stack,
+                ))
             }
         }
     }
@@ -2916,6 +2970,9 @@ PUTSTR T"#;
             "source_excerpt should contain the failing expression, got: {:?}",
             err.source_excerpt
         );
+        assert_eq!(err.call_stack.len(), 1);
+        assert_eq!(err.call_stack[0].word_name, "<top-level>");
+        assert_eq!(err.call_stack[0].actual_arity, 0);
     }
 
     #[test]
@@ -2947,6 +3004,10 @@ PUTSTR T"#;
             "source_excerpt should contain the call site identifier, got: {:?}",
             err.source_excerpt
         );
+        assert_eq!(err.call_stack.len(), 2);
+        assert_eq!(err.call_stack[0].word_name, "BAD_WORD");
+        assert_eq!(err.call_stack[0].actual_arity, 0);
+        assert_eq!(err.call_stack[1].word_name, "<top-level>");
     }
 
     // --- compile_program integration tests (issue #266) ---
@@ -3892,6 +3953,10 @@ NESTED -1";
             "error must point to OUTER call site at line 7, got {}",
             err.line
         );
+        assert_eq!(err.call_stack.len(), 3);
+        assert_eq!(err.call_stack[0].word_name, "INNER");
+        assert_eq!(err.call_stack[1].word_name, "OUTER");
+        assert_eq!(err.call_stack[2].word_name, "<top-level>");
     }
 
     // --- WHILE / ENDWH ---

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -748,6 +748,7 @@ impl Interpreter {
         let kind = self.vm.headers[xt.index()].kind.clone();
         let arity = self.vm.headers[xt.index()].arity;
         let local_count = self.vm.headers[xt.index()].local_count;
+        let immediate_word_name = self.vm.headers[xt.index()].name.clone();
 
         // Feed remaining tokens into vm.token_stream so the IMMEDIATE word can
         // consume them via vm.next_token().
@@ -759,6 +760,7 @@ impl Interpreter {
         let saved_return_stack_len = self.vm.return_stack.len();
         let saved_bp = self.vm.bp;
 
+        let mut active_immediate_word_frame: Option<StackTraceFrame> = None;
         let run_result = match kind {
             // Native primitive: call the function pointer directly (avoids
             // temporary-buffer issues when the primitive writes to the dictionary).
@@ -797,6 +799,10 @@ impl Interpreter {
                     if let Some(e) = push_err {
                         Err(e)
                     } else {
+                        active_immediate_word_frame = Some(StackTraceFrame {
+                            word_name: immediate_word_name,
+                            actual_arity: 0,
+                        });
                         let result = self.vm.run(body_addr);
                         // On success, tear down all local slots.  truncate()
                         // removes both the zero-initialised local slots and any
@@ -820,7 +826,15 @@ impl Interpreter {
 
         // On error, rollback compile state and stacks.
         let call_stack = if run_result.is_err() {
-            Some(self.vm.stack_trace_frames())
+            let mut frames = self.vm.stack_trace_frames();
+            if let Some(frame) = active_immediate_word_frame {
+                let insert_pos = frames
+                    .iter()
+                    .position(|existing| existing.word_name == "<top-level>")
+                    .unwrap_or(frames.len());
+                frames.insert(insert_pos, frame);
+            }
+            Some(frames)
         } else {
             None
         };
@@ -2646,6 +2660,23 @@ IPARAM 42";
             result.is_err(),
             "expected error when IMMEDIATE word has formal parameters"
         );
+        let err = result.unwrap_err();
+        assert!(
+            err.call_stack.is_empty(),
+            "pre-execution IMMEDIATE dispatch error should not synthesize a runtime frame"
+        );
+    }
+
+    #[test]
+    fn test_immediate_word_runtime_error_captures_word_frame() {
+        let mut interp = Interpreter::new();
+        let src = "DEF BAD\n  PUTDEC 1 / 0\nEND\nIMMEDIATE BAD\nBAD";
+        let result = interp.exec_source(src);
+        let err = result.expect_err("expected runtime error from IMMEDIATE word");
+        assert_eq!(err.call_stack.len(), 2);
+        assert_eq!(err.call_stack[0].word_name, "BAD");
+        assert_eq!(err.call_stack[0].actual_arity, 0);
+        assert_eq!(err.call_stack[1].word_name, "<top-level>");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,16 @@ fn print_error(err: &InterpreterError) {
     for line in err.source_excerpt.lines() {
         eprintln!("  {line}");
     }
+    if !err.call_stack.is_empty() {
+        eprintln!("Call stack:");
+        for (idx, frame) in err.call_stack.iter().enumerate() {
+            if frame.word_name == "<top-level>" {
+                eprintln!("  {idx}: <top-level>");
+            } else {
+                eprintln!("  {idx}: {}(argc={})", frame.word_name, frame.actual_arity);
+            }
+        }
+    }
 }
 
 fn run_file(path: &str) -> std::process::ExitCode {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -8,6 +8,15 @@ use std::collections::HashMap;
 use std::collections::VecDeque;
 use std::io::{BufRead, BufReader, Write};
 
+/// Human-readable snapshot of one runtime call frame.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StackTraceFrame {
+    /// Name of the compiled word executing in this frame.
+    pub word_name: String,
+    /// Number of arguments supplied by the caller.
+    pub actual_arity: usize,
+}
+
 /// State maintained during compilation of a new word definition (DEF..END).
 #[derive(Debug)]
 pub struct CompileState {
@@ -272,6 +281,40 @@ impl VM {
             output_writer: Box::new(std::io::stdout()),
             rng: rand::rngs::SmallRng::from_entropy(),
         }
+    }
+
+    /// Return the current call stack as human-readable frames, innermost first.
+    ///
+    /// When top-level execution is active, a trailing `<top-level>` frame is
+    /// appended so callers can render a consistent stack dump.
+    pub fn stack_trace_frames(&self) -> Vec<StackTraceFrame> {
+        let mut frames = Vec::new();
+
+        for frame in self.return_stack.iter().rev() {
+            match frame {
+                ReturnFrame::Call {
+                    callee_xt,
+                    actual_arity,
+                    ..
+                } => {
+                    let word_name = self
+                        .headers
+                        .get(callee_xt.index())
+                        .map(|entry| entry.name.clone())
+                        .unwrap_or_else(|| format!("<invalid-xt:{}>", callee_xt.index()));
+                    frames.push(StackTraceFrame {
+                        word_name,
+                        actual_arity: *actual_arity,
+                    });
+                }
+                ReturnFrame::TopLevel => frames.push(StackTraceFrame {
+                    word_name: "<top-level>".to_string(),
+                    actual_arity: 0,
+                }),
+            }
+        }
+
+        frames
     }
 
     /// Returns true while `vm.run()` is executing top-level code, outside any
@@ -697,6 +740,7 @@ impl VM {
                     // Direct dispatch (no CALL instruction): actual_arity is unknown.
                     // Variadic words should always be called via CALL, not this path.
                     self.return_stack.push(ReturnFrame::Call {
+                        callee_xt: xt,
                         return_pc,
                         saved_bp,
                         saved_array_pool_len: self.arrays.len(),
@@ -764,6 +808,7 @@ impl VM {
                                 });
                             }
                             self.return_stack.push(ReturnFrame::Call {
+                                callee_xt: target_xt,
                                 return_pc,
                                 saved_bp,
                                 saved_array_pool_len: self.arrays.len(),
@@ -789,6 +834,7 @@ impl VM {
                 EntryKind::Exit => {
                     match self.return_stack.pop().ok_or(TbxError::StackUnderflow)? {
                         ReturnFrame::Call {
+                            callee_xt: _,
                             return_pc,
                             saved_bp,
                             saved_array_pool_len,
@@ -894,6 +940,7 @@ impl VM {
                     };
                     match self.return_stack.pop().ok_or(TbxError::StackUnderflow)? {
                         ReturnFrame::Call {
+                            callee_xt: _,
                             return_pc,
                             saved_bp,
                             saved_array_pool_len,
@@ -1855,6 +1902,7 @@ mod tests {
         // Pre-fill the return stack to its limit with dummy frames
         for _ in 0..MAX_RETURN_STACK_DEPTH {
             vm.return_stack.push(ReturnFrame::Call {
+                callee_xt: word_xt,
                 return_pc: 0,
                 saved_bp: 0,
                 saved_array_pool_len: 0,
@@ -1897,6 +1945,7 @@ mod tests {
         // Pre-fill the return stack to its limit
         for _ in 0..MAX_RETURN_STACK_DEPTH {
             vm.return_stack.push(ReturnFrame::Call {
+                callee_xt: word_xt,
                 return_pc: 0,
                 saved_bp: 0,
                 saved_array_pool_len: 0,
@@ -2948,6 +2997,7 @@ mod tests {
         // existed when the word was called).
         vm.return_stack.push(ReturnFrame::TopLevel);
         vm.return_stack.push(ReturnFrame::Call {
+            callee_xt: Xt(0),
             return_pc: 0,
             saved_bp: 0,
             saved_array_pool_len: 1,
@@ -2973,6 +3023,41 @@ mod tests {
                 "global array should pass ReturnVal check"
             );
         }
+    }
+
+    #[test]
+    fn test_stack_trace_frames_innermost_first() {
+        let mut vm = VM::new();
+
+        let outer_xt = vm.register(crate::dict::WordEntry::new_word("OUTER", 0));
+        let inner_xt = vm.register(crate::dict::WordEntry::new_word("INNER", 0));
+
+        vm.return_stack.push(ReturnFrame::TopLevel);
+        vm.return_stack.push(ReturnFrame::Call {
+            callee_xt: outer_xt,
+            return_pc: 10,
+            saved_bp: 0,
+            saved_array_pool_len: 0,
+            saved_string_pool_len: 0,
+            actual_arity: 1,
+        });
+        vm.return_stack.push(ReturnFrame::Call {
+            callee_xt: inner_xt,
+            return_pc: 20,
+            saved_bp: 1,
+            saved_array_pool_len: 0,
+            saved_string_pool_len: 0,
+            actual_arity: 2,
+        });
+
+        let frames = vm.stack_trace_frames();
+        assert_eq!(frames.len(), 3);
+        assert_eq!(frames[0].word_name, "INNER");
+        assert_eq!(frames[0].actual_arity, 2);
+        assert_eq!(frames[1].word_name, "OUTER");
+        assert_eq!(frames[1].actual_arity, 1);
+        assert_eq!(frames[2].word_name, "<top-level>");
+        assert_eq!(frames[2].actual_arity, 0);
     }
 
     // --- Pool truncation on return (direct vm.arrays / vm.strings length checks) ---


### PR DESCRIPTION
## 概要

Refs #529

実行時エラー時に、ソース行番号とは別に word 名ベースの呼出履歴を表示できるようにしました。

## 変更内容

- `ReturnFrame::Call` に `callee_xt` を追加し、実行中 word を保持
- `VM::stack_trace_frames()` を追加し、innermost-first の呼出履歴を取得可能に変更
- `InterpreterError` に call stack スナップショットを保持させ、runtime error 生成時に退避
- CLI のエラー表示に `Call stack:` セクションを追加
- top-level / 単一 word / 入れ子呼び出しの stack trace を検証するテストを追加

## 確認

- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo fmt --check`
