### PR TITLE
`@A[i]` による array binding 要素読み取りを実装する

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -572,25 +572,76 @@ impl<'a> ExprCompiler<'a> {
                 }
 
                 // -------------------------------------------------------
-                // Array binding sigil `@` — not yet implemented
+                // Array binding sigil `@` — array element read `@A[i]`
                 // -------------------------------------------------------
                 Token::At => {
-                    // `@` must be followed by an identifier to form `@A` or `@A[i]`.
+                    // `@` must be followed by an identifier to form `@A[i]`.
                     // Bare `@`, `@[...]`, or `@ <non-ident>` are malformed.
-                    // The full array-binding feature is not yet implemented; reject
-                    // all uses with a clear error rather than panicking.
-                    let next_is_ident = tokens
-                        .get(i + 1)
-                        .map(|st| matches!(st.token, Token::Ident(_)))
-                        .unwrap_or(false);
-                    if next_is_ident {
-                        return Err(TbxError::InvalidExpression {
-                            reason: "array sigil @ is not yet implemented",
-                        });
-                    } else {
-                        return Err(TbxError::InvalidExpression {
-                            reason: "@ must be followed by an identifier",
-                        });
+                    // `@A` without a following `[` is also an error (bare array
+                    // handle read is not supported in this phase).
+                    let next_tok = tokens.get(i + 1).map(|st| st.token.clone());
+                    match next_tok {
+                        Some(Token::Ident(name)) => {
+                            let name = name.to_ascii_uppercase();
+                            let lbracket_pos = i + 2;
+                            let has_lbracket = tokens
+                                .get(lbracket_pos)
+                                .map(|st| matches!(st.token, Token::LBracket))
+                                .unwrap_or(false);
+                            if !has_lbracket {
+                                return Err(TbxError::InvalidExpression {
+                                    reason: "@Ident must be followed by '[': use @A[i] syntax",
+                                });
+                            }
+                            // Parse the bracket-enclosed index expression.
+                            let (index_toks, close_pos) =
+                                parse_at_index_tokens(tokens, lbracket_pos)?;
+
+                            // Emit: load the array handle (local or global).
+                            if let Some(local_idx) =
+                                self.local_table.and_then(|lt| lt.get(&name)).copied()
+                            {
+                                // Local array binding: load the Cell::Array handle from
+                                // the local slot via LIT StackAddr(idx) FETCH.
+                                emit_local_read(&mut output, local_idx, self.vm)?;
+                            } else {
+                                // Global array binding: look up by bare name `A`.
+                                let xt = self
+                                    .vm
+                                    .lookup_including_self(&name, self.self_word.as_deref())
+                                    .ok_or_else(|| TbxError::UndefinedSymbol {
+                                        name: name.clone(),
+                                    })?;
+                                match &self.vm.headers[xt.index()].kind {
+                                    EntryKind::Variable(addr) => {
+                                        emit_var_read(&mut output, *addr, self.vm)?;
+                                    }
+                                    _ => {
+                                        return Err(TbxError::TypeError {
+                                            expected: "array variable for @-sigil access",
+                                            got: "non-variable",
+                                        });
+                                    }
+                                }
+                            }
+
+                            // Emit: compile the index expression.
+                            let index_cells = self.compile_expr(index_toks)?;
+                            output.extend(index_cells);
+
+                            // Emit: ARRAY_GET — pops (Array, index) and pushes element.
+                            let array_get_xt = require_xt(self.vm, "ARRAY_GET")?;
+                            output.push(Cell::Xt(array_get_xt));
+
+                            // Advance past `@`, Ident, `[`, <index_toks>, `]`.
+                            i = close_pos;
+                            prev_was_operand = true;
+                        }
+                        _ => {
+                            return Err(TbxError::InvalidExpression {
+                                reason: "@ must be followed by an identifier",
+                            });
+                        }
                     }
                 }
 
@@ -634,6 +685,50 @@ fn require_xt(vm: &VM, name: &'static str) -> Result<Xt, TbxError> {
         expected: "system word to be registered",
         got: "not found",
     })
+}
+
+/// Find the index of the matching closing `]` for an already-consumed `[`.
+///
+/// `tokens[start..]` is the content after the opening `[`.  Returns the index
+/// in `tokens` of the first `]` at depth 0 (accounting for nested brackets),
+/// or `None` if no such `]` exists.
+fn find_matching_rbracket(tokens: &[SpannedToken], start: usize) -> Option<usize> {
+    let mut depth = 0usize;
+    for (j, st) in tokens.iter().enumerate().skip(start) {
+        match &st.token {
+            Token::LBracket => depth += 1,
+            Token::RBracket => {
+                if depth == 0 {
+                    return Some(j);
+                }
+                depth -= 1;
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Return the tokens inside `[` `]` of an `@A[...]` index expression and the
+/// position of the matching closing bracket.
+///
+/// `lbracket_pos` is the index of the `[` token in `tokens`.
+fn parse_at_index_tokens(
+    tokens: &[SpannedToken],
+    lbracket_pos: usize,
+) -> Result<(&[SpannedToken], usize), TbxError> {
+    let idx_start = lbracket_pos + 1;
+    let close_pos =
+        find_matching_rbracket(tokens, idx_start).ok_or(TbxError::InvalidExpression {
+            reason: "missing ']' in @A[...] index expression",
+        })?;
+    let index_toks = &tokens[idx_start..close_pos];
+    if index_toks.is_empty() {
+        return Err(TbxError::InvalidExpression {
+            reason: "array index expression must not be empty: use @A[index]",
+        });
+    }
+    Ok((index_toks, close_pos))
 }
 
 /// Find the index of the matching closing `)` for an already-consumed `(`.
@@ -1740,18 +1835,78 @@ mod tests {
     }
 
     // ------------------------------------------------------------------
-    // Token::At — array sigil @ (not yet implemented)
+    // Token::At — array binding sigil `@A[i]` element read
     // ------------------------------------------------------------------
 
+    /// `@A[2]` against a global variable A holding a Cell::Array handle must
+    /// compile to: LIT DictAddr(0) FETCH LIT 2 ARRAY_GET.
     #[test]
-    fn test_at_before_ident_is_unimplemented_error() {
-        // `@A[1]` must produce the "not yet implemented" error without panicking.
-        // Register A as a global variable so the identifier would otherwise resolve.
+    fn test_at_global_array_element_read() {
+        let mut vm = make_vm();
+        // Allocate a dictionary slot for the global variable.
+        vm.dict_write(Cell::Int(0)).unwrap();
+        vm.register(crate::dict::WordEntry::new_variable("A", 0));
+
+        let tokens = lex("@A[2]");
+        let result = ExprCompiler::new(&mut vm).compile_expr(&tokens).unwrap();
+
+        let lit_xt = vm.lookup("LIT").unwrap();
+        let fetch_xt = vm.lookup("FETCH").unwrap();
+        let array_get_xt = vm.lookup("ARRAY_GET").unwrap();
+
+        assert_eq!(
+            result,
+            vec![
+                Cell::Xt(lit_xt),
+                Cell::DictAddr(0),
+                Cell::Xt(fetch_xt),
+                Cell::Xt(lit_xt),
+                Cell::Int(2),
+                Cell::Xt(array_get_xt),
+            ]
+        );
+    }
+
+    /// `@A[i]` against a local variable A must compile to:
+    /// LIT StackAddr(idx) FETCH LIT <i> ARRAY_GET.
+    #[test]
+    fn test_at_local_array_element_read() {
+        let mut vm = make_vm();
+
+        // Build a local variable table with "A" at slot 0.
+        let mut local_table = HashMap::new();
+        local_table.insert("A".to_string(), 0usize);
+
+        let tokens = lex("@A[3]");
+        let result = ExprCompiler::with_context(&mut vm, Some(&local_table), None, None)
+            .compile_expr(&tokens)
+            .unwrap();
+
+        let lit_xt = vm.lookup("LIT").unwrap();
+        let fetch_xt = vm.lookup("FETCH").unwrap();
+        let array_get_xt = vm.lookup("ARRAY_GET").unwrap();
+
+        assert_eq!(
+            result,
+            vec![
+                Cell::Xt(lit_xt),
+                Cell::StackAddr(0),
+                Cell::Xt(fetch_xt),
+                Cell::Xt(lit_xt),
+                Cell::Int(3),
+                Cell::Xt(array_get_xt),
+            ]
+        );
+    }
+
+    /// `@A` without a following `[` must produce a clear syntax error.
+    #[test]
+    fn test_at_without_bracket_is_error() {
         let mut vm = make_vm();
         vm.dict_write(Cell::Int(0)).unwrap();
         vm.register(crate::dict::WordEntry::new_variable("A", 0));
 
-        let tokens = lex("@A[1]");
+        let tokens = lex("@A");
         let err = ExprCompiler::new(&mut vm)
             .compile_expr(&tokens)
             .unwrap_err();
@@ -1759,9 +1914,41 @@ mod tests {
             matches!(
                 err,
                 TbxError::InvalidExpression { reason }
-                    if reason.contains("not yet implemented")
+                    if reason.contains("must be followed by '['")
             ),
-            "expected not-yet-implemented error for @A[1], got: {err:?}"
+            "expected error about missing '[' for @A, got: {err:?}"
+        );
+    }
+
+    /// `@A[]` (empty bracket index) must produce a syntax error.
+    #[test]
+    fn test_at_empty_bracket_index_is_error() {
+        let mut vm = make_vm();
+        vm.dict_write(Cell::Int(0)).unwrap();
+        vm.register(crate::dict::WordEntry::new_variable("A", 0));
+
+        let tokens = lex("@A[]");
+        let err = ExprCompiler::new(&mut vm)
+            .compile_expr(&tokens)
+            .unwrap_err();
+        assert!(
+            matches!(err, TbxError::InvalidExpression { .. }),
+            "expected InvalidExpression for @A[], got: {err:?}"
+        );
+    }
+
+    /// `@NOEXIST[1]` (undefined identifier) must produce UndefinedSymbol.
+    #[test]
+    fn test_at_undefined_symbol_is_error() {
+        let mut vm = make_vm();
+
+        let tokens = lex("@NOEXIST[1]");
+        let err = ExprCompiler::new(&mut vm)
+            .compile_expr(&tokens)
+            .unwrap_err();
+        assert!(
+            matches!(err, TbxError::UndefinedSymbol { ref name } if name == "NOEXIST"),
+            "expected UndefinedSymbol for @NOEXIST[1], got: {err:?}"
         );
     }
 

--- a/tests/tbx_lib_tests.rs
+++ b/tests/tbx_lib_tests.rs
@@ -720,3 +720,63 @@ fn test_dim_global_size_expr_error_restores_vm_state() {
         "PUTDEC 1 should produce '1' after recovery"
     );
 }
+
+// ---------------------------------------------------------------------------
+// @A[i] — array binding element read (issue #665)
+// ---------------------------------------------------------------------------
+
+/// `@A[i]` on a local array binding declared with `DIM @A[n]` must return
+/// the value previously written with `SET &A(i), v`.
+#[test]
+fn test_at_array_local_index_read() {
+    let mut interp = Interpreter::new();
+    // DIM @A[3] creates a local array of 3 elements.
+    // SET &A(1), 10 writes 10 to element 1.
+    // RETURN @A[1] reads it back via the new @A[i] syntax.
+    let src = concat!(
+        "DEF F()\n",
+        "  DIM @A[3]\n",
+        "  SET &A(1), 10\n",
+        "  RETURN @A[1]\n",
+        "END\n",
+        "PUTDEC F()\n",
+    );
+    interp
+        .exec_source(src)
+        .expect("@A[1] should read back the value written by SET &A(1), 10");
+    assert_eq!(interp.take_output(), "10");
+}
+
+/// `@A[I + 1]` with an arithmetic expression as the index must evaluate the
+/// expression at runtime and return the correct element.
+#[test]
+fn test_at_array_local_expr_index_read() {
+    let mut interp = Interpreter::new();
+    // DIM @A[3] + SET &A(2), 20 + VAR I = 1 + RETURN @A[I + 1] == 20.
+    let src = concat!(
+        "DEF F()\n",
+        "  DIM @A[3]\n",
+        "  SET &A(2), 20\n",
+        "  VAR I = 1\n",
+        "  RETURN @A[I + 1]\n",
+        "END\n",
+        "PUTDEC F()\n",
+    );
+    interp
+        .exec_source(src)
+        .expect("@A[I + 1] should read element 2 written by SET &A(2), 20");
+    assert_eq!(interp.take_output(), "20");
+}
+
+/// `@G[i]` on a global array binding declared with `DIM @G[n]` at the top
+/// level must return the value previously written with `SET &G(i), v`.
+#[test]
+fn test_at_array_global_index_read() {
+    let mut interp = Interpreter::new();
+    // DIM @G[3] at top level + SET &G(1), 30 + PUTDEC @G[1] == 30.
+    let src = concat!("DIM @G[3]\n", "SET &G(1), 30\n", "PUTDEC @G[1]\n",);
+    interp
+        .exec_source(src)
+        .expect("@G[1] should read back the value written by SET &G(1), 30");
+    assert_eq!(interp.take_output(), "30");
+}


### PR DESCRIPTION
## 概要

`DIM @A[n]` で宣言された array binding に対して、`@A[i]` 構文で要素を読み取れるようにする。
expression compiler の `Token::At` ハンドリングを更新し、local / global の両方で動作するようにした。

## 変更内容

- `src/expr.rs`: `Token::At` の処理を「not yet implemented エラー」から実際の array element read にアップデート
  - `@Ident[index]` をパースして `<load array handle>` + `<index_expr>` + `ARRAY_GET` を emit する
  - local array binding（`local_table` 経由）と global array binding（辞書 lookup）の両方に対応
  - `@Ident` 単体（`[` なし）は明確なエラーにする
  - `@<非ident>` は引き続き明確なエラーにする
- `find_matching_rbracket` ヘルパー関数を追加（`[...]` 内のトークン範囲を探す）
- `parse_at_index_tokens` ヘルパー関数を追加（`@A[...]` の index トークンを抽出する）
- 既存の `test_at_before_ident_is_unimplemented_error` テストを削除し、新しいテストに置き換え
  - `test_at_global_array_element_read`: global variable への `@A[2]` が正しいコードを生成する
  - `test_at_local_array_element_read`: local variable への `@A[3]` が正しいコードを生成する
  - `test_at_without_bracket_is_error`: `@A` 単体がエラーになる
  - `test_at_empty_bracket_index_is_error`: `@A[]` がエラーになる
  - `test_at_undefined_symbol_is_error`: `@NOEXIST[1]` が UndefinedSymbol エラーになる

Closes #665
