### PR TITLE
IMMEDIATEワード向けトークン消費ヘルパを追加する

### DIFF
--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -3,7 +3,6 @@ use crate::constants::MAX_DICTIONARY_CELLS;
 use crate::dict::{EntryKind, WordEntry, FLAG_IMMEDIATE, FLAG_SYSTEM};
 use crate::error::TbxError;
 use crate::expr::ExprCompiler;
-use crate::lexer::Token;
 use crate::vm::{CompileState, VM};
 use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -215,15 +214,7 @@ pub fn literal_prim(vm: &mut VM) -> Result<(), TbxError> {
 ///
 /// This is the TBX equivalent of Forth's `CREATE`.
 pub fn header_prim(vm: &mut VM) -> Result<(), TbxError> {
-    let tok = vm.next_token()?;
-    let name = match tok.token {
-        Token::Ident(n) => n.to_ascii_uppercase(),
-        _ => {
-            return Err(TbxError::InvalidExpression {
-                reason: "HEADER: expected identifier token",
-            })
-        }
-    };
+    let name = vm.expect_ident("HEADER: expected identifier token")?;
     let entry = WordEntry::new_word(&name, vm.dp);
     vm.register(entry);
     Ok(())
@@ -238,15 +229,7 @@ pub fn header_prim(vm: &mut VM) -> Result<(), TbxError> {
 /// Unlike Forth's `IMMEDIATE` (which implicitly operates on the most recently defined word),
 /// TBX requires the target word name to be specified explicitly.
 pub fn immediate_prim(vm: &mut VM) -> Result<(), TbxError> {
-    let tok = vm.next_token()?;
-    let name = match tok.token {
-        Token::Ident(n) => n.to_ascii_uppercase(),
-        _ => {
-            return Err(TbxError::InvalidExpression {
-                reason: "IMMEDIATE: expected identifier token",
-            })
-        }
-    };
+    let name = vm.expect_ident("IMMEDIATE: expected identifier token")?;
     let xt = vm
         .lookup(&name)
         .ok_or_else(|| TbxError::UndefinedSymbol { name: name.clone() })?;
@@ -269,15 +252,7 @@ pub fn def_prim(vm: &mut VM) -> Result<(), TbxError> {
     }
 
     // Read word name from token stream.
-    let name_tok = vm.next_token()?;
-    let name = match name_tok.token {
-        crate::lexer::Token::Ident(n) => n.to_ascii_uppercase(),
-        _ => {
-            return Err(TbxError::InvalidExpression {
-                reason: "expected word name after DEF",
-            })
-        }
-    };
+    let name = vm.expect_ident("expected word name after DEF")?;
 
     // Parse optional parameter list: DEF WORD(X, Y, ...) or DEF WORD(...)
     //
@@ -543,15 +518,7 @@ pub fn end_prim(vm: &mut VM) -> Result<(), TbxError> {
 pub fn var_prim(vm: &mut VM) -> Result<(), TbxError> {
     loop {
         // Read the next identifier.
-        let name_tok = vm.next_token()?;
-        let name = match name_tok.token {
-            crate::lexer::Token::Ident(n) => n.to_ascii_uppercase(),
-            _ => {
-                return Err(TbxError::InvalidExpression {
-                    reason: "expected variable name after VAR",
-                })
-            }
-        };
+        let name = vm.expect_ident("expected variable name after VAR")?;
 
         if vm.is_compiling {
             // Local variable: add to compile state's local table.
@@ -1103,13 +1070,7 @@ fn skip_comma_prim(vm: &mut VM) -> Result<(), TbxError> {
         });
     }
 
-    let tok = vm.next_token()?;
-    match tok.token {
-        Token::Comma => Ok(()),
-        _ => Err(TbxError::InvalidExpression {
-            reason: "SKIP_COMMA: expected ','",
-        }),
-    }
+    vm.expect_comma("SKIP_COMMA: expected ','")
 }
 
 /// COMPILE_LVALUE_SAVE — emit `LIT addr` to the dictionary and push addr onto the compile stack.
@@ -1128,22 +1089,9 @@ fn compile_lvalue_save_prim(vm: &mut VM) -> Result<(), TbxError> {
     }
 
     // Consume the leading `&` (address-of operator) before the variable name.
-    let amp_tok = vm.next_token()?;
-    if !matches!(amp_tok.token, Token::Ampersand) {
-        return Err(TbxError::InvalidExpression {
-            reason: "COMPILE_LVALUE_SAVE: expected '&' before variable name",
-        });
-    }
+    vm.expect_ampersand("COMPILE_LVALUE_SAVE: expected '&' before variable name")?;
 
-    let tok = vm.next_token()?;
-    let name = match tok.token {
-        Token::Ident(n) => n.to_ascii_uppercase(),
-        _ => {
-            return Err(TbxError::InvalidExpression {
-                reason: "COMPILE_LVALUE_SAVE: expected variable name",
-            })
-        }
-    };
+    let name = vm.expect_ident("COMPILE_LVALUE_SAVE: expected variable name")?;
 
     // Resolve address: local table first, then global dictionary.
     // Use the take→use→restore pattern to satisfy the borrow checker.
@@ -1205,15 +1153,7 @@ fn compile_lvalue_prim(vm: &mut VM) -> Result<(), TbxError> {
         });
     }
 
-    let tok = vm.next_token()?;
-    let name = match tok.token {
-        Token::Ident(n) => n.to_ascii_uppercase(),
-        _ => {
-            return Err(TbxError::InvalidExpression {
-                reason: "COMPILE_LVALUE: expected variable name",
-            })
-        }
-    };
+    let name = vm.expect_ident("COMPILE_LVALUE: expected variable name")?;
 
     // Resolve address: local table first, then global dictionary.
     // Follow the same take→use→restore→apply-? pattern as compile_expr_prim so that
@@ -1274,13 +1214,8 @@ fn skip_eq_prim(vm: &mut VM) -> Result<(), TbxError> {
         });
     }
 
-    let tok = vm.next_token()?;
-    match tok.token {
-        Token::Op(ref s) if s == "=" => Ok(()),
-        _ => Err(TbxError::InvalidExpression {
-            reason: "SKIP_EQ: expected '='",
-        }),
-    }
+    vm.expect_op("=", "SKIP_EQ: expected '='")?;
+    Ok(())
 }
 
 /// LOOKUP — pop a string from the stack, look up the named word, and push its Xt.
@@ -1318,15 +1253,7 @@ fn use_prim(vm: &mut VM) -> Result<(), TbxError> {
         });
     }
 
-    let tok = vm.next_token()?;
-    let path = match tok.token {
-        crate::lexer::Token::StringLit(p) => p,
-        _ => {
-            return Err(TbxError::InvalidExpression {
-                reason: "USE expects a string literal as its argument",
-            })
-        }
-    };
+    let path = vm.expect_string_lit("USE expects a string literal as its argument")?;
 
     // Reject any extra tokens on the same statement (e.g. USE "f.tbx" EXTRA).
     if let Some(stream) = &vm.token_stream {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -321,6 +321,70 @@ impl VM {
         }
     }
 
+    /// Consume the next token and return its identifier string (uppercased).
+    ///
+    /// Returns `InvalidExpression { reason }` if the next token is not an
+    /// `Ident`. Returns `TokenStreamEmpty` if the stream is empty.
+    ///
+    /// `reason` is used as the error `reason` field when the token is not an
+    /// identifier; it should describe what the caller expected, e.g.
+    /// `"HEADER: expected identifier token"`.
+    pub fn expect_ident(&mut self, reason: &'static str) -> Result<String, TbxError> {
+        let tok = self.next_token()?;
+        match tok.token {
+            crate::lexer::Token::Ident(n) => Ok(n.to_ascii_uppercase()),
+            _ => Err(TbxError::InvalidExpression { reason }),
+        }
+    }
+
+    /// Consume the next token and verify it is `Token::Op(op)`.
+    ///
+    /// Returns `Ok(())` if the token matches; `InvalidExpression { reason }`
+    /// otherwise. Returns `TokenStreamEmpty` if the stream is empty.
+    pub fn expect_op(&mut self, op: &'static str, reason: &'static str) -> Result<(), TbxError> {
+        let tok = self.next_token()?;
+        match tok.token {
+            crate::lexer::Token::Op(ref s) if s == op => Ok(()),
+            _ => Err(TbxError::InvalidExpression { reason }),
+        }
+    }
+
+    /// Consume the next token and verify it is `Token::Comma`.
+    ///
+    /// Returns `Ok(())` if the token is a comma; `InvalidExpression { reason }`
+    /// otherwise. Returns `TokenStreamEmpty` if the stream is empty.
+    pub fn expect_comma(&mut self, reason: &'static str) -> Result<(), TbxError> {
+        let tok = self.next_token()?;
+        match tok.token {
+            crate::lexer::Token::Comma => Ok(()),
+            _ => Err(TbxError::InvalidExpression { reason }),
+        }
+    }
+
+    /// Consume the next token and verify it is `Token::Ampersand`.
+    ///
+    /// Returns `Ok(())` if the token is `&`; `InvalidExpression { reason }`
+    /// otherwise. Returns `TokenStreamEmpty` if the stream is empty.
+    pub fn expect_ampersand(&mut self, reason: &'static str) -> Result<(), TbxError> {
+        let tok = self.next_token()?;
+        match tok.token {
+            crate::lexer::Token::Ampersand => Ok(()),
+            _ => Err(TbxError::InvalidExpression { reason }),
+        }
+    }
+
+    /// Consume the next token and return its string literal value.
+    ///
+    /// Returns `InvalidExpression { reason }` if the next token is not a
+    /// `StringLit`. Returns `TokenStreamEmpty` if the stream is empty.
+    pub fn expect_string_lit(&mut self, reason: &'static str) -> Result<String, TbxError> {
+        let tok = self.next_token()?;
+        match tok.token {
+            crate::lexer::Token::StringLit(s) => Ok(s),
+            _ => Err(TbxError::InvalidExpression { reason }),
+        }
+    }
+
     /// Register a word entry in the header table, linking it into the search list.
     /// Returns the `Xt` (execution token) of the newly added entry.
     pub fn register(&mut self, mut entry: WordEntry) -> Xt {
@@ -2542,6 +2606,160 @@ mod tests {
         vm.token_stream = Some(VecDeque::from([tok1.clone(), tok2.clone()]));
         assert_eq!(vm.next_token(), Ok(tok1));
         assert_eq!(vm.next_token(), Ok(tok2));
+    }
+
+    // ── token expectation helper tests ───────────────────────────────────────
+
+    #[test]
+    fn test_expect_ident_ok() {
+        // expect_ident returns the uppercased name when the next token is Ident.
+        let mut vm = VM::new();
+        vm.token_stream = Some(VecDeque::from([make_spanned(crate::lexer::Token::Ident(
+            "hello".to_string(),
+        ))]));
+        assert_eq!(vm.expect_ident("test reason"), Ok("HELLO".to_string()));
+    }
+
+    #[test]
+    fn test_expect_ident_wrong_token() {
+        // expect_ident returns InvalidExpression when the token is not Ident.
+        let mut vm = VM::new();
+        vm.token_stream = Some(VecDeque::from([make_spanned(crate::lexer::Token::IntLit(
+            42,
+        ))]));
+        assert_eq!(
+            vm.expect_ident("test: expected ident"),
+            Err(crate::error::TbxError::InvalidExpression {
+                reason: "test: expected ident"
+            })
+        );
+    }
+
+    #[test]
+    fn test_expect_ident_empty_stream() {
+        // expect_ident propagates TokenStreamEmpty when the stream is exhausted.
+        let mut vm = VM::new();
+        vm.token_stream = Some(VecDeque::new());
+        assert_eq!(
+            vm.expect_ident("test reason"),
+            Err(crate::error::TbxError::TokenStreamEmpty)
+        );
+    }
+
+    #[test]
+    fn test_expect_op_ok() {
+        // expect_op returns Ok(()) when the next token matches the operator.
+        let mut vm = VM::new();
+        vm.token_stream = Some(VecDeque::from([make_spanned(crate::lexer::Token::Op(
+            "=".to_string(),
+        ))]));
+        assert_eq!(vm.expect_op("=", "test: expected '='"), Ok(()));
+    }
+
+    #[test]
+    fn test_expect_op_wrong_op() {
+        // expect_op returns InvalidExpression when the operator does not match.
+        let mut vm = VM::new();
+        vm.token_stream = Some(VecDeque::from([make_spanned(crate::lexer::Token::Op(
+            "+".to_string(),
+        ))]));
+        assert_eq!(
+            vm.expect_op("=", "test: expected '='"),
+            Err(crate::error::TbxError::InvalidExpression {
+                reason: "test: expected '='"
+            })
+        );
+    }
+
+    #[test]
+    fn test_expect_op_wrong_token_kind() {
+        // expect_op returns InvalidExpression when the token is not Op at all.
+        let mut vm = VM::new();
+        vm.token_stream = Some(VecDeque::from([make_spanned(crate::lexer::Token::Ident(
+            "X".to_string(),
+        ))]));
+        assert_eq!(
+            vm.expect_op("=", "test: expected '='"),
+            Err(crate::error::TbxError::InvalidExpression {
+                reason: "test: expected '='"
+            })
+        );
+    }
+
+    #[test]
+    fn test_expect_comma_ok() {
+        // expect_comma returns Ok(()) when the next token is Comma.
+        let mut vm = VM::new();
+        vm.token_stream = Some(VecDeque::from([make_spanned(crate::lexer::Token::Comma)]));
+        assert_eq!(vm.expect_comma("test: expected ','"), Ok(()));
+    }
+
+    #[test]
+    fn test_expect_comma_wrong_token() {
+        // expect_comma returns InvalidExpression when the token is not Comma.
+        let mut vm = VM::new();
+        vm.token_stream = Some(VecDeque::from([make_spanned(crate::lexer::Token::Ident(
+            "X".to_string(),
+        ))]));
+        assert_eq!(
+            vm.expect_comma("test: expected ','"),
+            Err(crate::error::TbxError::InvalidExpression {
+                reason: "test: expected ','"
+            })
+        );
+    }
+
+    #[test]
+    fn test_expect_ampersand_ok() {
+        // expect_ampersand returns Ok(()) when the next token is Ampersand.
+        let mut vm = VM::new();
+        vm.token_stream = Some(VecDeque::from([make_spanned(
+            crate::lexer::Token::Ampersand,
+        )]));
+        assert_eq!(vm.expect_ampersand("test: expected '&'"), Ok(()));
+    }
+
+    #[test]
+    fn test_expect_ampersand_wrong_token() {
+        // expect_ampersand returns InvalidExpression when the token is not Ampersand.
+        let mut vm = VM::new();
+        vm.token_stream = Some(VecDeque::from([make_spanned(crate::lexer::Token::IntLit(
+            1,
+        ))]));
+        assert_eq!(
+            vm.expect_ampersand("test: expected '&'"),
+            Err(crate::error::TbxError::InvalidExpression {
+                reason: "test: expected '&'"
+            })
+        );
+    }
+
+    #[test]
+    fn test_expect_string_lit_ok() {
+        // expect_string_lit returns the string content when the token is StringLit.
+        let mut vm = VM::new();
+        vm.token_stream = Some(VecDeque::from([make_spanned(
+            crate::lexer::Token::StringLit("hello.tbx".to_string()),
+        )]));
+        assert_eq!(
+            vm.expect_string_lit("test: expected string literal"),
+            Ok("hello.tbx".to_string())
+        );
+    }
+
+    #[test]
+    fn test_expect_string_lit_wrong_token() {
+        // expect_string_lit returns InvalidExpression when the token is not StringLit.
+        let mut vm = VM::new();
+        vm.token_stream = Some(VecDeque::from([make_spanned(crate::lexer::Token::Ident(
+            "X".to_string(),
+        ))]));
+        assert_eq!(
+            vm.expect_string_lit("test: expected string literal"),
+            Err(crate::error::TbxError::InvalidExpression {
+                reason: "test: expected string literal"
+            })
+        );
     }
 
     // ------------------------------------------------------------------

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -2762,6 +2762,50 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_expect_op_empty_stream() {
+        // expect_op propagates TokenStreamEmpty when the stream is exhausted.
+        let mut vm = VM::new();
+        vm.token_stream = Some(VecDeque::new());
+        assert_eq!(
+            vm.expect_op("=", "test: expected '='"),
+            Err(crate::error::TbxError::TokenStreamEmpty)
+        );
+    }
+
+    #[test]
+    fn test_expect_comma_empty_stream() {
+        // expect_comma propagates TokenStreamEmpty when the stream is exhausted.
+        let mut vm = VM::new();
+        vm.token_stream = Some(VecDeque::new());
+        assert_eq!(
+            vm.expect_comma("test: expected ','"),
+            Err(crate::error::TbxError::TokenStreamEmpty)
+        );
+    }
+
+    #[test]
+    fn test_expect_ampersand_empty_stream() {
+        // expect_ampersand propagates TokenStreamEmpty when the stream is exhausted.
+        let mut vm = VM::new();
+        vm.token_stream = Some(VecDeque::new());
+        assert_eq!(
+            vm.expect_ampersand("test: expected '&'"),
+            Err(crate::error::TbxError::TokenStreamEmpty)
+        );
+    }
+
+    #[test]
+    fn test_expect_string_lit_empty_stream() {
+        // expect_string_lit propagates TokenStreamEmpty when the stream is exhausted.
+        let mut vm = VM::new();
+        vm.token_stream = Some(VecDeque::new());
+        assert_eq!(
+            vm.expect_string_lit("test: expected string literal"),
+            Err(crate::error::TbxError::TokenStreamEmpty)
+        );
+    }
+
     // ------------------------------------------------------------------
     // End-to-end integration tests: array pool management
     // ------------------------------------------------------------------


### PR DESCRIPTION
## 概要

`vm.next_token()` + `match` による個別トークン検査パターンが複数箇所に重複していたため、再利用可能なトークン消費ヘルパを `VM` メソッドとして追加し、既存の重複コードをヘルパ経由に置き換えた。

## 変更内容

### `src/vm.rs`

以下の5つのヘルパメソッドを `VM` に追加した（`next_token()` の直後に配置）:

- `expect_ident(reason) -> Result<String, TbxError>` — 次のトークンが `Ident` であることを検証し、大文字化した名前を返す
- `expect_op(op, reason) -> Result<(), TbxError>` — 次のトークンが指定した演算子 `Op(op)` であることを検証する
- `expect_comma(reason) -> Result<(), TbxError>` — 次のトークンが `Comma` であることを検証する
- `expect_ampersand(reason) -> Result<(), TbxError>` — 次のトークンが `Ampersand` であることを検証する
- `expect_string_lit(reason) -> Result<String, TbxError>` — 次のトークンが `StringLit` であることを検証し、その文字列を返す

各ヘルパの単体テストを12件追加した（ok/error/empty-stream の各パス）。

### `src/primitives.rs`

以下の箇所で `next_token()` + `match` を対応するヘルパに置き換えた:

- `header_prim` → `expect_ident`
- `immediate_prim` → `expect_ident`
- `def_prim`（ワード名読み取り部分のみ） → `expect_ident`
- `var_prim`（ループ先頭の識別子読み取り） → `expect_ident`
- `compile_lvalue_prim` → `expect_ident`
- `compile_lvalue_save_prim` → `expect_ampersand` + `expect_ident`
- `skip_eq_prim` → `expect_op("=")`
- `skip_comma_prim` → `expect_comma`
- `use_prim` → `expect_string_lit`

`use crate::lexer::Token;` インポートが不要になったため削除した。

## スコープ外（変更していない箇所）

- `def_prim` のパラメータリストDFAパーサ（複雑なステートマシンのため）
- `CompileEntry::Token` や token 専用 compile-time primitive の追加
- TBX 標準ライブラリの書き換え

Closes #638
