### PR TITLE
stabilize_array_element_write() の枠を導入する

### DIFF
--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -348,6 +348,39 @@ fn check_array_element_write(vm: &VM, array_pool_idx: usize, value: &Cell) -> Re
     }
 }
 
+/// Validate and (in future phases) transform `value` before it is stored in
+/// the array at `array_pool_idx`.
+///
+/// This is the Phase 5B entry-point for array element writes.  In the current
+/// phase (5B-1) the behaviour is identical to `check_array_element_write`:
+/// validation only, no clone/promote.  Subsequent phases will intercept
+/// specific lifetime combinations here and return a modified `Cell` (e.g. a
+/// global clone of a `CallerOwned` string).
+///
+/// # Allow/deny matrix (Phase 5A — unchanged in 5B-1)
+///
+/// | array lifetime           | string lifetime  | result |
+/// |--------------------------|------------------|--------|
+/// | any                      | `FrameLocal`     | deny   |
+/// | any                      | `Global`         | allow  |
+/// | `FrameLocal`             | `CallerOwned`    | allow  |
+/// | `Global` / `CallerOwned` | `CallerOwned`    | deny   |
+///
+/// # Errors
+///
+/// Returns an error when the combination is unsafe or unsupported (e.g.
+/// `Cell::Array` is always rejected as a nested array).
+fn stabilize_array_element_write(
+    vm: &mut VM,
+    array_pool_idx: usize,
+    value: Cell,
+) -> Result<Cell, TbxError> {
+    // Phase 5B-1: validate only; clone/promote will be added in later phases.
+    // The immutable borrow of `vm` ends before any future mutable operations.
+    check_array_element_write(vm, array_pool_idx, &value)?;
+    Ok(value)
+}
+
 /// Write `value` to element `elem_idx` of the array at `pool_idx`.
 fn write_array_element(
     vm: &mut VM,
@@ -355,9 +388,9 @@ fn write_array_element(
     elem_idx: usize,
     value: Cell,
 ) -> Result<(), TbxError> {
-    // Reject types that could dangle when the owning frame is freed.
-    // The helper must be called before get_mut() to avoid borrow conflicts.
-    check_array_element_write(vm, pool_idx, &value)?;
+    // Validate (and in later phases, transform) the value before storing it.
+    // Must be called before get_mut() to avoid borrow conflicts.
+    let value = stabilize_array_element_write(vm, pool_idx, value)?;
     let pool_size = vm.arrays.len();
     let arr = vm
         .arrays


### PR DESCRIPTION
## 概要

Phase 5B の準備として、`write_array_element()` が値を格納する前に通る
stabilization フックとして `stabilize_array_element_write()` を導入する。
現フェーズ (5B-1) では Phase 5A と同じバリデーションのみを行い、挙動は変わらない。
後続 issue での clone/promote を追加しやすい構造に整理することが目的。

## 変更内容

- `stabilize_array_element_write(vm, array_pool_idx, value) -> Result<Cell, TbxError>` を新規追加
  - Phase 5B-1 では `check_array_element_write()` に委譲してバリデーションのみ実施
  - `Cell::Array` は引き続き `InvalidArrayElement { got: "Array" }` で拒否
  - `Cell::Str` は Phase 5A のマトリクスどおりに許可・拒否
  - スカラー値はそのまま `Ok(value)` で返す
- `write_array_element()` が `check_array_element_write()` を直接呼ぶ代わりに
  `stabilize_array_element_write()` から返された `Cell` を格納するよう変更

Closes #573
