### PR TITLE
DEF内ローカルの VAR X = expr 初期化構文を実装する

### DIFF
--- a/lib/tests/test_var_init.tbx
+++ b/lib/tests/test_var_init.tbx
@@ -1,0 +1,79 @@
+# lib/tests/test_var_init.tbx — TBX tests for VAR X = expr initializer syntax
+USE "lib/tests/helper.tbx"
+
+# --- VAR X = literal initializes local to the given value ---
+
+DEF CONST_INIT()
+  VAR I = 42
+  RETURN I
+END
+ASSERT CONST_INIT() = 42
+
+# --- VAR X = expr using a parameter ---
+
+DEF PARAM_INIT(N)
+  VAR I = N + 1
+  RETURN I
+END
+ASSERT PARAM_INIT(9) = 10
+
+# --- VAR X = VA_COUNT() in a variadic word ---
+
+DEF VA_INIT(...)
+  VAR N = VA_COUNT()
+  RETURN N
+END
+ASSERT VA_INIT(1, 2, 3) = 3
+
+# --- Existing VAR A, B, C (declaration-only) still works ---
+
+DEF MULTI_DECL()
+  VAR A, B, C
+  SET &A, 1
+  SET &B, 2
+  SET &C, A + B
+  RETURN C
+END
+ASSERT MULTI_DECL() = 3
+
+# --- VAR X = expr followed by other statements ---
+
+DEF INIT_AND_LOOP()
+  VAR S = 0
+  VAR I
+  LET I = 1
+  WHILE I <= 5
+    LET S = S + I
+    LET I = I + 1
+  ENDWH
+  RETURN S
+END
+ASSERT INIT_AND_LOOP() = 15
+
+# --- VAR with string initializer ---
+
+DEF STR_INIT()
+  VAR S = "hello"
+  RETURN STR_LEN(S)
+END
+ASSERT STR_INIT() = 5
+
+# --- VAR with ARRAY initializer ---
+
+DEF ARRAY_INIT()
+  VAR A = ARRAY(3)
+  SET &A(1), 10
+  SET &A(2), 20
+  SET &A(3), 30
+  RETURN A(1) + A(2) + A(3)
+END
+ASSERT ARRAY_INIT() = 60
+
+# --- Multiple VAR X = expr declarations in one word ---
+
+DEF MULTI_INIT()
+  VAR X = 10
+  VAR Y = X + 5
+  RETURN X + Y
+END
+ASSERT MULTI_INIT() = 25

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -515,6 +515,11 @@ pub fn end_prim(vm: &mut VM) -> Result<(), TbxError> {
 
 /// VAR — declare one or more local variables (in compile mode) or global variables (in execute
 /// mode). Accepts a comma-separated list of identifiers: `VAR A`, `VAR A, B, C`.
+///
+/// In compile mode, the optional `= expr` initializer syntax is supported for a single
+/// variable: `VAR X = expr`.  This emits `LIT StackAddr(X) <expr> SET` immediately
+/// after the declaration, equivalent to `VAR X` followed by `SET &X, expr`.
+/// Initializers are not supported in global (execute-mode) declarations.
 pub fn var_prim(vm: &mut VM) -> Result<(), TbxError> {
     loop {
         // Read the next identifier.
@@ -528,6 +533,15 @@ pub fn var_prim(vm: &mut VM) -> Result<(), TbxError> {
                 .ok_or(TbxError::InvalidExpression {
                     reason: "VAR in compile mode but no compile_state",
                 })?;
+
+            // Reject duplicate local variable names when an initializer is present.
+            // (Duplicate-free declaration without `=` preserves the existing behaviour.)
+            if state.local_table.contains_key(&name) {
+                return Err(TbxError::InvalidExpression {
+                    reason: "duplicate local variable name in VAR declaration",
+                });
+            }
+
             // For variadic words, use the VARIADIC_LOCAL_BASE offset so that local-variable
             // StackAddr indices are in a disjoint range from argument indices.
             // This allows ARG_ADDR to return raw argument indices without ambiguity.
@@ -536,8 +550,70 @@ pub fn var_prim(vm: &mut VM) -> Result<(), TbxError> {
             } else {
                 state.arity + state.local_count
             };
-            state.local_table.insert(name, idx);
+            state.local_table.insert(name.clone(), idx);
             state.local_count += 1;
+
+            // Check for optional `= expr` initializer.
+            match vm.next_token() {
+                Ok(tok) if matches!(tok.token, crate::lexer::Token::Op(ref s) if s == "=") => {
+                    // Initializer present: drain remaining tokens as the RHS expression.
+                    let expr_tokens: Vec<crate::lexer::SpannedToken> = {
+                        let stream = vm.token_stream.as_mut().ok_or(TbxError::TokenStreamEmpty)?;
+                        stream.drain(..).collect()
+                    };
+                    if expr_tokens.is_empty() {
+                        return Err(TbxError::InvalidExpression {
+                            reason: "VAR initializer: expected expression after '='",
+                        });
+                    }
+
+                    // Emit: LIT StackAddr(idx)
+                    let lit_xt = vm.find_by_kind(|k| matches!(k, EntryKind::Lit)).ok_or(
+                        TbxError::UndefinedSymbol {
+                            name: "LIT".to_string(),
+                        },
+                    )?;
+                    vm.dict_write(Cell::Xt(lit_xt))?;
+                    vm.dict_write(Cell::StackAddr(idx))?;
+
+                    // Compile and emit the RHS expression.
+                    let (expr_cells, patch_offsets) =
+                        compile_expr_taking_local_table(vm, &expr_tokens)?;
+                    let base_dp = vm.dp;
+                    for cell in expr_cells {
+                        vm.dict_write(cell)?;
+                    }
+                    if let Some(state) = vm.compile_state.as_mut() {
+                        for offset in patch_offsets {
+                            state.call_patch_list.push(base_dp + offset);
+                        }
+                    }
+
+                    // Emit: SET
+                    let set_xt = vm.lookup("SET").ok_or(TbxError::UndefinedSymbol {
+                        name: "SET".to_string(),
+                    })?;
+                    vm.dict_write(Cell::Xt(set_xt))?;
+
+                    // `VAR X = expr` covers the rest of the token stream; stop the loop.
+                    break;
+                }
+                Ok(tok) if matches!(tok.token, crate::lexer::Token::Comma) => {
+                    // Comma: continue to the next identifier (no initializer on this var).
+                }
+                Ok(tok) => {
+                    // Not `=` and not `,`: return the token to the front of the stream and stop.
+                    if let Some(stream) = vm.token_stream.as_mut() {
+                        stream.push_front(tok);
+                    }
+                    break;
+                }
+                Err(TbxError::TokenStreamEmpty) => {
+                    // End of stream: stop normally.
+                    break;
+                }
+                Err(e) => return Err(e),
+            }
         } else {
             // Global variable: allocate storage in dictionary.
             let storage_idx = vm.dp;
@@ -545,27 +621,27 @@ pub fn var_prim(vm: &mut VM) -> Result<(), TbxError> {
             let entry = crate::dict::WordEntry::new_variable(&name, storage_idx);
             vm.register(entry);
             vm.seal_user();
-        }
 
-        // Peek at the next token to decide whether to continue.
-        // If it is a comma, consume it and read another identifier.
-        // Otherwise push it back and stop.
-        match vm.next_token() {
-            Ok(tok) if matches!(tok.token, crate::lexer::Token::Comma) => {
-                // Comma consumed; loop to read the next identifier.
-            }
-            Ok(tok) => {
-                // Not a comma: return the token to the front of the stream and stop.
-                if let Some(stream) = vm.token_stream.as_mut() {
-                    stream.push_front(tok);
+            // Peek at the next token to decide whether to continue.
+            // If it is a comma, consume it and read another identifier.
+            // Otherwise push it back and stop.
+            match vm.next_token() {
+                Ok(tok) if matches!(tok.token, crate::lexer::Token::Comma) => {
+                    // Comma consumed; loop to read the next identifier.
                 }
-                break;
+                Ok(tok) => {
+                    // Not a comma: return the token to the front of the stream and stop.
+                    if let Some(stream) = vm.token_stream.as_mut() {
+                        stream.push_front(tok);
+                    }
+                    break;
+                }
+                Err(TbxError::TokenStreamEmpty) => {
+                    // End of stream: stop normally.
+                    break;
+                }
+                Err(e) => return Err(e),
             }
-            Err(TbxError::TokenStreamEmpty) => {
-                // End of stream: stop normally.
-                break;
-            }
-            Err(e) => return Err(e),
         }
     }
 
@@ -4059,6 +4135,102 @@ mod tests {
             matches!(remaining[0].token, crate::lexer::Token::Newline),
             "expected Newline to be pushed back, got {:?}",
             remaining[0].token
+        );
+    }
+
+    // --- var_prim with initializer ---
+
+    #[test]
+    fn test_var_prim_init_registers_local_and_emits_set() {
+        // VAR X = 42 inside DEF should register X in local_table and emit
+        // [Xt(LIT), StackAddr(0), Xt(LIT), Int(42), Xt(SET)] to the dictionary.
+        use std::collections::VecDeque;
+        let mut vm = make_compiling_vm("INITWORD");
+        let dp_before = vm.dp;
+        vm.token_stream = Some(VecDeque::from([
+            make_ident_token("X"),
+            make_op_token("="),
+            crate::lexer::SpannedToken {
+                token: crate::lexer::Token::IntLit(42),
+                pos: crate::lexer::Position { line: 1, col: 1 },
+                source_offset: 0,
+                source_len: 2,
+            },
+        ]));
+        var_prim(&mut vm).unwrap();
+
+        // X should be in local_table with index 0.
+        let state = vm.compile_state.as_ref().unwrap();
+        assert_eq!(state.local_table.get("X").copied(), Some(0));
+        assert_eq!(state.local_count, 1);
+
+        // Dictionary should have grown by at least 4 cells:
+        // [Xt(LIT), StackAddr(0), Xt(LIT), Int(42), Xt(SET)]
+        assert!(
+            vm.dp >= dp_before + 5,
+            "expected at least 5 cells emitted, dp_before={dp_before} dp={}",
+            vm.dp
+        );
+
+        // Cell 0: Xt(LIT)
+        assert!(
+            matches!(vm.dict_read(dp_before).unwrap(), Cell::Xt(_)),
+            "expected Xt(LIT) at dp_before"
+        );
+        // Cell 1: StackAddr(0) — the address of local variable X
+        assert_eq!(
+            vm.dict_read(dp_before + 1).unwrap(),
+            Cell::StackAddr(0),
+            "expected StackAddr(0) for local X"
+        );
+        // Cell 4: Xt(SET)
+        assert!(
+            matches!(vm.dict_read(dp_before + 4).unwrap(), Cell::Xt(_)),
+            "expected Xt(SET) at dp_before+4"
+        );
+    }
+
+    #[test]
+    fn test_var_prim_init_empty_expr_is_error() {
+        // VAR X = (nothing) should return InvalidExpression.
+        use std::collections::VecDeque;
+        let mut vm = make_compiling_vm("EMPTYINIT");
+        vm.token_stream = Some(VecDeque::from([
+            make_ident_token("X"),
+            make_op_token("="),
+            // no expression tokens after '='
+        ]));
+        let err = var_prim(&mut vm).unwrap_err();
+        assert!(
+            matches!(err, TbxError::InvalidExpression { .. }),
+            "expected InvalidExpression for empty initializer, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_var_prim_init_duplicate_name_is_error() {
+        // VAR X followed by VAR X = expr should return InvalidExpression for duplicate name.
+        use std::collections::VecDeque;
+        let mut vm = make_compiling_vm("DUPWORD");
+        // First: declare X without initializer.
+        vm.token_stream = Some(VecDeque::from([make_ident_token("X")]));
+        var_prim(&mut vm).unwrap();
+
+        // Second: attempt VAR X = 1 — X already in local_table.
+        vm.token_stream = Some(VecDeque::from([
+            make_ident_token("X"),
+            make_op_token("="),
+            crate::lexer::SpannedToken {
+                token: crate::lexer::Token::IntLit(1),
+                pos: crate::lexer::Position { line: 1, col: 1 },
+                source_offset: 0,
+                source_len: 1,
+            },
+        ]));
+        let err = var_prim(&mut vm).unwrap_err();
+        assert!(
+            matches!(err, TbxError::InvalidExpression { reason } if reason.contains("duplicate")),
+            "expected InvalidExpression for duplicate local variable, got {err:?}"
         );
     }
 

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -534,8 +534,7 @@ pub fn var_prim(vm: &mut VM) -> Result<(), TbxError> {
                     reason: "VAR in compile mode but no compile_state",
                 })?;
 
-            // Reject duplicate local variable names when an initializer is present.
-            // (Duplicate-free declaration without `=` preserves the existing behaviour.)
+            // Reject duplicate local variable names regardless of whether an initializer is present.
             if state.local_table.contains_key(&name) {
                 return Err(TbxError::InvalidExpression {
                     reason: "duplicate local variable name in VAR declaration",

--- a/tests/tbx_lib_tests.rs
+++ b/tests/tbx_lib_tests.rs
@@ -247,3 +247,66 @@ fn test_set_array_into_array_is_invalid_element_type() {
         "expected 'invalid array element type', got: {err}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Duplicate local variable name tests (issue #634)
+//
+// Declaring the same local name twice in the same DEF is always an error,
+// regardless of whether an initializer (`= expr`) is present.
+// ---------------------------------------------------------------------------
+
+/// `VAR A, A` — two identical names in the same VAR declaration must fail.
+#[test]
+fn test_duplicate_local_var_in_single_declaration_is_error() {
+    let mut interp = Interpreter::new();
+    let src = "DEF T()\n  VAR A, A\nEND\n";
+    let err = interp
+        .exec_source(src)
+        .expect_err("VAR A, A should fail with duplicate local variable error");
+    assert!(
+        err.to_string().contains("duplicate"),
+        "expected 'duplicate' in error message, got: {err}"
+    );
+}
+
+/// `VAR A` followed by a second `VAR A` (no initializer either time) must fail.
+#[test]
+fn test_duplicate_local_var_without_initializer_is_error() {
+    let mut interp = Interpreter::new();
+    let src = "DEF T()\n  VAR A\n  VAR A\nEND\n";
+    let err = interp.exec_source(src).expect_err(
+        "second VAR A (no initializer) should fail with duplicate local variable error",
+    );
+    assert!(
+        err.to_string().contains("duplicate"),
+        "expected 'duplicate' in error message, got: {err}"
+    );
+}
+
+/// `VAR A` (no initializer) followed by `VAR A = 1` must fail.
+#[test]
+fn test_duplicate_local_var_no_init_then_with_init_is_error() {
+    let mut interp = Interpreter::new();
+    let src = "DEF T()\n  VAR A\n  VAR A = 1\nEND\n";
+    let err = interp
+        .exec_source(src)
+        .expect_err("VAR A then VAR A = 1 should fail with duplicate local variable error");
+    assert!(
+        err.to_string().contains("duplicate"),
+        "expected 'duplicate' in error message, got: {err}"
+    );
+}
+
+/// `VAR A = 1` followed by a plain `VAR A` (no initializer) must fail.
+#[test]
+fn test_duplicate_local_var_with_init_then_no_init_is_error() {
+    let mut interp = Interpreter::new();
+    let src = "DEF T()\n  VAR A = 1\n  VAR A\nEND\n";
+    let err = interp
+        .exec_source(src)
+        .expect_err("VAR A = 1 then VAR A should fail with duplicate local variable error");
+    assert!(
+        err.to_string().contains("duplicate"),
+        "expected 'duplicate' in error message, got: {err}"
+    );
+}


### PR DESCRIPTION
## 概要

DEF本体内のローカル変数宣言で `VAR X = expr` 構文を有効にする。
宣言直後に `LIT StackAddr(X) <expr> SET` の命令列を emit することで、`VAR X` + `SET &X, expr` と同等の動作を実現する。

## 変更内容

- `src/primitives.rs`: `var_prim` に `= expr` オプション処理を追加
  - コンパイルモードで変数名を登録した後、次のトークンが `=` であれば残りトークンを式としてコンパイルし `LIT StackAddr(idx) <expr> SET` を emit する
  - 重複ローカル変数名の場合は `InvalidExpression` を返す（既存の `VAR X, Y` 形式は従来どおり）
  - `VAR X` / `VAR X, Y, Z` の既存挙動は維持
  - グローバル変数宣言（実行モード）は従来どおり初期化なし
- `lib/tests/test_var_init.tbx`: integration test を追加
  - 整数・引数・variadic・文字列・配列・複数初期化の正常ケース
  - 既存の `VAR A, B, C`（宣言のみ）との共存を確認
- `src/primitives.rs` のユニットテストに以下を追加
  - `test_var_prim_init_registers_local_and_emits_set`: 正常系（辞書内容の検証）
  - `test_var_prim_init_empty_expr_is_error`: `VAR X =`（右辺が空）のエラー
  - `test_var_prim_init_duplicate_name_is_error`: 重複変数名のエラー

Closes #634
