### PR TITLE
配列要素へのglobal/compile-time literal Strの書き込みを許可する

### DIFF
--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -262,17 +262,53 @@ pub fn set_prim(vm: &mut VM) -> Result<(), TbxError> {
     }
 }
 
-/// Check that `value` is a permitted array element type.
+/// Check that `value` is a permitted array element type (static shape check,
+/// no VM context required).
 ///
-/// Array elements are restricted to scalar types: `Int`, `Float`, `Bool`, and
-/// `None`.  Nested reference types (`Array` and `Str`) are forbidden because
-/// they can introduce dangling references when the owning frame is cleaned up.
+/// `Cell::Array` is always rejected (nested arrays are not supported).
+/// `Cell::Str` is also rejected here; callers that need lifetime-aware string
+/// checks should use `check_array_element_write` instead.
 fn check_array_element_type(value: &Cell) -> Result<(), TbxError> {
     match value {
         Cell::Array(_) => Err(TbxError::InvalidArrayElement { got: "Array" }),
         Cell::Str(_) => Err(TbxError::InvalidArrayElement { got: "Str" }),
         _ => Ok(()),
     }
+}
+
+/// Check that `value` may be written to the array at `array_pool_idx`.
+///
+/// This is the lifetime-aware counterpart to `check_array_element_type` and
+/// is used by `write_array_element` (the `SET`/`STORE` path).
+///
+/// * `Cell::Array` is always rejected (nested arrays are not supported).
+/// * All non-reference scalars are accepted unconditionally.
+/// * `Cell::Str` is accepted only when its pool index is in the global region
+///   (`PoolRefLifetime::Global`).  Frame-local and caller-owned strings are
+///   rejected with `TbxError::StringFrameEscape` to prevent dangling
+///   references after the owning frame is cleaned up.
+///
+/// The `array_pool_idx` parameter is reserved for future use (target-array
+/// lifetime checks) and is not examined in this implementation.
+fn check_array_element_write(
+    vm: &VM,
+    _array_pool_idx: usize,
+    value: &Cell,
+) -> Result<(), TbxError> {
+    match value {
+        // Nested arrays are unconditionally rejected.
+        Cell::Array(_) => return Err(TbxError::InvalidArrayElement { got: "Array" }),
+        // String lifetime check: only global strings are allowed.
+        Cell::Str(idx) => match classify_pool_ref(vm, PoolRef::String(*idx)) {
+            PoolRefLifetime::Global => {}
+            PoolRefLifetime::CallerOwned | PoolRefLifetime::FrameLocal => {
+                return Err(TbxError::StringFrameEscape);
+            }
+        },
+        // All other scalar types are accepted.
+        _ => {}
+    }
+    Ok(())
 }
 
 /// Write `value` to element `elem_idx` of the array at `pool_idx`.
@@ -282,8 +318,9 @@ fn write_array_element(
     elem_idx: usize,
     value: Cell,
 ) -> Result<(), TbxError> {
-    // Reject reference types that could dangle when the owning frame is freed.
-    check_array_element_type(&value)?;
+    // Reject types that could dangle when the owning frame is freed.
+    // The helper must be called before get_mut() to avoid borrow conflicts.
+    check_array_element_write(vm, pool_idx, &value)?;
     let pool_size = vm.arrays.len();
     let arr = vm
         .arrays
@@ -7321,6 +7358,119 @@ mod tests {
         vm.push(Cell::Int(42)).unwrap();
         set_prim(&mut vm).unwrap();
         assert_eq!(vm.arrays[0][0], Cell::Int(42));
+    }
+
+    // --- array element write: Cell::Str lifetime checks ---
+
+    #[test]
+    fn test_set_global_str_to_array_element_is_allowed() {
+        // A Str with pool_idx < global_string_pool_len is global and may be stored.
+        let mut vm = VM::new();
+        vm.strings.push("hello".to_string());
+        vm.global_string_pool_len = 1; // promote to global
+        vm.arrays.push(vec![Cell::None]);
+        // set_prim: stack = [..., addr, value]
+        vm.push(Cell::ArrayAddr {
+            pool_idx: 0,
+            elem_idx: 0,
+        })
+        .unwrap();
+        vm.push(Cell::Str(0)).unwrap();
+        set_prim(&mut vm).unwrap();
+        assert_eq!(vm.arrays[0][0], Cell::Str(0));
+    }
+
+    #[test]
+    fn test_store_global_str_to_array_element_is_allowed() {
+        // Same as above but using store_prim (stack = [value, addr]).
+        let mut vm = VM::new();
+        vm.strings.push("world".to_string());
+        vm.global_string_pool_len = 1;
+        vm.arrays.push(vec![Cell::None]);
+        // store_prim: stack = [value, addr], pops addr first.
+        vm.push(Cell::Str(0)).unwrap();
+        vm.push(Cell::ArrayAddr {
+            pool_idx: 0,
+            elem_idx: 0,
+        })
+        .unwrap();
+        store_prim(&mut vm).unwrap();
+        assert_eq!(vm.arrays[0][0], Cell::Str(0));
+    }
+
+    #[test]
+    fn test_set_frame_local_str_to_array_element_is_string_frame_escape() {
+        // A Str with pool_idx >= global_string_pool_len is frame-local and must be rejected.
+        let mut vm = VM::new();
+        vm.strings.push("local".to_string());
+        // global_string_pool_len = 0, so Str(0) is frame-local.
+        vm.arrays.push(vec![Cell::None]);
+        vm.push(Cell::ArrayAddr {
+            pool_idx: 0,
+            elem_idx: 0,
+        })
+        .unwrap();
+        vm.push(Cell::Str(0)).unwrap();
+        assert_eq!(set_prim(&mut vm), Err(TbxError::StringFrameEscape));
+    }
+
+    #[test]
+    fn test_set_caller_owned_str_to_array_element_is_string_frame_escape() {
+        // A Str in the caller-owned region (between caller's boundary and current frame's
+        // boundary) must also be rejected.
+        use crate::cell::ReturnFrame;
+        let mut vm = VM::new();
+        // Two strings: one "caller-owned" at idx 0, one global at idx... none here.
+        vm.strings.push("caller".to_string());
+        vm.strings.push("local".to_string());
+        // global_string_pool_len = 0, so nothing is global.
+        // Push a call frame: the caller saw string_pool_len = 0 before the call,
+        // and a nested call sees string_pool_len = 1.
+        vm.return_stack.push(ReturnFrame::TopLevel);
+        vm.return_stack.push(ReturnFrame::Call {
+            callee_xt: crate::cell::Xt(0),
+            return_pc: 0,
+            saved_bp: 0,
+            saved_array_pool_len: 0,
+            saved_string_pool_len: 0, // outer boundary
+            actual_arity: 0,
+        });
+        vm.return_stack.push(ReturnFrame::Call {
+            callee_xt: crate::cell::Xt(0),
+            return_pc: 0,
+            saved_bp: 0,
+            saved_array_pool_len: 0,
+            saved_string_pool_len: 1, // inner boundary; Str(0) is caller-owned
+            actual_arity: 0,
+        });
+        vm.arrays.push(vec![Cell::None]);
+        // Str(0): idx=0, innermost saved_string_pool_len=1 → idx < 1 → CallerOwned
+        vm.push(Cell::ArrayAddr {
+            pool_idx: 0,
+            elem_idx: 0,
+        })
+        .unwrap();
+        vm.push(Cell::Str(0)).unwrap();
+        assert_eq!(set_prim(&mut vm), Err(TbxError::StringFrameEscape));
+    }
+
+    #[test]
+    fn test_set_nested_array_to_array_element_is_invalid_array_element() {
+        // Cell::Array must always be rejected as an array element.
+        let mut vm = VM::new();
+        vm.arrays.push(vec![Cell::None]); // pool_idx = 0: target array
+        vm.arrays.push(vec![Cell::None]); // pool_idx = 1: value to store
+        vm.global_array_pool_len = 2; // both are global
+        vm.push(Cell::ArrayAddr {
+            pool_idx: 0,
+            elem_idx: 0,
+        })
+        .unwrap();
+        vm.push(Cell::Array(1)).unwrap();
+        assert_eq!(
+            set_prim(&mut vm),
+            Err(TbxError::InvalidArrayElement { got: "Array" })
+        );
     }
 
     // --- fetch_prim with ArrayAddr ---

--- a/tests/tbx_lib_tests.rs
+++ b/tests/tbx_lib_tests.rs
@@ -124,19 +124,48 @@ fn test_array_index_zero_is_out_of_bounds() {
 // Array element type restriction tests (issue #487)
 // ---------------------------------------------------------------------------
 
-/// SET &A(i), STR("...") must fail with InvalidArrayElement.
+/// SET &A(i), STR("...") must fail with StringFrameEscape because STR()
+/// produces a frame-local runtime string that must not escape to an array.
+/// (Global / compile-time literal strings are allowed; see
+/// test_set_literal_str_into_array_is_allowed.)
 #[test]
-fn test_set_str_into_array_is_invalid_element_type() {
+fn test_set_runtime_str_into_array_is_string_frame_escape() {
     let mut interp = Interpreter::new();
-    // Attempt to store a Str cell into an array element via SET.
+    // STR("hello") allocates a frame-local string; storing it in the array
+    // must be rejected.
     let src = "DEF T()\n  VAR A\n  LET A = ARRAY(3)\n  SET &A(1), STR(\"hello\")\nEND\nT()\n";
     let err = interp
         .exec_source(src)
-        .expect_err("storing Str in array should fail");
+        .expect_err("storing frame-local Str in array should fail");
     assert!(
-        err.to_string().contains("invalid array element type"),
-        "expected 'invalid array element type', got: {err}"
+        err.to_string().contains("string cannot escape"),
+        "expected 'string cannot escape', got: {err}"
     );
+}
+
+/// SET &A(1), "hello" (compile-time literal) must succeed.
+/// String literals are interned into the global string pool at compile time,
+/// so they satisfy the Global lifetime requirement.
+/// Array indices are 1-based in TBX.
+#[test]
+fn test_set_literal_str_into_array_is_allowed() {
+    let mut interp = Interpreter::new();
+    let src = "VAR A\nSET &A, ARRAY(1)\nSET &A(1), \"hello\"\nPUTSTR A(1)\n";
+    interp
+        .exec_source(src)
+        .expect("storing string literal in array should succeed");
+}
+
+/// Same as above but inside a compiled word to verify frame-local arrays also
+/// accept global string literals.
+#[test]
+fn test_set_literal_str_into_array_inside_def_is_allowed() {
+    let mut interp = Interpreter::new();
+    let src =
+        "DEF MAKE()\n  VAR A\n  SET &A, ARRAY(1)\n  SET &A(1), \"inside\"\n  PUTSTR A(1)\nEND\nMAKE\n";
+    interp
+        .exec_source(src)
+        .expect("storing string literal in array inside DEF should succeed");
 }
 
 /// TO_ARRAY(STR("a"), STR("b")) must fail with InvalidArrayElement.

--- a/tests/tbx_lib_tests.rs
+++ b/tests/tbx_lib_tests.rs
@@ -144,8 +144,8 @@ fn test_set_runtime_str_into_array_is_string_frame_escape() {
 }
 
 /// SET &A(1), "hello" (compile-time literal) must succeed.
-/// String literals are interned into the global string pool at compile time,
-/// so they satisfy the Global lifetime requirement.
+/// String literals are stored into VM::strings as global compile-time literals
+/// at compile time, so they satisfy the Global lifetime requirement.
 /// Array indices are 1-based in TBX.
 #[test]
 fn test_set_literal_str_into_array_is_allowed() {
@@ -154,6 +154,7 @@ fn test_set_literal_str_into_array_is_allowed() {
     interp
         .exec_source(src)
         .expect("storing string literal in array should succeed");
+    assert_eq!(interp.take_output(), "hello");
 }
 
 /// Same as above but inside a compiled word to verify frame-local arrays also
@@ -166,6 +167,7 @@ fn test_set_literal_str_into_array_inside_def_is_allowed() {
     interp
         .exec_source(src)
         .expect("storing string literal in array inside DEF should succeed");
+    assert_eq!(interp.take_output(), "inside");
 }
 
 /// TO_ARRAY(STR("a"), STR("b")) must fail with InvalidArrayElement.


### PR DESCRIPTION
## 概要

Phase 5A の最初の最小ステップとして、配列要素への `Cell::Str` 書き込みを global / compile-time literal のみ許可する。`write_array_element`（`SET`/`STORE` 経路）に lifetime-aware な helper `check_array_element_write` を導入し、`classify_pool_ref` を使って `PoolRefLifetime::Global` のみを受け入れる。

## 変更内容

- `src/primitives.rs`:
  - `check_array_element_write(vm, array_pool_idx, value)` を新規追加。`Cell::Array` は無条件拒否、`Cell::Str` は `PoolRefLifetime::Global` のみ許可（`FrameLocal`/`CallerOwned` は `StringFrameEscape`）、それ以外のスカラーは許可
  - `write_array_element` で `check_array_element_type` の代わりに `check_array_element_write` を呼ぶよう変更（borrow conflict を避けるため `get_mut` より前に呼ぶ）
  - `check_array_element_type` は変更なし。`to_array_prim` は引き続きこちらを使うため `Cell::Str` は `InvalidArrayElement` で拒否される
  - unit test 5 件を追加（global Str 許可 / frame-local Str 拒否 / caller-owned Str 拒否 / nested Array 拒否）
- `tests/tbx_lib_tests.rs`:
  - `test_set_str_into_array_is_invalid_element_type` を `test_set_runtime_str_into_array_is_string_frame_escape` に更新（期待エラーが `InvalidArrayElement` → `StringFrameEscape` に変わったため）
  - string literal を配列要素に格納できる integration test 2 件を追加（top-level / DEF 内）

Closes #560
