### PR TITLE
array element への Cell::Str(Rc<str>) 格納を解禁する (D-4, #591)

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -172,19 +172,6 @@ pub enum TbxError {
     /// of being truncated.
     ArrayFrameEscape,
 
-    /// A runtime string value escaped its owning stack frame via a global variable write.
-    ///
-    /// Strings (created by `STR`, `STR_CONCAT`, etc.) that are created inside a
-    /// word are bound to the stack frame in which they were created.  Attempting
-    /// to store a frame-local `Cell::Str` value into a global variable (via
-    /// `STORE` or `SET` targeting a `DictAddr`) is forbidden, because the string
-    /// pool is truncated on EXIT and the stored index would dangle.
-    ///
-    /// Note: returning a frame-local string via `RETURN` is allowed (ownership
-    /// transfer) — the string slot is moved to the caller's pool boundary instead
-    /// of being truncated.
-    StringFrameEscape,
-
     /// A variadic word was called with fewer arguments than its fixed parameter count.
     ///
     /// `name` is the word name, `expected_min` is the number of fixed parameters
@@ -197,12 +184,11 @@ pub enum TbxError {
 
     /// A value of a type that is not permitted as an array element was stored.
     ///
-    /// Array elements are restricted to scalar types (`Int`, `Float`, `Bool`, `None`).
-    /// Attempting to store a `Cell::Array` or `Cell::Str` value as an array element
-    /// is forbidden because it would introduce nested reference types that could
-    /// escape their owning stack frame.
+    /// Array elements may be scalars (`Int`, `Float`, `Bool`, `None`) or
+    /// `Cell::Str(Rc<str>)` string handles.  Attempting to store a nested
+    /// `Cell::Array` value is forbidden because nested arrays are not supported.
     InvalidArrayElement {
-        /// The type name of the value that was rejected (e.g. `"Array"`, `"Str"`).
+        /// The type name of the value that was rejected (e.g. `"Array"`).
         got: &'static str,
     },
 }
@@ -314,9 +300,6 @@ impl std::fmt::Display for TbxError {
             TbxError::ArrayFrameEscape => {
                 write!(f, "array cannot escape its owning stack frame")
             }
-            TbxError::StringFrameEscape => {
-                write!(f, "string cannot escape its owning stack frame")
-            }
             TbxError::WrongNumberOfArguments {
                 name,
                 expected_min,
@@ -330,7 +313,7 @@ impl std::fmt::Display for TbxError {
             TbxError::InvalidArrayElement { got } => {
                 write!(
                     f,
-                    "invalid array element type: {got} is not allowed; only Int, Float, Bool, and None are permitted"
+                    "invalid array element type: {got} is not allowed; nested arrays are not permitted"
                 )
             }
         }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -205,15 +205,11 @@ pub fn set_prim(vm: &mut VM) -> Result<(), TbxError> {
 /// no VM context required).
 ///
 /// `Cell::Array` is always rejected (nested arrays are not supported).
-/// `Cell::Str` is also rejected here: storing strings inside arrays is
-/// liberation-tracked separately by #591.  Per-string lifetime classification
-/// is no longer expressible at this layer because `Cell::Str` is now
-/// `Rc<str>`-backed (it has no pool index), so `check_array_element_write`
-/// likewise rejects all `Cell::Str` values.
+/// `Cell::Str(Rc<str>)` is allowed: the `Rc` handle keeps the string alive
+/// independently of any stack frame, so there is no dangling risk (#591).
 fn check_array_element_type(value: &Cell) -> Result<(), TbxError> {
     match value {
         Cell::Array(_) => Err(TbxError::InvalidArrayElement { got: "Array" }),
-        Cell::Str(_) => Err(TbxError::InvalidArrayElement { got: "Str" }),
         _ => Ok(()),
     }
 }
@@ -224,15 +220,11 @@ fn check_array_element_type(value: &Cell) -> Result<(), TbxError> {
 /// used by `write_array_element` (the `SET`/`STORE` path).
 ///
 /// * `Cell::Array` is always rejected (nested arrays are not supported).
-/// * `Cell::Str` is blanket-rejected with `StringFrameEscape` during the
-///   transition to `Rc<str>`-backed strings.  Now that `Cell::Str` no longer
-///   carries a pool index, the per-string lifetime classification used by
-///   the previous Phase 5A matrix is impossible to express here.  Allowing
-///   strings into arrays will be done in #591 (which can use Rc-based
-///   ownership without lifetime tracking); until then this remains a
-///   conservative reject to preserve the pre-Phase-5B "no strings in arrays"
-///   contract.
-/// * All non-reference scalars are accepted unconditionally.
+/// * `Cell::Str(Rc<str>)` is accepted: because `Cell::Str` is now backed by
+///   `Rc<str>`, the element holds an independent reference-count; the string
+///   lives as long as any `Rc` handle points to it, regardless of stack-frame
+///   lifetime.  No per-lifetime classification is needed (#591).
+/// * All other scalar types are accepted unconditionally.
 fn check_array_element_write(
     _vm: &VM,
     _array_pool_idx: usize,
@@ -241,34 +233,23 @@ fn check_array_element_write(
     match value {
         // Nested arrays are unconditionally rejected.
         Cell::Array(_) => Err(TbxError::InvalidArrayElement { got: "Array" }),
-        // Blanket reject Cell::Str: lifetime classification is no longer
-        // possible with Rc<str>-backed strings, and array-write liberation
-        // is tracked separately in #591.
-        Cell::Str(_) => Err(TbxError::StringFrameEscape),
-        // All other scalar types are accepted.
+        // All other types (including Cell::Str(Rc<str>)) are accepted.
         _ => Ok(()),
     }
 }
 
-/// Validate and (in future phases) transform `value` before it is stored in
-/// the array at `array_pool_idx`.
+/// Validate and transform `value` before it is stored in the array at
+/// `array_pool_idx`.
 ///
 /// This is the Phase 5B entry-point for array element writes.
 ///
-/// Current policy (#588 D-1):
+/// Current policy (#591 D-4):
 ///
 /// * Nested `Cell::Array` is rejected with `InvalidArrayElement`.
-/// * `Cell::Str` is rejected with `StringFrameEscape`.  Now that `Cell::Str`
-///   is `Rc<str>`-backed it no longer carries a pool index, so the previous
-///   Phase 5A lifetime matrix (FrameLocal/Global/CallerOwned) is no longer
-///   expressible at this layer.  Liberation of the array write path for
-///   strings is tracked separately by #591, which will allow Rc<str> elements
-///   without further lifetime tracking.
+/// * `Cell::Str(Rc<str>)` is accepted.  The element stores a clone of the
+///   `Rc` handle, so the string's lifetime is tied to the reference count
+///   rather than to any stack frame.
 /// * All other types are accepted.
-///
-/// Future phases may intercept specific cases here and return a modified
-/// `Cell` (e.g. a wrapped or specialised representation), but the D-1 phase
-/// performs validation only — no clone/promote.
 ///
 /// # Errors
 ///
@@ -278,8 +259,7 @@ fn stabilize_array_element_write(
     array_pool_idx: usize,
     value: Cell,
 ) -> Result<Cell, TbxError> {
-    // Phase 5B-1: validate only; clone/promote will be added in later phases.
-    // The immutable borrow of `vm` ends before any future mutable operations.
+    // Validate the element type before any mutable borrow of `vm`.
     check_array_element_write(vm, array_pool_idx, &value)?;
     Ok(value)
 }
@@ -1458,7 +1438,7 @@ pub fn to_array_prim(vm: &mut VM) -> Result<(), TbxError> {
     let mut elems: Vec<Cell> = Vec::with_capacity(count);
     for _ in 0..count {
         let elem = vm.pop()?;
-        // Reject reference types that could dangle when the owning frame is freed.
+        // Reject nested arrays; Cell::Str(Rc<str>) is now allowed (#591).
         check_array_element_type(&elem)?;
         elems.push(elem);
     }
@@ -7067,35 +7047,16 @@ mod tests {
         assert_eq!(vm.arrays[0][0], Cell::Int(42));
     }
 
-    // --- array element write: Cell::Str ---
+    // --- array element write: Cell::Str (D-4: Rc<str> liberation, #591) ---
     //
-    // After #588 (D-1), `Cell::Str` is `Rc<str>`-backed and `check_array_element_write`
-    // blanket-rejects any string with `StringFrameEscape` (see the
-    // function-level comment).  The lifetime-distinction tests below were
-    // structured around the pool-index model and are deferred until #591
-    // (which can use Rc-based ownership without lifetime tracking) revisits
-    // the array-write policy.
+    // Since #591 (D-4), `Cell::Str` is `Rc<str>`-backed and array element
+    // writes accept `Cell::Str` for all array lifetimes (global, caller-owned,
+    // frame-local).  No per-source-lifetime classification is needed because
+    // the `Rc` handle keeps the string alive independently of any stack frame.
 
     #[test]
-    #[ignore = "#591: blanket reject in D-1; per-lifetime allow rules will be reintroduced when the array-write path is liberated."]
-    fn test_set_global_str_to_array_element_is_allowed() {
-        // Pre-#588: a globally-promoted string could be stored into any array.
-        // Now `check_array_element_write` rejects all `Cell::Str` values; the
-        // successor test will simply assert that `Cell::string(...)` can be
-        // stored into a frame-local array via Rc-based ownership (#591).
-    }
-
-    #[test]
-    #[ignore = "#591: blanket reject in D-1; see test_set_global_str_to_array_element_is_allowed."]
-    fn test_store_global_str_to_array_element_is_allowed() {}
-
-    #[test]
-    fn test_set_str_to_array_element_is_string_frame_escape() {
-        // D-1 blanket reject: any `Cell::Str` written through `SET` to an
-        // array element fails with `StringFrameEscape`, regardless of the
-        // string's origin (frame-local, caller-owned, or globally-promoted).
-        // This conservatively preserves the pre-Phase-5B "no strings in
-        // arrays" contract until #591 liberates the path.
+    fn test_set_str_to_array_element_is_allowed() {
+        // Cell::Str(Rc<str>) written through SET must succeed (#591).
         let mut vm = VM::new();
         vm.arrays.push(vec![Cell::None]);
         vm.push(Cell::ArrayAddr {
@@ -7103,35 +7064,57 @@ mod tests {
             elem_idx: 0,
         })
         .unwrap();
-        vm.push(Cell::string("local")).unwrap();
-        assert_eq!(set_prim(&mut vm), Err(TbxError::StringFrameEscape));
+        vm.push(Cell::string("hello")).unwrap();
+        set_prim(&mut vm).unwrap();
+        assert_eq!(vm.arrays[0][0], Cell::string("hello"));
     }
 
     #[test]
-    fn test_store_str_to_array_element_is_string_frame_escape() {
-        // Same as the SET path above, exercised through STORE.
+    fn test_store_str_to_array_element_is_allowed() {
+        // Same as the SET path above, exercised through STORE (#591).
         let mut vm = VM::new();
         vm.arrays.push(vec![Cell::None]);
-        vm.push(Cell::string("local")).unwrap();
+        vm.push(Cell::string("world")).unwrap();
         vm.push(Cell::ArrayAddr {
             pool_idx: 0,
             elem_idx: 0,
         })
         .unwrap();
-        assert_eq!(store_prim(&mut vm), Err(TbxError::StringFrameEscape));
+        store_prim(&mut vm).unwrap();
+        assert_eq!(vm.arrays[0][0], Cell::string("world"));
     }
 
     #[test]
-    #[ignore = "#591: requires lifetime-aware allow rules that depend on per-string pool indices, which Rc<str> removes."]
-    fn test_set_caller_owned_str_to_global_array_element_is_string_frame_escape() {}
+    fn test_set_str_to_global_array_element_is_allowed() {
+        // Storing a Str into a global array (global_array_pool_len covers it) must succeed.
+        let mut vm = VM::new();
+        vm.arrays.push(vec![Cell::None]);
+        vm.global_array_pool_len = 1; // mark as global
+        vm.push(Cell::ArrayAddr {
+            pool_idx: 0,
+            elem_idx: 0,
+        })
+        .unwrap();
+        vm.push(Cell::string("global")).unwrap();
+        set_prim(&mut vm).unwrap();
+        assert_eq!(vm.arrays[0][0], Cell::string("global"));
+    }
 
     #[test]
-    #[ignore = "#591: requires lifetime-aware allow rules that depend on per-string pool indices, which Rc<str> removes."]
-    fn test_set_caller_owned_str_to_frame_local_array_element_is_allowed() {}
-
-    #[test]
-    #[ignore = "#591: requires lifetime-aware allow rules that depend on per-string pool indices, which Rc<str> removes."]
-    fn test_set_caller_owned_str_to_caller_owned_array_element_is_string_frame_escape() {}
+    fn test_set_str_to_frame_local_array_element_is_allowed() {
+        // Storing a Str into a frame-local array must succeed (#591).
+        let mut vm = VM::new();
+        vm.arrays.push(vec![Cell::None]);
+        // global_array_pool_len = 0 (default) → array is frame-local
+        vm.push(Cell::ArrayAddr {
+            pool_idx: 0,
+            elem_idx: 0,
+        })
+        .unwrap();
+        vm.push(Cell::string("frame-local")).unwrap();
+        set_prim(&mut vm).unwrap();
+        assert_eq!(vm.arrays[0][0], Cell::string("frame-local"));
+    }
 
     #[test]
     fn test_set_nested_array_to_array_element_is_invalid_array_element() {

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -246,9 +246,9 @@ fn check_array_element_write(
 /// Current policy (#591 D-4):
 ///
 /// * Nested `Cell::Array` is rejected with `InvalidArrayElement`.
-/// * `Cell::Str(Rc<str>)` is accepted.  The element stores a clone of the
-///   `Rc` handle, so the string's lifetime is tied to the reference count
-///   rather than to any stack frame.
+/// * `Cell::Str(Rc<str>)` is accepted.  The element stores the `Rc` handle,
+///   so the string's lifetime is tied to the reference count rather than to
+///   any stack frame.
 /// * All other types are accepted.
 ///
 /// # Errors

--- a/tests/tbx_lib_tests.rs
+++ b/tests/tbx_lib_tests.rs
@@ -121,32 +121,31 @@ fn test_array_index_zero_is_out_of_bounds() {
 }
 
 // ---------------------------------------------------------------------------
-// Array element type restriction tests (issue #487)
+// Array element string tests (issue #591, D-4: Rc<str> liberation)
 // ---------------------------------------------------------------------------
+//
+// Since #591, `Cell::Str(Rc<str>)` is permitted as an array element for all
+// array lifetimes (global, caller-owned, frame-local).  The `Rc` handle keeps
+// the string alive independently of any stack frame, so no per-source-lifetime
+// classification is needed.  Nested `Cell::Array` is still rejected.
 
-/// SET &A(i), STR("...") must fail with StringFrameEscape because STR()
-/// produces a frame-local runtime string that must not escape to an array.
-/// (Global / compile-time literal strings are allowed; see
-/// test_set_literal_str_into_array_is_allowed.)
+/// SET &A(1), STR("hello") inside a word must succeed (#591).
+/// STR() produces a runtime Rc<str>-backed string, which is now allowed as
+/// an array element.  The word is called without parentheses (statement form)
+/// because it has no return value.
 #[test]
-fn test_set_runtime_str_into_array_is_string_frame_escape() {
+fn test_set_runtime_str_into_array_is_allowed() {
     let mut interp = Interpreter::new();
-    // STR("hello") allocates a frame-local string; storing it in the array
-    // must be rejected.
-    let src = "DEF T()\n  VAR A\n  LET A = ARRAY(3)\n  SET &A(1), STR(\"hello\")\nEND\nT()\n";
-    let err = interp
+    // Note: void DEF is called without parentheses (statement form).
+    let src = "DEF T()\n  VAR A\n  LET A = ARRAY(1)\n  SET &A(1), STR(\"hello\")\nEND\nT\n";
+    interp
         .exec_source(src)
-        .expect_err("storing frame-local Str in array should fail");
-    assert!(
-        err.to_string().contains("string cannot escape"),
-        "expected 'string cannot escape', got: {err}"
-    );
+        .expect("storing runtime Str in array should succeed");
 }
 
-/// SET &A(1), "hello" (compile-time literal) must succeed once array element
-/// writes accept `Cell::Str(Rc<str>)` again. Array indices are 1-based in TBX.
+/// SET &A(1), "hello" (compile-time literal) must succeed (#591).
+/// Array indices are 1-based in TBX.
 #[test]
-#[ignore = "#591: array element writes blanket-reject Cell::Str during D-1 (#588). The allow rule for globally-owned strings will be reintroduced when the array-write path is liberated for Rc<str>."]
 fn test_set_literal_str_into_array_is_allowed() {
     let mut interp = Interpreter::new();
     let src = "VAR A\nSET &A, ARRAY(1)\nSET &A(1), \"hello\"\nPUTSTR A(1)\n";
@@ -157,9 +156,8 @@ fn test_set_literal_str_into_array_is_allowed() {
 }
 
 /// Same as above but inside a compiled word to verify frame-local arrays also
-/// accept global string literals.
+/// accept string literals.
 #[test]
-#[ignore = "#591: see test_set_literal_str_into_array_is_allowed."]
 fn test_set_literal_str_into_array_inside_def_is_allowed() {
     let mut interp = Interpreter::new();
     let src =
@@ -170,21 +168,71 @@ fn test_set_literal_str_into_array_inside_def_is_allowed() {
     assert_eq!(interp.take_output(), "inside");
 }
 
-/// TO_ARRAY(STR("a"), STR("b")) must fail with InvalidArrayElement.
+/// STR_CONCAT result stored in global array, read back after word return (#591).
+/// Exercises the runtime-string safety: the Rc handle outlives the call frame.
+/// The void DEF is called without parentheses (statement form).
 #[test]
-fn test_to_array_with_str_elements_is_error() {
+fn test_set_runtime_str_into_global_array_survives_word_return() {
     let mut interp = Interpreter::new();
-    let src = "TO_ARRAY(STR(\"a\"), STR(\"b\"))\n";
-    let err = interp
+    // F is a void word; call it without parentheses to avoid DROP_TO_MARKER mismatch.
+    let src = "VAR A\nSET &A, ARRAY(1)\nDEF F()\n  SET &A(1), STR_CONCAT(\"foo\", \"bar\")\nEND\nF\nPUTSTR A(1)\n";
+    interp
         .exec_source(src)
-        .expect_err("TO_ARRAY with Str elements should fail");
-    assert!(
-        err.to_string().contains("invalid array element type"),
-        "expected 'invalid array element type', got: {err}"
-    );
+        .expect("storing runtime Str in global array should succeed");
+    assert_eq!(interp.take_output(), "foobar");
 }
 
-/// Storing a nested array (Cell::Array) as an element must fail.
+/// frame-local array can store and immediately read back a runtime string (#591).
+/// The void DEF is called without parentheses (statement form).
+#[test]
+fn test_set_runtime_str_into_frame_local_array_is_allowed() {
+    let mut interp = Interpreter::new();
+    // F is a void word; call it without parentheses to avoid DROP_TO_MARKER mismatch.
+    let src = "DEF F()\n  VAR A\n  SET &A, ARRAY(1)\n  SET &A(1), STR(\"hello\")\n  PUTSTR A(1)\nEND\nF\n";
+    interp
+        .exec_source(src)
+        .expect("storing runtime Str in frame-local array should succeed");
+    assert_eq!(interp.take_output(), "hello");
+}
+
+/// Caller-owned string parameter stored in a frame-local array must succeed (#591).
+#[test]
+fn test_set_caller_owned_str_param_into_frame_local_array_is_allowed() {
+    let mut interp = Interpreter::new();
+    let src = "DEF USE(S)\n  VAR A\n  SET &A, ARRAY(1)\n  SET &A(1), S\n  PUTSTR A(1)\nEND\nUSE(\"arg\")\n";
+    interp
+        .exec_source(src)
+        .expect("storing caller-owned Str param in frame-local array should succeed");
+    assert_eq!(interp.take_output(), "arg");
+}
+
+/// TO_ARRAY(STR("a"), STR("b")) must now succeed (#591); the results can be
+/// read back via array indexing.
+#[test]
+fn test_to_array_with_str_elements_is_allowed() {
+    let mut interp = Interpreter::new();
+    // Store TO_ARRAY result, read element 1 and 2 back via PUTSTR.
+    let src = "VAR A\nSET &A, TO_ARRAY(STR(\"alpha\"), STR(\"beta\"))\nPUTSTR A(1)\nPUTSTR A(2)\n";
+    interp
+        .exec_source(src)
+        .expect("TO_ARRAY with Str elements should succeed");
+    assert_eq!(interp.take_output(), "alphabeta");
+}
+
+/// STR_LEN / STR_EQ / STR_CONCAT can operate on a Cell::Str read from an array element.
+#[test]
+fn test_str_ops_on_array_element_str() {
+    let mut interp = Interpreter::new();
+    // Use PUTSTR to exercise reading the element and passing it to string primitives.
+    // STR_CONCAT output confirms the element was successfully read as Str.
+    let src = "VAR A\nSET &A, ARRAY(1)\nSET &A(1), \"hello\"\nPUTSTR STR_CONCAT(A(1), \"!\")\n";
+    interp
+        .exec_source(src)
+        .expect("string ops on array element should succeed");
+    assert_eq!(interp.take_output(), "hello!");
+}
+
+/// Storing a nested array (Cell::Array) as an element must still fail.
 #[test]
 fn test_set_array_into_array_is_invalid_element_type() {
     let mut interp = Interpreter::new();
@@ -199,72 +247,3 @@ fn test_set_array_into_array_is_invalid_element_type() {
         "expected 'invalid array element type', got: {err}"
     );
 }
-
-// ---------------------------------------------------------------------------
-// Caller-owned string in array element (issue #567)
-// ---------------------------------------------------------------------------
-
-/// A caller-owned string parameter may be stored in a frame-local array element.
-///
-/// DEF USE(S)
-///   VAR A
-///   SET &A, ARRAY(1)
-///   SET &A(1), S
-///   PUTSTR A(1)
-/// END
-/// USE("arg")
-///
-/// S is caller-owned from the perspective of USE's call frame, and A is
-/// frame-local, so this is safe and must succeed.
-#[test]
-#[ignore = "#591: array element writes blanket-reject Cell::Str during D-1 (#588). The lifetime-aware allow rules will be reintroduced when the array-write path is liberated for Rc<str>."]
-fn test_set_caller_owned_str_param_into_frame_local_array_is_allowed() {
-    let mut interp = Interpreter::new();
-    let src = "DEF USE(S)\n  VAR A\n  SET &A, ARRAY(1)\n  SET &A(1), S\n  PUTSTR A(1)\nEND\nUSE(\"arg\")\n";
-    interp
-        .exec_source(src)
-        .expect("storing caller-owned Str param in frame-local array should succeed");
-    assert_eq!(interp.take_output(), "arg");
-}
-
-/// A frame-local runtime string (produced by STR()) must still be rejected
-/// even when the target array is frame-local.  This prevents dangling
-/// references when the inner call frame returns.
-#[test]
-fn test_set_frame_local_runtime_str_into_frame_local_array_is_string_frame_escape() {
-    let mut interp = Interpreter::new();
-    let src = "DEF T()\n  VAR A\n  SET &A, ARRAY(1)\n  SET &A(1), STR(\"hello\")\nEND\nT()\n";
-    let err = interp
-        .exec_source(src)
-        .expect_err("storing frame-local runtime Str in array should fail");
-    assert!(
-        err.to_string().contains("string cannot escape"),
-        "expected 'string cannot escape', got: {err}"
-    );
-}
-
-// ---------------------------------------------------------------------------
-// Phase 5A deny-cases not directly expressible at TBX integration level
-// ---------------------------------------------------------------------------
-//
-// The following Phase 5A combinations are denied by the runtime but cannot
-// be exercised through integration tests due to current TBX limitations:
-//
-// 1. CallerOwned Str → Global Array:
-//    String literals are always promoted to the global string pool at compile
-//    time, so they are never CallerOwned.  A dynamically-generated (frame-local)
-//    string returned from a word becomes CallerOwned in the caller, but there
-//    is currently no way to pass that returned value as a parameter to another
-//    word via a DEF-body statement call (DEF-inside-DEF statement calls trigger
-//    a DROP_TO_MARKER mismatch due to a known limitation in the statement
-//    compilation path).
-//
-// 2. CallerOwned Str → CallerOwned Array:
-//    For the same reason as above, building a scenario where both the array
-//    and the string are CallerOwned (i.e., created in distinct outer frames)
-//    is not achievable through the integration-test harness in its current form.
-//
-// Both cases are covered at the unit-test level:
-//   - `test_set_caller_owned_str_to_global_array_element_is_string_frame_escape`
-//   - `test_set_caller_owned_str_to_caller_owned_array_element_is_string_frame_escape`
-// in `src/primitives.rs`.


### PR DESCRIPTION
## 概要

`Cell::Str(Rc<str>)` バックドの文字列を array element に安全に格納できるようにする（Phase 5B D-4）。
`Rc` handle を持つ array element は文字列実体の寿命をスタックフレームとは独立して管理できるため、
lifetime matrix による拒否は不要になった。

## 変更内容

- `src/primitives.rs`:
  - `check_array_element_type` / `check_array_element_write` から `Cell::Str` の拒否を除去
  - `stabilize_array_element_write` のコメントを D-4 ポリシーに更新
  - `TO_ARRAY` の element 受け入れも `Cell::Str` を許可（`check_array_element_type` 経由）
  - D-1 時点の blanket reject テスト群（`StringFrameEscape` を期待）を allow テストに置き換え
  - グローバル / フレームローカル各 array への SET / STORE テストを追加
- `src/error.rs`:
  - `StringFrameEscape` variant を削除（array write path 以外での使用がなくなったため）
  - `InvalidArrayElement` の doc コメント・Display メッセージを `Str` 許可後の状態に更新
- `tests/tbx_lib_tests.rs`:
  - `StringFrameEscape` を期待していたテスト群を allow テストに置き換え
  - ignore 状態だったテストを実際の pass テストに復活
  - `TO_ARRAY(STR(...))` 成功テスト・読み出し read path テストを追加

## 確認

- `cargo fmt` 済み
- `cargo clippy --all-targets -- -D warnings` 通過
- `cargo test` 全件通過（875 unit + 38 integration）

Closes #591
