### PR TITLE
tuple projection T[i] を実装する

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -501,6 +501,12 @@ impl<'a> ExprCompiler<'a> {
                     }
                     // Pop the LBracket.
                     op_stack.pop();
+                    // Reject `T[]`: the index expression is missing.
+                    if !prev_was_operand {
+                        return Err(TbxError::InvalidExpression {
+                            reason: "missing index expression in []",
+                        });
+                    }
                     // Emit TUPLE_GET: stack is [..., <tuple>, <index>] → element value.
                     let tuple_get_xt = require_xt(self.vm, "TUPLE_GET")?;
                     output.push(Cell::Xt(tuple_get_xt));
@@ -1688,6 +1694,25 @@ mod tests {
                     if reason.contains("unmatched '['")
             ),
             "expected unmatched '[' error for T[1, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_empty_bracket_index_error() {
+        // `T[]` must be rejected as a syntax error: index expression is missing.
+        let mut vm = make_vm();
+        vm.register(WordEntry::new_word("T", 0));
+        let tokens = lex("T[]");
+        let err = ExprCompiler::new(&mut vm)
+            .compile_expr(&tokens)
+            .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                TbxError::InvalidExpression { reason }
+                    if reason.contains("missing index expression in []")
+            ),
+            "expected missing index expression error for T[], got: {err:?}"
         );
     }
 }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -501,10 +501,10 @@ impl<'a> ExprCompiler<'a> {
                     }
                     // Pop the LBracket.
                     op_stack.pop();
-                    // Index/projection is not yet implemented (Phase 4).
-                    return Err(TbxError::InvalidExpression {
-                        reason: "index/projection with [] is not yet implemented",
-                    });
+                    // Emit TUPLE_GET: stack is [..., <tuple>, <index>] → element value.
+                    let tuple_get_xt = require_xt(self.vm, "TUPLE_GET")?;
+                    output.push(Cell::Xt(tuple_get_xt));
+                    prev_was_operand = true;
                 }
 
                 // -------------------------------------------------------
@@ -1583,25 +1583,32 @@ mod tests {
     }
 
     // ------------------------------------------------------------------
-    // Bracket tokens: index/projection not yet implemented
+    // Bracket tokens: tuple projection T[i]
     // ------------------------------------------------------------------
 
     #[test]
-    fn test_bracket_index_not_yet_implemented() {
-        // `T[1]` must produce InvalidExpression with the "not yet implemented" reason.
+    fn test_bracket_index_emits_tuple_get() {
+        // `T[1]` must compile successfully and emit TUPLE_GET as the last instruction.
         let mut vm = make_vm();
         vm.register(WordEntry::new_word("T", 0));
         let tokens = lex("T[1]");
-        let err = ExprCompiler::new(&mut vm)
+        let output = ExprCompiler::new(&mut vm)
             .compile_expr(&tokens)
-            .unwrap_err();
-        assert!(
-            matches!(
-                err,
-                TbxError::InvalidExpression { reason }
-                    if reason.contains("not yet implemented")
-            ),
-            "expected 'not yet implemented' error for T[1], got: {err:?}"
+            .expect("T[1] should compile without error");
+        // The output must end with a Cell::Xt that resolves to "TUPLE_GET".
+        let last = output.last().expect("output must be non-empty");
+        let xt = match last {
+            Cell::Xt(x) => *x,
+            other => panic!("expected Cell::Xt at end of output, got: {other:?}"),
+        };
+        let entry = vm
+            .headers
+            .get(xt.0)
+            .expect("xt must resolve to a dictionary entry");
+        assert_eq!(
+            entry.name, "TUPLE_GET",
+            "last emitted word must be TUPLE_GET, got: {}",
+            entry.name
         );
     }
 

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1826,6 +1826,9 @@ pub fn register_all(vm: &mut VM) {
     let mut array_addr_entry = WordEntry::new_primitive("ARRAY_ADDR", array_addr_prim);
     array_addr_entry.flags = FLAG_SYSTEM;
     vm.register(array_addr_entry);
+    let mut tuple_get_entry = WordEntry::new_primitive("TUPLE_GET", tuple_get_prim);
+    tuple_get_entry.flags = FLAG_SYSTEM;
+    vm.register(tuple_get_entry);
 
     // Variadic argument primitives.
     // VA_COUNT returns the total argument count of the current call.

--- a/src/primitives/arrays.rs
+++ b/src/primitives/arrays.rs
@@ -208,6 +208,52 @@ pub fn array_addr_prim(vm: &mut VM) -> Result<(), TbxError> {
     Ok(())
 }
 
+/// TUPLE_GET — read an element from a tuple (1-based index).
+///
+/// Stack: `[..., Cell::Tuple(elements), Cell::Int(elem_idx)]` → `value`
+///
+/// Tuple indices are 1-based from the user's perspective: valid range is `1..=N`.
+pub fn tuple_get_prim(vm: &mut VM) -> Result<(), TbxError> {
+    // Pop index.
+    let idx_raw = vm.pop()?;
+    let elem_idx_raw = match idx_raw {
+        Cell::Int(n) => n,
+        other => {
+            return Err(TbxError::TypeError {
+                expected: "Int",
+                got: other.type_name(),
+            })
+        }
+    };
+    // Pop tuple.
+    let elements = match vm.pop()? {
+        Cell::Tuple(elems) => elems,
+        other => {
+            return Err(TbxError::TypeError {
+                expected: "Tuple",
+                got: other.type_name(),
+            })
+        }
+    };
+    let size = elements.len();
+    if elem_idx_raw < 1 {
+        return Err(TbxError::ArrayIndexOutOfBounds {
+            index: elem_idx_raw,
+            size,
+        });
+    }
+    let elem_idx = (elem_idx_raw - 1) as usize;
+    if elem_idx >= size {
+        return Err(TbxError::ArrayIndexOutOfBounds {
+            index: elem_idx_raw,
+            size,
+        });
+    }
+    let value = elements[elem_idx].clone();
+    vm.push(value)?;
+    Ok(())
+}
+
 /// ARRAY_LEN — return the length of an array.
 ///
 /// Pops `Cell::Array(pool_idx)` from the stack and pushes the number of elements
@@ -288,6 +334,78 @@ pub fn array_concat_prim(vm: &mut VM) -> Result<(), TbxError> {
 mod tests {
     use super::*;
     use crate::cell::Cell;
+
+    // --- tuple_get_prim ---
+
+    #[test]
+    fn test_tuple_get_prim_basic() {
+        // User index 2 maps to internal index 1.
+        let mut vm = VM::new();
+        let tuple = Cell::new_tuple(vec![Cell::Int(10), Cell::Int(20), Cell::Int(30)]).unwrap();
+        vm.push(tuple).unwrap();
+        vm.push(Cell::Int(2)).unwrap();
+        tuple_get_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Int(20)));
+    }
+
+    #[test]
+    fn test_tuple_get_prim_index_out_of_bounds_zero() {
+        // Index 0 is invalid in 1-based indexing.
+        let mut vm = VM::new();
+        let tuple = Cell::new_tuple(vec![Cell::Int(1), Cell::Int(2)]).unwrap();
+        vm.push(tuple).unwrap();
+        vm.push(Cell::Int(0)).unwrap();
+        assert!(matches!(
+            tuple_get_prim(&mut vm),
+            Err(TbxError::ArrayIndexOutOfBounds { index: 0, .. })
+        ));
+    }
+
+    #[test]
+    fn test_tuple_get_prim_index_out_of_bounds_high() {
+        // Index 4 is out of range for a 3-element tuple.
+        let mut vm = VM::new();
+        let tuple = Cell::new_tuple(vec![Cell::Int(1), Cell::Int(2), Cell::Int(3)]).unwrap();
+        vm.push(tuple).unwrap();
+        vm.push(Cell::Int(4)).unwrap();
+        assert!(matches!(
+            tuple_get_prim(&mut vm),
+            Err(TbxError::ArrayIndexOutOfBounds { index: 4, size: 3 })
+        ));
+    }
+
+    #[test]
+    fn test_tuple_get_prim_wrong_index_type() {
+        // Float index must produce a TypeError.
+        let mut vm = VM::new();
+        let tuple = Cell::new_tuple(vec![Cell::Int(1)]).unwrap();
+        vm.push(tuple).unwrap();
+        vm.push(Cell::Float(1.0)).unwrap();
+        assert!(matches!(
+            tuple_get_prim(&mut vm),
+            Err(TbxError::TypeError {
+                expected: "Int",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn test_tuple_get_prim_wrong_target_type() {
+        // Using a non-tuple value as the target must produce a TypeError.
+        let mut vm = VM::new();
+        vm.push(Cell::Int(99)).unwrap();
+        vm.push(Cell::Int(1)).unwrap();
+        assert!(matches!(
+            tuple_get_prim(&mut vm),
+            Err(TbxError::TypeError {
+                expected: "Tuple",
+                ..
+            })
+        ));
+    }
+
+    // --- to_array_prim ---
 
     /// Verify that TO_ARRAY accepts Cell::Str(Rc<str>) as an array element.
     ///

--- a/tests/tbx_lib_tests.rs
+++ b/tests/tbx_lib_tests.rs
@@ -368,3 +368,107 @@ fn test_str_tuple_regression_issue_657() {
         .expect("STR(TUPLE(1, 2)) should still work after [] token introduction");
     assert_eq!(interp.take_output(), "(1, 2)");
 }
+
+// ---------------------------------------------------------------------------
+// Tuple projection T[i] tests (issue #659)
+// ---------------------------------------------------------------------------
+
+/// T[i] basic projection: each element can be accessed by 1-based index.
+#[test]
+fn test_tuple_projection_basic() {
+    let mut interp = Interpreter::new();
+    let src = "DEF CHECK()\n  VAR T\n  LET T = TUPLE(2026, 5, 18)\n  PRINTLN T[1]\n  PRINTLN T[2]\n  PRINTLN T[3]\nEND\nCHECK\n";
+    interp
+        .exec_source(src)
+        .expect("tuple projection T[i] should work");
+    assert_eq!(interp.take_output(), "2026\n5\n18\n");
+}
+
+/// T[I] with a variable index must evaluate the variable at runtime.
+#[test]
+fn test_tuple_projection_with_variable_index() {
+    let mut interp = Interpreter::new();
+    let src = "DEF CHECK()\n  VAR I\n  VAR T\n  LET I = 2\n  LET T = TUPLE(10, 20, 30)\n  PRINTLN T[I]\nEND\nCHECK\n";
+    interp
+        .exec_source(src)
+        .expect("tuple projection T[I] with variable index should work");
+    assert_eq!(interp.take_output(), "20\n");
+}
+
+/// T[1 + 1] with an arithmetic expression as index must work.
+#[test]
+fn test_tuple_projection_with_expr_index() {
+    let mut interp = Interpreter::new();
+    let src = "DEF CHECK()\n  VAR T\n  LET T = TUPLE(10, 20, 30)\n  PRINTLN T[1 + 1]\nEND\nCHECK\n";
+    interp
+        .exec_source(src)
+        .expect("tuple projection T[1+1] with expression index should work");
+    assert_eq!(interp.take_output(), "20\n");
+}
+
+/// Mixed-type tuples: string, integer, and boolean elements.
+#[test]
+fn test_tuple_projection_mixed_types() {
+    let mut interp = Interpreter::new();
+    // Use `1 = 1` to produce a Bool(true) value, since TRUE is not a registered symbol.
+    let src = concat!(
+        "DEF CHECK()\n",
+        "  VAR T\n",
+        "  LET T = TUPLE(\"tbx\", 1, 1 = 1)\n",
+        "  PUTSTR T[1]\n",
+        "  PUTSTR \" \"\n",
+        "  PUTDEC T[2]\n",
+        "  PUTSTR \" \"\n",
+        "  PUTVAL T[3]\n",
+        "END\n",
+        "CHECK\n"
+    );
+    interp
+        .exec_source(src)
+        .expect("tuple projection on mixed-type tuple should work");
+    assert_eq!(interp.take_output(), "tbx 1 TRUE");
+}
+
+/// T[0] and T[N+1] must produce an out-of-bounds error.
+#[test]
+fn test_tuple_projection_index_out_of_bounds() {
+    let mut interp = Interpreter::new();
+    let src = "DEF CHECK()\n  VAR T\n  LET T = TUPLE(1, 2, 3)\n  PRINTLN T[0]\nEND\nCHECK\n";
+    interp
+        .exec_source(src)
+        .expect_err("T[0] should fail with out-of-bounds error");
+
+    let mut interp2 = Interpreter::new();
+    let src2 = "DEF CHECK()\n  VAR T\n  LET T = TUPLE(1, 2, 3)\n  PRINTLN T[4]\nEND\nCHECK\n";
+    interp2
+        .exec_source(src2)
+        .expect_err("T[4] should fail with out-of-bounds error for a 3-element tuple");
+}
+
+/// T[1.5] with a non-integer index must produce a TypeError.
+#[test]
+fn test_tuple_projection_wrong_index_type() {
+    let mut interp = Interpreter::new();
+    let src = "DEF CHECK()\n  VAR T\n  LET T = TUPLE(1, 2, 3)\n  PRINTLN T[1.5]\nEND\nCHECK\n";
+    let err = interp
+        .exec_source(src)
+        .expect_err("T[1.5] should fail with a type error");
+    assert!(
+        err.to_string().contains("type error"),
+        "expected 'type error', got: {err}"
+    );
+}
+
+/// X[1] on a non-tuple value must produce a TypeError.
+#[test]
+fn test_tuple_projection_non_tuple_target() {
+    let mut interp = Interpreter::new();
+    let src = "DEF CHECK()\n  VAR X\n  LET X = 42\n  PRINTLN X[1]\nEND\nCHECK\n";
+    let err = interp
+        .exec_source(src)
+        .expect_err("X[1] on non-tuple should fail with a type error");
+    assert!(
+        err.to_string().contains("type error"),
+        "expected 'type error', got: {err}"
+    );
+}


### PR DESCRIPTION
## 概要

`TUPLE(...)` で作成したタプルに対して `T[i]` 構文（1-based インデックス）でその要素を取得できるようにする。
`ARRAY_GET` の実装をモデルに `TUPLE_GET` primitive を追加し、式コンパイラの `Token::RBracket` ハンドラで emit するよう変更した。

## 変更内容

- `src/primitives/arrays.rs`: `tuple_get_prim` を追加（1-based インデックスで `Cell::Tuple` の要素を取得）
- `src/primitives.rs`: `register_all` に `TUPLE_GET`（`FLAG_SYSTEM`）を登録
- `src/expr.rs`: `Token::RBracket` ハンドラの "not yet implemented" エラーを除去し、`TUPLE_GET` を emit するよう変更；`test_bracket_index_not_yet_implemented` を `test_bracket_index_emits_tuple_get` に更新
- `src/primitives/arrays.rs` `#[cfg(test)]`: `tuple_get_prim` の単体テスト5件を追加
- `tests/tbx_lib_tests.rs`: `T[i]` 構文の統合テスト7件を追加（基本動作・変数インデックス・式インデックス・混合型・境界外・型エラー・非タプルターゲット）

Closes #659
