### PR TITLE
`DIM @A[n]` による array binding 宣言を実装する

### DIFF
--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -660,6 +660,250 @@ pub fn var_prim(vm: &mut VM) -> Result<(), TbxError> {
     Ok(())
 }
 
+/// DIM — declare an array binding `DIM @A[n]`.
+///
+/// Syntax: `DIM @ Ident [ size_expr ]`
+///
+/// In compile mode (inside DEF..END):
+///   - Registers the bare identifier in `local_table` as a new local slot.
+///   - Emits code that creates an array of `size_expr` elements at runtime and
+///     stores it in the local slot: `LIT StackAddr(idx) [size_expr] ARRAY SET`.
+///
+/// In execute mode (top level):
+///   - Creates a global variable entry (`EntryKind::Variable`) backed by a
+///     `Cell::Array` in the array pool.
+///   - The size expression is evaluated immediately via a temporary code buffer.
+///
+/// Collision rules (bare name used as the key in both modes):
+///   - A name already present in `local_table` is rejected (duplicate local).
+///   - A name already present in the global dictionary (`vm.lookup`) is rejected.
+pub fn dim_prim(vm: &mut VM) -> Result<(), TbxError> {
+    use crate::lexer::Token;
+
+    // Consume `@`.
+    let at_tok = vm.next_token()?;
+    if at_tok.token != Token::At {
+        return Err(TbxError::InvalidExpression {
+            reason: "DIM: expected '@' after DIM",
+        });
+    }
+
+    // Consume the binding identifier.
+    let name = vm.expect_ident("DIM: expected identifier after '@'")?;
+
+    // Consume `[`.
+    let lb_tok = match vm.next_token() {
+        Ok(tok) => tok,
+        Err(TbxError::TokenStreamEmpty) => {
+            return Err(TbxError::InvalidExpression {
+                reason: "DIM: expected '[' after identifier (use DIM @A[n] syntax)",
+            });
+        }
+        Err(e) => return Err(e),
+    };
+    if lb_tok.token != Token::LBracket {
+        return Err(TbxError::InvalidExpression {
+            reason: "DIM: expected '[' after identifier (use DIM @A[n] syntax)",
+        });
+    }
+
+    // Collect tokens up to the matching `]` (depth-aware in case size_expr
+    // contains nested brackets, e.g. tuple projection in a future phase).
+    let size_tokens: Vec<crate::lexer::SpannedToken> = {
+        let stream = vm.token_stream.as_mut().ok_or(TbxError::TokenStreamEmpty)?;
+        let mut depth: usize = 1;
+        let mut collected: Vec<crate::lexer::SpannedToken> = Vec::new();
+        loop {
+            let tok = stream.pop_front().ok_or(TbxError::InvalidExpression {
+                reason: "DIM: unterminated '[' — expected ']'",
+            })?;
+            match &tok.token {
+                Token::LBracket => {
+                    depth += 1;
+                    collected.push(tok);
+                }
+                Token::RBracket => {
+                    depth -= 1;
+                    if depth == 0 {
+                        break;
+                    }
+                    collected.push(tok);
+                }
+                Token::Newline | Token::Eof => {
+                    return Err(TbxError::InvalidExpression {
+                        reason: "DIM: unterminated '[' — unexpected end of line",
+                    });
+                }
+                _ => {
+                    collected.push(tok);
+                }
+            }
+        }
+        collected
+    };
+
+    // Reject empty size expression: `DIM @A[]`.
+    if size_tokens.is_empty() {
+        return Err(TbxError::InvalidExpression {
+            reason: "DIM: array size expression must not be empty",
+        });
+    }
+
+    if vm.is_compiling {
+        // --- Compile mode (inside DEF) ---
+
+        // Check for name collision in local_table.
+        let has_local = vm
+            .compile_state
+            .as_ref()
+            .map(|s| s.local_table.contains_key(&name))
+            .unwrap_or(false);
+        if has_local {
+            return Err(TbxError::InvalidExpression {
+                reason: "DIM: array binding name already declared as a local",
+            });
+        }
+
+        // Check for name collision in the global dictionary.
+        if vm.lookup(&name).is_some() {
+            return Err(TbxError::InvalidExpression {
+                reason: "DIM: array binding name already declared as a global",
+            });
+        }
+
+        // Allocate a new local slot for the array handle.
+        let state = vm
+            .compile_state
+            .as_mut()
+            .ok_or(TbxError::InvalidExpression {
+                reason: "DIM: compile mode but no compile_state",
+            })?;
+        let idx = if state.is_variadic {
+            crate::constants::VARIADIC_LOCAL_BASE + state.local_count
+        } else {
+            state.arity + state.local_count
+        };
+        state.local_table.insert(name.clone(), idx);
+        state.local_count += 1;
+
+        // Compile the size expression.
+        let (size_cells, patch_offsets) = compile_expr_taking_local_table(vm, &size_tokens)?;
+
+        // Look up primitives needed for code generation.
+        let lit_xt =
+            vm.find_by_kind(|k| matches!(k, EntryKind::Lit))
+                .ok_or(TbxError::UndefinedSymbol {
+                    name: "LIT".to_string(),
+                })?;
+        let array_xt = vm.lookup("ARRAY").ok_or(TbxError::UndefinedSymbol {
+            name: "ARRAY".to_string(),
+        })?;
+        let set_xt = vm.lookup("SET").ok_or(TbxError::UndefinedSymbol {
+            name: "SET".to_string(),
+        })?;
+
+        // Emit: LIT StackAddr(idx)  — push the address of the local slot.
+        vm.dict_write(Cell::Xt(lit_xt))?;
+        vm.dict_write(Cell::StackAddr(idx))?;
+
+        // Emit: [size_cells]  — evaluate the size at runtime.
+        let base_dp = vm.dp;
+        for cell in size_cells {
+            vm.dict_write(cell)?;
+        }
+        // Register self-recursive call patch positions.
+        if let Some(state) = vm.compile_state.as_mut() {
+            for offset in patch_offsets {
+                state.call_patch_list.push(base_dp + offset);
+            }
+        }
+
+        // Emit: ARRAY  — create the array and push its handle.
+        vm.dict_write(Cell::Xt(array_xt))?;
+
+        // Emit: SET  — store the array handle into the local slot.
+        vm.dict_write(Cell::Xt(set_xt))?;
+    } else {
+        // --- Execute mode (top level) ---
+
+        // Check for name collision in the global dictionary.
+        if vm.lookup(&name).is_some() {
+            return Err(TbxError::InvalidExpression {
+                reason: "DIM: array binding name already declared as a global",
+            });
+        }
+
+        // Evaluate the size expression by compiling it to a temporary code
+        // buffer and running it.  The result (Cell::Int) is left on the stack.
+        let (size_cells, _patch_offsets) = compile_expr_taking_local_table(vm, &size_tokens)?;
+
+        // Build temporary code buffer: [size_cells, EXIT].
+        let buf_start = vm.dp;
+        for cell in &size_cells {
+            vm.dict_write(cell.clone())?;
+        }
+        let exit_xt =
+            vm.find_by_kind(|k| matches!(k, EntryKind::Exit))
+                .ok_or(TbxError::UndefinedSymbol {
+                    name: "EXIT".to_string(),
+                })?;
+        vm.dict_write(Cell::Xt(exit_xt))?;
+
+        // Run the temporary buffer to evaluate the size expression.
+        let saved_stack_len = vm.data_stack.len();
+        let run_result = vm.run(buf_start);
+
+        // Clean up the temporary code buffer regardless of outcome.
+        vm.dp = buf_start;
+        vm.dictionary.truncate(buf_start);
+
+        if let Err(e) = run_result {
+            vm.data_stack.truncate(saved_stack_len);
+            return Err(e);
+        }
+
+        // Pop the evaluated size from the stack.
+        let size_val = vm.pop()?;
+        let size = match size_val {
+            Cell::Int(n) => {
+                if n <= 0 {
+                    return Err(TbxError::InvalidArgument {
+                        message: format!("DIM: array size must be positive, got {n}"),
+                    });
+                }
+                n as usize
+            }
+            other => {
+                return Err(TbxError::TypeError {
+                    expected: "Int",
+                    got: other.type_name(),
+                });
+            }
+        };
+
+        // Allocate the global variable slot in the dictionary.
+        let storage_idx = vm.dp;
+        vm.dict_write(Cell::None)?;
+
+        // Create the array in the array pool.
+        let pool_idx = vm.arrays.len();
+        vm.arrays.push(vec![Cell::None; size]);
+
+        // Promote to the global array region so it persists across word calls.
+        vm.global_array_pool_len = vm.global_array_pool_len.max(pool_idx + 1);
+
+        // Store the array handle in the variable slot.
+        vm.dict_write_at(storage_idx, Cell::Array(pool_idx))?;
+
+        // Register the variable in the dictionary.
+        let entry = crate::dict::WordEntry::new_variable(&name, storage_idx);
+        vm.register(entry);
+        vm.seal_user();
+    }
+
+    Ok(())
+}
+
 /// GOTO — compile GOTO N into the dictionary (compile mode only).
 pub fn goto_prim(vm: &mut VM) -> Result<(), TbxError> {
     if !vm.is_compiling {
@@ -1728,6 +1972,9 @@ pub fn register_all(vm: &mut VM) {
     let mut var_entry = WordEntry::new_primitive("VAR", var_prim);
     var_entry.flags = FLAG_IMMEDIATE | FLAG_SYSTEM;
     vm.register(var_entry);
+    let mut dim_entry = WordEntry::new_primitive("DIM", dim_prim);
+    dim_entry.flags = FLAG_IMMEDIATE | FLAG_SYSTEM;
+    vm.register(dim_entry);
     let mut goto_entry = WordEntry::new_primitive("GOTO", goto_prim);
     goto_entry.flags = FLAG_IMMEDIATE | FLAG_SYSTEM;
     vm.register(goto_entry);

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -849,8 +849,13 @@ pub fn dim_prim(vm: &mut VM) -> Result<(), TbxError> {
                 })?;
         vm.dict_write(Cell::Xt(exit_xt))?;
 
-        // Run the temporary buffer to evaluate the size expression.
+        // Snapshot VM state before running the temporary buffer so we can
+        // fully restore it if the size expression evaluation fails.
         let saved_stack_len = vm.data_stack.len();
+        let saved_return_stack_len = vm.return_stack.len();
+        let saved_pc = vm.pc;
+        let saved_bp = vm.bp;
+
         let run_result = vm.run(buf_start);
 
         // Clean up the temporary code buffer regardless of outcome.
@@ -858,7 +863,13 @@ pub fn dim_prim(vm: &mut VM) -> Result<(), TbxError> {
         vm.dictionary.truncate(buf_start);
 
         if let Err(e) = run_result {
+            // Restore all VM state that vm.run() may have mutated before
+            // the error, including return_stack frames pushed by user words
+            // called inside the size expression.
             vm.data_stack.truncate(saved_stack_len);
+            vm.return_stack.truncate(saved_return_stack_len);
+            vm.pc = saved_pc;
+            vm.bp = saved_bp;
             return Err(e);
         }
 

--- a/tests/tbx_lib_tests.rs
+++ b/tests/tbx_lib_tests.rs
@@ -683,3 +683,40 @@ fn test_dim_collides_with_global_var_is_error() {
         "expected 'invalid expression' in error message, got: {msg}"
     );
 }
+
+/// `DIM @G[expr]` where the size expression evaluation fails at runtime
+/// must not leave the VM's return stack, pc, or bp in a corrupted state.
+/// After the error, a subsequent valid operation must succeed, proving
+/// that the VM state was fully restored.
+///
+/// The `1 / 0` size expression is evaluated in a temporary code buffer via
+/// `vm.run()`.  Before entering `vm.run()`, it pushes `ReturnFrame::TopLevel`
+/// onto the return stack; a division-by-zero mid-run leaves that frame (and
+/// any deeper frames that had been pushed) without ever popping them.
+/// The fix snapshots and restores `return_stack`, `pc`, and `bp` on error.
+#[test]
+fn test_dim_global_size_expr_error_restores_vm_state() {
+    let mut interp = Interpreter::new();
+
+    // A division-by-zero inside the size expression causes vm.run() to abort
+    // partway through, leaving ReturnFrame::TopLevel on the return stack if
+    // the state is not properly restored.
+    let err = interp
+        .exec_source("DIM @G[1 / 0]\n")
+        .expect_err("DIM @G[1/0] should fail with division by zero");
+    assert!(
+        err.to_string().contains("division by zero"),
+        "expected 'division by zero' in error message, got: {err}"
+    );
+
+    // The VM must still be usable: a normal statement must succeed, showing
+    // that return_stack / pc / bp were cleanly restored after the failure.
+    interp
+        .exec_source("PUTDEC 1\n")
+        .expect("VM should be usable after DIM size-expression error");
+    assert_eq!(
+        interp.take_output(),
+        "1",
+        "PUTDEC 1 should produce '1' after recovery"
+    );
+}

--- a/tests/tbx_lib_tests.rs
+++ b/tests/tbx_lib_tests.rs
@@ -472,3 +472,214 @@ fn test_tuple_projection_non_tuple_target() {
         "expected 'type error', got: {err}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// DIM @A[n] — array binding declaration (issue #663)
+// ---------------------------------------------------------------------------
+
+/// `DIM @A[n]` inside a DEF must succeed and not interfere with RETURN.
+#[test]
+fn test_dim_local_array_declaration_succeeds() {
+    let mut interp = Interpreter::new();
+    // F() declares a local array and returns 1; PUTDEC prints it.
+    let src = "DEF F()\n  DIM @A[8]\n  RETURN 1\nEND\nPUTDEC F()\n";
+    interp
+        .exec_source(src)
+        .expect("DIM @A[8] inside DEF should succeed");
+    assert_eq!(interp.take_output(), "1");
+}
+
+/// `DIM @A[N]` with a variable-size expression inside DEF must succeed.
+#[test]
+fn test_dim_local_array_with_var_size_succeeds() {
+    let mut interp = Interpreter::new();
+    let src = "DEF F()\n  VAR N = 8\n  DIM @A[N]\n  RETURN 1\nEND\nPUTDEC F()\n";
+    interp
+        .exec_source(src)
+        .expect("DIM @A[N] with variable size inside DEF should succeed");
+    assert_eq!(interp.take_output(), "1");
+}
+
+/// `DIM @A[4 + 4]` with an arithmetic expression inside DEF must succeed.
+#[test]
+fn test_dim_local_array_with_expr_size_succeeds() {
+    let mut interp = Interpreter::new();
+    let src = "DEF F()\n  DIM @A[4 + 4]\n  RETURN 1\nEND\nPUTDEC F()\n";
+    interp
+        .exec_source(src)
+        .expect("DIM @A[4 + 4] inside DEF should succeed");
+    assert_eq!(interp.take_output(), "1");
+}
+
+/// `DIM @G[4]` at the top level (global) must succeed.
+#[test]
+fn test_dim_global_array_declaration_succeeds() {
+    let mut interp = Interpreter::new();
+    let src = "DIM @G[4]\n";
+    interp
+        .exec_source(src)
+        .expect("DIM @G[4] at top level should succeed");
+}
+
+/// Duplicate `DIM @A[n]` inside a DEF must produce an error.
+#[test]
+fn test_dim_duplicate_local_array_is_error() {
+    let mut interp = Interpreter::new();
+    let src = "DEF F()\n  DIM @A[8]\n  DIM @A[8]\n  RETURN 0\nEND\n";
+    let err = interp
+        .exec_source(src)
+        .expect_err("duplicate DIM @A inside DEF should fail");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("invalid expression"),
+        "expected 'invalid expression' in error message, got: {msg}"
+    );
+}
+
+/// `VAR A` followed by `DIM @A[n]` inside a DEF must produce a name collision error.
+#[test]
+fn test_dim_collides_with_var_local_is_error() {
+    let mut interp = Interpreter::new();
+    let src = "DEF F()\n  VAR A\n  DIM @A[8]\n  RETURN 0\nEND\n";
+    let err = interp
+        .exec_source(src)
+        .expect_err("DIM @A after VAR A inside DEF should fail");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("invalid expression"),
+        "expected 'invalid expression' in error message, got: {msg}"
+    );
+}
+
+/// `DIM @A[n]` followed by `VAR A` inside a DEF must produce a name collision error.
+#[test]
+fn test_var_collides_with_dim_local_is_error() {
+    let mut interp = Interpreter::new();
+    let src = "DEF F()\n  DIM @A[8]\n  VAR A\n  RETURN 0\nEND\n";
+    let err = interp
+        .exec_source(src)
+        .expect_err("VAR A after DIM @A inside DEF should fail");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("invalid expression"),
+        "expected 'invalid expression' in error message, got: {msg}"
+    );
+}
+
+/// `DIM @A` without `[n]` must produce a parse error.
+#[test]
+fn test_dim_missing_brackets_is_error() {
+    let mut interp = Interpreter::new();
+    let src = "DEF F()\n  DIM @A\n  RETURN 0\nEND\n";
+    let err = interp
+        .exec_source(src)
+        .expect_err("DIM @A without [n] should fail");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("invalid expression"),
+        "expected 'invalid expression' in error message, got: {msg}"
+    );
+}
+
+/// `DIM @A[]` with an empty size must produce a parse error.
+#[test]
+fn test_dim_empty_brackets_is_error() {
+    let mut interp = Interpreter::new();
+    let src = "DEF F()\n  DIM @A[]\n  RETURN 0\nEND\n";
+    let err = interp.exec_source(src).expect_err("DIM @A[] should fail");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("invalid expression"),
+        "expected 'invalid expression' in error message, got: {msg}"
+    );
+}
+
+/// `DIM @[8]` without an identifier must produce a parse error.
+#[test]
+fn test_dim_missing_ident_is_error() {
+    let mut interp = Interpreter::new();
+    let src = "DEF F()\n  DIM @[8]\n  RETURN 0\nEND\n";
+    let err = interp
+        .exec_source(src)
+        .expect_err("DIM @[8] without identifier should fail");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("invalid expression"),
+        "expected 'invalid expression' in error message, got: {msg}"
+    );
+}
+
+/// `DIM @A(8)` using parentheses instead of brackets must produce a parse error.
+#[test]
+fn test_dim_parens_instead_of_brackets_is_error() {
+    let mut interp = Interpreter::new();
+    let src = "DEF F()\n  DIM @A(8)\n  RETURN 0\nEND\n";
+    let err = interp
+        .exec_source(src)
+        .expect_err("DIM @A(8) should fail — new syntax requires brackets");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("invalid expression"),
+        "expected 'invalid expression' in error message, got: {msg}"
+    );
+}
+
+/// `DIM @A[0]` with size zero must produce an error.
+#[test]
+fn test_dim_zero_size_is_error() {
+    let mut interp = Interpreter::new();
+    let src = "DEF F()\n  DIM @A[0]\n  RETURN 0\nEND\nF\n";
+    let err = interp
+        .exec_source(src)
+        .expect_err("DIM @A[0] should fail with invalid size");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("positive") || msg.contains("invalid"),
+        "expected size error in message, got: {msg}"
+    );
+}
+
+/// `DIM @A[-1]` with negative size must produce an error.
+#[test]
+fn test_dim_negative_size_is_error() {
+    let mut interp = Interpreter::new();
+    let src = "DEF F()\n  DIM @A[-1]\n  RETURN 0\nEND\nF\n";
+    let err = interp
+        .exec_source(src)
+        .expect_err("DIM @A[-1] should fail with invalid size");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("positive") || msg.contains("invalid"),
+        "expected size error in message, got: {msg}"
+    );
+}
+
+/// `DIM @G[4]` at global scope followed by a duplicate `DIM @G[4]` must error.
+#[test]
+fn test_dim_duplicate_global_array_is_error() {
+    let mut interp = Interpreter::new();
+    let src = "DIM @G[4]\nDIM @G[4]\n";
+    let err = interp
+        .exec_source(src)
+        .expect_err("duplicate DIM @G at top level should fail");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("invalid expression"),
+        "expected 'invalid expression' in error message, got: {msg}"
+    );
+}
+
+/// `VAR G` at global scope followed by `DIM @G[4]` must produce a name collision error.
+#[test]
+fn test_dim_collides_with_global_var_is_error() {
+    let mut interp = Interpreter::new();
+    let src = "VAR G\nDIM @G[4]\n";
+    let err = interp
+        .exec_source(src)
+        .expect_err("DIM @G after global VAR G should fail");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("invalid expression"),
+        "expected 'invalid expression' in error message, got: {msg}"
+    );
+}


### PR DESCRIPTION
## 概要

issue #663 で設計された `DIM @A[n]` array binding 宣言構文を実装する。
`VAR` と同様の IMMEDIATE+SYSTEM primitive `DIM` を追加し、DEF 内ではローカル配列スロットへのコード emit、トップレベルではグローバル変数として配列を登録する。

## 変更内容

- `src/primitives.rs` に `dim_prim` を追加し、`DIM` として IMMEDIATE+SYSTEM 登録する
  - compile mode (DEF 内): `local_table` に bare identifier を登録し、`LIT StackAddr + [size_expr] + ARRAY + SET` を emit
  - execute mode (top level): サイズ式を一時コードバッファで評価し、`Cell::Array` を辞書に登録するグローバル変数を作成する
- `@` は prefix token として扱い、binding key は bare identifier (例: `@A` → `A`) とする
- `Token::LBracket / RBracket` を使ったサイズ式パース（depth-aware で将来の nested bracket に対応）
- 衝突チェック: `local_table` への重複、グローバル辞書への重複をエラーにする
- size ≤ 0、空ブラケット `DIM @A[]`、`DIM @A`（ブラケットなし）などをエラーにする
- `tests/tbx_lib_tests.rs` に integration tests 14 件を追加する（成功ケース・エラーケース）

## 非目標（この PR では実装しない）

- `@A[i]` 配列要素アクセス（Phase 7）
- `&@A[i]` アドレス取得（Phase 8）
- `LET @A[i] = expr` / `SET &@A[i], expr`（Phase 7 以降）
- 既存 `DIM A(n)` 構文の削除・非推奨化

Closes #663
