### PR TITLE
primitives分割 Phase 2: compare.rs を切り出す

### DIFF
--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -12,10 +12,12 @@ use std::time::{SystemTime, UNIX_EPOCH};
 // `primitives.rs` remains the façade and registration entry point; the
 // `pub use` re-exports keep `crate::primitives::<name>` paths working for
 // existing callers and tests.
+mod compare;
 mod logic;
 mod numeric;
 mod stack;
 
+pub use compare::*;
 pub use logic::*;
 pub use numeric::*;
 pub use stack::*;
@@ -290,100 +292,6 @@ fn write_array_element(
         });
     }
     arr[elem_idx] = value;
-    Ok(())
-}
-
-/// EQ — equality comparison. Pushes Bool(true) if the two top values are equal.
-/// Int/Float mixed pairs are compared by promoting Int to Float.
-/// Two `Cell::Str` values are compared by string content.
-pub fn eq_prim(vm: &mut VM) -> Result<(), TbxError> {
-    let b = vm.pop()?;
-    let a = vm.pop()?;
-    let result = match (&a, &b) {
-        (Cell::Int(x), Cell::Float(y)) => (*x as f64) == *y,
-        (Cell::Float(x), Cell::Int(y)) => *x == (*y as f64),
-        // Content equality on `Rc<str>` is delegated to its `PartialEq`
-        // (which dereferences to `str`); same as `a == b` for the Str pair.
-        (Cell::Str(_), Cell::Str(_)) => resolve_str_cell(&a)? == resolve_str_cell(&b)?,
-        _ => a == b,
-    };
-    vm.push(Cell::Bool(result))?;
-    Ok(())
-}
-
-/// NEQ — inequality comparison. Pushes Bool(true) if the two top values are not equal.
-/// Int/Float mixed pairs are compared by promoting Int to Float.
-/// Two `Cell::Str` values are compared by string content.
-pub fn neq_prim(vm: &mut VM) -> Result<(), TbxError> {
-    let b = vm.pop()?;
-    let a = vm.pop()?;
-    let result = match (&a, &b) {
-        (Cell::Int(x), Cell::Float(y)) => (*x as f64) != *y,
-        (Cell::Float(x), Cell::Int(y)) => *x != (*y as f64),
-        (Cell::Str(_), Cell::Str(_)) => resolve_str_cell(&a)? != resolve_str_cell(&b)?,
-        _ => a != b,
-    };
-    vm.push(Cell::Bool(result))?;
-    Ok(())
-}
-
-/// LT — less than. Pushes Bool(true) if a < b (numeric only, with Int/Float promotion).
-pub fn lt_prim(vm: &mut VM) -> Result<(), TbxError> {
-    let b = vm.pop_number()?;
-    let a = vm.pop_number()?;
-    let result = match (&a, &b) {
-        (Cell::Int(x), Cell::Int(y)) => x < y,
-        (Cell::Float(x), Cell::Float(y)) => x < y,
-        (Cell::Int(x), Cell::Float(y)) => (*x as f64) < *y,
-        (Cell::Float(x), Cell::Int(y)) => *x < (*y as f64),
-        _ => unreachable!("pop_number guarantees Int or Float"),
-    };
-    vm.push(Cell::Bool(result))?;
-    Ok(())
-}
-
-/// GT — greater than. Pushes Bool(true) if a > b (numeric only, with Int/Float promotion).
-pub fn gt_prim(vm: &mut VM) -> Result<(), TbxError> {
-    let b = vm.pop_number()?;
-    let a = vm.pop_number()?;
-    let result = match (&a, &b) {
-        (Cell::Int(x), Cell::Int(y)) => x > y,
-        (Cell::Float(x), Cell::Float(y)) => x > y,
-        (Cell::Int(x), Cell::Float(y)) => (*x as f64) > *y,
-        (Cell::Float(x), Cell::Int(y)) => *x > (*y as f64),
-        _ => unreachable!("pop_number guarantees Int or Float"),
-    };
-    vm.push(Cell::Bool(result))?;
-    Ok(())
-}
-
-/// LE — less than or equal. Pushes Bool(true) if a <= b (numeric only, with Int/Float promotion).
-pub fn le_prim(vm: &mut VM) -> Result<(), TbxError> {
-    let b = vm.pop_number()?;
-    let a = vm.pop_number()?;
-    let result = match (&a, &b) {
-        (Cell::Int(x), Cell::Int(y)) => x <= y,
-        (Cell::Float(x), Cell::Float(y)) => x <= y,
-        (Cell::Int(x), Cell::Float(y)) => (*x as f64) <= *y,
-        (Cell::Float(x), Cell::Int(y)) => *x <= (*y as f64),
-        _ => unreachable!("pop_number guarantees Int or Float"),
-    };
-    vm.push(Cell::Bool(result))?;
-    Ok(())
-}
-
-/// GE — greater than or equal. Pushes Bool(true) if a >= b (numeric only, with Int/Float promotion).
-pub fn ge_prim(vm: &mut VM) -> Result<(), TbxError> {
-    let b = vm.pop_number()?;
-    let a = vm.pop_number()?;
-    let result = match (&a, &b) {
-        (Cell::Int(x), Cell::Int(y)) => x >= y,
-        (Cell::Float(x), Cell::Float(y)) => x >= y,
-        (Cell::Int(x), Cell::Float(y)) => (*x as f64) >= *y,
-        (Cell::Float(x), Cell::Int(y)) => *x >= (*y as f64),
-        _ => unreachable!("pop_number guarantees Int or Float"),
-    };
-    vm.push(Cell::Bool(result))?;
     Ok(())
 }
 

--- a/src/primitives/compare.rs
+++ b/src/primitives/compare.rs
@@ -1,0 +1,103 @@
+//! Low-dependency comparison primitives.
+//!
+//! These primitives implement equality and ordering comparisons over the data
+//! stack. They only depend on [`Cell`], [`VM`], and [`TbxError`], and preserve
+//! the existing Int/Float promotion semantics.
+//!
+//! `EQ` and `NEQ` rely on `Cell`'s `PartialEq` implementation for the general
+//! case (which compares `Cell::Str` values by string content via `Rc<str>`'s
+//! `PartialEq`), while still handling `Int`/`Float` mixed pairs explicitly.
+
+use crate::cell::Cell;
+use crate::error::TbxError;
+use crate::vm::VM;
+
+/// EQ — equality comparison. Pushes Bool(true) if the two top values are equal.
+/// Int/Float mixed pairs are compared by promoting Int to Float.
+/// All other pairs, including two Cell::Str values, use Cell's PartialEq.
+pub fn eq_prim(vm: &mut VM) -> Result<(), TbxError> {
+    let b = vm.pop()?;
+    let a = vm.pop()?;
+    let result = match (&a, &b) {
+        (Cell::Int(x), Cell::Float(y)) => (*x as f64) == *y,
+        (Cell::Float(x), Cell::Int(y)) => *x == (*y as f64),
+        _ => a == b,
+    };
+    vm.push(Cell::Bool(result))?;
+    Ok(())
+}
+
+/// NEQ — inequality comparison. Pushes Bool(true) if the two top values are not equal.
+/// Int/Float mixed pairs are compared by promoting Int to Float.
+/// All other pairs, including two Cell::Str values, use Cell's PartialEq.
+pub fn neq_prim(vm: &mut VM) -> Result<(), TbxError> {
+    let b = vm.pop()?;
+    let a = vm.pop()?;
+    let result = match (&a, &b) {
+        (Cell::Int(x), Cell::Float(y)) => (*x as f64) != *y,
+        (Cell::Float(x), Cell::Int(y)) => *x != (*y as f64),
+        _ => a != b,
+    };
+    vm.push(Cell::Bool(result))?;
+    Ok(())
+}
+
+/// LT — less than. Pushes Bool(true) if a < b (numeric only, with Int/Float promotion).
+pub fn lt_prim(vm: &mut VM) -> Result<(), TbxError> {
+    let b = vm.pop_number()?;
+    let a = vm.pop_number()?;
+    let result = match (&a, &b) {
+        (Cell::Int(x), Cell::Int(y)) => x < y,
+        (Cell::Float(x), Cell::Float(y)) => x < y,
+        (Cell::Int(x), Cell::Float(y)) => (*x as f64) < *y,
+        (Cell::Float(x), Cell::Int(y)) => *x < (*y as f64),
+        _ => unreachable!("pop_number guarantees Int or Float"),
+    };
+    vm.push(Cell::Bool(result))?;
+    Ok(())
+}
+
+/// GT — greater than. Pushes Bool(true) if a > b (numeric only, with Int/Float promotion).
+pub fn gt_prim(vm: &mut VM) -> Result<(), TbxError> {
+    let b = vm.pop_number()?;
+    let a = vm.pop_number()?;
+    let result = match (&a, &b) {
+        (Cell::Int(x), Cell::Int(y)) => x > y,
+        (Cell::Float(x), Cell::Float(y)) => x > y,
+        (Cell::Int(x), Cell::Float(y)) => (*x as f64) > *y,
+        (Cell::Float(x), Cell::Int(y)) => *x > (*y as f64),
+        _ => unreachable!("pop_number guarantees Int or Float"),
+    };
+    vm.push(Cell::Bool(result))?;
+    Ok(())
+}
+
+/// LE — less than or equal. Pushes Bool(true) if a <= b (numeric only, with Int/Float promotion).
+pub fn le_prim(vm: &mut VM) -> Result<(), TbxError> {
+    let b = vm.pop_number()?;
+    let a = vm.pop_number()?;
+    let result = match (&a, &b) {
+        (Cell::Int(x), Cell::Int(y)) => x <= y,
+        (Cell::Float(x), Cell::Float(y)) => x <= y,
+        (Cell::Int(x), Cell::Float(y)) => (*x as f64) <= *y,
+        (Cell::Float(x), Cell::Int(y)) => *x <= (*y as f64),
+        _ => unreachable!("pop_number guarantees Int or Float"),
+    };
+    vm.push(Cell::Bool(result))?;
+    Ok(())
+}
+
+/// GE — greater than or equal. Pushes Bool(true) if a >= b (numeric only, with Int/Float promotion).
+pub fn ge_prim(vm: &mut VM) -> Result<(), TbxError> {
+    let b = vm.pop_number()?;
+    let a = vm.pop_number()?;
+    let result = match (&a, &b) {
+        (Cell::Int(x), Cell::Int(y)) => x >= y,
+        (Cell::Float(x), Cell::Float(y)) => x >= y,
+        (Cell::Int(x), Cell::Float(y)) => (*x as f64) >= *y,
+        (Cell::Float(x), Cell::Int(y)) => *x >= (*y as f64),
+        _ => unreachable!("pop_number guarantees Int or Float"),
+    };
+    vm.push(Cell::Bool(result))?;
+    Ok(())
+}


### PR DESCRIPTION
## 概要

`src/primitives.rs` に残っていた比較系 primitive（EQ/NEQ/LT/GT/LE/GE）を `src/primitives/compare.rs` に切り出す。primitives 分割リファクタリング（#563）の Phase 2 として、numeric.rs・logic.rs・stack.rs に続く小さな移動を実施した。

## 変更内容

- `src/primitives/compare.rs` を新規作成し、`eq_prim` / `neq_prim` / `lt_prim` / `gt_prim` / `le_prim` / `ge_prim` を移動
- `EQ` / `NEQ` の実装から `resolve_str_cell` への依存を削除。`Cell::Str` の PartialEq は `Rc<str>` の文字列内容比較に委譲するため、特別扱いが不要になった
- `src/primitives.rs` に `mod compare;` と `pub use compare::*;` を追加し、既存の `crate::primitives::*` パスを維持

Closes #608
