### PR TITLE
feat: [] トークンと index/projection 構文基盤を導入する (#657)

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -802,8 +802,10 @@ fn emit_op_item(op: &OpItem, output: &mut Vec<Cell>, vm: &VM) -> Result<(), TbxE
             });
         }
         OpItem::LBracket => {
-            // Should not reach here; LBracket is always popped at Token::RBracket.
-            unreachable!("LBracket should have been consumed by Token::RBracket handler")
+            // A stray LBracket surviving to drain means an unmatched '[' — error.
+            return Err(TbxError::InvalidExpression {
+                reason: "unmatched '[' in expression",
+            });
         }
     }
     Ok(())
@@ -1660,6 +1662,25 @@ mod tests {
         assert!(
             matches!(err, TbxError::InvalidExpression { .. }),
             "Token::Error should produce InvalidExpression, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_unmatched_lbracket_error() {
+        // `T[1` (no closing ']') must produce an unmatched '[' error.
+        let mut vm = make_vm();
+        vm.register(WordEntry::new_word("T", 0));
+        let tokens = lex("T[1");
+        let err = ExprCompiler::new(&mut vm)
+            .compile_expr(&tokens)
+            .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                TbxError::InvalidExpression { reason }
+                    if reason.contains("unmatched '['")
+            ),
+            "expected unmatched '[' error for T[1, got: {err:?}"
         );
     }
 }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -32,6 +32,8 @@ enum OpItem {
     /// Comma-as-binary-operator used outside of function calls (precedence 11).
     /// Both sides are evaluated in order; this marker produces no VM instruction.
     CommaSep,
+    /// Left-bracket sentinel for index/projection expressions.
+    LBracket,
 }
 
 /// Metadata attached to a `LParen` operator-stack item to distinguish call types.
@@ -467,6 +469,45 @@ impl<'a> ExprCompiler<'a> {
                 }
 
                 // -------------------------------------------------------
+                // Bracket tokens (index / projection — Phase 4 placeholder)
+                // -------------------------------------------------------
+                Token::LBracket => {
+                    if prev_was_operand {
+                        // Postfix index/projection: `expr[...]`
+                        op_stack.push(OpItem::LBracket);
+                        prev_was_operand = false;
+                    } else {
+                        return Err(TbxError::InvalidExpression {
+                            reason: "'[' without a preceding expression is not supported",
+                        });
+                    }
+                }
+
+                Token::RBracket => {
+                    // Pop operators until LBracket.
+                    loop {
+                        match op_stack.last() {
+                            Some(OpItem::LBracket) => break,
+                            None => {
+                                return Err(TbxError::InvalidExpression {
+                                    reason: "unmatched ']' in expression",
+                                });
+                            }
+                            _ => {
+                                let op = op_stack.pop().unwrap();
+                                emit_op_item(&op, &mut output, self.vm)?;
+                            }
+                        }
+                    }
+                    // Pop the LBracket.
+                    op_stack.pop();
+                    // Index/projection is not yet implemented (Phase 4).
+                    return Err(TbxError::InvalidExpression {
+                        reason: "index/projection with [] is not yet implemented",
+                    });
+                }
+
+                // -------------------------------------------------------
                 // Comma (argument separator or low-priority binary op)
                 // -------------------------------------------------------
                 Token::Comma => {
@@ -704,8 +745,8 @@ fn pop_ops_while(
 ) -> Result<(), TbxError> {
     loop {
         match op_stack.last() {
-            // LParen is never popped by precedence rules.
-            Some(OpItem::LParen { .. }) | None => break,
+            // LParen and LBracket are never popped by precedence rules.
+            Some(OpItem::LParen { .. }) | Some(OpItem::LBracket) | None => break,
             Some(op) => {
                 let top_prec = op_prec(op);
                 // Standard SYA rule (our numbering: lower = higher priority):
@@ -735,6 +776,7 @@ fn op_prec(op: &OpItem) -> u8 {
         OpItem::UnaryNeg => 1,
         OpItem::CommaSep => 11,
         OpItem::LParen { .. } => u8::MAX, // sentinel; never compared in practice
+        OpItem::LBracket => u8::MAX,      // sentinel; never compared in practice
     }
 }
 
@@ -758,6 +800,10 @@ fn emit_op_item(op: &OpItem, output: &mut Vec<Cell>, vm: &VM) -> Result<(), TbxE
             return Err(TbxError::InvalidExpression {
                 reason: "unmatched '(' in expression",
             });
+        }
+        OpItem::LBracket => {
+            // Should not reach here; LBracket is always popped at Token::RBracket.
+            unreachable!("LBracket should have been consumed by Token::RBracket handler")
         }
     }
     Ok(())
@@ -1531,6 +1577,65 @@ mod tests {
         assert!(
             matches!(err, TbxError::InvalidExpression { reason } if reason.contains("trailing comma")),
             "trailing comma should produce InvalidExpression, got {err:?}"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Bracket tokens: index/projection not yet implemented
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_bracket_index_not_yet_implemented() {
+        // `T[1]` must produce InvalidExpression with the "not yet implemented" reason.
+        let mut vm = make_vm();
+        vm.register(WordEntry::new_word("T", 0));
+        let tokens = lex("T[1]");
+        let err = ExprCompiler::new(&mut vm)
+            .compile_expr(&tokens)
+            .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                TbxError::InvalidExpression { reason }
+                    if reason.contains("not yet implemented")
+            ),
+            "expected 'not yet implemented' error for T[1], got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_isolated_rbracket_error() {
+        // A lone `]` with no matching `[` must produce an unmatched ']' error.
+        let mut vm = make_vm();
+        let tokens = lex("1 ]");
+        let err = ExprCompiler::new(&mut vm)
+            .compile_expr(&tokens)
+            .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                TbxError::InvalidExpression { reason }
+                    if reason.contains("unmatched ']'")
+            ),
+            "expected unmatched ']' error, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_lbracket_without_preceding_operand_error() {
+        // `[1]` (no preceding expression) must be rejected.
+        let mut vm = make_vm();
+        let tokens = lex("[1]");
+        let err = ExprCompiler::new(&mut vm)
+            .compile_expr(&tokens)
+            .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                TbxError::InvalidExpression { reason }
+                    if reason.contains("'[' without a preceding expression")
+            ),
+            "expected '[' without preceding expression error, got: {err:?}"
         );
     }
 

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -42,6 +42,10 @@ pub enum Token {
     LParen,
     /// Right parenthesis `)`. Maps to TOK_OP.
     RParen,
+    /// Left bracket `[`. Used for index / projection expressions.
+    LBracket,
+    /// Right bracket `]`. Used for index / projection expressions.
+    RBracket,
     /// Line terminator (newline or end of statement). Outer-interpreter-only.
     Newline,
     /// End of input. Outer-interpreter-only.
@@ -58,9 +62,13 @@ impl Token {
         match self {
             Token::Ident(_) => Some(TOK_ID),
             Token::IntLit(_) | Token::FloatLit(_) => Some(TOK_NUM),
-            Token::Op(_) | Token::Comma | Token::Ampersand | Token::LParen | Token::RParen => {
-                Some(TOK_OP)
-            }
+            Token::Op(_)
+            | Token::Comma
+            | Token::Ampersand
+            | Token::LParen
+            | Token::RParen
+            | Token::LBracket
+            | Token::RBracket => Some(TOK_OP),
             Token::Semicolon => Some(TOK_DELIM),
             Token::StringLit(_) => Some(TOK_STR),
             // Ellipsis is a DEF-parsing-only token; never exposed via TOKEN primitive.
@@ -477,6 +485,18 @@ impl<'a> Lexer<'a> {
             },
             ')' => SpannedToken {
                 token: Token::RParen,
+                pos: start_pos,
+                source_offset: start_off,
+                source_len: end_off - start_off,
+            },
+            '[' => SpannedToken {
+                token: Token::LBracket,
+                pos: start_pos,
+                source_offset: start_off,
+                source_len: end_off - start_off,
+            },
+            ']' => SpannedToken {
+                token: Token::RBracket,
                 pos: start_pos,
                 source_offset: start_off,
                 source_len: end_off - start_off,
@@ -1286,6 +1306,43 @@ mod tests {
                 Token::Eof,
             ]
         );
+    }
+
+    // --- brackets ---
+
+    #[test]
+    fn test_lbracket() {
+        assert_eq!(tokens("["), vec![Token::LBracket, Token::Eof]);
+    }
+
+    #[test]
+    fn test_rbracket() {
+        assert_eq!(tokens("]"), vec![Token::RBracket, Token::Eof]);
+    }
+
+    #[test]
+    fn test_bracket_index_sequence() {
+        // T[1] should tokenize as [Ident("T"), LBracket, IntLit(1), RBracket, Eof].
+        assert_eq!(
+            tokens("T[1]"),
+            vec![
+                Token::Ident("T".to_string()),
+                Token::LBracket,
+                Token::IntLit(1),
+                Token::RBracket,
+                Token::Eof,
+            ]
+        );
+    }
+
+    #[test]
+    fn test_kind_code_lbracket() {
+        assert_eq!(Token::LBracket.kind_code(), Some(TOK_OP));
+    }
+
+    #[test]
+    fn test_kind_code_rbracket() {
+        assert_eq!(Token::RBracket.kind_code(), Some(TOK_OP));
     }
 
     // --- integer overflow → Error ---

--- a/tests/tbx_lib_tests.rs
+++ b/tests/tbx_lib_tests.rs
@@ -329,3 +329,42 @@ fn test_tuple_with_array_element_is_invalid() {
         "expected 'tuple element type not allowed', got: {err}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Regression tests for issue #657: [] token introduction
+// ---------------------------------------------------------------------------
+
+/// TUPLE(1, 2, 3) must still compile and produce the correct STR output.
+/// Ensures that introducing LBracket/RBracket did not break tuple parsing.
+#[test]
+fn test_tuple_regression_issue_657() {
+    let mut interp = Interpreter::new();
+    // Use PUTSTR + take_output instead of ASSERT (which requires helper.tbx).
+    let src = "DEF CHECK()\n  VAR T\n  LET T = TUPLE(1, 2, 3)\n  PUTSTR STR(T)\nEND\nCHECK\n";
+    interp
+        .exec_source(src)
+        .expect("TUPLE(1, 2, 3) should still work after [] token introduction");
+    assert_eq!(interp.take_output(), "(1, 2, 3)");
+}
+
+/// F(1) function call syntax must still work after [] token introduction.
+#[test]
+fn test_function_call_regression_issue_657() {
+    let mut interp = Interpreter::new();
+    let src = "DEF DOUBLE(X)\n  RETURN X * 2\nEND\nPUTDEC DOUBLE(3)\n";
+    interp
+        .exec_source(src)
+        .expect("function call F(1) should still work after [] token introduction");
+    assert_eq!(interp.take_output(), "6");
+}
+
+/// STR(TUPLE(1, 2)) must still produce the correct output.
+#[test]
+fn test_str_tuple_regression_issue_657() {
+    let mut interp = Interpreter::new();
+    let src = "DEF CHECK()\n  PUTSTR STR(TUPLE(1, 2))\nEND\nCHECK\n";
+    interp
+        .exec_source(src)
+        .expect("STR(TUPLE(1, 2)) should still work after [] token introduction");
+    assert_eq!(interp.take_output(), "(1, 2)");
+}


### PR DESCRIPTION
## 概要

lexer に `[` / `]` トークンを追加し、expression compiler に postfix `[]` の受け口を作る Phase 3 の実装。tuple projection の実行意味（`T[i]` の実際の動作）は実装せず、`X[1]` を認識したら "not yet implemented" 相当の明確なエラーを返す。

## 変更内容

- `src/lexer.rs`: `Token::LBracket` / `Token::RBracket` を追加（`kind_code` は `TOK_OP`）、`scan_operator` に `[` / `]` のスキャンケースを追加
- `src/expr.rs`: `OpItem::LBracket` を追加、SYA ループに `Token::LBracket` / `Token::RBracket` の処理を実装、`op_prec` / `emit_op_item` / `pop_ops_while` を対応させる
- `src/lexer.rs` テスト: `[` / `]` 単体トークン化、`T[1]` シーケンス、`kind_code` を追加
- `src/expr.rs` テスト: `T[1]` が "not yet implemented" エラー、孤立 `]` エラー、`[` without preceding expression エラーを追加
- `tests/tbx_lib_tests.rs`: `TUPLE(1, 2, 3)` / `F(1)` / `STR(TUPLE(1, 2))` の regression テストを追加

Closes #657
