### PR TITLE
`&@A[i]` による array element address access を実装する

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -363,6 +363,76 @@ impl<'a> ExprCompiler<'a> {
                                     }
                                 }
                             }
+                            Some(Token::At) => {
+                                // `&@A[i]` — array element address access.
+                                // Consume `@` and then expect: Ident `[` index_expr `]`.
+                                i += 1;
+                                let at_next = tokens.get(i).map(|st| st.token.clone());
+                                match at_next {
+                                    Some(Token::Ident(array_name)) => {
+                                        let array_name = array_name.to_ascii_uppercase();
+                                        let lbracket_pos = i + 1;
+                                        let has_lbracket = tokens
+                                            .get(lbracket_pos)
+                                            .map(|st| matches!(st.token, Token::LBracket))
+                                            .unwrap_or(false);
+                                        if !has_lbracket {
+                                            return Err(TbxError::InvalidExpression {
+                                                reason: "&@Ident must be followed by '[': use &@A[i] syntax",
+                                            });
+                                        }
+                                        // Parse the bracket-enclosed index expression.
+                                        let (index_toks, close_pos) =
+                                            parse_at_index_tokens(tokens, lbracket_pos)?;
+
+                                        // Load the array handle (local or global).
+                                        if let Some(local_idx) = self
+                                            .local_table
+                                            .and_then(|lt| lt.get(&array_name))
+                                            .copied()
+                                        {
+                                            emit_local_read(&mut output, local_idx, self.vm)?;
+                                        } else {
+                                            let xt = self
+                                                .vm
+                                                .lookup_including_self(
+                                                    &array_name,
+                                                    self.self_word.as_deref(),
+                                                )
+                                                .ok_or_else(|| TbxError::UndefinedSymbol {
+                                                    name: array_name.clone(),
+                                                })?;
+                                            match &self.vm.headers[xt.index()].kind {
+                                                EntryKind::Variable(addr) => {
+                                                    emit_var_read(&mut output, *addr, self.vm)?;
+                                                }
+                                                _ => {
+                                                    return Err(TbxError::TypeError {
+                                                        expected:
+                                                            "array variable for &@-sigil address",
+                                                        got: "non-variable",
+                                                    });
+                                                }
+                                            }
+                                        }
+
+                                        // Compile the index expression.
+                                        let index_cells = self.compile_expr(index_toks)?;
+                                        output.extend(index_cells);
+
+                                        // Emit ARRAY_ADDR.
+                                        let array_addr_xt = require_xt(self.vm, "ARRAY_ADDR")?;
+                                        output.push(Cell::Xt(array_addr_xt));
+
+                                        i = close_pos;
+                                    }
+                                    _ => {
+                                        return Err(TbxError::InvalidExpression {
+                                            reason: "&@ must be followed by an identifier: use &@A[i] syntax",
+                                        });
+                                    }
+                                }
+                            }
                             _ => {
                                 return Err(TbxError::TypeError {
                                     expected: "identifier after unary &",
@@ -2051,6 +2121,137 @@ mod tests {
                 Cell::Int(1),
                 Cell::Int(0),
             ]
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // &@A[i] — array element address access (issue #667)
+    // ------------------------------------------------------------------
+
+    /// `&@A[2]` against a global variable A must compile to:
+    /// LIT DictAddr(0) FETCH LIT 2 ARRAY_ADDR.
+    #[test]
+    fn test_ampersand_at_global_array_element_address() {
+        let mut vm = make_vm();
+        vm.dict_write(Cell::Int(0)).unwrap();
+        vm.register(crate::dict::WordEntry::new_variable("A", 0));
+
+        let tokens = lex("&@A[2]");
+        let result = ExprCompiler::new(&mut vm).compile_expr(&tokens).unwrap();
+
+        let lit_xt = vm.lookup("LIT").unwrap();
+        let fetch_xt = vm.lookup("FETCH").unwrap();
+        let array_addr_xt = vm.lookup("ARRAY_ADDR").unwrap();
+
+        assert_eq!(
+            result,
+            vec![
+                Cell::Xt(lit_xt),
+                Cell::DictAddr(0),
+                Cell::Xt(fetch_xt),
+                Cell::Xt(lit_xt),
+                Cell::Int(2),
+                Cell::Xt(array_addr_xt),
+            ]
+        );
+    }
+
+    /// `&@A[3]` against a local variable A at slot 0 must compile to:
+    /// LIT StackAddr(0) FETCH LIT 3 ARRAY_ADDR.
+    #[test]
+    fn test_ampersand_at_local_array_element_address() {
+        let mut vm = make_vm();
+
+        let mut local_table = HashMap::new();
+        local_table.insert("A".to_string(), 0usize);
+
+        let tokens = lex("&@A[3]");
+        let result = ExprCompiler::with_context(&mut vm, Some(&local_table), None, None)
+            .compile_expr(&tokens)
+            .unwrap();
+
+        let lit_xt = vm.lookup("LIT").unwrap();
+        let fetch_xt = vm.lookup("FETCH").unwrap();
+        let array_addr_xt = vm.lookup("ARRAY_ADDR").unwrap();
+
+        assert_eq!(
+            result,
+            vec![
+                Cell::Xt(lit_xt),
+                Cell::StackAddr(0),
+                Cell::Xt(fetch_xt),
+                Cell::Xt(lit_xt),
+                Cell::Int(3),
+                Cell::Xt(array_addr_xt),
+            ]
+        );
+    }
+
+    /// `&@A` (missing `[`) must produce a clear syntax error.
+    #[test]
+    fn test_ampersand_at_missing_bracket_is_error() {
+        let mut vm = make_vm();
+        vm.dict_write(Cell::Int(0)).unwrap();
+        vm.register(crate::dict::WordEntry::new_variable("A", 0));
+
+        let tokens = lex("&@A");
+        let err = ExprCompiler::new(&mut vm)
+            .compile_expr(&tokens)
+            .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                TbxError::InvalidExpression { reason }
+                    if reason.contains("must be followed by '['")
+            ),
+            "expected error about missing '[' for &@A, got: {err:?}"
+        );
+    }
+
+    /// `&@` (missing identifier) must produce a clear syntax error.
+    #[test]
+    fn test_ampersand_at_missing_ident_is_error() {
+        let mut vm = make_vm();
+
+        let tokens = lex("&@[1]");
+        let err = ExprCompiler::new(&mut vm)
+            .compile_expr(&tokens)
+            .unwrap_err();
+        assert!(
+            matches!(err, TbxError::InvalidExpression { .. }),
+            "expected InvalidExpression for &@[1], got: {err:?}"
+        );
+    }
+
+    /// `&@NOEXIST[1]` (undefined identifier) must produce UndefinedSymbol.
+    #[test]
+    fn test_ampersand_at_undefined_symbol_is_error() {
+        let mut vm = make_vm();
+
+        let tokens = lex("&@NOEXIST[1]");
+        let err = ExprCompiler::new(&mut vm)
+            .compile_expr(&tokens)
+            .unwrap_err();
+        assert!(
+            matches!(err, TbxError::UndefinedSymbol { ref name } if name == "NOEXIST"),
+            "expected UndefinedSymbol for &@NOEXIST[1], got: {err:?}"
+        );
+    }
+
+    /// `&@A[]` (empty index) must produce a syntax error.
+    #[test]
+    fn test_ampersand_at_empty_bracket_index_is_error() {
+        let mut vm = make_vm();
+        vm.dict_write(Cell::Int(0)).unwrap();
+        vm.register(crate::dict::WordEntry::new_variable("A", 0));
+
+        let tokens = lex("&@A[]");
+        let err = ExprCompiler::new(&mut vm)
+            .compile_expr(&tokens)
+            .unwrap_err();
+        assert!(
+            matches!(err, TbxError::InvalidExpression { .. }),
+            "expected InvalidExpression for &@A[], got: {err:?}"
         );
     }
 }

--- a/tests/tbx_lib_tests.rs
+++ b/tests/tbx_lib_tests.rs
@@ -780,3 +780,137 @@ fn test_at_array_global_index_read() {
         .expect("@G[1] should read back the value written by SET &G(1), 30");
     assert_eq!(interp.take_output(), "30");
 }
+
+// ---------------------------------------------------------------------------
+// &@A[i] — array element address access (issue #667)
+// ---------------------------------------------------------------------------
+
+/// `SET &@A[i], v` on a local array binding must write the value and
+/// `@A[i]` must read it back.
+#[test]
+fn test_set_at_array_local_element_address() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF F()\n",
+        "  DIM @A[3]\n",
+        "  SET &@A[1], 10\n",
+        "  RETURN @A[1]\n",
+        "END\n",
+        "PUTDEC F()\n",
+    );
+    interp
+        .exec_source(src)
+        .expect("SET &@A[1], 10 should write 10 to element 1 of local array");
+    assert_eq!(interp.take_output(), "10");
+}
+
+/// `SET &@A[I + 1], v` with an arithmetic index expression must write to the
+/// correct element.
+#[test]
+fn test_set_at_array_local_expr_index() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF F()\n",
+        "  DIM @A[3]\n",
+        "  VAR I = 1\n",
+        "  SET &@A[I + 1], 20\n",
+        "  RETURN @A[2]\n",
+        "END\n",
+        "PUTDEC F()\n",
+    );
+    interp
+        .exec_source(src)
+        .expect("SET &@A[I + 1], 20 should write 20 to element 2");
+    assert_eq!(interp.take_output(), "20");
+}
+
+/// `SET &@G[i], v` on a global array binding declared at the top level must
+/// write the value and `@G[i]` must read it back.
+#[test]
+fn test_set_at_array_global_element_address() {
+    let mut interp = Interpreter::new();
+    let src = concat!("DIM @G[3]\n", "SET &@G[1], 30\n", "PUTDEC @G[1]\n",);
+    interp
+        .exec_source(src)
+        .expect("SET &@G[1], 30 should write 30 to element 1 of global array");
+    assert_eq!(interp.take_output(), "30");
+}
+
+/// `SET &@A[2], 99` then `@A[2]` must return 99.
+#[test]
+fn test_set_at_array_second_element() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF F()\n",
+        "  DIM @A[3]\n",
+        "  SET &@A[2], 99\n",
+        "  RETURN @A[2]\n",
+        "END\n",
+        "PUTDEC F()\n",
+    );
+    interp
+        .exec_source(src)
+        .expect("SET &@A[2], 99 should write 99 to element 2");
+    assert_eq!(interp.take_output(), "99");
+}
+
+/// Existing `SET &A(i), v` syntax must still work after introducing `&@A[i]`.
+#[test]
+fn test_set_legacy_array_syntax_still_works() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF F()\n",
+        "  DIM @A[3]\n",
+        "  SET &A(1), 10\n",
+        "  RETURN @A[1]\n",
+        "END\n",
+        "PUTDEC F()\n",
+    );
+    interp
+        .exec_source(src)
+        .expect("legacy SET &A(1) syntax should still work");
+    assert_eq!(interp.take_output(), "10");
+}
+
+/// `&@A` without brackets must produce a compile-time error.
+#[test]
+fn test_at_array_address_missing_bracket_is_error() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF F()\n",
+        "  DIM @A[3]\n",
+        "  SET &@A, 10\n",
+        "  RETURN 0\n",
+        "END\n",
+        "F\n",
+    );
+    interp
+        .exec_source(src)
+        .expect_err("&@A without brackets should fail");
+}
+
+/// `&@` without an identifier must produce a compile-time error.
+#[test]
+fn test_at_array_address_missing_ident_is_error() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF F()\n",
+        "  SET &@[1], 10\n",
+        "  RETURN 0\n",
+        "END\n",
+        "F\n",
+    );
+    interp
+        .exec_source(src)
+        .expect_err("&@[1] without identifier should fail");
+}
+
+/// `&@A[i]` on an undefined binding must produce an UndefinedSymbol error.
+#[test]
+fn test_at_array_address_undefined_binding_is_error() {
+    let mut interp = Interpreter::new();
+    let src = "SET &@A[1], 10\n";
+    interp
+        .exec_source(src)
+        .expect_err("&@A[1] on undefined binding should fail");
+}


### PR DESCRIPTION
## 概要

issue #652 Phase 8 として、`DIM @A[n]` で宣言された array binding に対して `&@A[i]` による array element address / lvalue access を導入する。これにより `SET &@A[i], expr` で array element に代入できるようになる。

## 変更内容

- `src/expr.rs`: `Token::Ampersand` ハンドラの unary ケースに `Token::At` が続く場合の処理を追加
  - parse sequence: `& @ Ident [ index_expr ]`
  - emit sequence: `<load array handle (local or global)> <compile index expr> ARRAY_ADDR`
  - `ARRAY_ADDR` は既存 primitive を再利用
  - malformed な構文（`&@`、`&@[1]`、`&@A`、`&@A[]` など）はコンパイル時エラーとして返す
  - local array binding (StackAddr) / global array binding (DictAddr) の両方に対応
- `src/expr.rs`: `&@A[i]` のコンパイル結果を検証するユニットテストを追加（global / local / エラーケース）
- `tests/tbx_lib_tests.rs`: `SET &@A[i], expr` + `@A[i]` 読み返しの統合テストを追加
  - local array、index expression、global array、第2要素への書き込み
  - regression: 既存の `SET &A(i), v` 構文が引き続き動作することを確認
  - エラーケース: `&@A` (ブラケットなし)、`&@[1]` (識別子なし)、`&@A[1]` (未定義バインディング)

Closes #667
