### PR TITLE
ステートメント文脈の NAME() に InvalidStatementCallSyntax エラーを出す

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -191,6 +191,12 @@ pub enum TbxError {
         /// The type name of the value that was rejected (e.g. `"Array"`).
         got: &'static str,
     },
+
+    /// A word was called with function-call syntax (`NAME()` / `NAME(args...)`) at
+    /// statement level, where only the bare `NAME` form is valid.
+    InvalidStatementCallSyntax {
+        name: String,
+    },
 }
 
 impl std::fmt::Display for TbxError {
@@ -314,6 +320,12 @@ impl std::fmt::Display for TbxError {
                 write!(
                     f,
                     "invalid array element type: {got} is not allowed; nested arrays are not permitted"
+                )
+            }
+            TbxError::InvalidStatementCallSyntax { name } => {
+                write!(
+                    f,
+                    "invalid statement call syntax: '{name}()' is not allowed as a statement; use '{name}' without parentheses"
                 )
             }
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -192,8 +192,12 @@ pub enum TbxError {
         got: &'static str,
     },
 
-    /// A word was called with function-call syntax (`NAME()` / `NAME(args...)`) at
+    /// A word was called with empty-parens function-call syntax (`NAME()`) at
     /// statement level, where only the bare `NAME` form is valid.
+    ///
+    /// Currently detects only the zero-argument form `NAME()` (arg_tokens == `[LParen, RParen]`).
+    /// Non-empty parens `NAME(args...)` are indistinguishable at the token level from the
+    /// grouped-expression form `NAME (args...)` and are therefore not rejected here.
     InvalidStatementCallSyntax {
         name: String,
     },

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -480,6 +480,20 @@ impl Interpreter {
             }));
         }
 
+        // Reject empty-parens function-call syntax at statement level: NAME().
+        // arg_tokens == [LParen, RParen] means the user wrote `NAME()` as a statement,
+        // which is not the formal call form. The bare `NAME` form is correct.
+        // Non-empty parens like `NAME(arg)` are indistinguishable at the token level from
+        // the grouped-expression form `NAME (arg)` and are therefore left to pass through.
+        if matches!(
+            arg_tokens,
+            [a, b] if a.token == Token::LParen && b.token == Token::RParen
+        ) {
+            return Err(make_err(TbxError::InvalidStatementCallSyntax {
+                name: stmt_name.to_string(),
+            }));
+        }
+
         // Compile the argument expression to a cell sequence.
         // Local variables in the current compile scope shadow globals (local_table checked first).
         // Uses the same take-compile-restore pattern as `compile_expr_taking_local_table` in
@@ -4932,5 +4946,91 @@ PUTDEC 1; PUTDEC ADD(
             err.col
         );
         assert_eq!(err.source_excerpt, "PUTDEC ADD(\n  1,\n  1 / 0\n)");
+    }
+
+    // ── issue #631: InvalidStatementCallSyntax ────────────────────────────
+
+    const SETG_DEF: &str = "VAR G\nDEF SETG()\n  SET &G, 1\nEND\n";
+    const GETG_DEF: &str = "VAR G\nSET &G, 42\nDEF GETG()\n  RETURN G\nEND\n";
+
+    #[test]
+    fn test_stmt_call_with_parens_exec_source_gives_proper_error() {
+        // exec_source path: SETG() as a statement must produce InvalidStatementCallSyntax.
+        let mut interp = Interpreter::new();
+        let result = interp.exec_source(&format!("{SETG_DEF}SETG()\nPUTDEC G"));
+        let err = result.expect_err("expected error");
+        assert!(
+            matches!(err.kind, TbxError::InvalidStatementCallSyntax { .. }),
+            "expected InvalidStatementCallSyntax, got: {:?}",
+            err.kind
+        );
+        let msg = err.to_string();
+        assert!(
+            !msg.contains("DROP_TO_MARKER"),
+            "message must not expose DROP_TO_MARKER: {msg}"
+        );
+        assert!(
+            !msg.contains("marker"),
+            "message must not expose 'marker': {msg}"
+        );
+        assert!(
+            msg.contains("SETG"),
+            "message should mention the word name: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_stmt_call_with_parens_exec_line_gives_proper_error() {
+        // exec_line path: SETG() as a statement must produce InvalidStatementCallSyntax.
+        let mut interp = Interpreter::new();
+        interp.exec_source(SETG_DEF).unwrap();
+        let result = interp.exec_line("SETG()", 5);
+        let err = result.expect_err("expected error");
+        assert!(
+            matches!(err.kind, TbxError::InvalidStatementCallSyntax { .. }),
+            "expected InvalidStatementCallSyntax, got: {:?}",
+            err.kind
+        );
+        let msg = err.to_string();
+        assert!(
+            !msg.contains("DROP_TO_MARKER"),
+            "message must not expose DROP_TO_MARKER: {msg}"
+        );
+        assert!(
+            !msg.contains("marker"),
+            "message must not expose 'marker': {msg}"
+        );
+    }
+
+    #[test]
+    fn test_stmt_call_with_nonempty_parens_is_currently_accepted() {
+        // NAME(args...) at statement level is indistinguishable from the grouped-expression
+        // form `NAME (args...)` at the token level, so it is currently accepted.
+        // Only the zero-argument form NAME() is rejected (see blueprint-language.md §544).
+        let mut interp = Interpreter::new();
+        interp
+            .exec_source("DEF FOO(X)\n  PUTDEC X\nEND\nFOO(1)")
+            .expect("NAME(arg) as statement should currently succeed");
+        assert_eq!(interp.take_output().trim(), "1");
+    }
+
+    #[test]
+    fn test_stmt_call_without_parens_still_works() {
+        // Formal statement call NAME (no parens) must continue to work.
+        let mut interp = Interpreter::new();
+        interp
+            .exec_source(&format!("{SETG_DEF}SETG\nPUTDEC G"))
+            .unwrap();
+        assert_eq!(interp.take_output().trim(), "1");
+    }
+
+    #[test]
+    fn test_expression_call_with_parens_still_works() {
+        // NAME() inside an operand expression must continue to work.
+        let mut interp = Interpreter::new();
+        interp
+            .exec_source(&format!("{GETG_DEF}PUTDEC GETG()"))
+            .unwrap();
+        assert_eq!(interp.take_output().trim(), "42");
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -2645,7 +2645,7 @@ mod tests {
         let result = run_source(
             "VAR G\n\
              DEF BAD_STORE()\n  VAR A\n  LET A = ARRAY(2)\n  SET &G, A\nEND\n\
-             BAD_STORE()",
+             BAD_STORE",
         );
         assert!(
             matches!(result, Err(crate::error::TbxError::ArrayFrameEscape)),
@@ -2762,7 +2762,7 @@ mod tests {
         let result = run_source(
             "VAR gvar\n\
              DEF BAD()\n  VAR a\n  LET a = ARRAY(3)\n  SET &gvar, a\nEND\n\
-             BAD()",
+             BAD",
         );
         assert!(
             matches!(result, Err(crate::error::TbxError::ArrayFrameEscape)),

--- a/tests/tbx_lib_tests.rs
+++ b/tests/tbx_lib_tests.rs
@@ -110,7 +110,7 @@ fn test_array_index_zero_is_out_of_bounds() {
         .set_base_dir(base)
         .expect("CARGO_MANIFEST_DIR is always absolute");
     // Array indices are 1-based; index 0 must return ArrayIndexOutOfBounds.
-    let src = "DEF T()\n  VAR A\n  LET A = ARRAY(3)\n  RETURN A(0)\nEND\nT()\n";
+    let src = "DEF T()\n  VAR A\n  LET A = ARRAY(3)\n  RETURN A(0)\nEND\nT\n";
     let err = interp
         .exec_source(src)
         .expect_err("index 0 should be out of bounds");
@@ -238,7 +238,7 @@ fn test_set_array_into_array_is_invalid_element_type() {
     let mut interp = Interpreter::new();
     // Create an outer array and a nested array, then try to store the inner in outer.
     let src =
-        "DEF T()\n  VAR A, B\n  LET A = ARRAY(3)\n  LET B = ARRAY(2)\n  SET &A(1), B\nEND\nT()\n";
+        "DEF T()\n  VAR A, B\n  LET A = ARRAY(3)\n  LET B = ARRAY(2)\n  SET &A(1), B\nEND\nT\n";
     let err = interp
         .exec_source(src)
         .expect_err("storing Array in array element should fail");


### PR DESCRIPTION
## 概要

ステートメント文脈で `SETG()` のように空カッコ付きで呼び出したとき、内部実装を露出する `DROP_TO_MARKER: no marker found on the data stack` の代わりに、構文上の問題を説明する適切なエラーを返す。

## 変更内容

- `TbxError::InvalidStatementCallSyntax { name }` variant を追加し、`'{name}()' is not allowed as a statement; use '{name}' without parentheses` を表示
- `Interpreter::write_stmt_to_dict` で arg_tokens が `[LParen, RParen]`（空括弧）のとき早期に同エラーを返す
  - 非空括弧 `NAME(arg)` はトークンレベルでグループ式 `NAME (arg)` と区別できないため対象外
- `exec_source` / `exec_line` 両経路をカバーする回帰テストを `src/interpreter.rs` に追加
- 既存テストで `BAD_STORE()` / `BAD()` / `T()` をステートメント呼び出しに使っていたものを `BAD_STORE` / `BAD` / `T` （正式形式）に修正

## エラー例

```
Error: line 5:1: invalid statement call syntax: 'SETG()' is not allowed as a statement; use 'SETG' without parentheses
  SETG()
```

Closes #631
