### PR TITLE
@ (array binding sigil) を lexer/token/expr に追加する

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -572,6 +572,29 @@ impl<'a> ExprCompiler<'a> {
                 }
 
                 // -------------------------------------------------------
+                // Array binding sigil `@` — not yet implemented
+                // -------------------------------------------------------
+                Token::At => {
+                    // `@` must be followed by an identifier to form `@A` or `@A[i]`.
+                    // Bare `@`, `@[...]`, or `@ <non-ident>` are malformed.
+                    // The full array-binding feature is not yet implemented; reject
+                    // all uses with a clear error rather than panicking.
+                    let next_is_ident = tokens
+                        .get(i + 1)
+                        .map(|st| matches!(st.token, Token::Ident(_)))
+                        .unwrap_or(false);
+                    if next_is_ident {
+                        return Err(TbxError::InvalidExpression {
+                            reason: "array sigil @ is not yet implemented",
+                        });
+                    } else {
+                        return Err(TbxError::InvalidExpression {
+                            reason: "@ must be followed by an identifier",
+                        });
+                    }
+                }
+
+                // -------------------------------------------------------
                 // Expression terminators
                 // -------------------------------------------------------
                 Token::Newline | Token::Eof | Token::Semicolon => break,
@@ -1713,6 +1736,134 @@ mod tests {
                     if reason.contains("missing index expression in []")
             ),
             "expected missing index expression error for T[], got: {err:?}"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Token::At — array sigil @ (not yet implemented)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_at_before_ident_is_unimplemented_error() {
+        // `@A[1]` must produce the "not yet implemented" error without panicking.
+        // Register A as a global variable so the identifier would otherwise resolve.
+        let mut vm = make_vm();
+        vm.dict_write(Cell::Int(0)).unwrap();
+        vm.register(crate::dict::WordEntry::new_variable("A", 0));
+
+        let tokens = lex("@A[1]");
+        let err = ExprCompiler::new(&mut vm)
+            .compile_expr(&tokens)
+            .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                TbxError::InvalidExpression { reason }
+                    if reason.contains("not yet implemented")
+            ),
+            "expected not-yet-implemented error for @A[1], got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_bare_at_is_syntax_error() {
+        // A bare `@` (not followed by an identifier) must be a clear syntax error.
+        let mut vm = make_vm();
+        let tokens = lex("@");
+        let err = ExprCompiler::new(&mut vm)
+            .compile_expr(&tokens)
+            .unwrap_err();
+        assert!(
+            matches!(err, TbxError::InvalidExpression { .. }),
+            "expected InvalidExpression for bare @, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_at_bracket_is_syntax_error() {
+        // `@[1]` (@ not followed by an identifier) must be a clear syntax error.
+        let mut vm = make_vm();
+        let tokens = lex("@[1]");
+        let err = ExprCompiler::new(&mut vm)
+            .compile_expr(&tokens)
+            .unwrap_err();
+        assert!(
+            matches!(err, TbxError::InvalidExpression { .. }),
+            "expected InvalidExpression for @[1], got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_at_space_int_is_syntax_error() {
+        // `@ 1` (@ followed by an integer, not an identifier) must be a clear syntax error.
+        let mut vm = make_vm();
+        let tokens = lex("@ 1");
+        let err = ExprCompiler::new(&mut vm)
+            .compile_expr(&tokens)
+            .unwrap_err();
+        assert!(
+            matches!(err, TbxError::InvalidExpression { .. }),
+            "expected InvalidExpression for `@ 1`, got: {err:?}"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Regression: existing syntax must still work after @ token addition
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_regression_ampersand_variable_read() {
+        // `VAR A; SET &A, 42` — &A must still compile as an address-of.
+        let mut vm = make_vm();
+        vm.dict_write(Cell::Int(0)).unwrap();
+        vm.register(crate::dict::WordEntry::new_variable("A", 0));
+
+        let tokens = lex("&A");
+        let result = ExprCompiler::new(&mut vm).compile_expr(&tokens).unwrap();
+
+        let lit_xt = vm.lookup("LIT").unwrap();
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0], Cell::Xt(lit_xt));
+        assert_eq!(result[1], Cell::DictAddr(0));
+    }
+
+    #[test]
+    fn test_regression_tuple_projection() {
+        // `T[1]` must still compile to TUPLE_GET (regression for T[i] support).
+        let mut vm = make_vm();
+        vm.register(crate::dict::WordEntry::new_word("T", 0));
+        let tokens = lex("T[1]");
+        let output = ExprCompiler::new(&mut vm)
+            .compile_expr(&tokens)
+            .expect("T[1] should compile without error");
+        let last = output.last().expect("output must be non-empty");
+        let xt = match last {
+            Cell::Xt(x) => *x,
+            other => panic!("expected Cell::Xt at end of output, got: {other:?}"),
+        };
+        assert_eq!(vm.headers[xt.0].name, "TUPLE_GET");
+    }
+
+    #[test]
+    fn test_regression_function_call() {
+        // `F(9)` — function call must still work after @ token addition.
+        let mut vm = make_vm();
+        let f_xt = vm.register(crate::dict::WordEntry::new_word("F", 0));
+        let tokens = lex("F(9)");
+        let result = ExprCompiler::new(&mut vm).compile_expr(&tokens).unwrap();
+
+        let lit_xt = vm.lookup("LIT").unwrap();
+        let call_xt = vm.lookup("CALL").unwrap();
+        assert_eq!(
+            result,
+            vec![
+                Cell::Xt(lit_xt),
+                Cell::Int(9),
+                Cell::Xt(call_xt),
+                Cell::Xt(f_xt),
+                Cell::Int(1),
+                Cell::Int(0),
+            ]
         );
     }
 }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -46,6 +46,9 @@ pub enum Token {
     LBracket,
     /// Right bracket `]`. Used for index / projection expressions.
     RBracket,
+    /// At-sign `@`. Used as the array binding sigil prefix.
+    /// Maps to TOK_OP.
+    At,
     /// Line terminator (newline or end of statement). Outer-interpreter-only.
     Newline,
     /// End of input. Outer-interpreter-only.
@@ -65,6 +68,7 @@ impl Token {
             Token::Op(_)
             | Token::Comma
             | Token::Ampersand
+            | Token::At
             | Token::LParen
             | Token::RParen
             | Token::LBracket
@@ -507,6 +511,12 @@ impl<'a> Lexer<'a> {
             '%' => self.op1("%", start_pos, start_off),
             '=' => self.op1("=", start_pos, start_off),
             '-' => self.op1("-", start_pos, start_off),
+            '@' => SpannedToken {
+                token: Token::At,
+                pos: start_pos,
+                source_offset: start_off,
+                source_len: end_off - start_off,
+            },
             '&' => {
                 if self.peek_char() == Some('&') {
                     self.advance();
@@ -1343,6 +1353,61 @@ mod tests {
     #[test]
     fn test_kind_code_rbracket() {
         assert_eq!(Token::RBracket.kind_code(), Some(TOK_OP));
+    }
+
+    // --- @ (At) ---
+
+    #[test]
+    fn test_at_single() {
+        // A lone `@` must be tokenised as Token::At.
+        assert_eq!(tokens("@"), vec![Token::At, Token::Eof]);
+    }
+
+    #[test]
+    fn test_at_before_ident() {
+        // `@A` must produce At followed by Ident("A").
+        assert_eq!(
+            tokens("@A"),
+            vec![Token::At, Token::Ident("A".to_string()), Token::Eof]
+        );
+    }
+
+    #[test]
+    fn test_at_ident_bracket_sequence() {
+        // `@A[1]` must tokenise as At, Ident("A"), LBracket, IntLit(1), RBracket, Eof.
+        assert_eq!(
+            tokens("@A[1]"),
+            vec![
+                Token::At,
+                Token::Ident("A".to_string()),
+                Token::LBracket,
+                Token::IntLit(1),
+                Token::RBracket,
+                Token::Eof,
+            ]
+        );
+    }
+
+    #[test]
+    fn test_ampersand_at_ident_bracket_sequence() {
+        // `&@A[1]` must tokenise as Ampersand, At, Ident("A"), LBracket, IntLit(1), RBracket, Eof.
+        assert_eq!(
+            tokens("&@A[1]"),
+            vec![
+                Token::Ampersand,
+                Token::At,
+                Token::Ident("A".to_string()),
+                Token::LBracket,
+                Token::IntLit(1),
+                Token::RBracket,
+                Token::Eof,
+            ]
+        );
+    }
+
+    #[test]
+    fn test_kind_code_at() {
+        assert_eq!(Token::At.kind_code(), Some(TOK_OP));
     }
 
     // --- integer overflow → Error ---


### PR DESCRIPTION
## 概要

`@` を array binding sigil として lexer / token / expression compiler が扱えるようにする構文基盤を導入する。
将来の配列バインディング機能の土台として、`@` トークンの認識と適切なエラーハンドリングを実装する。

## 変更内容

- `Token::At` を追加し、`kind_code()` が `TOK_OP` を返すようにする
- lexer の `scan_operator` で `@` を単独トークンとして tokenize できるようにする
- `ExprCompiler` に `Token::At` の分岐を追加する
  - `@Ident` / `@Ident[i]` 形式は「未実装エラー (`array sigil @ is not yet implemented`)」を返す
  - bare `@` / `@[...]` / `@ <非identifier>` は構文エラーを返す（panic しない）
- lexer テスト 5 件を追加（`@` 単体、`@A`、`@A[1]`、`&@A[1]`、`kind_code` 確認）
- expr テスト 6 件を追加（`@A[1]` 未実装エラー、bare `@`、`@[1]`、`@ 1`、`&A` リグレッション、`T[i]` リグレッション、`F(x)` リグレッション）

Closes #661
