### PR TITLE
string primitives / literals を Rc-backed string に移行する (D-2)

### DIFF
--- a/src/cell.rs
+++ b/src/cell.rs
@@ -122,10 +122,11 @@ pub enum Cell {
     ///
     /// Note: `VM::strings` (the legacy index-based string pool) and the
     /// associated `saved_string_pool_len` / `global_string_pool_len` fields
-    /// are retained for the transition period.  `Cell::Str` itself no longer
-    /// indexes into them.  Full removal of the pool and pool-length fields is
-    /// tracked by follow-up issue #590, and array-write-path liberation is
-    /// tracked by #591.
+    /// are retained for the transition period, but as of D-2 (#589) no
+    /// runtime path touches them — string primitives and literal
+    /// compilation operate directly on `Rc<str>`.  Full removal of the
+    /// pool and pool-length fields is tracked by follow-up issue #590,
+    /// and array-write-path liberation is tracked by #591.
     Str(std::rc::Rc<str>),
     /// Address of an element in an array.
     ///

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -148,25 +148,17 @@ impl<'a> ExprCompiler<'a> {
                     // Pre-#588 the literal was indexed into `VM::strings` and
                     // promoted into the global string region so `SET &G,
                     // "..."` from inside a word would not trip the
-                    // `StringFrameEscape` check.  With `Cell::Str` now
-                    // `Rc<str>`-backed, no pool index is needed: the literal
-                    // owns its own string via the Rc reference count.
+                    // `StringFrameEscape` check.  D-1 (#588) kept the pool
+                    // push for a minimal transition; D-2 (#589) removes it
+                    // because no runtime path consumes the pushed entry —
+                    // the `Rc<str>` embedded directly in the compiled cell
+                    // owns its own content via the Rc reference count.
                     //
-                    // We still push the literal into `VM::strings` and bump
-                    // `global_string_pool_len` for the duration of #588's
-                    // minimal transition.  No code path now consumes the
-                    // pushed entry, but keeping the push minimises diff
-                    // churn and lets a couple of legacy regression tests
-                    // (e.g. `test_string_literal_uses_strings_pool`) keep
-                    // observing the pool.  Both will be retired with the
-                    // string pool itself in #590.
+                    // The `VM::strings` field, `saved_string_pool_len`, and
+                    // `global_string_pool_len` themselves remain in place;
+                    // their full retirement is tracked by #590.
                     if s.len() > u16::MAX as usize {
                         return Err(TbxError::StringTooLong { len: s.len() });
-                    }
-                    let idx = self.vm.strings.len();
-                    self.vm.strings.push(s.clone());
-                    if idx >= self.vm.global_string_pool_len {
-                        self.vm.global_string_pool_len = idx + 1;
                     }
                     emit_lit(&mut output, Cell::string(s), self.vm)?;
                     prev_was_operand = true;

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -419,7 +419,9 @@ pub fn eq_prim(vm: &mut VM) -> Result<(), TbxError> {
     let result = match (&a, &b) {
         (Cell::Int(x), Cell::Float(y)) => (*x as f64) == *y,
         (Cell::Float(x), Cell::Int(y)) => *x == (*y as f64),
-        (Cell::Str(_), Cell::Str(_)) => resolve_str_cell(vm, &a)? == resolve_str_cell(vm, &b)?,
+        // Content equality on `Rc<str>` is delegated to its `PartialEq`
+        // (which dereferences to `str`); same as `a == b` for the Str pair.
+        (Cell::Str(_), Cell::Str(_)) => resolve_str_cell(&a)? == resolve_str_cell(&b)?,
         _ => a == b,
     };
     vm.push(Cell::Bool(result))?;
@@ -435,7 +437,7 @@ pub fn neq_prim(vm: &mut VM) -> Result<(), TbxError> {
     let result = match (&a, &b) {
         (Cell::Int(x), Cell::Float(y)) => (*x as f64) != *y,
         (Cell::Float(x), Cell::Int(y)) => *x != (*y as f64),
-        (Cell::Str(_), Cell::Str(_)) => resolve_str_cell(vm, &a)? != resolve_str_cell(vm, &b)?,
+        (Cell::Str(_), Cell::Str(_)) => resolve_str_cell(&a)? != resolve_str_cell(&b)?,
         _ => a != b,
     };
     vm.push(Cell::Bool(result))?;
@@ -507,8 +509,10 @@ pub fn ge_prim(vm: &mut VM) -> Result<(), TbxError> {
 /// Escape sequences (\n, \t, \\) in the stored string are output literally
 /// as they were already expanded at compile time.
 pub fn putstr_prim(vm: &mut VM) -> Result<(), TbxError> {
+    // `pop_string_value` returns the inner `Rc<str>` directly; we only need
+    // a `&str` view to write into the output buffer.
     let s = vm.pop_string_value()?;
-    vm.write_output(&s);
+    vm.write_output(s.as_ref());
     Ok(())
 }
 
@@ -533,9 +537,14 @@ pub fn str_prim(vm: &mut VM) -> Result<(), TbxError> {
 pub fn str_concat_prim(vm: &mut VM) -> Result<(), TbxError> {
     let b_cell = vm.pop()?;
     let a_cell = vm.pop()?;
-    let b = resolve_str_cell(vm, &b_cell)?;
-    let a = resolve_str_cell(vm, &a_cell)?;
-    let result = a + &b;
+    let b = resolve_str_cell(&b_cell)?;
+    let a = resolve_str_cell(&a_cell)?;
+    // Concatenation always produces a fresh string; allocate a `String`
+    // first to amortise the join, then convert into a new `Rc<str>` for
+    // the resulting `Cell::Str`.
+    let mut result = String::with_capacity(a.len() + b.len());
+    result.push_str(a.as_ref());
+    result.push_str(b.as_ref());
     vm.push(Cell::string(result))?;
     Ok(())
 }
@@ -547,7 +556,7 @@ pub fn str_concat_prim(vm: &mut VM) -> Result<(), TbxError> {
 /// The length is the number of Unicode scalar values (chars), not UTF-8 bytes.
 pub fn str_len_prim(vm: &mut VM) -> Result<(), TbxError> {
     let s_cell = vm.pop()?;
-    let s = resolve_str_cell(vm, &s_cell)?;
+    let s = resolve_str_cell(&s_cell)?;
     let len = s.chars().count() as i64;
     vm.push(Cell::Int(len))?;
     Ok(())
@@ -564,8 +573,9 @@ pub fn str_len_prim(vm: &mut VM) -> Result<(), TbxError> {
 pub fn str_eq_prim(vm: &mut VM) -> Result<(), TbxError> {
     let b_cell = vm.pop()?;
     let a_cell = vm.pop()?;
-    let b = resolve_str_cell(vm, &b_cell)?;
-    let a = resolve_str_cell(vm, &a_cell)?;
+    let b = resolve_str_cell(&b_cell)?;
+    let a = resolve_str_cell(&a_cell)?;
+    // `Rc<str>` derefs to `str`, so `==` compares string content directly.
     vm.push(Cell::Bool(a == b))?;
     Ok(())
 }
@@ -579,10 +589,12 @@ pub fn str_eq_prim(vm: &mut VM) -> Result<(), TbxError> {
 pub fn str_indexof_prim(vm: &mut VM) -> Result<(), TbxError> {
     let needle_cell = vm.pop()?;
     let haystack_cell = vm.pop()?;
-    let needle = resolve_str_cell(vm, &needle_cell)?;
-    let haystack = resolve_str_cell(vm, &haystack_cell)?;
+    let needle = resolve_str_cell(&needle_cell)?;
+    let haystack = resolve_str_cell(&haystack_cell)?;
+    // `Rc<str>` derefs to `&str`, so `find` / slicing work directly without
+    // an intermediate `String` allocation.
     let pos = haystack
-        .find(&needle)
+        .find(needle.as_ref())
         .map(|byte_idx| haystack[..byte_idx].chars().count() as i64 + 1)
         .unwrap_or(0);
     vm.push(Cell::Int(pos))?;
@@ -611,7 +623,7 @@ pub fn str_slice_prim(vm: &mut VM) -> Result<(), TbxError> {
         });
     }
 
-    let s = resolve_str_cell(vm, &s_cell)?;
+    let s = resolve_str_cell(&s_cell)?;
     let chars: Vec<char> = s.chars().collect();
     let char_len = chars.len() as i64;
     let raw_start = if start > 0 {
@@ -632,7 +644,9 @@ pub fn str_slice_prim(vm: &mut VM) -> Result<(), TbxError> {
 /// Stack: `[..., s: Str]` → `Cell::Str(new)`
 pub fn str_trim_prim(vm: &mut VM) -> Result<(), TbxError> {
     let s_cell = vm.pop()?;
-    let s = resolve_str_cell(vm, &s_cell)?;
+    let s = resolve_str_cell(&s_cell)?;
+    // `s.trim_matches(...)` borrows from the `Rc<str>` and yields `&str`;
+    // `Cell::string` allocates a fresh owned string.
     let trimmed = s.trim_matches(char::is_whitespace).to_string();
     vm.push(Cell::string(trimmed))?;
     Ok(())
@@ -643,7 +657,7 @@ pub fn str_trim_prim(vm: &mut VM) -> Result<(), TbxError> {
 /// Stack: `[..., s: Str]` → `Cell::Str(new)`
 pub fn str_upper_prim(vm: &mut VM) -> Result<(), TbxError> {
     let s_cell = vm.pop()?;
-    let s = resolve_str_cell(vm, &s_cell)?;
+    let s = resolve_str_cell(&s_cell)?;
     let upper = s.to_uppercase();
     vm.push(Cell::string(upper))?;
     Ok(())
@@ -654,7 +668,7 @@ pub fn str_upper_prim(vm: &mut VM) -> Result<(), TbxError> {
 /// Stack: `[..., s: Str]` → `Cell::Str(new)`
 pub fn str_lower_prim(vm: &mut VM) -> Result<(), TbxError> {
     let s_cell = vm.pop()?;
-    let s = resolve_str_cell(vm, &s_cell)?;
+    let s = resolve_str_cell(&s_cell)?;
     let lower = s.to_lowercase();
     vm.push(Cell::string(lower))?;
     Ok(())
@@ -667,9 +681,9 @@ pub fn str_replace_first_prim(vm: &mut VM) -> Result<(), TbxError> {
     let replacement_cell = vm.pop()?;
     let needle_cell = vm.pop()?;
     let s_cell = vm.pop()?;
-    let replacement = resolve_str_cell(vm, &replacement_cell)?;
-    let needle = resolve_str_cell(vm, &needle_cell)?;
-    let s = resolve_str_cell(vm, &s_cell)?;
+    let replacement = resolve_str_cell(&replacement_cell)?;
+    let needle = resolve_str_cell(&needle_cell)?;
+    let s = resolve_str_cell(&s_cell)?;
 
     if needle.is_empty() {
         return Err(TbxError::InvalidArgument {
@@ -677,15 +691,20 @@ pub fn str_replace_first_prim(vm: &mut VM) -> Result<(), TbxError> {
         });
     }
 
-    let result = if let Some(idx) = s.find(&needle) {
+    // When no occurrence is found we can return the same `Rc<str>` by
+    // cloning it cheaply (Rc reference-count bump) without allocating a
+    // new buffer.
+    if let Some(idx) = s.find(needle.as_ref()) {
         let (prefix, rest) = s.split_at(idx);
         let suffix = &rest[needle.len()..];
-        prefix.to_string() + &replacement + suffix
+        let mut result = String::with_capacity(prefix.len() + replacement.len() + suffix.len());
+        result.push_str(prefix);
+        result.push_str(replacement.as_ref());
+        result.push_str(suffix);
+        vm.push(Cell::string(result))?;
     } else {
-        s
-    };
-
-    vm.push(Cell::string(result))?;
+        vm.push(Cell::Str(s))?;
+    }
     Ok(())
 }
 
@@ -696,9 +715,9 @@ pub fn str_replace_all_prim(vm: &mut VM) -> Result<(), TbxError> {
     let replacement_cell = vm.pop()?;
     let needle_cell = vm.pop()?;
     let s_cell = vm.pop()?;
-    let replacement = resolve_str_cell(vm, &replacement_cell)?;
-    let needle = resolve_str_cell(vm, &needle_cell)?;
-    let s = resolve_str_cell(vm, &s_cell)?;
+    let replacement = resolve_str_cell(&replacement_cell)?;
+    let needle = resolve_str_cell(&needle_cell)?;
+    let s = resolve_str_cell(&s_cell)?;
 
     if needle.is_empty() {
         return Err(TbxError::InvalidArgument {
@@ -706,19 +725,21 @@ pub fn str_replace_all_prim(vm: &mut VM) -> Result<(), TbxError> {
         });
     }
 
-    let result = s.replace(&needle, &replacement);
+    // `str::replace` always allocates a fresh `String`, even when the needle
+    // is absent.  We keep that simple behaviour here.
+    let result = s.replace(needle.as_ref(), replacement.as_ref());
     vm.push(Cell::string(result))?;
     Ok(())
 }
 
-/// Helper: resolve a `Cell::Str` to an owned `String`.
+/// Helper: resolve a `Cell::Str` to its inner `Rc<str>` handle.
 ///
-/// `Cell::Str` is `Rc<str>`-backed (#588), so this is just an `Rc -> String`
-/// copy.  The `vm` parameter is retained for now to minimise call-site
-/// churn; it can be dropped together with the legacy string pool in #590.
-fn resolve_str_cell(_vm: &VM, cell: &Cell) -> Result<String, TbxError> {
+/// `Cell::Str` is `Rc<str>`-backed (#588), so this is a cheap `Rc::clone`
+/// rather than a content copy.  Callers that need to mutate or own a
+/// `String` should call `.to_string()` on the result.
+fn resolve_str_cell(cell: &Cell) -> Result<std::rc::Rc<str>, TbxError> {
     match cell {
-        Cell::Str(rc) => Ok(rc.to_string()),
+        Cell::Str(rc) => Ok(rc.clone()),
         other => Err(TbxError::TypeError {
             expected: "Str",
             got: other.type_name(),
@@ -855,7 +876,7 @@ pub fn assert_fail_prim(_vm: &mut VM) -> Result<(), TbxError> {
 ///
 /// Expects a `Cell::Str` on top of the data stack.
 pub fn assert_fail_msg_prim(vm: &mut VM) -> Result<(), TbxError> {
-    let message = vm.pop_string_value()?;
+    let message = vm.pop_string_value()?.to_string();
     Err(TbxError::AssertionFailedWithMessage { message })
 }
 
@@ -1898,7 +1919,9 @@ fn cs_open_tag_prim(vm: &mut VM) -> Result<(), TbxError> {
             reason: "CS_OPEN_TAG outside compile mode",
         });
     }
-    let tag = vm.pop_string_value()?;
+    // `CompileEntry::Tag` holds an owned `String`, so materialise one from
+    // the `Rc<str>` returned by `pop_string_value`.
+    let tag = vm.pop_string_value()?.to_string();
     vm.compile_stack.push(CompileEntry::Tag(tag));
     Ok(())
 }
@@ -1917,7 +1940,9 @@ fn cs_close_tag_prim(vm: &mut VM) -> Result<(), TbxError> {
             reason: "CS_CLOSE_TAG outside compile mode",
         });
     }
-    let expected = vm.pop_string_value()?;
+    // `TbxError::NoOpenTag` / `MismatchedTag` carry owned `String` values,
+    // so we materialise an owned copy from the popped `Rc<str>`.
+    let expected = vm.pop_string_value()?.to_string();
     match vm.compile_stack.pop() {
         None => Err(TbxError::NoOpenTag { expected }),
         Some(CompileEntry::Tag(found)) if found == expected => Ok(()),
@@ -2216,8 +2241,14 @@ fn skip_eq_prim(vm: &mut VM) -> Result<(), TbxError> {
 ///
 /// Expects a `Cell::Str` on top of the data stack.
 fn lookup_prim(vm: &mut VM) -> Result<(), TbxError> {
-    let name = vm.pop_string_value()?;
-    let xt = vm.lookup(&name).ok_or(TbxError::UndefinedSymbol { name })?;
+    let name_rc = vm.pop_string_value()?;
+    let xt = vm.lookup(name_rc.as_ref()).ok_or_else(|| {
+        // Materialise an owned `String` for the error payload only on the
+        // failure path.
+        TbxError::UndefinedSymbol {
+            name: name_rc.to_string(),
+        }
+    })?;
     vm.push(Cell::Xt(xt))
 }
 
@@ -3871,6 +3902,132 @@ mod tests {
             str_concat_prim(&mut vm),
             Err(TbxError::TypeError { .. })
         ));
+    }
+
+    // ----------------------------------------------------------------
+    // D-2 (#589) regression tests: confirm string primitives operate on
+    // `Cell::Str(Rc<str>)` without going through `VM::strings`.
+    // ----------------------------------------------------------------
+
+    #[test]
+    fn test_d2_str_prim_pushes_cell_str_with_rc() {
+        // `STR` on an Int produces a `Cell::Str` carrying an `Rc<str>` that
+        // matches the decimal rendering of the input.
+        let mut vm = VM::new();
+        vm.push(Cell::Int(123)).unwrap();
+        str_prim(&mut vm).unwrap();
+        let cell = vm.pop().unwrap();
+        match &cell {
+            Cell::Str(rc) => assert_eq!(rc.as_ref(), "123"),
+            other => panic!("expected Cell::Str, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_d2_str_prim_on_str_reuses_underlying_rc() {
+        // `STR` on a `Cell::Str` should reuse the underlying `Rc<str>` (an
+        // identity-like conversion) rather than allocating a new buffer.
+        let mut vm = VM::new();
+        let original: std::rc::Rc<str> = "shared".into();
+        vm.push(Cell::Str(original.clone())).unwrap();
+        str_prim(&mut vm).unwrap();
+        match vm.pop().unwrap() {
+            Cell::Str(rc) => {
+                assert!(
+                    std::rc::Rc::ptr_eq(&rc, &original),
+                    "STR on Cell::Str should reuse the inner Rc, not allocate"
+                );
+            }
+            other => panic!("expected Cell::Str, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_d2_str_concat_produces_fresh_rc_with_combined_content() {
+        // `STR_CONCAT` produces a new `Cell::Str` whose content is the
+        // concatenation of the two operands.  The resulting Rc must own
+        // its own buffer (it cannot alias either input by `Rc::ptr_eq`).
+        let mut vm = VM::new();
+        let left: std::rc::Rc<str> = "foo".into();
+        let right: std::rc::Rc<str> = "bar".into();
+        vm.push(Cell::Str(left.clone())).unwrap();
+        vm.push(Cell::Str(right.clone())).unwrap();
+        str_concat_prim(&mut vm).unwrap();
+        match vm.pop().unwrap() {
+            Cell::Str(rc) => {
+                assert_eq!(rc.as_ref(), "foobar");
+                assert!(!std::rc::Rc::ptr_eq(&rc, &left));
+                assert!(!std::rc::Rc::ptr_eq(&rc, &right));
+            }
+            other => panic!("expected Cell::Str, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_d2_str_primitives_do_not_touch_vm_strings_pool() {
+        // None of the read-only / generative string primitives should push
+        // into `VM::strings` after D-2 (#589).  The full retirement of the
+        // pool is tracked by #590; this test pins down that, even with the
+        // pool field still present, no string primitive interacts with it.
+        let mut vm = VM::new();
+        let pool_len_before = vm.strings.len();
+
+        // STR_LEN on a literal Rc-backed Cell::Str.
+        vm.push(Cell::string("hello")).unwrap();
+        str_len_prim(&mut vm).unwrap();
+        let _ = vm.pop().unwrap();
+
+        // STR_EQ on two literal Rc-backed Cell::Str.
+        vm.push(Cell::string("aa")).unwrap();
+        vm.push(Cell::string("aa")).unwrap();
+        str_eq_prim(&mut vm).unwrap();
+        let _ = vm.pop().unwrap();
+
+        // STR_CONCAT on two literal Rc-backed Cell::Str.
+        vm.push(Cell::string("x")).unwrap();
+        vm.push(Cell::string("y")).unwrap();
+        str_concat_prim(&mut vm).unwrap();
+        let _ = vm.pop().unwrap();
+
+        // STR on a non-Str input.
+        vm.push(Cell::Int(7)).unwrap();
+        str_prim(&mut vm).unwrap();
+        let _ = vm.pop().unwrap();
+
+        // PUTSTR consumes a literal Cell::Str.
+        vm.push(Cell::string("out")).unwrap();
+        putstr_prim(&mut vm).unwrap();
+        assert_eq!(vm.take_output(), "out");
+
+        assert_eq!(
+            vm.strings.len(),
+            pool_len_before,
+            "string primitives must not push into `VM::strings` after D-2 (#589)"
+        );
+    }
+
+    #[test]
+    fn test_d2_pop_string_value_returns_underlying_rc() {
+        // `pop_string_value` returns the inner `Rc<str>`; the handle must
+        // be the very Rc that was pushed on the stack (no copy).
+        let mut vm = VM::new();
+        let original: std::rc::Rc<str> = "abc".into();
+        vm.push(Cell::Str(original.clone())).unwrap();
+        let popped = vm.pop_string_value().expect("expected Cell::Str on stack");
+        assert!(
+            std::rc::Rc::ptr_eq(&popped, &original),
+            "pop_string_value should return the same Rc that was pushed"
+        );
+    }
+
+    #[test]
+    fn test_d2_putstr_emits_rc_backed_literal_content() {
+        // End-to-end check: a Cell::Str carrying an Rc<str> with literal
+        // content is correctly emitted by PUTSTR through the output buffer.
+        let mut vm = VM::new();
+        vm.push(Cell::string("rc-literal")).unwrap();
+        putstr_prim(&mut vm).unwrap();
+        assert_eq!(vm.take_output(), "rc-literal");
     }
 
     // --- str_len_prim tests ---

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -182,22 +182,24 @@ pub struct VM {
     /// Updated to `arrays.len()` whenever a `TopLevel` frame is popped in
     /// `Exit` (i.e. at the end of every top-level execution segment).
     pub global_array_pool_len: usize,
-    /// Runtime string pool: indexed by `Cell::Str(usize)` values.
+    /// Legacy runtime string pool — once indexed by `Cell::Str(usize)`.
     ///
-    /// Each entry is a `String` created by string primitives such as `STR`,
-    /// `STR_CONCAT`, etc.  On every word EXIT or RETURN_VAL, the pool is
-    /// truncated back to the length saved in
-    /// `ReturnFrame::Call::saved_string_pool_len`, freeing all strings
-    /// allocated within that call.
+    /// Pre-#588 each entry was a `String` created by string primitives
+    /// (`STR`, `STR_CONCAT`, etc.) and looked up by index from `Cell::Str`.
+    /// After D-1 (#588) `Cell::Str` wraps `Rc<str>` directly, and after
+    /// D-2 (#589) no compile-time or runtime path pushes or reads this
+    /// pool any more.  The field, together with `global_string_pool_len`
+    /// and `saved_string_pool_len`, is kept solely so the surrounding
+    /// EXIT / RETURN_VAL truncation code (and a few legacy tests) keeps
+    /// building until the pool is removed wholesale by #590.
     pub strings: Vec<String>,
     /// Length of the "global" (persistent) region of `strings`.
     ///
-    /// Strings at indices `0..global_string_pool_len` were created at the top
-    /// level (outside any `DEF..END`) and are never freed.  They may safely be
-    /// stored in `VARIABLE` slots and shared across word calls.
-    ///
-    /// Updated to `strings.len()` whenever a `TopLevel` frame is popped in
-    /// `Exit` (i.e. at the end of every top-level execution segment).
+    /// Pre-D-2 this distinguished compile-time literals (global) from
+    /// runtime-allocated strings (frame-local).  Now that `Cell::Str` no
+    /// longer indexes into `strings`, the distinction is purely
+    /// historical and the value will be retired with the pool itself
+    /// (#590).
     pub global_string_pool_len: usize,
     /// Internal buffer holding the last line read by ACCEPT.
     ///
@@ -453,21 +455,20 @@ impl VM {
         }
     }
 
-    /// Pop a `Cell::Str` value from the data stack and return a fresh `String`
-    /// copy of its contents.
+    /// Pop a `Cell::Str` value from the data stack and return its inner
+    /// `Rc<str>` handle.
     ///
-    /// `Cell::Str` now wraps an `Rc<str>` (issue #588); this helper still
-    /// returns an owned `String` for API compatibility with existing string
-    /// primitives.  A future cleanup (#589) may switch the return type to
-    /// `Rc<str>` to avoid the copy.
+    /// Returning the underlying `Rc<str>` avoids copying the string content;
+    /// callers that need an owned `String` can call `.to_string()` on the
+    /// result, while read-only callers can use `.as_ref()` for a `&str`.
     ///
     /// # Errors
     ///
     /// Returns `Err(TbxError::StackUnderflow)` if the stack is empty.
     /// Returns `Err(TbxError::TypeError)` if the top value is not `Cell::Str`.
-    pub fn pop_string_value(&mut self) -> Result<String, TbxError> {
+    pub fn pop_string_value(&mut self) -> Result<std::rc::Rc<str>, TbxError> {
         match self.pop()? {
-            Cell::Str(s) => Ok(s.to_string()),
+            Cell::Str(s) => Ok(s),
             other => Err(TbxError::TypeError {
                 expected: "Str",
                 got: other.type_name(),
@@ -2731,17 +2732,18 @@ mod tests {
         // Regression test for the review feedback on PR #543.
         //
         // A string literal that appears inside a DEF ... END body is a
-        // compile-time constant: `compile_expr` pushes it onto
-        // `vm.strings` and immediately advances `global_string_pool_len`
-        // so the literal lives in the global string region.  This makes
-        // and lets compiled words assign string literals into global
-        // variables via `SET &G, "..."` without triggering
-        // `StringFrameEscape`.
+        // compile-time constant.  Before D-2 (#589) the compile path
+        // pushed it into `vm.strings` and advanced `global_string_pool_len`
+        // so the global-string check in `check_dict_reference_write`
+        // succeeded.  After D-2 the literal is embedded directly as a
+        // `Cell::Str(Rc<str>)`; since `pool_ref_from_cell` returns `None`
+        // for `Cell::Str`, the dict-store path now bypasses the lifetime
+        // check entirely, which keeps the same observable outcome.
         //
-        // Run-time generated strings (e.g. via `STR_CONCAT`) remain
-        // frame-local and still need to escape the frame via `RETURN`
-        // before they can be stored into a global; see
-        // `test_str_frame_escape_via_store_to_dict_is_error`.
+        // Run-time generated strings (e.g. via `STR_CONCAT`) are also
+        // `Rc<str>`-backed and likewise carry no pool index, so they too
+        // can now be stored into a global directly.  Full retirement of
+        // the legacy pool fields is tracked by #590.
         let result = run_source(
             "VAR G\n\
              DEF SETG()\n  SET &G, \"inside\"\nEND\n\
@@ -2985,12 +2987,15 @@ mod tests {
         // After a word that creates a local string but returns a non-string value,
         // vm.strings should be truncated back to its length before the call.
         //
-        // Compile time pushes the string literals "foo" and "bar" into
-        // `vm.strings` (since #542 / #539 Phase 2), so the pool length before
-        // the user word runs is non-zero.  The runtime concatenation result
-        // produced inside `STR_THEN_INT` must still be discarded on EXIT,
-        // so the length after `PUTDEC` finishes must equal the length
-        // just before the user word was called.
+        // Before D-2 (#589), the compile path pushed string literals into
+        // `vm.strings` so the pool length was non-zero by the time the
+        // user word ran.  D-2 stopped pushing literals into the pool, so
+        // the length is now 0 both before and after the call.  String
+        // primitives (`STR_CONCAT`, etc.) no longer touch the pool
+        // either, so the EXIT-time truncation has nothing to do for
+        // strings; the assertion still holds because we compare pool
+        // length to its pre-call value.  Full retirement of the pool is
+        // tracked by #590.
         let mut interp = crate::interpreter::Interpreter::new();
         interp
             .exec_source(
@@ -3011,24 +3016,63 @@ mod tests {
     /// Phase 2 of issue #539: a top-level string literal must be stored in
     /// `vm.strings` as a `Cell::Str` reference. See issue #542.
     #[test]
+    #[ignore = "#590: string literals no longer back into `VM::strings` after D-2 (#589); `Cell::Str(Rc<str>)` embeds the literal directly. The successor test `test_string_literal_putstr_outputs_content` exercises the user-visible behaviour without inspecting the pool."]
     fn test_string_literal_uses_strings_pool() {
-        let mut interp = crate::interpreter::Interpreter::new();
-        let strings_before = interp.vm().strings.len();
+        // Pre-D-2: the literal was pushed into `vm.strings` at compile time
+        // so a `Cell::Str(usize)` index could resolve it.  With `Cell::Str`
+        // now `Rc<str>`-backed (#588) and literal compilation no longer
+        // touching the pool (#589), this assertion has no remaining
+        // meaning at this layer; full retirement of the pool is tracked
+        // by #590.
+    }
 
+    /// D-2 (#589) successor for `test_string_literal_uses_strings_pool`:
+    /// confirm that compiling and executing a `PUTSTR "..."` literal
+    /// produces the expected output without relying on any string pool
+    /// inspection.
+    #[test]
+    fn test_string_literal_putstr_outputs_content() {
+        let mut interp = crate::interpreter::Interpreter::new();
         interp
             .exec_source("PUTSTR \"phase2-test\"\n")
             .expect("exec_source failed");
+        assert_eq!(interp.take_output(), "phase2-test");
+    }
 
-        // The literal must have been pushed into `vm.strings`.
-        assert!(
-            interp
-                .vm()
-                .strings
-                .iter()
-                .skip(strings_before)
-                .any(|s| s == "phase2-test"),
-            "string literal must be stored in vm.strings"
+    /// D-2 (#589): a compiled string literal used multiple times — and
+    /// from inside a loop — must continue to produce the same content on
+    /// every iteration.  This guards against any accidental ownership
+    /// move that would consume the embedded `Rc<str>` on first use.
+    #[test]
+    fn test_string_literal_reused_multiple_times() {
+        let mut interp = crate::interpreter::Interpreter::new();
+        interp
+            .exec_source(
+                "DEF SHOUT()\n  PUTSTR \"hi\"\nEND\n\
+                 SHOUT\nSHOUT\nSHOUT\n",
+            )
+            .expect("exec_source failed");
+        assert_eq!(interp.take_output(), "hihihi");
+    }
+
+    /// D-2 (#589): a compiled string literal compared with `STR_EQ` must
+    /// honour content equality (`Rc<str>` derefs to `str` so the
+    /// derived `PartialEq` already compares content).
+    #[test]
+    fn test_string_literal_str_eq_compares_content() {
+        let mut interp = crate::interpreter::Interpreter::new();
+        let src = concat!(
+            "DEF CHECK()\n",
+            "  IF STR_EQ(\"hello\", \"hello\")\n",
+            "    PUTSTR \"yes\"\n",
+            "  ELSE\n",
+            "    PUTSTR \"no\"\n",
+            "  ENDIF\n",
+            "END\n",
+            "CHECK\n",
         );
+        interp.exec_source(src).expect("exec_source failed");
+        assert_eq!(interp.take_output(), "yes");
     }
 
     /// Phase 2 of issue #539: a string literal stored in a `VARIABLE` slot


### PR DESCRIPTION
## Summary

Phase 5B-D2 (#589) を実装。`Cell::Str` は D-1 (#588) で `Rc<str>` 化済みだが、string primitive と string literal の compile path は依然として `VM::strings` pool を経由していた。本 PR はこれらを Rc-backed string に直接アクセスする実装に置き換える。

Part of #589 / parent: #571 / theme trunk: `phase5b-rc-str`

## 主な変更内容

### `pop_string_value()` の戻り型変更

- `Result<String, _>` → `Result<Rc<str>, _>`
- 呼び出し側は `.as_ref()` で `&str` を、`.to_string()` で `String` を取り出せる。
- 余計なコピーが消え、`Rc::clone` (refcount bump) で済む。

### `resolve_str_cell()` の戻り型変更

- `(&VM, &Cell) -> Result<String, _>` → `(&Cell) -> Result<Rc<str>, _>`
- 引数から不要だった `vm` を削除。

### string primitives を Rc-backed 前提で書き換え

- `PUTSTR` / `STR` / `STR_LEN` / `STR_EQ` / `STR_CONCAT` / `STR_INDEXOF` / `STR_SLICE` / `STR_TRIM` / `STR_UPPER` / `STR_LOWER` / `STR_REPLACE_FIRST` / `STR_REPLACE_ALL`
- いずれも `vm.strings.push` / `vm.strings.get` を経由しない。
- `STR_REPLACE_FIRST` は needle が見つからない場合、元の `Rc<str>` をそのまま push し直す cheap path を追加。

### `ASSERT_FAIL_MSG` / `CS_OPEN_TAG` / `CS_CLOSE_TAG` / `LOOKUP`

- これらは `TbxError` フィールドや `CompileEntry::Tag` に `String` を要求するため、`pop_string_value()?.to_string()` で変換する。

### string literal の compile path

- `expr.rs` の `Token::StringLit` 分岐から `vm.strings.push()` / `global_string_pool_len` のインクリメントを除去。
- literal は `Cell::Str(Rc<str>)` として compiled cell に直接埋め込まれる。

### テスト追加・更新

- `primitives.rs` に `test_d2_*` 系のテストを追加:
  - `test_d2_str_prim_pushes_cell_str_with_rc`
  - `test_d2_str_prim_on_str_reuses_underlying_rc`
  - `test_d2_str_concat_produces_fresh_rc_with_combined_content`
  - `test_d2_str_primitives_do_not_touch_vm_strings_pool`
  - `test_d2_pop_string_value_returns_underlying_rc`
  - `test_d2_putstr_emits_rc_backed_literal_content`
- `vm.rs` に compile-level の literal 動作確認テストを追加:
  - `test_string_literal_putstr_outputs_content`
  - `test_string_literal_reused_multiple_times` (literal を複数回使えることを保証)
  - `test_string_literal_str_eq_compares_content` (content equality)
- 既存の `test_string_literal_uses_strings_pool` は pool 直接観察に依存しているため `#[ignore = "#590: ..."]` に変更し、successor をコメントで明示。
- `test_runtime_strings_len_truncated_when_not_returned` のコメントを D-2 の状態に合わせて更新 (テスト自体はそのまま通過)。
- `test_str_literal_inside_word_can_be_assigned_to_global_var` のコメントを D-2 の状態に合わせて更新。

## スコープ外 (本 PR では扱わない)

D-2 のスコープを狭く保つため、以下は後続 issue で対応する:

- `VM::strings` / `global_string_pool_len` / `saved_string_pool_len` フィールド自体の削除 (#590)
- EXIT / RETURN_VAL における string pool の swap / truncate ロジック削除 (#590)
- array element への `Cell::Str` 格納解禁 (#591)
- `check_array_element_write` の `Cell::Str` 拒否ルール変更 (#591)
- docs の最終更新 (#592)

つまり「pool フィールド自体は残してよいが、primitive と literal は pool に依存しない実装にする」が本 PR の核心。

## 残っている `#[ignore]` テスト (#590 / #591 で対応予定)

`#590` (pool 削除):
- `src/primitives.rs`: `test_string_frame_escape_via_store`, `test_global_string_stored_via_store`
- `src/vm.rs`: `test_str_frame_escape_via_store_to_dict_is_error`, `test_str_literal_inside_word_lives_in_global_region`, `test_string_literal_uses_strings_pool`

`#591` (array write 解禁):
- `tests/tbx_lib_tests.rs`: `test_set_literal_str_into_array_is_allowed`, `test_set_literal_str_into_array_inside_def_is_allowed`, `test_set_caller_owned_str_param_into_frame_local_array_is_allowed`
- `src/primitives.rs`: 5 件 (`test_set_global_str_to_array_element_is_allowed` 他)

## 残っている `vm.strings` 参照箇所 (#590 で対応予定)

- `src/vm.rs`:
  - `pub strings: Vec<String>` フィールド定義
  - `pub global_string_pool_len: usize` フィールド定義
  - `Exit` / `ReturnVal` での `saved_string_pool_len` の swap / truncate
  - TopLevel pop での `global_string_pool_len` 更新
  - `Debug` impl の field 出力
- `src/primitives.rs`:
  - `PoolKind::String` / `PoolRef::String` (現状 `pool_ref_from_cell` は `Cell::Str` に対して `None` を返すため、dict 書き込み path での lifetime 判定には使われない)
  - `is_global_pool_ref` / `promote_pool_ref_to_global` の `String` 分岐 (Array path 用のヘルパだが string 分岐も残置)

これらはすべて D-3 (#590) のスコープ。

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (874 unit + 10 integration + 1 doc-test, 10 ignored ― すべて成功)
- [x] `rg -n "pop_string_value|PUTSTR|STR_LEN|STR_EQ|STR_CONCAT|Cell::Str\(|VM::strings|strings\.get|strings\.push" src tests` で `strings.push` / `strings.get` がコメント以外に残っていないこと確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
