### PR TITLE
TUPLE(...) プリミティブを追加する (#655)

### DIFF
--- a/lib/tests/test_tuple.tbx
+++ b/lib/tests/test_tuple.tbx
@@ -1,0 +1,79 @@
+# lib/tests/test_tuple.tbx — TBX tests for the TUPLE primitive
+USE "lib/tests/helper.tbx"
+
+# --- TUPLE: basic creation and STR conversion ---
+
+DEF TUPLE_BASIC()
+  VAR T
+  LET T = TUPLE(1, 2, 3)
+  PUTSTR STR(T)
+  RETURN 1
+END
+ASSERT TUPLE_BASIC() = 1
+ASSERT_OUTPUT "(1, 2, 3)"
+
+# --- TUPLE: element order is preserved (first arg is leftmost) ---
+
+DEF TUPLE_ORDER()
+  VAR T
+  LET T = TUPLE(10, 20, 30)
+  PUTSTR STR(T)
+  RETURN 1
+END
+ASSERT TUPLE_ORDER() = 1
+ASSERT_OUTPUT "(10, 20, 30)"
+
+# --- TUPLE: single element ---
+
+DEF TUPLE_SINGLE()
+  VAR T
+  LET T = TUPLE(42)
+  PUTSTR STR(T)
+  RETURN 1
+END
+ASSERT TUPLE_SINGLE() = 1
+ASSERT_OUTPUT "(42)"
+
+# --- TUPLE: mixed types (Str, Int, Bool) ---
+# Use a comparison expression (1 = 1) to produce a Bool(true) value.
+
+DEF TUPLE_MIXED()
+  VAR T
+  LET T = TUPLE("tbx", 1, 1 = 1)
+  PUTSTR STR(T)
+  RETURN 1
+END
+ASSERT TUPLE_MIXED() = 1
+ASSERT_OUTPUT "(tbx, 1, true)"
+
+# --- TUPLE: empty tuple TUPLE() is allowed ---
+
+DEF TUPLE_EMPTY()
+  VAR T
+  LET T = TUPLE()
+  PUTSTR STR(T)
+  RETURN 1
+END
+ASSERT TUPLE_EMPTY() = 1
+ASSERT_OUTPUT "()"
+
+# --- TUPLE: can be used as a function return value ---
+
+DEF MAKE_TUPLE()
+  RETURN TUPLE(7, 8, 9)
+END
+DEF TUPLE_RETURN()
+  VAR T
+  LET T = MAKE_TUPLE()
+  PUTSTR STR(T)
+  RETURN 1
+END
+ASSERT TUPLE_RETURN() = 1
+ASSERT_OUTPUT "(7, 8, 9)"
+
+# --- TUPLE: can be stored in a top-level variable ---
+
+VAR GLOBAL_TUPLE
+SET &GLOBAL_TUPLE, TUPLE(100, 200)
+PUTSTR STR(GLOBAL_TUPLE)
+ASSERT_OUTPUT "(100, 200)"

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1807,10 +1807,15 @@ pub fn register_all(vm: &mut VM) {
     // an element address (used internally by the expression compiler for `A(I)` and `&A(I)`).
     // TO_ARRAY packs stack values into a new array; FROM_ARRAY expands one onto the stack.
     // ARRAY_LEN returns the length of an array; ARRAY_CONCAT concatenates two arrays.
+    // TUPLE packs stack values into a new immutable Cell::Tuple.
     let mut to_array_entry = WordEntry::new_primitive("TO_ARRAY", to_array_prim);
     to_array_entry.is_variadic = true;
     // arity stays 0: TO_ARRAY accepts zero or more arguments.
     vm.register(to_array_entry);
+    let mut tuple_entry = WordEntry::new_primitive("TUPLE", to_tuple_prim);
+    tuple_entry.is_variadic = true;
+    // arity stays 0: TUPLE accepts zero or more arguments (empty tuple is allowed).
+    vm.register(tuple_entry);
     vm.register(WordEntry::new_primitive("FROM_ARRAY", from_array_prim));
     vm.register(WordEntry::new_primitive("ARRAY", array_prim));
     vm.register(WordEntry::new_primitive("ARRAY_LEN", array_len_prim));
@@ -5899,6 +5904,104 @@ mod tests {
         let first = vm.pop().unwrap();
         assert_eq!(first, Cell::Array(0));
         assert_eq!(second, Cell::Array(1));
+    }
+
+    // --- to_tuple_prim ---
+
+    #[test]
+    fn test_to_tuple_prim_basic() {
+        // Stack: [1, 2, 3, Int(3)] → Cell::Tuple([Int(1), Int(2), Int(3)])
+        let mut vm = VM::new();
+        vm.push(Cell::Int(1)).unwrap();
+        vm.push(Cell::Int(2)).unwrap();
+        vm.push(Cell::Int(3)).unwrap();
+        vm.push(Cell::Int(3)).unwrap(); // arity
+        to_tuple_prim(&mut vm).unwrap();
+        assert_eq!(
+            vm.pop(),
+            Ok(Cell::Tuple(vec![Cell::Int(1), Cell::Int(2), Cell::Int(3)]))
+        );
+    }
+
+    #[test]
+    fn test_to_tuple_prim_preserves_order() {
+        // First argument becomes index 0 (lowest position in the tuple).
+        let mut vm = VM::new();
+        vm.push(Cell::Int(10)).unwrap();
+        vm.push(Cell::Int(20)).unwrap();
+        vm.push(Cell::Int(30)).unwrap();
+        vm.push(Cell::Int(3)).unwrap(); // arity
+        to_tuple_prim(&mut vm).unwrap();
+        let result = vm.pop().unwrap();
+        let Cell::Tuple(elems) = result else {
+            panic!("expected Cell::Tuple");
+        };
+        assert_eq!(elems[0], Cell::Int(10));
+        assert_eq!(elems[1], Cell::Int(20));
+        assert_eq!(elems[2], Cell::Int(30));
+    }
+
+    #[test]
+    fn test_to_tuple_prim_single_element() {
+        // Stack: [Int(42), Int(1)] → Cell::Tuple([Int(42)])
+        let mut vm = VM::new();
+        vm.push(Cell::Int(42)).unwrap();
+        vm.push(Cell::Int(1)).unwrap(); // arity
+        to_tuple_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Tuple(vec![Cell::Int(42)])));
+    }
+
+    #[test]
+    fn test_to_tuple_prim_mixed_types() {
+        // Mix of Int, Float, Bool, and Str.
+        let mut vm = VM::new();
+        vm.push(Cell::Int(1)).unwrap();
+        vm.push(Cell::Float(2.5)).unwrap();
+        vm.push(Cell::Bool(true)).unwrap();
+        vm.push(Cell::string("hello")).unwrap();
+        vm.push(Cell::Int(4)).unwrap(); // arity
+        to_tuple_prim(&mut vm).unwrap();
+        assert_eq!(
+            vm.pop(),
+            Ok(Cell::Tuple(vec![
+                Cell::Int(1),
+                Cell::Float(2.5),
+                Cell::Bool(true),
+                Cell::string("hello"),
+            ]))
+        );
+    }
+
+    #[test]
+    fn test_to_tuple_prim_rejects_array() {
+        // Cell::Array is a forbidden tuple element type.
+        let mut vm = VM::new();
+        vm.arrays.push(vec![Cell::Int(1)]);
+        vm.push(Cell::Array(0)).unwrap();
+        vm.push(Cell::Int(1)).unwrap(); // arity
+        assert!(matches!(
+            to_tuple_prim(&mut vm),
+            Err(TbxError::InvalidTupleElement { .. })
+        ));
+    }
+
+    #[test]
+    fn test_to_tuple_prim_negative_arity_returns_error() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(-1)).unwrap(); // negative arity
+        assert!(matches!(
+            to_tuple_prim(&mut vm),
+            Err(TbxError::InvalidArgument { .. })
+        ));
+    }
+
+    #[test]
+    fn test_to_tuple_prim_empty() {
+        // Stack: [Int(0)] → Cell::Tuple([]) (empty tuple)
+        let mut vm = VM::new();
+        vm.push(Cell::Int(0)).unwrap(); // arity = 0
+        to_tuple_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Tuple(vec![])));
     }
 
     // --- from_array_prim ---

--- a/src/primitives/arrays.rs
+++ b/src/primitives/arrays.rs
@@ -43,6 +43,35 @@ pub fn to_array_prim(vm: &mut VM) -> Result<(), TbxError> {
     Ok(())
 }
 
+/// TUPLE — collect N values from the stack into a new immutable tuple.
+///
+/// Pops the arity `n` from the stack, then pops `n` values and assembles them
+/// into a `Cell::Tuple`.  Elements are validated by `Cell::new_tuple`; nested
+/// `Tuple`, `Array`, `ArrayAddr`, `Xt`, `None`, and `Marker` are rejected.
+///
+/// `TUPLE()` with zero arguments produces an empty tuple `()`.
+pub fn to_tuple_prim(vm: &mut VM) -> Result<(), TbxError> {
+    // Pop the arity pushed by the compiler.
+    let n = vm.pop_int()?;
+    if n < 0 {
+        return Err(TbxError::InvalidArgument {
+            message: format!("TUPLE arity must be non-negative, got {n}"),
+        });
+    }
+    let count = n as usize;
+    // Pop `count` values in reverse order, then reverse to restore original order.
+    let mut elems: Vec<Cell> = Vec::with_capacity(count);
+    for _ in 0..count {
+        let elem = vm.pop()?;
+        elems.push(elem);
+    }
+    elems.reverse();
+    // Cell::new_tuple validates element types and returns an error for forbidden types.
+    let tuple = Cell::new_tuple(elems)?;
+    vm.push(tuple)?;
+    Ok(())
+}
+
 /// FROM_ARRAY — expand an array onto the stack.
 ///
 /// Pops `Cell::Array(pool_idx)` from the stack and pushes every element of the

--- a/tests/tbx_lib_tests.rs
+++ b/tests/tbx_lib_tests.rs
@@ -310,3 +310,22 @@ fn test_duplicate_local_var_with_init_then_no_init_is_error() {
         "expected 'duplicate' in error message, got: {err}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// TUPLE primitive error-path tests (issue #655)
+// ---------------------------------------------------------------------------
+
+/// TUPLE(ARRAY(3)) must fail at runtime with an invalid-element-type error
+/// because Cell::Array is a forbidden tuple element type.
+#[test]
+fn test_tuple_with_array_element_is_invalid() {
+    let mut interp = Interpreter::new();
+    let src = "DEF T()\n  VAR A\n  LET A = ARRAY(3)\n  RETURN TUPLE(A)\nEND\nT\n";
+    let err = interp
+        .exec_source(src)
+        .expect_err("TUPLE(Array) should fail with invalid tuple element error");
+    assert!(
+        err.to_string().contains("tuple element type not allowed"),
+        "expected 'tuple element type not allowed', got: {err}"
+    );
+}


### PR DESCRIPTION
## 概要

`Cell::Tuple(Vec<Cell>)` (#653) を TBX プログラムから生成できるよう、`TUPLE(...)` プリミティブを追加する。`TO_ARRAY` の実装をお手本にしており、可変長引数の構文 `TUPLE(1, 2, 3)` で `Cell::Tuple` を返す。

## 変更内容

- `src/primitives/arrays.rs`: `to_tuple_prim` 関数を追加（`Cell::new_tuple` で要素型チェック込み）
- `src/primitives.rs`: `register_all` に `TUPLE` エントリを登録（`is_variadic = true`）
- `src/primitives.rs`: 単体テスト7本を追加（basic / order / single / mixed / rejects_array / negative_arity / empty）
- `lib/tests/test_tuple.tbx`: 統合テスト（基本動作・順序・単一要素・混合型・空タプル・関数戻り値・グローバル変数）
- `tests/tbx_lib_tests.rs`: `TUPLE(Array)` が `InvalidTupleElement` エラーになることを確認するテストを追加

## 空タプル `TUPLE()` について

**実装できた。**

`expr.rs` の `emit_call_by_kind`（line 673–680）は variadic primitive に対して `LIT, Int(arity), Xt` を emit する。`F()` の形（next_is_rparen が true）では arity=0 を渡すため、`to_tuple_prim` は `n=0` を pop して `Cell::new_tuple(vec![])` を返す。`dict.rs` の `check_variadic_arity` は variadic word の `arity` フィールドが 0 であれば 0引数を拒否しないため、コンパイル時チェックも通過する。`TO_ARRAY()` と同一の仕組みで空タプルが自然に動作することを確認した。

Closes #655
