### PR TITLE
Cell::Str を Rc<str> backed immutable string handle に移行する (D-1)

### DIFF
--- a/src/cell.rs
+++ b/src/cell.rs
@@ -107,26 +107,26 @@ pub enum Cell {
     /// nested `Array` or `Str` references), so ownership transfer does not
     /// require recursive inspection of element types.
     Array(usize),
-    /// Runtime string handle — index into `VM::strings` (the runtime string pool).
+    /// Immutable reference-counted string handle (`Rc<str>`).
     ///
-    /// Created by string primitives such as `STR`, `STR_CONCAT`, etc.
-    /// The pool entry at this index holds a `String`.
+    /// Created by string primitives such as `STR`, `STR_CONCAT`, etc., and by
+    /// string literals embedded in compiled code.
     ///
-    /// Strings come in three flavours:
-    /// - **Frame-local strings** (`pool_idx >= saved_string_pool_len` of the current
-    ///   call frame) are owned by that frame.  On EXIT they are freed; on RETURN_VAL
-    ///   the returned string is moved to the frame-boundary slot via ownership
-    ///   transfer (swap + truncate) so it survives the pool cleanup.
-    /// - **Global strings** (`pool_idx < vm.global_string_pool_len`) are created
-    ///   at the top level (outside any `DEF..END`) and are never freed.  They
-    ///   may safely be stored in `VARIABLE` slots and shared across word calls.
-    /// - **Caller-owned strings** (`pool_idx < saved_string_pool_len` of the current
-    ///   call frame but not globally permanent) were created before the call; they
-    ///   can be returned without modification.
+    /// Cloning a `Cell::Str` is cheap (it only bumps the `Rc` reference count).
+    /// The lifetime of the underlying string is managed by reference counting,
+    /// so a `Cell::Str` may be freely passed around the data stack, returned
+    /// from words, and stored in dictionary slots without lifetime tracking.
     ///
-    /// Note: `Cell::Str(a) == Cell::Str(b)` uses index comparison (identity),
-    /// not content comparison.  Use the `STR_EQ` primitive for content equality.
-    Str(usize),
+    /// Equality (`PartialEq`) compares string content (see the `PartialEq` impl
+    /// below).
+    ///
+    /// Note: `VM::strings` (the legacy index-based string pool) and the
+    /// associated `saved_string_pool_len` / `global_string_pool_len` fields
+    /// are retained for the transition period.  `Cell::Str` itself no longer
+    /// indexes into them.  Full removal of the pool and pool-length fields is
+    /// tracked by follow-up issue #590, and array-write-path liberation is
+    /// tracked by #591.
+    Str(std::rc::Rc<str>),
     /// Address of an element in an array.
     ///
     /// Produced by the `&A(I)` construct where `A` holds a `Cell::Array`.
@@ -167,7 +167,7 @@ impl std::fmt::Display for Cell {
             Cell::Xt(x) => write!(f, "xt:{}", x.0),
             Cell::Bool(b) => write!(f, "{}", b),
             Cell::Array(idx) => write!(f, "<array:{}>", idx),
-            Cell::Str(idx) => write!(f, "<str:{}>", idx),
+            Cell::Str(s) => write!(f, "{}", s),
             Cell::ArrayAddr { pool_idx, elem_idx } => {
                 write!(f, "<arrayaddr:{}[{}]>", pool_idx, elem_idx)
             }
@@ -241,6 +241,23 @@ impl Cell {
         }
     }
 
+    /// Construct a `Cell::Str` from any value that can be converted into `Rc<str>`.
+    ///
+    /// Accepts `&str`, `String`, `Rc<str>`, and `Box<str>`.  Cloning the
+    /// resulting cell is cheap (`Rc` reference-count bump).
+    pub fn string<S: Into<std::rc::Rc<str>>>(s: S) -> Self {
+        Cell::Str(s.into())
+    }
+
+    /// Returns a reference to the inner `Rc<str>` if this cell is `Str`, otherwise `None`.
+    pub fn as_str(&self) -> Option<&std::rc::Rc<str>> {
+        if let Cell::Str(s) = self {
+            Some(s)
+        } else {
+            None
+        }
+    }
+
     /// Returns a static string naming the variant. Useful for error messages and debugging.
     pub fn type_name(&self) -> &'static str {
         match self {
@@ -289,6 +306,10 @@ impl PartialEq for Cell {
             (Cell::Bool(a), Cell::Bool(b)) => a == b,
             (Cell::None, Cell::None) => true,
             (Cell::Array(a), Cell::Array(b)) => a == b,
+            // Content equality: two Str cells are equal when their underlying
+            // string contents match.  (Previously this was an index comparison
+            // when `Cell::Str` was `usize`; `Rc<str>` derives `PartialEq` from
+            // the wrapped `str`, so the comparison now reflects content.)
             (Cell::Str(a), Cell::Str(b)) => a == b,
             (
                 Cell::ArrayAddr {
@@ -443,7 +464,38 @@ mod tests {
         assert_eq!(Cell::Bool(false).type_name(), "Bool");
         assert_eq!(Cell::None.type_name(), "None");
         assert_eq!(Cell::Array(0).type_name(), "Array");
-        assert_eq!(Cell::Str(0).type_name(), "Str");
+        assert_eq!(Cell::string("hello").type_name(), "Str");
+    }
+
+    #[test]
+    fn test_str_equality_by_content() {
+        // Two Str cells with identical content must be equal regardless of
+        // which Rc instance they reference.
+        assert_eq!(Cell::string("hello"), Cell::string("hello"));
+        // Two Str cells with different content must not be equal.
+        assert_ne!(Cell::string("hello"), Cell::string("world"));
+    }
+
+    #[test]
+    fn test_str_display() {
+        // Display now prints the underlying content directly.
+        assert_eq!(Cell::string("hello").to_string(), "hello");
+        assert_eq!(Cell::string("").to_string(), "");
+    }
+
+    #[test]
+    fn test_string_helper() {
+        // Cell::string() should produce Cell::Str.
+        let c = Cell::string("foo");
+        assert_eq!(c.type_name(), "Str");
+        assert_eq!(c.as_str().map(|s| s.as_ref()), Some("foo"));
+    }
+
+    #[test]
+    fn test_as_str() {
+        let c = Cell::string("bar");
+        assert_eq!(c.as_str().map(|s| s.as_ref()), Some("bar"));
+        assert_eq!(Cell::Int(1).as_str(), None);
     }
 
     #[test]

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -142,45 +142,33 @@ impl<'a> ExprCompiler<'a> {
                 }
 
                 Token::StringLit(s) => {
-                    // String literals live in `VM::strings` and are emitted
-                    // as `Cell::Str`. Keep the current literal length limit
-                    // so compile-time string handling stays within the
-                    // existing contract.
-                    //
                     // String literals are compile-time constants embedded in
-                    // the compiled code.  Store them in `VM::strings` and
-                    // immediately include them in the global string region
-                    // so they survive word calls and may be stored into
-                    // global variables from compiled words (see PR #543
-                    // review feedback).  Without this promotion, a literal
-                    // compiled inside a `DEF ... END` body would have
-                    // `pool_idx >= global_string_pool_len` at call time,
-                    // and `SET &G, "..."` from inside the word would be
-                    // rejected with `StringFrameEscape` even though the
-                    // value is a compile-time constant rather than a
-                    // frame-local string.
+                    // the compiled code as `Cell::Str(Rc<str>)` payloads.
                     //
-                    // Note: the entry pushed here is NOT rolled back when a
-                    // surrounding `DEF ... END` compilation fails.  The
-                    // dictionary / header rollback for failed compilation
-                    // does not extend to `VM::strings`, so any literal
-                    // pushed here becomes a session-lived orphan entry on
-                    // compile failure.  Advancing `global_string_pool_len`
-                    // here makes that orphan entry also occupy a slot in
-                    // the global region.  This is acceptable under the
-                    // post-#540 policy of not reclaiming fine-grained
-                    // unused regions within a session; the only way to
-                    // recover the slot is a full recompaction from source
-                    // or a VM reset.
+                    // Pre-#588 the literal was indexed into `VM::strings` and
+                    // promoted into the global string region so `SET &G,
+                    // "..."` from inside a word would not trip the
+                    // `StringFrameEscape` check.  With `Cell::Str` now
+                    // `Rc<str>`-backed, no pool index is needed: the literal
+                    // owns its own string via the Rc reference count.
+                    //
+                    // We still push the literal into `VM::strings` and bump
+                    // `global_string_pool_len` for the duration of #588's
+                    // minimal transition.  No code path now consumes the
+                    // pushed entry, but keeping the push minimises diff
+                    // churn and lets a couple of legacy regression tests
+                    // (e.g. `test_string_literal_uses_strings_pool`) keep
+                    // observing the pool.  Both will be retired with the
+                    // string pool itself in #590.
                     if s.len() > u16::MAX as usize {
                         return Err(TbxError::StringTooLong { len: s.len() });
                     }
                     let idx = self.vm.strings.len();
-                    self.vm.strings.push(s);
+                    self.vm.strings.push(s.clone());
                     if idx >= self.vm.global_string_pool_len {
                         self.vm.global_string_pool_len = idx + 1;
                     }
-                    emit_lit(&mut output, Cell::Str(idx), self.vm)?;
+                    emit_lit(&mut output, Cell::string(s), self.vm)?;
                     prev_was_operand = true;
                 }
 
@@ -1019,7 +1007,6 @@ mod tests {
     #[test]
     fn test_string_literal() {
         let mut vm = make_vm();
-        let strings_before = vm.strings.len();
         let tokens = lex(r#""hello""#);
         let result = ExprCompiler::new(&mut vm).compile_expr(&tokens).unwrap();
 
@@ -1027,17 +1014,14 @@ mod tests {
 
         assert_eq!(result.len(), 2);
         assert_eq!(result[0], Cell::Xt(lit_xt));
-        // The string literal is now stored in `VM::strings` and the
-        // compiler emits `Cell::Str(idx)` (Phase 2 of issue #539).
-        assert_eq!(result[1], Cell::Str(strings_before));
-        assert_eq!(
-            vm.strings.get(strings_before).map(String::as_str),
-            Some("hello")
-        );
+        // After #588, the literal is emitted as `Cell::Str(Rc<str>)` carrying
+        // the literal content directly.
+        assert_eq!(result[1], Cell::string("hello"));
     }
 
-    /// Phase 2 of issue #539: ensure that string literal compilation emits
-    /// a `Cell::Str` handle in the compiled output.
+    /// Ensure that string literal compilation emits a `Cell::Str` handle in
+    /// the compiled output (#539 Phase 2; payload changed to `Rc<str>` in
+    /// #588).
     #[test]
     fn test_string_literal_emits_str() {
         let mut vm = make_vm();

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -87,7 +87,11 @@ struct PoolBounds {
 fn pool_ref_from_cell(cell: &Cell) -> Option<PoolRef> {
     match cell {
         Cell::Array(idx) => Some(PoolRef::Array(*idx)),
-        Cell::Str(idx) => Some(PoolRef::String(*idx)),
+        // `Cell::Str` is now `Rc<str>`-backed and does not carry a pool index.
+        // The Rc reference count manages its lifetime, so there is no PoolRef
+        // to return.  See follow-up issue #590 for the full retirement of
+        // `VM::strings` / `PoolRef::String`.
+        Cell::Str(_) => None,
         _ => None,
     }
 }
@@ -249,8 +253,11 @@ pub fn set_prim(vm: &mut VM) -> Result<(), TbxError> {
 /// no VM context required).
 ///
 /// `Cell::Array` is always rejected (nested arrays are not supported).
-/// `Cell::Str` is also rejected here; callers that need lifetime-aware string
-/// checks should use `check_array_element_write` instead.
+/// `Cell::Str` is also rejected here: storing strings inside arrays is
+/// liberation-tracked separately by #591.  Per-string lifetime classification
+/// is no longer expressible at this layer because `Cell::Str` is now
+/// `Rc<str>`-backed (it has no pool index), so `check_array_element_write`
+/// likewise rejects all `Cell::Str` values.
 fn check_array_element_type(value: &Cell) -> Result<(), TbxError> {
     match value {
         Cell::Array(_) => Err(TbxError::InvalidArrayElement { got: "Array" }),
@@ -262,7 +269,13 @@ fn check_array_element_type(value: &Cell) -> Result<(), TbxError> {
 /// Check that a `Cell::Str` at `str_idx` may be written to the array at
 /// `array_pool_idx`.
 ///
-/// The allow/deny matrix (Phase 5A):
+/// **Dead code as of #588 (D-1).** Now that `Cell::Str` is `Rc<str>`-backed
+/// and no longer carries a pool index, `check_array_element_write` rejects
+/// all `Cell::Str` values up front, so this helper is unreachable.  It is
+/// kept (with `#[allow(dead_code)]`) for reference until #590 / #591 retire
+/// the legacy string pool and decide the final array-write policy.
+///
+/// Historical allow/deny matrix (Phase 5A):
 ///
 /// | array lifetime | string lifetime | result |
 /// |----------------|-----------------|--------|
@@ -271,20 +284,12 @@ fn check_array_element_type(value: &Cell) -> Result<(), TbxError> {
 /// | `FrameLocal`   | `CallerOwned`   | allow  |
 /// | `Global` / `CallerOwned` | `CallerOwned` | deny |
 ///
-/// Rationale:
-/// - `FrameLocal` strings are freed when the current call frame returns, so
-///   they must never be placed in any array.
-/// - `Global` strings are safe in any array.
-/// - `CallerOwned` strings are safe only in `FrameLocal` arrays: the array
-///   is bound to the current frame and will die before the string's owning
-///   frame returns.  `CallerOwned` arrays and `Global` arrays may outlive the
-///   string's owning frame because `CallerOwned` does not track which outer
-///   frame owns the resource — two `CallerOwned` values can belong to
-///   different frames with unrelated lifetimes.
-///
 /// # Errors
 ///
 /// Returns `TbxError::StringFrameEscape` when the combination is unsafe.
+// TODO(#590/#591): remove once VM::strings is retired and the new array-write
+// policy is locked in.
+#[allow(dead_code)]
 fn check_string_array_element_write(
     vm: &VM,
     array_pool_idx: usize,
@@ -312,20 +317,31 @@ fn check_string_array_element_write(
 
 /// Check that `value` may be written to the array at `array_pool_idx`.
 ///
-/// This is the lifetime-aware counterpart to `check_array_element_type` and
-/// is used by `write_array_element` (the `SET`/`STORE` path).
+/// This is the validation counterpart to `check_array_element_type` and is
+/// used by `write_array_element` (the `SET`/`STORE` path).
 ///
 /// * `Cell::Array` is always rejected (nested arrays are not supported).
+/// * `Cell::Str` is blanket-rejected with `StringFrameEscape` during the
+///   transition to `Rc<str>`-backed strings.  Now that `Cell::Str` no longer
+///   carries a pool index, the per-string lifetime classification used by
+///   the previous Phase 5A matrix is impossible to express here.  Allowing
+///   strings into arrays will be done in #591 (which can use Rc-based
+///   ownership without lifetime tracking); until then this remains a
+///   conservative reject to preserve the pre-Phase-5B "no strings in arrays"
+///   contract.
 /// * All non-reference scalars are accepted unconditionally.
-/// * `Cell::Str` lifetime rules are delegated to
-///   `check_string_array_element_write`; see that function for the full
-///   allow/deny matrix (Phase 5A).
-fn check_array_element_write(vm: &VM, array_pool_idx: usize, value: &Cell) -> Result<(), TbxError> {
+fn check_array_element_write(
+    _vm: &VM,
+    _array_pool_idx: usize,
+    value: &Cell,
+) -> Result<(), TbxError> {
     match value {
         // Nested arrays are unconditionally rejected.
         Cell::Array(_) => Err(TbxError::InvalidArrayElement { got: "Array" }),
-        // Delegate to the dedicated helper that classifies both lifetimes.
-        Cell::Str(str_idx) => check_string_array_element_write(vm, array_pool_idx, *str_idx),
+        // Blanket reject Cell::Str: lifetime classification is no longer
+        // possible with Rc<str>-backed strings, and array-write liberation
+        // is tracked separately in #591.
+        Cell::Str(_) => Err(TbxError::StringFrameEscape),
         // All other scalar types are accepted.
         _ => Ok(()),
     }
@@ -334,25 +350,26 @@ fn check_array_element_write(vm: &VM, array_pool_idx: usize, value: &Cell) -> Re
 /// Validate and (in future phases) transform `value` before it is stored in
 /// the array at `array_pool_idx`.
 ///
-/// This is the Phase 5B entry-point for array element writes.  In the current
-/// phase (5B-1) the behaviour is identical to `check_array_element_write`:
-/// validation only, no clone/promote.  Subsequent phases will intercept
-/// specific lifetime combinations here and return a modified `Cell` (e.g. a
-/// global clone of a `CallerOwned` string).
+/// This is the Phase 5B entry-point for array element writes.
 ///
-/// # Allow/deny matrix (Phase 5A — unchanged in 5B-1)
+/// Current policy (#588 D-1):
 ///
-/// | array lifetime           | string lifetime  | result |
-/// |--------------------------|------------------|--------|
-/// | any                      | `FrameLocal`     | deny   |
-/// | any                      | `Global`         | allow  |
-/// | `FrameLocal`             | `CallerOwned`    | allow  |
-/// | `Global` / `CallerOwned` | `CallerOwned`    | deny   |
+/// * Nested `Cell::Array` is rejected with `InvalidArrayElement`.
+/// * `Cell::Str` is rejected with `StringFrameEscape`.  Now that `Cell::Str`
+///   is `Rc<str>`-backed it no longer carries a pool index, so the previous
+///   Phase 5A lifetime matrix (FrameLocal/Global/CallerOwned) is no longer
+///   expressible at this layer.  Liberation of the array write path for
+///   strings is tracked separately by #591, which will allow Rc<str> elements
+///   without further lifetime tracking.
+/// * All other types are accepted.
+///
+/// Future phases may intercept specific cases here and return a modified
+/// `Cell` (e.g. a wrapped or specialised representation), but the D-1 phase
+/// performs validation only — no clone/promote.
 ///
 /// # Errors
 ///
-/// Returns an error when the combination is unsafe or unsupported (e.g.
-/// `Cell::Array` is always rejected as a nested array).
+/// Returns an error when the combination is unsafe or unsupported.
 fn stabilize_array_element_write(
     vm: &mut VM,
     array_pool_idx: usize,
@@ -497,25 +514,16 @@ pub fn putstr_prim(vm: &mut VM) -> Result<(), TbxError> {
 
 /// STR — convert a value to its string representation and push a `Cell::Str` handle.
 ///
-/// Accepts any `Cell` value.  The result is a new entry in `vm.strings`.
+/// Accepts any `Cell` value.
 pub fn str_prim(vm: &mut VM) -> Result<(), TbxError> {
     let cell = vm.pop()?;
-    let s = match &cell {
-        // For Str, return the content directly (identity-like conversion).
-        Cell::Str(idx) => vm
-            .strings
-            .get(*idx)
-            .cloned()
-            .ok_or(TbxError::IndexOutOfBounds {
-                index: *idx,
-                size: vm.strings.len(),
-            })?,
+    let s: std::rc::Rc<str> = match &cell {
+        // For Str, reuse the underlying Rc (identity-like conversion).
+        Cell::Str(rc) => rc.clone(),
         // For everything else, use Display.
-        other => other.to_string(),
+        other => other.to_string().into(),
     };
-    let idx = vm.strings.len();
-    vm.strings.push(s);
-    vm.push(Cell::Str(idx))?;
+    vm.push(Cell::Str(s))?;
     Ok(())
 }
 
@@ -528,9 +536,7 @@ pub fn str_concat_prim(vm: &mut VM) -> Result<(), TbxError> {
     let b = resolve_str_cell(vm, &b_cell)?;
     let a = resolve_str_cell(vm, &a_cell)?;
     let result = a + &b;
-    let idx = vm.strings.len();
-    vm.strings.push(result);
-    vm.push(Cell::Str(idx))?;
+    vm.push(Cell::string(result))?;
     Ok(())
 }
 
@@ -551,8 +557,10 @@ pub fn str_len_prim(vm: &mut VM) -> Result<(), TbxError> {
 ///
 /// Stack: `[..., a: Str, b: Str]` → `Cell::Bool`
 ///
-/// Unlike `Cell::Str(a) == Cell::Str(b)` (index comparison), this compares
-/// the actual string contents.
+/// With `Cell::Str` now `Rc<str>`-backed, the `PartialEq` impl on `Cell`
+/// already compares string content, so this primitive is effectively
+/// equivalent to `EQ` for two `Cell::Str` operands.  It is retained because
+/// the language exposes `STR_EQ` as part of the string-manipulation surface.
 pub fn str_eq_prim(vm: &mut VM) -> Result<(), TbxError> {
     let b_cell = vm.pop()?;
     let a_cell = vm.pop()?;
@@ -615,9 +623,7 @@ pub fn str_slice_prim(vm: &mut VM) -> Result<(), TbxError> {
     let end_idx = start_idx.saturating_add(len as usize).min(chars.len());
     let result: String = chars[start_idx..end_idx].iter().collect();
 
-    let idx = vm.strings.len();
-    vm.strings.push(result);
-    vm.push(Cell::Str(idx))?;
+    vm.push(Cell::string(result))?;
     Ok(())
 }
 
@@ -628,9 +634,7 @@ pub fn str_trim_prim(vm: &mut VM) -> Result<(), TbxError> {
     let s_cell = vm.pop()?;
     let s = resolve_str_cell(vm, &s_cell)?;
     let trimmed = s.trim_matches(char::is_whitespace).to_string();
-    let idx = vm.strings.len();
-    vm.strings.push(trimmed);
-    vm.push(Cell::Str(idx))?;
+    vm.push(Cell::string(trimmed))?;
     Ok(())
 }
 
@@ -641,9 +645,7 @@ pub fn str_upper_prim(vm: &mut VM) -> Result<(), TbxError> {
     let s_cell = vm.pop()?;
     let s = resolve_str_cell(vm, &s_cell)?;
     let upper = s.to_uppercase();
-    let idx = vm.strings.len();
-    vm.strings.push(upper);
-    vm.push(Cell::Str(idx))?;
+    vm.push(Cell::string(upper))?;
     Ok(())
 }
 
@@ -654,9 +656,7 @@ pub fn str_lower_prim(vm: &mut VM) -> Result<(), TbxError> {
     let s_cell = vm.pop()?;
     let s = resolve_str_cell(vm, &s_cell)?;
     let lower = s.to_lowercase();
-    let idx = vm.strings.len();
-    vm.strings.push(lower);
-    vm.push(Cell::Str(idx))?;
+    vm.push(Cell::string(lower))?;
     Ok(())
 }
 
@@ -685,9 +685,7 @@ pub fn str_replace_first_prim(vm: &mut VM) -> Result<(), TbxError> {
         s
     };
 
-    let idx = vm.strings.len();
-    vm.strings.push(result);
-    vm.push(Cell::Str(idx))?;
+    vm.push(Cell::string(result))?;
     Ok(())
 }
 
@@ -709,23 +707,18 @@ pub fn str_replace_all_prim(vm: &mut VM) -> Result<(), TbxError> {
     }
 
     let result = s.replace(&needle, &replacement);
-    let idx = vm.strings.len();
-    vm.strings.push(result);
-    vm.push(Cell::Str(idx))?;
+    vm.push(Cell::string(result))?;
     Ok(())
 }
 
-/// Helper: resolve a `Cell::Str` to a `String` via the runtime string pool.
-fn resolve_str_cell(vm: &VM, cell: &Cell) -> Result<String, TbxError> {
+/// Helper: resolve a `Cell::Str` to an owned `String`.
+///
+/// `Cell::Str` is `Rc<str>`-backed (#588), so this is just an `Rc -> String`
+/// copy.  The `vm` parameter is retained for now to minimise call-site
+/// churn; it can be dropped together with the legacy string pool in #590.
+fn resolve_str_cell(_vm: &VM, cell: &Cell) -> Result<String, TbxError> {
     match cell {
-        Cell::Str(idx) => vm
-            .strings
-            .get(*idx)
-            .cloned()
-            .ok_or(TbxError::IndexOutOfBounds {
-                index: *idx,
-                size: vm.strings.len(),
-            }),
+        Cell::Str(rc) => Ok(rc.to_string()),
         other => Err(TbxError::TypeError {
             expected: "Str",
             got: other.type_name(),
@@ -795,16 +788,8 @@ pub fn putval_prim(vm: &mut VM) -> Result<(), TbxError> {
             vm.write_output(&s);
         }
         Cell::Bool(b) => vm.write_output(if b { "TRUE" } else { "FALSE" }),
-        Cell::Str(idx) => {
-            let s = vm
-                .strings
-                .get(idx)
-                .cloned()
-                .ok_or(TbxError::IndexOutOfBounds {
-                    index: idx,
-                    size: vm.strings.len(),
-                })?;
-            vm.write_output(&s);
+        Cell::Str(rc) => {
+            vm.write_output(rc.as_ref());
         }
         other => {
             return Err(TbxError::TypeError {
@@ -2334,9 +2319,9 @@ pub fn getdec_prim(vm: &mut VM) -> Result<(), TbxError> {
 
 /// GETSTR — read one line from the input and push it as a `Cell::Str` onto the data stack.
 ///
-/// Calls `accept_prim` internally to read a line, then stores the result in `vm.strings`
-/// (the runtime string pool) and pushes `Cell::Str(idx)` where `idx` is the new entry's
-/// index.  The trailing newline is stripped by `accept_prim`.
+/// Calls `accept_prim` internally to read a line, then wraps the result in
+/// an `Rc<str>` and pushes it as `Cell::Str`.  The trailing newline is
+/// stripped by `accept_prim`.
 ///
 /// This is the string counterpart of `GETDEC`.  The resulting `Cell::Str` is compatible
 /// with all existing string primitives (`PUTSTR`, `STR`, `STR_CONCAT`, `STR_LEN`,
@@ -2345,9 +2330,7 @@ pub fn getdec_prim(vm: &mut VM) -> Result<(), TbxError> {
 /// Stack signature: `( -- s )`
 pub fn getstr_prim(vm: &mut VM) -> Result<(), TbxError> {
     let s = accept_prim(vm)?;
-    let idx = vm.strings.len();
-    vm.strings.push(s);
-    vm.push(Cell::Str(idx))
+    vm.push(Cell::string(s))
 }
 
 /// RND — generate a random integer in the range [1, n].
@@ -3413,22 +3396,18 @@ mod tests {
     #[test]
     fn test_eq_str_compares_content() {
         let mut vm = VM::new();
-        vm.strings.push("hello".to_string());
-        vm.strings.push("hello".to_string());
-        vm.push(Cell::Str(0)).unwrap();
-        vm.push(Cell::Str(1)).unwrap();
+        vm.push(Cell::string("hello")).unwrap();
+        vm.push(Cell::string("hello")).unwrap();
         eq_prim(&mut vm).unwrap();
         assert_eq!(vm.pop(), Ok(Cell::Bool(true)));
     }
 
     #[test]
-    fn test_eq_str_different_indices_same_content_is_true() {
-        // Two distinct Cell::Str entries pointing at identical content compare equal.
+    fn test_eq_str_different_handles_same_content_is_true() {
+        // Two distinct Cell::Str handles holding identical content compare equal.
         let mut vm = VM::new();
-        vm.strings.push("hello".to_string());
-        vm.strings.push("hello".to_string());
-        vm.push(Cell::Str(0)).unwrap();
-        vm.push(Cell::Str(1)).unwrap();
+        vm.push(Cell::string("hello")).unwrap();
+        vm.push(Cell::string("hello")).unwrap();
         eq_prim(&mut vm).unwrap();
         assert_eq!(vm.pop(), Ok(Cell::Bool(true)));
     }
@@ -3463,22 +3442,18 @@ mod tests {
     #[test]
     fn test_neq_str_compares_content() {
         let mut vm = VM::new();
-        vm.strings.push("foo".to_string());
-        vm.strings.push("bar".to_string());
-        vm.push(Cell::Str(0)).unwrap();
-        vm.push(Cell::Str(1)).unwrap();
+        vm.push(Cell::string("foo")).unwrap();
+        vm.push(Cell::string("bar")).unwrap();
         neq_prim(&mut vm).unwrap();
         assert_eq!(vm.pop(), Ok(Cell::Bool(true)));
     }
 
     #[test]
-    fn test_neq_str_different_indices_different_content_is_true() {
-        // Two distinct Cell::Str entries with different content compare not-equal.
+    fn test_neq_str_different_handles_different_content_is_true() {
+        // Two distinct Cell::Str handles with different content compare not-equal.
         let mut vm = VM::new();
-        vm.strings.push("hello".to_string());
-        vm.strings.push("world".to_string());
-        vm.push(Cell::Str(0)).unwrap();
-        vm.push(Cell::Str(1)).unwrap();
+        vm.push(Cell::string("hello")).unwrap();
+        vm.push(Cell::string("world")).unwrap();
         neq_prim(&mut vm).unwrap();
         assert_eq!(vm.pop(), Ok(Cell::Bool(true)));
     }
@@ -3803,8 +3778,7 @@ mod tests {
     #[test]
     fn test_putstr_basic() {
         let mut vm = VM::new();
-        vm.strings.push("hello".to_string());
-        vm.push(Cell::Str(0)).unwrap();
+        vm.push(Cell::string("hello")).unwrap();
         putstr_prim(&mut vm).unwrap();
         assert_eq!(vm.take_output(), "hello");
     }
@@ -3812,8 +3786,7 @@ mod tests {
     #[test]
     fn test_putstr_empty() {
         let mut vm = VM::new();
-        vm.strings.push(String::new());
-        vm.push(Cell::Str(0)).unwrap();
+        vm.push(Cell::string("")).unwrap();
         putstr_prim(&mut vm).unwrap();
         assert_eq!(vm.take_output(), "");
     }
@@ -3844,8 +3817,7 @@ mod tests {
         let mut vm = VM::new();
         vm.push(Cell::Int(42)).unwrap();
         str_prim(&mut vm).unwrap();
-        assert_eq!(vm.pop().unwrap(), Cell::Str(0));
-        assert_eq!(vm.strings[0], "42");
+        assert_eq!(vm.pop().unwrap(), Cell::string("42"));
     }
 
     #[test]
@@ -3853,8 +3825,7 @@ mod tests {
         let mut vm = VM::new();
         vm.push(Cell::Float(1.5)).unwrap();
         str_prim(&mut vm).unwrap();
-        assert_eq!(vm.pop().unwrap(), Cell::Str(0));
-        assert_eq!(vm.strings[0], "1.5");
+        assert_eq!(vm.pop().unwrap(), Cell::string("1.5"));
     }
 
     #[test]
@@ -3862,19 +3833,16 @@ mod tests {
         let mut vm = VM::new();
         vm.push(Cell::Bool(true)).unwrap();
         str_prim(&mut vm).unwrap();
-        assert_eq!(vm.pop().unwrap(), Cell::Str(0));
-        assert_eq!(vm.strings[0], "true");
+        assert_eq!(vm.pop().unwrap(), Cell::string("true"));
     }
 
     #[test]
     fn test_str_prim_from_cell_str() {
         let mut vm = VM::new();
-        vm.strings.push("existing".to_string());
-        vm.push(Cell::Str(0)).unwrap();
+        vm.push(Cell::string("existing")).unwrap();
         str_prim(&mut vm).unwrap();
-        // A new Str entry is created (even if content duplicates the original).
-        assert_eq!(vm.pop().unwrap(), Cell::Str(1));
-        assert_eq!(vm.strings[1], "existing");
+        // STR on a Str returns the same content (Rc clone, no copy).
+        assert_eq!(vm.pop().unwrap(), Cell::string("existing"));
     }
 
     #[test]
@@ -3888,20 +3856,16 @@ mod tests {
     #[test]
     fn test_str_concat_basic() {
         let mut vm = VM::new();
-        vm.strings.push("foo".to_string());
-        vm.strings.push("bar".to_string());
-        vm.push(Cell::Str(0)).unwrap();
-        vm.push(Cell::Str(1)).unwrap();
+        vm.push(Cell::string("foo")).unwrap();
+        vm.push(Cell::string("bar")).unwrap();
         str_concat_prim(&mut vm).unwrap();
-        assert_eq!(vm.pop().unwrap(), Cell::Str(2));
-        assert_eq!(vm.strings[2], "foobar");
+        assert_eq!(vm.pop().unwrap(), Cell::string("foobar"));
     }
 
     #[test]
     fn test_str_concat_type_error() {
         let mut vm = VM::new();
-        vm.strings.push("foo".to_string());
-        vm.push(Cell::Str(0)).unwrap();
+        vm.push(Cell::string("foo")).unwrap();
         vm.push(Cell::Int(42)).unwrap();
         assert!(matches!(
             str_concat_prim(&mut vm),
@@ -3914,8 +3878,7 @@ mod tests {
     #[test]
     fn test_str_len_basic() {
         let mut vm = VM::new();
-        vm.strings.push("hello".to_string());
-        vm.push(Cell::Str(0)).unwrap();
+        vm.push(Cell::string("hello")).unwrap();
         str_len_prim(&mut vm).unwrap();
         assert_eq!(vm.pop().unwrap(), Cell::Int(5));
     }
@@ -3923,8 +3886,7 @@ mod tests {
     #[test]
     fn test_str_len_empty() {
         let mut vm = VM::new();
-        vm.strings.push(String::new());
-        vm.push(Cell::Str(0)).unwrap();
+        vm.push(Cell::string("")).unwrap();
         str_len_prim(&mut vm).unwrap();
         assert_eq!(vm.pop().unwrap(), Cell::Int(0));
     }
@@ -3944,10 +3906,8 @@ mod tests {
     #[test]
     fn test_str_eq_equal() {
         let mut vm = VM::new();
-        vm.strings.push("hello".to_string());
-        vm.strings.push("hello".to_string());
-        vm.push(Cell::Str(0)).unwrap();
-        vm.push(Cell::Str(1)).unwrap();
+        vm.push(Cell::string("hello")).unwrap();
+        vm.push(Cell::string("hello")).unwrap();
         str_eq_prim(&mut vm).unwrap();
         assert_eq!(vm.pop().unwrap(), Cell::Bool(true));
     }
@@ -3955,21 +3915,19 @@ mod tests {
     #[test]
     fn test_str_eq_not_equal() {
         let mut vm = VM::new();
-        vm.strings.push("foo".to_string());
-        vm.strings.push("bar".to_string());
-        vm.push(Cell::Str(0)).unwrap();
-        vm.push(Cell::Str(1)).unwrap();
+        vm.push(Cell::string("foo")).unwrap();
+        vm.push(Cell::string("bar")).unwrap();
         str_eq_prim(&mut vm).unwrap();
         assert_eq!(vm.pop().unwrap(), Cell::Bool(false));
     }
 
     #[test]
-    fn test_str_eq_same_index_is_equal() {
-        // Even the same index via different cells should be equal.
+    fn test_str_eq_same_rc_is_equal() {
+        // Two Cell::Str that share the same Rc compare equal.
         let mut vm = VM::new();
-        vm.strings.push("x".to_string());
-        vm.push(Cell::Str(0)).unwrap();
-        vm.push(Cell::Str(0)).unwrap();
+        let s: std::rc::Rc<str> = "x".into();
+        vm.push(Cell::Str(s.clone())).unwrap();
+        vm.push(Cell::Str(s)).unwrap();
         str_eq_prim(&mut vm).unwrap();
         assert_eq!(vm.pop().unwrap(), Cell::Bool(true));
     }
@@ -3979,10 +3937,8 @@ mod tests {
     #[test]
     fn test_str_indexof_found_returns_1_based_position() {
         let mut vm = VM::new();
-        vm.strings.push("hello world".to_string());
-        vm.strings.push("world".to_string());
-        vm.push(Cell::Str(0)).unwrap();
-        vm.push(Cell::Str(1)).unwrap();
+        vm.push(Cell::string("hello world")).unwrap();
+        vm.push(Cell::string("world")).unwrap();
         str_indexof_prim(&mut vm).unwrap();
         assert_eq!(vm.pop().unwrap(), Cell::Int(7));
     }
@@ -3990,10 +3946,8 @@ mod tests {
     #[test]
     fn test_str_indexof_not_found_returns_zero() {
         let mut vm = VM::new();
-        vm.strings.push("abc".to_string());
-        vm.strings.push("z".to_string());
-        vm.push(Cell::Str(0)).unwrap();
-        vm.push(Cell::Str(1)).unwrap();
+        vm.push(Cell::string("abc")).unwrap();
+        vm.push(Cell::string("z")).unwrap();
         str_indexof_prim(&mut vm).unwrap();
         assert_eq!(vm.pop().unwrap(), Cell::Int(0));
     }
@@ -4001,10 +3955,8 @@ mod tests {
     #[test]
     fn test_str_indexof_counts_unicode_chars() {
         let mut vm = VM::new();
-        vm.strings.push("あいうえお".to_string());
-        vm.strings.push("うえ".to_string());
-        vm.push(Cell::Str(0)).unwrap();
-        vm.push(Cell::Str(1)).unwrap();
+        vm.push(Cell::string("あいうえお")).unwrap();
+        vm.push(Cell::string("うえ")).unwrap();
         str_indexof_prim(&mut vm).unwrap();
         assert_eq!(vm.pop().unwrap(), Cell::Int(3));
     }
@@ -4012,10 +3964,8 @@ mod tests {
     #[test]
     fn test_str_indexof_empty_needle_returns_one() {
         let mut vm = VM::new();
-        vm.strings.push("abc".to_string());
-        vm.strings.push(String::new());
-        vm.push(Cell::Str(0)).unwrap();
-        vm.push(Cell::Str(1)).unwrap();
+        vm.push(Cell::string("abc")).unwrap();
+        vm.push(Cell::string("")).unwrap();
         str_indexof_prim(&mut vm).unwrap();
         assert_eq!(vm.pop().unwrap(), Cell::Int(1));
     }
@@ -4023,8 +3973,7 @@ mod tests {
     #[test]
     fn test_str_indexof_type_error() {
         let mut vm = VM::new();
-        vm.strings.push("abc".to_string());
-        vm.push(Cell::Str(0)).unwrap();
+        vm.push(Cell::string("abc")).unwrap();
         vm.push(Cell::Int(1)).unwrap();
         assert!(matches!(
             str_indexof_prim(&mut vm),
@@ -4037,80 +3986,67 @@ mod tests {
     #[test]
     fn test_str_slice_basic() {
         let mut vm = VM::new();
-        vm.strings.push("abcdef".to_string());
-        vm.push(Cell::Str(0)).unwrap();
+        vm.push(Cell::string("abcdef")).unwrap();
         vm.push(Cell::Int(2)).unwrap();
         vm.push(Cell::Int(3)).unwrap();
         str_slice_prim(&mut vm).unwrap();
-        assert_eq!(vm.pop().unwrap(), Cell::Str(1));
-        assert_eq!(vm.strings[1], "bcd");
+        assert_eq!(vm.pop().unwrap(), Cell::string("bcd"));
     }
 
     #[test]
     fn test_str_slice_negative_start_counts_from_end() {
         let mut vm = VM::new();
-        vm.strings.push("abcdef".to_string());
-        vm.push(Cell::Str(0)).unwrap();
+        vm.push(Cell::string("abcdef")).unwrap();
         vm.push(Cell::Int(-3)).unwrap();
         vm.push(Cell::Int(2)).unwrap();
         str_slice_prim(&mut vm).unwrap();
-        assert_eq!(vm.pop().unwrap(), Cell::Str(1));
-        assert_eq!(vm.strings[1], "de");
+        assert_eq!(vm.pop().unwrap(), Cell::string("de"));
     }
 
     #[test]
     fn test_str_slice_clips_past_end() {
         let mut vm = VM::new();
-        vm.strings.push("abc".to_string());
-        vm.push(Cell::Str(0)).unwrap();
+        vm.push(Cell::string("abc")).unwrap();
         vm.push(Cell::Int(2)).unwrap();
         vm.push(Cell::Int(10)).unwrap();
         str_slice_prim(&mut vm).unwrap();
-        assert_eq!(vm.pop().unwrap(), Cell::Str(1));
-        assert_eq!(vm.strings[1], "bc");
+        assert_eq!(vm.pop().unwrap(), Cell::string("bc"));
     }
 
     #[test]
     fn test_str_slice_too_negative_start_clips_to_beginning() {
         let mut vm = VM::new();
-        vm.strings.push("abc".to_string());
-        vm.push(Cell::Str(0)).unwrap();
+        vm.push(Cell::string("abc")).unwrap();
         vm.push(Cell::Int(-10)).unwrap();
         vm.push(Cell::Int(2)).unwrap();
         str_slice_prim(&mut vm).unwrap();
-        assert_eq!(vm.pop().unwrap(), Cell::Str(1));
-        assert_eq!(vm.strings[1], "ab");
+        assert_eq!(vm.pop().unwrap(), Cell::string("ab"));
     }
 
     #[test]
     fn test_str_slice_counts_unicode_chars() {
         let mut vm = VM::new();
-        vm.strings.push("あいうえお".to_string());
-        vm.push(Cell::Str(0)).unwrap();
+        vm.push(Cell::string("あいうえお")).unwrap();
         vm.push(Cell::Int(2)).unwrap();
         vm.push(Cell::Int(2)).unwrap();
         str_slice_prim(&mut vm).unwrap();
-        assert_eq!(vm.pop().unwrap(), Cell::Str(1));
-        assert_eq!(vm.strings[1], "いう");
+        assert_eq!(vm.pop().unwrap(), Cell::string("いう"));
     }
 
     #[test]
     fn test_str_slice_zero_length_returns_empty_string() {
         let mut vm = VM::new();
-        vm.strings.push("abc".to_string());
-        vm.push(Cell::Str(0)).unwrap();
+        vm.push(Cell::string("abc")).unwrap();
         vm.push(Cell::Int(2)).unwrap();
         vm.push(Cell::Int(0)).unwrap();
         str_slice_prim(&mut vm).unwrap();
-        assert_eq!(vm.pop().unwrap(), Cell::Str(1));
-        assert_eq!(vm.strings[1], "");
+        assert_eq!(vm.pop().unwrap(), Cell::string(""));
     }
 
     #[test]
     fn test_str_slice_start_zero_is_invalid_argument() {
         let mut vm = VM::new();
-        vm.strings.push("abc".to_string());
-        vm.push(Cell::Str(0)).unwrap();
+        vm.push(Cell::string("abc")).unwrap();
         vm.push(Cell::Int(0)).unwrap();
         vm.push(Cell::Int(1)).unwrap();
         assert!(matches!(
@@ -4122,8 +4058,7 @@ mod tests {
     #[test]
     fn test_str_slice_negative_length_is_invalid_argument() {
         let mut vm = VM::new();
-        vm.strings.push("abc".to_string());
-        vm.push(Cell::Str(0)).unwrap();
+        vm.push(Cell::string("abc")).unwrap();
         vm.push(Cell::Int(1)).unwrap();
         vm.push(Cell::Int(-1)).unwrap();
         assert!(matches!(
@@ -4137,41 +4072,33 @@ mod tests {
     #[test]
     fn test_str_trim_removes_ascii_spaces() {
         let mut vm = VM::new();
-        vm.strings.push("  hello  ".to_string());
-        vm.push(Cell::Str(0)).unwrap();
+        vm.push(Cell::string("  hello  ")).unwrap();
         str_trim_prim(&mut vm).unwrap();
-        assert_eq!(vm.pop().unwrap(), Cell::Str(1));
-        assert_eq!(vm.strings[1], "hello");
+        assert_eq!(vm.pop().unwrap(), Cell::string("hello"));
     }
 
     #[test]
     fn test_str_trim_removes_unicode_whitespace() {
         let mut vm = VM::new();
-        vm.strings.push("\u{3000}abc\u{3000}".to_string());
-        vm.push(Cell::Str(0)).unwrap();
+        vm.push(Cell::string("\u{3000}abc\u{3000}")).unwrap();
         str_trim_prim(&mut vm).unwrap();
-        assert_eq!(vm.pop().unwrap(), Cell::Str(1));
-        assert_eq!(vm.strings[1], "abc");
+        assert_eq!(vm.pop().unwrap(), Cell::string("abc"));
     }
 
     #[test]
     fn test_str_trim_keeps_inner_whitespace() {
         let mut vm = VM::new();
-        vm.strings.push("  hello world  ".to_string());
-        vm.push(Cell::Str(0)).unwrap();
+        vm.push(Cell::string("  hello world  ")).unwrap();
         str_trim_prim(&mut vm).unwrap();
-        assert_eq!(vm.pop().unwrap(), Cell::Str(1));
-        assert_eq!(vm.strings[1], "hello world");
+        assert_eq!(vm.pop().unwrap(), Cell::string("hello world"));
     }
 
     #[test]
     fn test_str_trim_all_whitespace_becomes_empty() {
         let mut vm = VM::new();
-        vm.strings.push("\n\t\u{3000}".to_string());
-        vm.push(Cell::Str(0)).unwrap();
+        vm.push(Cell::string("\n\t\u{3000}")).unwrap();
         str_trim_prim(&mut vm).unwrap();
-        assert_eq!(vm.pop().unwrap(), Cell::Str(1));
-        assert_eq!(vm.strings[1], "");
+        assert_eq!(vm.pop().unwrap(), Cell::string(""));
     }
 
     // --- str_upper_prim tests ---
@@ -4179,21 +4106,17 @@ mod tests {
     #[test]
     fn test_str_upper_ascii() {
         let mut vm = VM::new();
-        vm.strings.push("Abc123".to_string());
-        vm.push(Cell::Str(0)).unwrap();
+        vm.push(Cell::string("Abc123")).unwrap();
         str_upper_prim(&mut vm).unwrap();
-        assert_eq!(vm.pop().unwrap(), Cell::Str(1));
-        assert_eq!(vm.strings[1], "ABC123");
+        assert_eq!(vm.pop().unwrap(), Cell::string("ABC123"));
     }
 
     #[test]
     fn test_str_upper_unicode_can_change_length() {
         let mut vm = VM::new();
-        vm.strings.push("straße".to_string());
-        vm.push(Cell::Str(0)).unwrap();
+        vm.push(Cell::string("straße")).unwrap();
         str_upper_prim(&mut vm).unwrap();
-        assert_eq!(vm.pop().unwrap(), Cell::Str(1));
-        assert_eq!(vm.strings[1], "STRASSE");
+        assert_eq!(vm.pop().unwrap(), Cell::string("STRASSE"));
     }
 
     // --- str_lower_prim tests ---
@@ -4201,21 +4124,17 @@ mod tests {
     #[test]
     fn test_str_lower_ascii() {
         let mut vm = VM::new();
-        vm.strings.push("AbC123".to_string());
-        vm.push(Cell::Str(0)).unwrap();
+        vm.push(Cell::string("AbC123")).unwrap();
         str_lower_prim(&mut vm).unwrap();
-        assert_eq!(vm.pop().unwrap(), Cell::Str(1));
-        assert_eq!(vm.strings[1], "abc123");
+        assert_eq!(vm.pop().unwrap(), Cell::string("abc123"));
     }
 
     #[test]
     fn test_str_lower_unicode() {
         let mut vm = VM::new();
-        vm.strings.push("ÄÖÜ".to_string());
-        vm.push(Cell::Str(0)).unwrap();
+        vm.push(Cell::string("ÄÖÜ")).unwrap();
         str_lower_prim(&mut vm).unwrap();
-        assert_eq!(vm.pop().unwrap(), Cell::Str(1));
-        assert_eq!(vm.strings[1], "äöü");
+        assert_eq!(vm.pop().unwrap(), Cell::string("äöü"));
     }
 
     // --- str_replace_first_prim tests ---
@@ -4223,54 +4142,39 @@ mod tests {
     #[test]
     fn test_str_replace_first_replaces_only_first_match() {
         let mut vm = VM::new();
-        vm.strings.push("abcabc".to_string());
-        vm.strings.push("ab".to_string());
-        vm.strings.push("X".to_string());
-        vm.push(Cell::Str(0)).unwrap();
-        vm.push(Cell::Str(1)).unwrap();
-        vm.push(Cell::Str(2)).unwrap();
+        vm.push(Cell::string("abcabc")).unwrap();
+        vm.push(Cell::string("ab")).unwrap();
+        vm.push(Cell::string("X")).unwrap();
         str_replace_first_prim(&mut vm).unwrap();
-        assert_eq!(vm.pop().unwrap(), Cell::Str(3));
-        assert_eq!(vm.strings[3], "Xcabc");
+        assert_eq!(vm.pop().unwrap(), Cell::string("Xcabc"));
     }
 
     #[test]
     fn test_str_replace_first_returns_copy_when_not_found() {
         let mut vm = VM::new();
-        vm.strings.push("abc".to_string());
-        vm.strings.push("z".to_string());
-        vm.strings.push("X".to_string());
-        vm.push(Cell::Str(0)).unwrap();
-        vm.push(Cell::Str(1)).unwrap();
-        vm.push(Cell::Str(2)).unwrap();
+        vm.push(Cell::string("abc")).unwrap();
+        vm.push(Cell::string("z")).unwrap();
+        vm.push(Cell::string("X")).unwrap();
         str_replace_first_prim(&mut vm).unwrap();
-        assert_eq!(vm.pop().unwrap(), Cell::Str(3));
-        assert_eq!(vm.strings[3], "abc");
+        assert_eq!(vm.pop().unwrap(), Cell::string("abc"));
     }
 
     #[test]
     fn test_str_replace_first_handles_unicode() {
         let mut vm = VM::new();
-        vm.strings.push("あいうあい".to_string());
-        vm.strings.push("あい".to_string());
-        vm.strings.push("x".to_string());
-        vm.push(Cell::Str(0)).unwrap();
-        vm.push(Cell::Str(1)).unwrap();
-        vm.push(Cell::Str(2)).unwrap();
+        vm.push(Cell::string("あいうあい")).unwrap();
+        vm.push(Cell::string("あい")).unwrap();
+        vm.push(Cell::string("x")).unwrap();
         str_replace_first_prim(&mut vm).unwrap();
-        assert_eq!(vm.pop().unwrap(), Cell::Str(3));
-        assert_eq!(vm.strings[3], "xうあい");
+        assert_eq!(vm.pop().unwrap(), Cell::string("xうあい"));
     }
 
     #[test]
     fn test_str_replace_first_empty_needle_is_invalid_argument() {
         let mut vm = VM::new();
-        vm.strings.push("abc".to_string());
-        vm.strings.push(String::new());
-        vm.strings.push("X".to_string());
-        vm.push(Cell::Str(0)).unwrap();
-        vm.push(Cell::Str(1)).unwrap();
-        vm.push(Cell::Str(2)).unwrap();
+        vm.push(Cell::string("abc")).unwrap();
+        vm.push(Cell::string("")).unwrap();
+        vm.push(Cell::string("X")).unwrap();
         assert!(matches!(
             str_replace_first_prim(&mut vm),
             Err(TbxError::InvalidArgument { .. })
@@ -4282,68 +4186,49 @@ mod tests {
     #[test]
     fn test_str_replace_all_replaces_all_matches() {
         let mut vm = VM::new();
-        vm.strings.push("abcabc".to_string());
-        vm.strings.push("ab".to_string());
-        vm.strings.push("X".to_string());
-        vm.push(Cell::Str(0)).unwrap();
-        vm.push(Cell::Str(1)).unwrap();
-        vm.push(Cell::Str(2)).unwrap();
+        vm.push(Cell::string("abcabc")).unwrap();
+        vm.push(Cell::string("ab")).unwrap();
+        vm.push(Cell::string("X")).unwrap();
         str_replace_all_prim(&mut vm).unwrap();
-        assert_eq!(vm.pop().unwrap(), Cell::Str(3));
-        assert_eq!(vm.strings[3], "XcXc");
+        assert_eq!(vm.pop().unwrap(), Cell::string("XcXc"));
     }
 
     #[test]
     fn test_str_replace_all_returns_copy_when_not_found() {
         let mut vm = VM::new();
-        vm.strings.push("abc".to_string());
-        vm.strings.push("z".to_string());
-        vm.strings.push("X".to_string());
-        vm.push(Cell::Str(0)).unwrap();
-        vm.push(Cell::Str(1)).unwrap();
-        vm.push(Cell::Str(2)).unwrap();
+        vm.push(Cell::string("abc")).unwrap();
+        vm.push(Cell::string("z")).unwrap();
+        vm.push(Cell::string("X")).unwrap();
         str_replace_all_prim(&mut vm).unwrap();
-        assert_eq!(vm.pop().unwrap(), Cell::Str(3));
-        assert_eq!(vm.strings[3], "abc");
+        assert_eq!(vm.pop().unwrap(), Cell::string("abc"));
     }
 
     #[test]
     fn test_str_replace_all_handles_unicode() {
         let mut vm = VM::new();
-        vm.strings.push("あいうあい".to_string());
-        vm.strings.push("あい".to_string());
-        vm.strings.push("x".to_string());
-        vm.push(Cell::Str(0)).unwrap();
-        vm.push(Cell::Str(1)).unwrap();
-        vm.push(Cell::Str(2)).unwrap();
+        vm.push(Cell::string("あいうあい")).unwrap();
+        vm.push(Cell::string("あい")).unwrap();
+        vm.push(Cell::string("x")).unwrap();
         str_replace_all_prim(&mut vm).unwrap();
-        assert_eq!(vm.pop().unwrap(), Cell::Str(3));
-        assert_eq!(vm.strings[3], "xうx");
+        assert_eq!(vm.pop().unwrap(), Cell::string("xうx"));
     }
 
     #[test]
     fn test_str_replace_all_uses_non_overlapping_matches() {
         let mut vm = VM::new();
-        vm.strings.push("aaaa".to_string());
-        vm.strings.push("aa".to_string());
-        vm.strings.push("b".to_string());
-        vm.push(Cell::Str(0)).unwrap();
-        vm.push(Cell::Str(1)).unwrap();
-        vm.push(Cell::Str(2)).unwrap();
+        vm.push(Cell::string("aaaa")).unwrap();
+        vm.push(Cell::string("aa")).unwrap();
+        vm.push(Cell::string("b")).unwrap();
         str_replace_all_prim(&mut vm).unwrap();
-        assert_eq!(vm.pop().unwrap(), Cell::Str(3));
-        assert_eq!(vm.strings[3], "bb");
+        assert_eq!(vm.pop().unwrap(), Cell::string("bb"));
     }
 
     #[test]
     fn test_str_replace_all_empty_needle_is_invalid_argument() {
         let mut vm = VM::new();
-        vm.strings.push("abc".to_string());
-        vm.strings.push(String::new());
-        vm.strings.push("X".to_string());
-        vm.push(Cell::Str(0)).unwrap();
-        vm.push(Cell::Str(1)).unwrap();
-        vm.push(Cell::Str(2)).unwrap();
+        vm.push(Cell::string("abc")).unwrap();
+        vm.push(Cell::string("")).unwrap();
+        vm.push(Cell::string("X")).unwrap();
         assert!(matches!(
             str_replace_all_prim(&mut vm),
             Err(TbxError::InvalidArgument { .. })
@@ -4353,45 +4238,28 @@ mod tests {
     // --- StringFrameEscape tests ---
 
     #[test]
+    #[ignore = "#590: relies on the pool-index distinction between frame-local and global strings, which Rc<str> removes. To be replaced once VM::strings is retired."]
     fn test_string_frame_escape_via_store() {
-        // A Str created inside a word (pool_idx >= global_string_pool_len) must not
-        // be stored into a DictAddr.
-        let mut vm = VM::new();
-        // global_string_pool_len = 0, so any Str(idx) will be a frame-local string.
-        vm.strings.push("local".to_string());
-        vm.push(Cell::Str(0)).unwrap();
-        vm.dictionary.push(Cell::None);
-        vm.dp = 1;
-        vm.push(Cell::DictAddr(0)).unwrap();
-        // STORE pops addr then value, so push value first then addr.
-        // Re-push in the right order.
-        vm.data_stack.clear();
-        vm.push(Cell::Str(0)).unwrap();
-        vm.push(Cell::DictAddr(0)).unwrap();
-        // store_prim pops addr first then value.
-        let result = store_prim(&mut vm);
-        assert_eq!(result, Err(TbxError::StringFrameEscape));
+        // Pre-#588: A Str created inside a word (pool_idx >= global_string_pool_len)
+        // must not be stored into a DictAddr.  Rc<str>-backed Cell::Str has no
+        // pool index, so this scenario is no longer expressible at this layer.
     }
 
     #[test]
+    #[ignore = "#590: depends on the pool-index distinction between global and non-global strings. Rc<str>-backed Cell::Str carries no index. The successor test will simply assert that Cell::string(...) can be stored in a dict slot."]
     fn test_global_string_stored_via_store() {
-        // A Str created at top level (pool_idx < global_string_pool_len) may be stored.
-        let mut vm = VM::new();
-        vm.strings.push("global".to_string());
-        vm.global_string_pool_len = 1; // promote to global
-        vm.dictionary.push(Cell::None);
-        vm.dp = 1;
-        // store_prim: stack = [value, addr], pops addr first.
-        vm.push(Cell::Str(0)).unwrap(); // value
-        vm.push(Cell::DictAddr(0)).unwrap(); // addr (top)
-        store_prim(&mut vm).unwrap();
-        assert_eq!(vm.dictionary[0], Cell::Str(0));
+        // Pre-#588: A Str created at top level (pool_idx < global_string_pool_len)
+        // could be stored without StringFrameEscape.  With Rc<str>, all
+        // Cell::Str values are now safe in dict slots, so the test loses its
+        // discriminating power.
     }
 
     #[test]
-    fn test_pool_ref_from_cell_array_and_str_only() {
+    fn test_pool_ref_from_cell_array_only() {
+        // Cell::Array still produces a PoolRef; Cell::Str is now Rc<str>-backed
+        // and returns None.
         assert_eq!(pool_ref_from_cell(&Cell::Array(3)), Some(PoolRef::Array(3)));
-        assert_eq!(pool_ref_from_cell(&Cell::Str(4)), Some(PoolRef::String(4)));
+        assert_eq!(pool_ref_from_cell(&Cell::string("hello")), None);
         assert_eq!(
             pool_ref_from_cell(&Cell::ArrayAddr {
                 pool_idx: 1,
@@ -4708,8 +4576,7 @@ mod tests {
     #[test]
     fn test_putval_str() {
         let mut vm = VM::new();
-        vm.strings.push("world".to_string());
-        vm.push(Cell::Str(0)).unwrap();
+        vm.push(Cell::string("world")).unwrap();
         putval_prim(&mut vm).unwrap();
         assert_eq!(vm.take_output(), "world");
     }
@@ -4938,8 +4805,7 @@ mod tests {
     #[test]
     fn test_assert_fail_msg_returns_assertion_failed_with_message() {
         let mut vm = VM::new();
-        vm.strings.push("SIGN(7) should be 1".to_string());
-        vm.push(Cell::Str(0)).unwrap();
+        vm.push(Cell::string("SIGN(7) should be 1")).unwrap();
         let result = assert_fail_msg_prim(&mut vm);
         assert!(matches!(
             result,
@@ -4953,8 +4819,7 @@ mod tests {
     #[test]
     fn test_assert_fail_msg_pops_message_from_stack() {
         let mut vm = VM::new();
-        vm.strings.push("msg".to_string());
-        vm.push(Cell::Str(0)).unwrap();
+        vm.push(Cell::string("msg")).unwrap();
         let _ = assert_fail_msg_prim(&mut vm);
         assert_eq!(vm.data_stack.len(), 0);
     }
@@ -6530,8 +6395,7 @@ mod tests {
         // CS_OPEN_TAG outside compile mode must return InvalidExpression.
         let mut vm = VM::new();
         register_all(&mut vm);
-        vm.strings.push("IF".to_string());
-        vm.push(Cell::Str(0)).unwrap();
+        vm.push(Cell::string("IF")).unwrap();
         let err = cs_open_tag_prim(&mut vm).unwrap_err();
         assert!(
             matches!(err, TbxError::InvalidExpression { .. }),
@@ -6541,10 +6405,10 @@ mod tests {
 
     #[test]
     fn test_cs_open_tag_pushes_tag_to_compile_stack() {
-        // CS_OPEN_TAG must pop a Cell::Str, resolve it and push Tag to compile_stack.
+        // CS_OPEN_TAG must pop a Cell::Str and push the corresponding Tag onto
+        // the compile_stack.
         let mut vm = make_compiling_vm("TESTWORD");
-        vm.strings.push("WHILE".to_string());
-        vm.push(Cell::Str(0)).unwrap();
+        vm.push(Cell::string("WHILE")).unwrap();
         cs_open_tag_prim(&mut vm).unwrap();
         // data stack must be empty.
         assert_eq!(vm.pop(), Err(TbxError::StackUnderflow));
@@ -6583,8 +6447,7 @@ mod tests {
         // CS_CLOSE_TAG outside compile mode must return InvalidExpression.
         let mut vm = VM::new();
         register_all(&mut vm);
-        vm.strings.push("IF".to_string());
-        vm.push(Cell::Str(0)).unwrap();
+        vm.push(Cell::string("IF")).unwrap();
         let err = cs_close_tag_prim(&mut vm).unwrap_err();
         assert!(
             matches!(err, TbxError::InvalidExpression { .. }),
@@ -6598,9 +6461,7 @@ mod tests {
         let mut vm = make_compiling_vm("TESTWORD");
         vm.compile_stack
             .push(CompileEntry::Tag("WHILE".to_string()));
-        let str_idx = vm.strings.len();
-        vm.strings.push("WHILE".to_string());
-        vm.push(Cell::Str(str_idx)).unwrap();
+        vm.push(Cell::string("WHILE")).unwrap();
         cs_close_tag_prim(&mut vm).unwrap();
         assert!(vm.compile_stack.is_empty());
     }
@@ -6613,9 +6474,7 @@ mod tests {
         // compile_stack anyway.
         let mut vm = make_compiling_vm("TESTWORD");
         vm.compile_stack.push(CompileEntry::Tag("IF".to_string()));
-        let str_idx = vm.strings.len();
-        vm.strings.push("WHILE".to_string());
-        vm.push(Cell::Str(str_idx)).unwrap();
+        vm.push(Cell::string("WHILE")).unwrap();
         let err = cs_close_tag_prim(&mut vm).unwrap_err();
         assert!(
             matches!(
@@ -6639,9 +6498,7 @@ mod tests {
     fn test_cs_close_tag_empty_stack_error() {
         // CS_CLOSE_TAG with an empty compile_stack must return NoOpenTag.
         let mut vm = make_compiling_vm("TESTWORD");
-        let str_idx = vm.strings.len();
-        vm.strings.push("WHILE".to_string());
-        vm.push(Cell::Str(str_idx)).unwrap();
+        vm.push(Cell::string("WHILE")).unwrap();
         let err = cs_close_tag_prim(&mut vm).unwrap_err();
         assert!(
             matches!(err, TbxError::NoOpenTag { ref expected } if expected == "WHILE"),
@@ -6654,9 +6511,7 @@ mod tests {
         // CS_CLOSE_TAG with a Cell (not Tag) on top of compile_stack must return NoOpenTag.
         let mut vm = make_compiling_vm("TESTWORD");
         vm.compile_stack.push(CompileEntry::Cell(Cell::Int(42)));
-        let str_idx = vm.strings.len();
-        vm.strings.push("IF".to_string());
-        vm.push(Cell::Str(str_idx)).unwrap();
+        vm.push(Cell::string("IF")).unwrap();
         let err = cs_close_tag_prim(&mut vm).unwrap_err();
         assert!(
             matches!(err, TbxError::NoOpenTag { ref expected } if expected == "IF"),
@@ -6674,26 +6529,18 @@ mod tests {
         // CS_OPEN_TAG and CS_CLOSE_TAG must support correct IF/WHILE nesting.
         let mut vm = make_compiling_vm("TESTWORD");
         // Simulate: IF ... WHILE ... ENDWH ... ENDIF
-        let if_idx_1 = vm.strings.len();
-        vm.strings.push("IF".to_string());
-        vm.push(Cell::Str(if_idx_1)).unwrap();
+        vm.push(Cell::string("IF")).unwrap();
         cs_open_tag_prim(&mut vm).unwrap(); // push Tag("IF")
 
-        let while_idx_1 = vm.strings.len();
-        vm.strings.push("WHILE".to_string());
-        vm.push(Cell::Str(while_idx_1)).unwrap();
+        vm.push(Cell::string("WHILE")).unwrap();
         cs_open_tag_prim(&mut vm).unwrap(); // push Tag("WHILE")
 
         // Close WHILE
-        let while_idx_2 = vm.strings.len();
-        vm.strings.push("WHILE".to_string());
-        vm.push(Cell::Str(while_idx_2)).unwrap();
+        vm.push(Cell::string("WHILE")).unwrap();
         cs_close_tag_prim(&mut vm).unwrap(); // pop Tag("WHILE")
 
         // Close IF
-        let if_idx_2 = vm.strings.len();
-        vm.strings.push("IF".to_string());
-        vm.push(Cell::Str(if_idx_2)).unwrap();
+        vm.push(Cell::string("IF")).unwrap();
         cs_close_tag_prim(&mut vm).unwrap(); // pop Tag("IF")
 
         assert!(vm.compile_stack.is_empty());
@@ -6989,7 +6836,7 @@ mod tests {
         let mut vm = VM::new();
         vm.input_reader = Box::new(Cursor::new("hello\n"));
         getstr_prim(&mut vm).unwrap();
-        assert_eq!(vm.pop(), Ok(Cell::Str(0)));
+        assert_eq!(vm.pop(), Ok(Cell::string("hello")));
     }
 
     #[test]
@@ -6998,8 +6845,7 @@ mod tests {
         let mut vm = VM::new();
         vm.input_reader = Box::new(Cursor::new("\n"));
         getstr_prim(&mut vm).unwrap();
-        assert_eq!(vm.pop(), Ok(Cell::Str(0)));
-        assert_eq!(vm.strings[0], "");
+        assert_eq!(vm.pop(), Ok(Cell::string("")));
     }
 
     #[test]
@@ -7008,7 +6854,7 @@ mod tests {
         let mut vm = VM::new();
         vm.input_reader = Box::new(Cursor::new("world\r\n"));
         getstr_prim(&mut vm).unwrap();
-        assert_eq!(vm.strings[0], "world");
+        assert_eq!(vm.pop().unwrap(), Cell::string("world"));
     }
 
     #[test]
@@ -7018,8 +6864,8 @@ mod tests {
         vm.input_reader = Box::new(Cursor::new("foo bar\n"));
         getstr_prim(&mut vm).unwrap();
         let cell = vm.pop().unwrap();
-        if let Cell::Str(idx) = cell {
-            assert_eq!(vm.strings[idx], "foo bar");
+        if let Cell::Str(s) = cell {
+            assert_eq!(s.as_ref(), "foo bar");
         } else {
             panic!("expected Cell::Str, got {:?}", cell);
         }
@@ -7240,183 +7086,71 @@ mod tests {
         assert_eq!(vm.arrays[0][0], Cell::Int(42));
     }
 
-    // --- array element write: Cell::Str lifetime checks ---
+    // --- array element write: Cell::Str ---
+    //
+    // After #588 (D-1), `Cell::Str` is `Rc<str>`-backed and `check_array_element_write`
+    // blanket-rejects any string with `StringFrameEscape` (see the
+    // function-level comment).  The lifetime-distinction tests below were
+    // structured around the pool-index model and are deferred until #591
+    // (which can use Rc-based ownership without lifetime tracking) revisits
+    // the array-write policy.
 
     #[test]
+    #[ignore = "#591: blanket reject in D-1; per-lifetime allow rules will be reintroduced when the array-write path is liberated."]
     fn test_set_global_str_to_array_element_is_allowed() {
-        // A Str with pool_idx < global_string_pool_len is global and may be stored.
-        let mut vm = VM::new();
-        vm.strings.push("hello".to_string());
-        vm.global_string_pool_len = 1; // promote to global
-        vm.arrays.push(vec![Cell::None]);
-        // set_prim: stack = [..., addr, value]
-        vm.push(Cell::ArrayAddr {
-            pool_idx: 0,
-            elem_idx: 0,
-        })
-        .unwrap();
-        vm.push(Cell::Str(0)).unwrap();
-        set_prim(&mut vm).unwrap();
-        assert_eq!(vm.arrays[0][0], Cell::Str(0));
+        // Pre-#588: a globally-promoted string could be stored into any array.
+        // Now `check_array_element_write` rejects all `Cell::Str` values; the
+        // successor test will simply assert that `Cell::string(...)` can be
+        // stored into a frame-local array via Rc-based ownership (#591).
     }
 
     #[test]
-    fn test_store_global_str_to_array_element_is_allowed() {
-        // Same as above but using store_prim (stack = [value, addr]).
-        let mut vm = VM::new();
-        vm.strings.push("world".to_string());
-        vm.global_string_pool_len = 1;
-        vm.arrays.push(vec![Cell::None]);
-        // store_prim: stack = [value, addr], pops addr first.
-        vm.push(Cell::Str(0)).unwrap();
-        vm.push(Cell::ArrayAddr {
-            pool_idx: 0,
-            elem_idx: 0,
-        })
-        .unwrap();
-        store_prim(&mut vm).unwrap();
-        assert_eq!(vm.arrays[0][0], Cell::Str(0));
-    }
+    #[ignore = "#591: blanket reject in D-1; see test_set_global_str_to_array_element_is_allowed."]
+    fn test_store_global_str_to_array_element_is_allowed() {}
 
     #[test]
-    fn test_set_frame_local_str_to_array_element_is_string_frame_escape() {
-        // A Str with pool_idx >= global_string_pool_len is frame-local and must be rejected.
+    fn test_set_str_to_array_element_is_string_frame_escape() {
+        // D-1 blanket reject: any `Cell::Str` written through `SET` to an
+        // array element fails with `StringFrameEscape`, regardless of the
+        // string's origin (frame-local, caller-owned, or globally-promoted).
+        // This conservatively preserves the pre-Phase-5B "no strings in
+        // arrays" contract until #591 liberates the path.
         let mut vm = VM::new();
-        vm.strings.push("local".to_string());
-        // global_string_pool_len = 0, so Str(0) is frame-local.
         vm.arrays.push(vec![Cell::None]);
         vm.push(Cell::ArrayAddr {
             pool_idx: 0,
             elem_idx: 0,
         })
         .unwrap();
-        vm.push(Cell::Str(0)).unwrap();
+        vm.push(Cell::string("local")).unwrap();
         assert_eq!(set_prim(&mut vm), Err(TbxError::StringFrameEscape));
     }
 
     #[test]
-    fn test_set_caller_owned_str_to_global_array_element_is_string_frame_escape() {
-        // A CallerOwned Str must be rejected when the target array is Global.
-        // Global arrays outlive the caller's frame, so storing a caller-owned
-        // string there risks a dangling reference.
-        use crate::cell::ReturnFrame;
+    fn test_store_str_to_array_element_is_string_frame_escape() {
+        // Same as the SET path above, exercised through STORE.
         let mut vm = VM::new();
-        // Str(0) will be caller-owned (not global).
-        vm.strings.push("caller".to_string());
-        vm.strings.push("local".to_string());
-        // global_string_pool_len = 0, so nothing is global.
-        // Push a call frame: the caller saw string_pool_len = 0 before the call,
-        // and a nested call sees string_pool_len = 1.
-        vm.return_stack.push(ReturnFrame::TopLevel);
-        vm.return_stack.push(ReturnFrame::Call {
-            callee_xt: crate::cell::Xt(0),
-            return_pc: 0,
-            saved_bp: 0,
-            saved_array_pool_len: 0,
-            saved_string_pool_len: 0, // outer boundary
-            actual_arity: 0,
-        });
-        vm.return_stack.push(ReturnFrame::Call {
-            callee_xt: crate::cell::Xt(0),
-            return_pc: 0,
-            saved_bp: 0,
-            saved_array_pool_len: 1, // inner boundary; Array(0) is caller-owned in array space
-            saved_string_pool_len: 1, // inner boundary; Str(0) is caller-owned
-            actual_arity: 0,
-        });
-        // Array(0) is global (idx 0 < global_array_pool_len = 1).
         vm.arrays.push(vec![Cell::None]);
-        vm.global_array_pool_len = 1; // promote Array(0) to global
-                                      // Str(0): idx=0, innermost saved_string_pool_len=1 → idx < 1 → CallerOwned
+        vm.push(Cell::string("local")).unwrap();
         vm.push(Cell::ArrayAddr {
             pool_idx: 0,
             elem_idx: 0,
         })
         .unwrap();
-        vm.push(Cell::Str(0)).unwrap();
-        assert_eq!(set_prim(&mut vm), Err(TbxError::StringFrameEscape));
+        assert_eq!(store_prim(&mut vm), Err(TbxError::StringFrameEscape));
     }
 
     #[test]
-    fn test_set_caller_owned_str_to_frame_local_array_element_is_allowed() {
-        // A CallerOwned Str may be stored in a FrameLocal array because the
-        // array is bound to the current frame and will die before the string's
-        // owning frame returns.
-        use crate::cell::ReturnFrame;
-        let mut vm = VM::new();
-        // Str(0) will be caller-owned.
-        vm.strings.push("caller".to_string());
-        vm.strings.push("local".to_string());
-        // global_string_pool_len = 0, so nothing is global.
-        vm.return_stack.push(ReturnFrame::TopLevel);
-        vm.return_stack.push(ReturnFrame::Call {
-            callee_xt: crate::cell::Xt(0),
-            return_pc: 0,
-            saved_bp: 0,
-            saved_array_pool_len: 0,
-            saved_string_pool_len: 0, // outer boundary
-            actual_arity: 0,
-        });
-        vm.return_stack.push(ReturnFrame::Call {
-            callee_xt: crate::cell::Xt(0),
-            return_pc: 0,
-            saved_bp: 0,
-            saved_array_pool_len: 0, // inner boundary; Array(0) is frame-local
-            saved_string_pool_len: 1, // inner boundary; Str(0) is caller-owned
-            actual_arity: 0,
-        });
-        // Array(0) is frame-local (idx 0 >= saved_array_pool_len=0 of the innermost frame).
-        vm.arrays.push(vec![Cell::None]);
-        // Str(0): idx=0, innermost saved_string_pool_len=1 → idx < 1 → CallerOwned
-        vm.push(Cell::ArrayAddr {
-            pool_idx: 0,
-            elem_idx: 0,
-        })
-        .unwrap();
-        vm.push(Cell::Str(0)).unwrap();
-        assert_eq!(set_prim(&mut vm), Ok(()));
-        assert_eq!(vm.arrays[0][0], Cell::Str(0));
-    }
+    #[ignore = "#591: requires lifetime-aware allow rules that depend on per-string pool indices, which Rc<str> removes."]
+    fn test_set_caller_owned_str_to_global_array_element_is_string_frame_escape() {}
 
     #[test]
-    fn test_set_caller_owned_str_to_caller_owned_array_element_is_string_frame_escape() {
-        // A CallerOwned Str must be rejected when the target array is CallerOwned.
-        // Both resources belong to "some outer frame", but PoolRefLifetime does not
-        // track which frame — they can belong to different frames with unrelated
-        // lifetimes, so this combination is unsafe.
-        use crate::cell::ReturnFrame;
-        let mut vm = VM::new();
-        // Str(0) will be caller-owned.
-        vm.strings.push("caller".to_string());
-        // global_string_pool_len = 0, so nothing is global.
-        vm.return_stack.push(ReturnFrame::TopLevel);
-        vm.return_stack.push(ReturnFrame::Call {
-            callee_xt: crate::cell::Xt(0),
-            return_pc: 0,
-            saved_bp: 0,
-            saved_array_pool_len: 0,
-            saved_string_pool_len: 0, // outer boundary
-            actual_arity: 0,
-        });
-        vm.return_stack.push(ReturnFrame::Call {
-            callee_xt: crate::cell::Xt(0),
-            return_pc: 0,
-            saved_bp: 0,
-            saved_array_pool_len: 1, // inner boundary; Array(0) is caller-owned
-            saved_string_pool_len: 1, // inner boundary; Str(0) is caller-owned
-            actual_arity: 0,
-        });
-        // Array(0) is caller-owned (idx 0 < innermost saved_array_pool_len=1).
-        vm.arrays.push(vec![Cell::None]);
-        // Str(0): idx=0, innermost saved_string_pool_len=1 → idx < 1 → CallerOwned
-        vm.push(Cell::ArrayAddr {
-            pool_idx: 0,
-            elem_idx: 0,
-        })
-        .unwrap();
-        vm.push(Cell::Str(0)).unwrap();
-        assert_eq!(set_prim(&mut vm), Err(TbxError::StringFrameEscape));
-    }
+    #[ignore = "#591: requires lifetime-aware allow rules that depend on per-string pool indices, which Rc<str> removes."]
+    fn test_set_caller_owned_str_to_frame_local_array_element_is_allowed() {}
+
+    #[test]
+    #[ignore = "#591: requires lifetime-aware allow rules that depend on per-string pool indices, which Rc<str> removes."]
+    fn test_set_caller_owned_str_to_caller_owned_array_element_is_string_frame_escape() {}
 
     #[test]
     fn test_set_nested_array_to_array_element_is_invalid_array_element() {
@@ -7994,7 +7728,7 @@ mod tests {
     #[test]
     fn test_second_type_error() {
         let mut vm = VM::new();
-        vm.push(Cell::Str(0)).unwrap();
+        vm.push(Cell::string("not a number")).unwrap();
         assert!(matches!(
             second_prim(&mut vm),
             Err(TbxError::TypeError { .. })

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -453,25 +453,21 @@ impl VM {
         }
     }
 
-    /// Pop a `Cell::Str` value from the data stack and return its resolved
-    /// contents from the runtime string pool (`VM::strings`).
+    /// Pop a `Cell::Str` value from the data stack and return a fresh `String`
+    /// copy of its contents.
+    ///
+    /// `Cell::Str` now wraps an `Rc<str>` (issue #588); this helper still
+    /// returns an owned `String` for API compatibility with existing string
+    /// primitives.  A future cleanup (#589) may switch the return type to
+    /// `Rc<str>` to avoid the copy.
     ///
     /// # Errors
     ///
     /// Returns `Err(TbxError::StackUnderflow)` if the stack is empty.
     /// Returns `Err(TbxError::TypeError)` if the top value is not `Cell::Str`.
-    /// Returns `Err(TbxError::IndexOutOfBounds)` if the `Cell::Str` index is
-    /// out of range for `VM::strings`.
     pub fn pop_string_value(&mut self) -> Result<String, TbxError> {
         match self.pop()? {
-            Cell::Str(idx) => self
-                .strings
-                .get(idx)
-                .cloned()
-                .ok_or(TbxError::IndexOutOfBounds {
-                    index: idx,
-                    size: self.strings.len(),
-                }),
+            Cell::Str(s) => Ok(s.to_string()),
             other => Err(TbxError::TypeError {
                 expected: "Str",
                 got: other.type_name(),
@@ -921,30 +917,23 @@ impl VM {
                     } else {
                         false
                     };
-                    // Ownership transfer for frame-local Cell::Str:
-                    // If the returned string was created in this frame
-                    // (pool_idx >= string_frame_boundary), swap it to the
-                    // boundary slot and mark it for preservation.
-                    let string_transferred = if let Cell::Str(pool_idx) = &retval {
-                        if *pool_idx >= string_frame_boundary {
-                            // Bounds check before swap: pool_idx must be a valid index.
-                            // Since pool_idx >= string_frame_boundary is already confirmed,
-                            // checking pool_idx < strings.len() also covers string_frame_boundary.
-                            if *pool_idx >= self.strings.len() {
-                                return Err(TbxError::IndexOutOfBounds {
-                                    index: *pool_idx,
-                                    size: self.strings.len(),
-                                });
-                            }
-                            self.strings.swap(*pool_idx, string_frame_boundary);
-                            retval = Cell::Str(string_frame_boundary);
-                            true
-                        } else {
-                            false
-                        }
-                    } else {
-                        false
-                    };
+                    // Ownership transfer for `Cell::Str`:
+                    //
+                    // Pre-#588, frame-local `Cell::Str(pool_idx)` values were
+                    // swapped to the frame-boundary slot in `VM::strings` so
+                    // they could survive the pool truncation below.  With
+                    // `Cell::Str(Rc<str>)`, the value carries its own
+                    // ownership via the Rc reference count, so no swap is
+                    // needed: the returned `retval` already owns its string.
+                    //
+                    // We still maintain `string_transferred` (always false now)
+                    // to keep the surrounding control flow stable.  The legacy
+                    // `VM::strings` pool truncation below also remains active;
+                    // it no longer affects `Cell::Str` cells, but is kept for
+                    // backward compatibility until #590 removes the pool
+                    // entirely.
+                    let _ = string_frame_boundary; // pool_idx no longer used
+                    let string_transferred = false;
                     match self.return_stack.pop().ok_or(TbxError::StackUnderflow)? {
                         ReturnFrame::Call {
                             callee_xt: _,
@@ -2729,18 +2718,12 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "#590: frame-local strings no longer need StringFrameEscape on dict store. With Rc<str>-backed Cell::Str, ownership is managed by the reference count, so the value can safely be stored in a global variable. The test will be replaced with a positive equivalent once the legacy string pool / lifetime tracking is removed."]
     fn test_str_frame_escape_via_store_to_dict_is_error() {
-        // Verify that SET of a frame-local Cell::Str into a global variable produces
-        // StringFrameEscape.  This is symmetric to test_array_frame_escape_via_store_to_dict_is_error.
-        let result = run_source(
-            "VAR G\n\
-             DEF BAD_STORE()\n  VAR S\n  LET S = STR_CONCAT(\"foo\", \"bar\")\n  SET &G, S\nEND\n\
-             BAD_STORE()",
-        );
-        assert!(
-            matches!(result, Err(crate::error::TbxError::StringFrameEscape)),
-            "expected StringFrameEscape, got: {result:?}"
-        );
+        // Pre-#588: STR_CONCAT inside a word produced a frame-local string
+        // whose dict store had to be rejected with StringFrameEscape.
+        // Rc<str>-backed Cell::Str carries its own ownership, so the value
+        // is always safe to store in a dict slot.
     }
 
     #[test]
@@ -2770,47 +2753,12 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "#590: depends on Cell::Str carrying a `global_string_pool_len`-based pool index. Rc<str>-backed Cell::Str has no such index, and the legacy pool will be retired with #590."]
     fn test_str_literal_inside_word_lives_in_global_region() {
-        // Companion to `test_str_literal_inside_word_can_be_assigned_to_global_var`:
-        // exercise the VM API directly to confirm that the literal is
-        // stored in the global region of the string pool (i.e. its index
-        // satisfies `idx < global_string_pool_len`) and that the slot of
-        // the global VAR ends up referring to that string.
-        let mut interp = crate::interpreter::Interpreter::new();
-        interp
-            .exec_source(
-                "VAR G\n\
-                 DEF SETG()\n  SET &G, \"inside\"\nEND\n\
-                 SETG\n\
-                 PUTSTR G\n",
-            )
-            .expect("exec_source failed");
-
-        assert_eq!(interp.take_output(), "inside");
-
-        let xt = interp
-            .vm()
-            .lookup("G")
-            .expect("global variable G not found");
-        let entry = &interp.vm().headers[xt.index()];
-        let cell = match entry.kind {
-            EntryKind::Variable(slot) => interp.vm().dict_read(slot).expect("dict_read failed"),
-            ref other => panic!("expected Variable kind, got {other:?}"),
-        };
-
-        match cell {
-            Cell::Str(idx) => {
-                assert_eq!(
-                    interp.vm().strings.get(idx).map(String::as_str),
-                    Some("inside")
-                );
-                assert!(
-                    idx < interp.vm().global_string_pool_len,
-                    "compiled string literal stored in global variable must be in the global string region"
-                );
-            }
-            other => panic!("expected Cell::Str, got {other:?}"),
-        }
+        // Pre-#588 this test confirmed that a literal compiled inside a
+        // `DEF ... END` body satisfied `idx < global_string_pool_len`.
+        // `Cell::Str` no longer carries an index after #588, so the
+        // assertion is no longer meaningful.
     }
 
     #[test]
@@ -3085,8 +3033,9 @@ mod tests {
 
     /// Phase 2 of issue #539: a string literal stored in a `VARIABLE` slot
     /// must be represented as `Cell::Str`. This confirms that the
-    /// compile path flows all the way through LET.
-    /// See issue #542.
+    /// compile path flows all the way through LET.  After #588 the payload
+    /// is `Cell::Str(Rc<str>)`, so we assert against `Cell::string("hi")`
+    /// directly instead of dereferencing a pool index.
     #[test]
     fn test_string_literal_stored_in_variable_is_str() {
         let mut interp = crate::interpreter::Interpreter::new();
@@ -3101,19 +3050,11 @@ mod tests {
             crate::dict::EntryKind::Variable(slot) => interp.vm().dictionary[slot].clone(),
             ref other => panic!("expected Variable kind, got {:?}", other),
         };
-        match cell {
-            Cell::Str(idx) => {
-                assert_eq!(
-                    interp.vm().strings.get(idx).map(String::as_str),
-                    Some("hi"),
-                    "stored string must resolve to its literal value"
-                );
-            }
-            other => panic!(
-                "string literal stored in VARIABLE should be Cell::Str, got {:?}",
-                other
-            ),
-        }
+        assert_eq!(
+            cell,
+            Cell::string("hi"),
+            "string literal stored in VARIABLE should be Cell::string(\"hi\"), got {cell:?}"
+        );
     }
 
     #[test]

--- a/tests/tbx_lib_tests.rs
+++ b/tests/tbx_lib_tests.rs
@@ -148,6 +148,7 @@ fn test_set_runtime_str_into_array_is_string_frame_escape() {
 /// at compile time, so they satisfy the Global lifetime requirement.
 /// Array indices are 1-based in TBX.
 #[test]
+#[ignore = "#591: array element writes blanket-reject Cell::Str during D-1 (#588). The allow rule for globally-owned strings will be reintroduced when the array-write path is liberated for Rc<str>."]
 fn test_set_literal_str_into_array_is_allowed() {
     let mut interp = Interpreter::new();
     let src = "VAR A\nSET &A, ARRAY(1)\nSET &A(1), \"hello\"\nPUTSTR A(1)\n";
@@ -160,6 +161,7 @@ fn test_set_literal_str_into_array_is_allowed() {
 /// Same as above but inside a compiled word to verify frame-local arrays also
 /// accept global string literals.
 #[test]
+#[ignore = "#591: see test_set_literal_str_into_array_is_allowed."]
 fn test_set_literal_str_into_array_inside_def_is_allowed() {
     let mut interp = Interpreter::new();
     let src =
@@ -217,6 +219,7 @@ fn test_set_array_into_array_is_invalid_element_type() {
 /// S is caller-owned from the perspective of USE's call frame, and A is
 /// frame-local, so this is safe and must succeed.
 #[test]
+#[ignore = "#591: array element writes blanket-reject Cell::Str during D-1 (#588). The lifetime-aware allow rules will be reintroduced when the array-write path is liberated for Rc<str>."]
 fn test_set_caller_owned_str_param_into_frame_local_array_is_allowed() {
     let mut interp = Interpreter::new();
     let src = "DEF USE(S)\n  VAR A\n  SET &A, ARRAY(1)\n  SET &A(1), S\n  PUTSTR A(1)\nEND\nUSE(\"arg\")\n";


### PR DESCRIPTION
## Summary

issue #588 (Phase 5B-D1) の **最小スコープ** 再実装。前回 PR #595 が #589 / #591 のスコープまで含んでいたため close されたので、`Cell::Str` の型移行と最小限のコンパイル通過を目的とした PR として作り直しました。

`Cell::Str(usize)` を `Cell::Str(Rc<str>)` に変更し、string の lifetime を VM の string pool boundary ではなく Rust の `Rc` に委ねます。

## 含めた変更（D-1 スコープ内）

- `Cell::Str` の variant 型を `usize` → `Rc<str>` に変更
- `Cell::string<S: Into<Rc<str>>>(s)` / `Cell::as_str()` ヘルパー追加
- `Cell` の `PartialEq` を index 比較 → content 比較に更新
- `Cell` の `Display` を content 直書きに変更
- `Cell::Str` variant doc 更新（Rc<str> ベース）
- `STR_EQ` の `Unlike Cell::Str(a) == Cell::Str(b) (index comparison)` 旨のコメントを更新
- `stabilize_array_element_write()` の Phase 5A matrix コメントを更新（nested Array は拒否、Cell::Str は #591 で解禁予定と明記）
- `expr.rs` の `StringLit` 処理を `Cell::string(s)` 発行に変更（pool push は差分最小化のため維持）
- 各 string primitive (`STR` / `STR_CONCAT` / `STR_SLICE` / `STR_TRIM` / `STR_UPPER` / `STR_LOWER` / `STR_REPLACE_FIRST` / `STR_REPLACE_ALL` / `GETSTR` / `PUTVAL` など) の `Cell::Str(idx)` 構築を `Cell::string(content)` に書き換え
- `pop_string_value` を Rc<str>.to_string() ベースに変更（API 形式は維持）
- `pool_ref_from_cell` で `Cell::Str(_) => None`
- `check_array_element_write` で `Cell::Str(_)` を blanket `StringFrameEscape` 拒否
- `check_string_array_element_write` を `#[allow(dead_code)]` 化
- `ReturnVal` の string ownership transfer ロジックを no-op 化（pool 削除は #590 で対応）

## 含めない変更（後続 issue で対応）

- `VM::strings` フィールドの完全削除（#590）
- `global_string_pool_len` / `saved_string_pool_len` フィールドの削除（#590）
- `ReturnVal` の string pool swap ロジックの完全削除（#590）
- `pop_string_value` を `Rc<str>` を返すよう API 改善（#589）
- `check_array_element_type` の `Cell::Str` 拒否ルール撤廃（#591）
- array write path の `Cell::Str` 解禁（#591）
- `tests/tbx_lib_tests.rs` の `StringFrameEscape` 期待テストを成功ケースに変えない（#591）

## `#[ignore]` を付けたテスト

`Cell::Str` から pool index がなくなったため、pool index に直接依存していたテストや、blanket reject によって意味が失われるテストを `#[ignore]` 化しました。後続 PR で復活させる方針です。

**#590 で復活予定（pool 関連テスト）:**
- `primitives::tests::test_string_frame_escape_via_store` — frame-local/global の pool index 区別に依存
- `primitives::tests::test_global_string_stored_via_store` — pool index の global 区別に依存
- `vm::tests::test_str_literal_inside_word_lives_in_global_region` — `idx < global_string_pool_len` を assert
- `vm::tests::test_str_frame_escape_via_store_to_dict_is_error` — Rc<str> ベースでは dict store は常に成功する

**#591 で復活予定（array write 関連テスト）:**
- `primitives::tests::test_set_global_str_to_array_element_is_allowed`
- `primitives::tests::test_store_global_str_to_array_element_is_allowed`
- `primitives::tests::test_set_caller_owned_str_to_global_array_element_is_string_frame_escape`
- `primitives::tests::test_set_caller_owned_str_to_frame_local_array_element_is_allowed`
- `primitives::tests::test_set_caller_owned_str_to_caller_owned_array_element_is_string_frame_escape`
- `tests::test_set_literal_str_into_array_is_allowed` (`tests/tbx_lib_tests.rs`)
- `tests::test_set_literal_str_into_array_inside_def_is_allowed` (`tests/tbx_lib_tests.rs`)
- `tests::test_set_caller_owned_str_param_into_frame_local_array_is_allowed` (`tests/tbx_lib_tests.rs`)

## 更新したコメント

- `Cell::Str` variant doc → Rc<str> ベース、`VM::strings` は移行期維持と明記
- `Cell::string` / `Cell::as_str` の doc 追加
- `Cell::PartialEq` の `Cell::Str` ブランチに content equality であることを明記
- `STR_EQ` の `Unlike Cell::Str(a) == Cell::Str(b) (index comparison)` → "now reflects content"
- `stabilize_array_element_write()` doc を Phase 5A matrix から #588 D-1 ポリシーへ更新（nested Array 拒否 / Cell::Str blanket reject / 後続 #591 で liberate と明記）
- `check_array_element_type` doc を `Cell::Str` の #591 trackingに更新
- `check_array_element_write` doc を blanket reject の根拠（pool 削除）と #591 への参照に更新
- `check_string_array_element_write` に `#[allow(dead_code)]` と #590/#591 への TODO
- `pop_string_value` doc を Rc<str> ベースに更新、`#589` で API 改善予定と明記
- `expr.rs` の `StringLit` 処理のコメントを Rc<str> ベースに更新
- `ReturnVal` の string ownership transfer に no-op 化の経緯と #590 TODO

## 動作確認

```bash
cargo fmt --check    # OK
cargo clippy --all-targets -- -D warnings    # OK
cargo test                                    # 866 passed; 9 ignored; lib tests
                                              # 33 passed; 3 ignored; integration tests
```

Part of #588
Refs: #571 (親), #587, #586, #589, #590, #591

## Test plan

- [x] `cargo fmt --check` 通過
- [x] `cargo clippy --all-targets -- -D warnings` 通過
- [x] `cargo test` 全テスト pass（`#[ignore]` 化したものを除く）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
