### PR TITLE
tbx-task の bash 補完ファイルと tt alias 手順を追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,23 @@ scripts/tbx-task prompt fix 615
 scripts/tbx-task prompt after-merge
 ```
 
+#### alias と bash 補完
+
+`~/.bashrc` に以下を追記すると `tt` で呼び出せ、Tab 補完も使えます。
+
+```bash
+source /path/to/tbx/scripts/completions/tbx-task.bash
+alias tt='scripts/tbx-task'
+complete -F _tbx_task_completion tt
+```
+
+補完例:
+
+```console
+tt <Tab>          # current prompt
+tt prompt <Tab>   # implement review fix after-merge
+```
+
 ## ドキュメント
 
 - [`blueprint.md`](./blueprint.md) — VM・辞書のアーキテクチャ設計

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ scripts/tbx-task prompt after-merge
 
 ```bash
 source /path/to/tbx/scripts/completions/tbx-task.bash
-alias tt='scripts/tbx-task'
+alias tt='/path/to/tbx/scripts/tbx-task'
 complete -F _tbx_task_completion tt
 ```
 

--- a/scripts/completions/tbx-task.bash
+++ b/scripts/completions/tbx-task.bash
@@ -1,0 +1,19 @@
+_tbx_task_completion() {
+    local cur prev
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    case "$prev" in
+        tbx-task|scripts/tbx-task|tt)
+            COMPREPLY=($(compgen -W "current prompt" -- "$cur"))
+            return
+            ;;
+        prompt)
+            COMPREPLY=($(compgen -W "implement review fix after-merge" -- "$cur"))
+            return
+            ;;
+    esac
+}
+
+complete -F _tbx_task_completion tbx-task
+complete -F _tbx_task_completion scripts/tbx-task


### PR DESCRIPTION
## 概要

`scripts/completions/tbx-task.bash` を追加し、`tbx-task` / `scripts/tbx-task` に bash Tab 補完を提供する。
また `tt` alias への補完登録手順と alias 例を README に追記する。

## 変更内容

- `scripts/completions/tbx-task.bash` を新規追加
  - top-level: `current` / `prompt` を補完
  - `prompt` サブコマンド: `implement` / `review` / `fix` / `after-merge` を補完
  - `tbx-task` と `scripts/tbx-task` に対して補完を自動登録
- `README.md` に alias と bash 補完の設定手順を追記
  - `source` + `alias tt` + `complete -F _tbx_task_completion tt` の3行例

Closes #627
