### PR TITLE
トップレベルの VAR 初期化構文をエラーにする

### DIFF
--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -614,39 +614,45 @@ pub fn var_prim(vm: &mut VM) -> Result<(), TbxError> {
                 Err(e) => return Err(e),
             }
         } else {
-            // Global variable: allocate storage in dictionary.
-            let storage_idx = vm.dp;
-            vm.dict_write(Cell::None)?;
-            let entry = crate::dict::WordEntry::new_variable(&name, storage_idx);
-            vm.register(entry);
-            vm.seal_user();
-
-            // Peek at the next token to decide whether to continue.
-            // If it is a comma, consume it and read another identifier.
-            // If it is `=`, reject it: initializers are not allowed at top level.
-            // Otherwise push it back and stop.
+            // Peek at the next token before registering the global variable.
+            // If it is `=`, reject it immediately without touching the dictionary.
+            // If it is a comma, consume it and register the variable, then continue.
+            // Otherwise push the token back and register the variable, then stop.
             match vm.next_token() {
-                Ok(tok) if matches!(tok.token, crate::lexer::Token::Comma) => {
-                    // Comma consumed; loop to read the next identifier.
-                }
                 Ok(tok) if matches!(tok.token, crate::lexer::Token::Op(ref s) if s == "=") => {
                     // `=` found at top level: VAR initializers are only allowed inside DEF.
+                    // Return the error *before* registering the variable so that the
+                    // dictionary is not modified on failure.
                     return Err(TbxError::InvalidExpression {
                         reason: "VAR initializer '= expr' is not allowed outside DEF",
                     });
                 }
-                Ok(tok) => {
-                    // Not a comma: return the token to the front of the stream and stop.
-                    if let Some(stream) = vm.token_stream.as_mut() {
-                        stream.push_front(tok);
+                peek => {
+                    // No `=`: register the global variable now that we know it is safe.
+                    let storage_idx = vm.dp;
+                    vm.dict_write(Cell::None)?;
+                    let entry = crate::dict::WordEntry::new_variable(&name, storage_idx);
+                    vm.register(entry);
+                    vm.seal_user();
+
+                    match peek {
+                        Ok(tok) if matches!(tok.token, crate::lexer::Token::Comma) => {
+                            // Comma consumed; loop to read the next identifier.
+                        }
+                        Ok(tok) => {
+                            // Not a comma: return the token to the front of the stream and stop.
+                            if let Some(stream) = vm.token_stream.as_mut() {
+                                stream.push_front(tok);
+                            }
+                            break;
+                        }
+                        Err(TbxError::TokenStreamEmpty) => {
+                            // End of stream: stop normally.
+                            break;
+                        }
+                        Err(e) => return Err(e),
                     }
-                    break;
                 }
-                Err(TbxError::TokenStreamEmpty) => {
-                    // End of stream: stop normally.
-                    break;
-                }
-                Err(e) => return Err(e),
             }
         }
     }
@@ -4263,6 +4269,11 @@ mod tests {
         assert!(
             matches!(err, TbxError::InvalidExpression { reason } if reason.contains("outside DEF")),
             "expected InvalidExpression mentioning 'outside DEF', got {err:?}"
+        );
+        // The variable must NOT have been registered: the dictionary must remain unchanged.
+        assert!(
+            vm.lookup("X").is_none(),
+            "variable 'X' must not be registered when VAR initializer is rejected at top level"
         );
     }
 

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -623,10 +623,17 @@ pub fn var_prim(vm: &mut VM) -> Result<(), TbxError> {
 
             // Peek at the next token to decide whether to continue.
             // If it is a comma, consume it and read another identifier.
+            // If it is `=`, reject it: initializers are not allowed at top level.
             // Otherwise push it back and stop.
             match vm.next_token() {
                 Ok(tok) if matches!(tok.token, crate::lexer::Token::Comma) => {
                     // Comma consumed; loop to read the next identifier.
+                }
+                Ok(tok) if matches!(tok.token, crate::lexer::Token::Op(ref s) if s == "=") => {
+                    // `=` found at top level: VAR initializers are only allowed inside DEF.
+                    return Err(TbxError::InvalidExpression {
+                        reason: "VAR initializer '= expr' is not allowed outside DEF",
+                    });
                 }
                 Ok(tok) => {
                     // Not a comma: return the token to the front of the stream and stop.
@@ -4230,6 +4237,53 @@ mod tests {
         assert!(
             matches!(err, TbxError::InvalidExpression { reason } if reason.contains("duplicate")),
             "expected InvalidExpression for duplicate local variable, got {err:?}"
+        );
+    }
+
+    // --- var_prim top-level initializer error ---
+
+    #[test]
+    fn test_var_prim_global_with_initializer_is_error() {
+        // VAR X = 1 outside DEF must return InvalidExpression.
+        use std::collections::VecDeque;
+        let mut vm = VM::new();
+        register_all(&mut vm);
+        // is_compiling is false by default (top-level / execute mode).
+        vm.token_stream = Some(VecDeque::from([
+            make_ident_token("X"),
+            make_op_token("="),
+            crate::lexer::SpannedToken {
+                token: crate::lexer::Token::IntLit(1),
+                pos: crate::lexer::Position { line: 1, col: 1 },
+                source_offset: 0,
+                source_len: 1,
+            },
+        ]));
+        let err = var_prim(&mut vm).unwrap_err();
+        assert!(
+            matches!(err, TbxError::InvalidExpression { reason } if reason.contains("outside DEF")),
+            "expected InvalidExpression mentioning 'outside DEF', got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_var_prim_global_without_initializer_still_works() {
+        // VAR X outside DEF (without initializer) must still register a global variable.
+        use std::collections::VecDeque;
+        let mut vm = VM::new();
+        register_all(&mut vm);
+        vm.token_stream = Some(VecDeque::from([make_ident_token("X")]));
+        var_prim(&mut vm).unwrap();
+        let xt = vm
+            .lookup("X")
+            .expect("X should be registered as a global variable");
+        assert!(
+            matches!(
+                vm.headers[xt.index()].kind,
+                crate::dict::EntryKind::Variable(_)
+            ),
+            "expected Variable entry for X, got {:?}",
+            vm.headers[xt.index()].kind
         );
     }
 


### PR DESCRIPTION
## 概要

DEF 外（トップレベル）で `VAR X = expr` が現れた場合に、明確なエラー（`InvalidExpression`）を返すようにする。グローバル変数宣言 + 初期化としては扱わない。

## 変更内容

- `src/primitives.rs` の `var_prim` グローバル変数側（`else` ブランチ）に `=` トークン検出時のエラー処理を追加
  - エラーメッセージ: `"VAR initializer '= expr' is not allowed outside DEF"`
- テスト `test_var_prim_global_with_initializer_is_error` を追加（エラーケース）
- テスト `test_var_prim_global_without_initializer_still_works` を追加（既存挙動の維持確認）

Closes #635
