### PR TITLE
`LET @A[i] = expr` によるarray element assignment sugar を実装する

### DIFF
--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1480,66 +1480,234 @@ fn compile_lvalue_save_prim(vm: &mut VM) -> Result<(), TbxError> {
     Ok(())
 }
 
-/// COMPILE_LVALUE — read a variable name from the token stream and emit `LIT addr` to the
-/// dictionary, where `addr` is the variable's stack or dictionary address.
+/// COMPILE_LVALUE — read a variable name (or `@A[i]` array element form) from the token
+/// stream and emit the corresponding lvalue address sequence to the dictionary.
 ///
-/// This is the compile-time counterpart to the `&var` address-of operator in expressions.
-/// Locals (from `compile_state.local_table`) resolve to `StackAddr`; global variables
-/// (`EntryKind::Variable`) resolve to `DictAddr`.
+/// Two forms are supported:
+///
+/// 1. Scalar: `LET A = expr`
+///    Emits `LIT addr`, where `addr` is the variable's stack or dictionary address.
+///    This is the compile-time counterpart to the `&var` address-of operator in expressions.
+///    Locals (from `compile_state.local_table`) resolve to `StackAddr`; global variables
+///    (`EntryKind::Variable`) resolve to `DictAddr`.
+///
+/// 2. Array element: `LET @A[i] = expr`
+///    Emits `<array handle read>  <index expr>  ARRAY_ADDR`, which leaves the element
+///    address on the stack, ready for the subsequent `SET` instruction emitted by the
+///    caller (`LET` in `basic.tbx`).  This sequence is equivalent to `SET &@A[i], expr`.
 ///
 /// Must be called in compile mode (inside an IMMEDIATE word invocation that runs during a
 /// DEF body compilation). Requires `token_stream` to be set.
 fn compile_lvalue_prim(vm: &mut VM) -> Result<(), TbxError> {
+    use crate::lexer::Token;
+
     if !vm.is_compiling {
         return Err(TbxError::InvalidExpression {
             reason: "COMPILE_LVALUE outside compile mode",
         });
     }
 
-    let name = vm.expect_ident("COMPILE_LVALUE: expected variable name")?;
+    // Peek at the next token to choose the scalar or array-element path.
+    let first_tok = vm.next_token()?;
 
-    // Resolve address: local table first, then global dictionary.
-    // Follow the same take→use→restore→apply-? pattern as compile_expr_prim so that
-    // local_table is always restored before any early return propagates.
-    let addr_cell = {
-        // Take local_table out to avoid borrow conflict with &mut vm below.
-        let local_table = vm
-            .compile_state
-            .as_mut()
-            .map(|s| std::mem::take(&mut s.local_table));
+    match first_tok.token {
+        Token::At => {
+            // Array element lvalue: `LET @A[i] = expr`
+            compile_at_array_lvalue(vm)
+        }
+        Token::Ident(raw_name) => {
+            let name = raw_name.to_ascii_uppercase();
+            // Scalar lvalue: resolve address and emit LIT <addr>.
+            let addr_cell = {
+                // Take local_table out to avoid borrow conflict with &mut vm below.
+                let local_table = vm
+                    .compile_state
+                    .as_mut()
+                    .map(|s| std::mem::take(&mut s.local_table));
 
-        let result: Result<Cell, TbxError> =
-            if let Some(idx) = local_table.as_ref().and_then(|lt| lt.get(&name)).copied() {
-                Ok(Cell::StackAddr(idx))
-            } else {
-                // No `?` here — collect the result and restore local_table first.
-                match vm.lookup(&name) {
-                    None => Err(TbxError::UndefinedSymbol { name }),
-                    Some(xt) => match &vm.headers[xt.index()].kind {
-                        EntryKind::Variable(addr) => Ok(Cell::DictAddr(*addr)),
-                        _ => Err(TbxError::TypeError {
-                            expected: "variable",
-                            got: "non-variable",
-                        }),
-                    },
+                let result: Result<Cell, TbxError> =
+                    if let Some(idx) = local_table.as_ref().and_then(|lt| lt.get(&name)).copied() {
+                        Ok(Cell::StackAddr(idx))
+                    } else {
+                        // No `?` here — collect the result and restore local_table first.
+                        match vm.lookup(&name) {
+                            None => Err(TbxError::UndefinedSymbol { name }),
+                            Some(xt) => match &vm.headers[xt.index()].kind {
+                                EntryKind::Variable(addr) => Ok(Cell::DictAddr(*addr)),
+                                _ => Err(TbxError::TypeError {
+                                    expected: "variable",
+                                    got: "non-variable",
+                                }),
+                            },
+                        }
+                    };
+
+                // Restore local_table unconditionally before propagating any error.
+                if let (Some(state), Some(lt)) = (vm.compile_state.as_mut(), local_table) {
+                    state.local_table = lt;
                 }
+                result?
             };
 
-        // Restore local_table unconditionally before propagating any error.
-        if let (Some(state), Some(lt)) = (vm.compile_state.as_mut(), local_table) {
-            state.local_table = lt;
+            // Emit LIT <addr> to the dictionary.
+            let lit_xt = vm.find_by_kind(|k| matches!(k, EntryKind::Lit)).ok_or(
+                TbxError::UndefinedSymbol {
+                    name: "LIT".to_string(),
+                },
+            )?;
+            vm.dict_write(Cell::Xt(lit_xt))?;
+            vm.dict_write(addr_cell)?;
+            Ok(())
         }
-        result?
+        _ => Err(TbxError::InvalidExpression {
+            reason: "COMPILE_LVALUE: expected variable name or '@' for array element assignment",
+        }),
+    }
+}
+
+/// Compile the lvalue sequence for `LET @A[i] = expr`.
+///
+/// Called after `@` has already been consumed from the token stream.
+///
+/// Parses `Ident [ index_expr ]` and emits:
+///   `<array handle read>  <compiled index_expr>  ARRAY_ADDR`
+///
+/// This leaves a `Cell::DictAddr` (element address) on the runtime stack, ready
+/// for the subsequent `SET` instruction that the `LET` word in `basic.tbx` appends.
+///
+/// Error cases — all produce compile-time errors (no panics):
+///   - No identifier after `@`        → `InvalidExpression`
+///   - No `[` after identifier        → `InvalidExpression` (`LET @A = expr`)
+///   - Empty index expression `@A[]`  → `InvalidExpression`
+///   - Unterminated `[`               → `InvalidExpression`
+///   - Undefined array name           → `UndefinedSymbol`
+///   - Name is not an array variable  → `TypeError`
+fn compile_at_array_lvalue(vm: &mut VM) -> Result<(), TbxError> {
+    use crate::lexer::Token;
+
+    // Expect the array binding identifier (bare name, e.g. `A` for `@A`).
+    let array_name_tok = vm.next_token()?;
+    let array_name = match array_name_tok.token {
+        Token::Ident(n) => n.to_ascii_uppercase(),
+        _ => {
+            return Err(TbxError::InvalidExpression {
+                reason: "LET @: expected array binding identifier (e.g. LET @A[i] = expr)",
+            });
+        }
     };
 
-    // Emit LIT <addr> to the dictionary.
+    // Expect `[`.
+    let lb_tok = vm.next_token().map_err(|_| TbxError::InvalidExpression {
+        reason: "LET @A: expected '[' after array name (e.g. LET @A[i] = expr)",
+    })?;
+    if lb_tok.token != Token::LBracket {
+        return Err(TbxError::InvalidExpression {
+            reason: "LET @A: expected '[' — bare '@A' is not a valid lvalue (use LET @A[i] = expr)",
+        });
+    }
+
+    // Collect tokens up to the matching `]`, depth-aware.
+    let index_tokens: Vec<crate::lexer::SpannedToken> = {
+        let stream = vm.token_stream.as_mut().ok_or(TbxError::TokenStreamEmpty)?;
+        let mut depth: usize = 1;
+        let mut collected: Vec<crate::lexer::SpannedToken> = Vec::new();
+        loop {
+            let tok = stream.pop_front().ok_or(TbxError::InvalidExpression {
+                reason: "LET @A[: unterminated '[' — expected ']'",
+            })?;
+            match &tok.token {
+                Token::LBracket => {
+                    depth += 1;
+                    collected.push(tok);
+                }
+                Token::RBracket => {
+                    depth -= 1;
+                    if depth == 0 {
+                        break;
+                    }
+                    collected.push(tok);
+                }
+                Token::Newline | Token::Eof => {
+                    return Err(TbxError::InvalidExpression {
+                        reason: "LET @A[: unterminated '[' — unexpected end of line",
+                    });
+                }
+                _ => {
+                    collected.push(tok);
+                }
+            }
+        }
+        collected
+    };
+
+    // Reject empty index: `LET @A[] = expr`.
+    if index_tokens.is_empty() {
+        return Err(TbxError::InvalidExpression {
+            reason: "LET @A[]: array index expression must not be empty (use LET @A[i] = expr)",
+        });
+    }
+
+    // Compile the index expression using the current local table.
+    let (index_cells, index_patch_offsets) = compile_expr_taking_local_table(vm, &index_tokens)?;
+
+    // Resolve the array handle: local binding takes priority over global.
+    let local_idx: Option<usize> = vm
+        .compile_state
+        .as_ref()
+        .and_then(|s| s.local_table.get(&array_name).copied());
+
     let lit_xt =
         vm.find_by_kind(|k| matches!(k, EntryKind::Lit))
             .ok_or(TbxError::UndefinedSymbol {
                 name: "LIT".to_string(),
             })?;
-    vm.dict_write(Cell::Xt(lit_xt))?;
-    vm.dict_write(addr_cell)?;
+    let fetch_xt = vm.lookup("FETCH").ok_or(TbxError::UndefinedSymbol {
+        name: "FETCH".to_string(),
+    })?;
+    let array_addr_xt = vm.lookup("ARRAY_ADDR").ok_or(TbxError::UndefinedSymbol {
+        name: "ARRAY_ADDR".to_string(),
+    })?;
+
+    if let Some(idx) = local_idx {
+        // Emit: LIT StackAddr(idx)  FETCH  — load the local array handle.
+        vm.dict_write(Cell::Xt(lit_xt))?;
+        vm.dict_write(Cell::StackAddr(idx))?;
+        vm.dict_write(Cell::Xt(fetch_xt))?;
+    } else {
+        // Look up in the global dictionary.
+        let xt = vm.lookup(&array_name).ok_or(TbxError::UndefinedSymbol {
+            name: array_name.clone(),
+        })?;
+        let addr = match &vm.headers[xt.index()].kind {
+            EntryKind::Variable(addr) => *addr,
+            _ => {
+                return Err(TbxError::TypeError {
+                    expected: "array variable for LET @-sigil lvalue",
+                    got: "non-variable",
+                });
+            }
+        };
+        // Emit: LIT DictAddr(addr)  FETCH  — load the global array handle.
+        vm.dict_write(Cell::Xt(lit_xt))?;
+        vm.dict_write(Cell::DictAddr(addr))?;
+        vm.dict_write(Cell::Xt(fetch_xt))?;
+    }
+
+    // Emit the compiled index expression.
+    let base_dp = vm.dp;
+    for cell in index_cells {
+        vm.dict_write(cell)?;
+    }
+    // Register any self-recursive call patch positions from the index expression.
+    if let Some(state) = vm.compile_state.as_mut() {
+        for offset in index_patch_offsets {
+            state.call_patch_list.push(base_dp + offset);
+        }
+    }
+
+    // Emit ARRAY_ADDR — pops (Array, index) and pushes the element address.
+    vm.dict_write(Cell::Xt(array_addr_xt))?;
+
     Ok(())
 }
 

--- a/tests/tbx_lib_tests.rs
+++ b/tests/tbx_lib_tests.rs
@@ -914,3 +914,219 @@ fn test_at_array_address_undefined_binding_is_error() {
         .exec_source(src)
         .expect_err("&@A[1] on undefined binding should fail");
 }
+
+// ───────────────────────────────────────────────────────────────────────────
+// LET @A[i] = expr — array element assignment sugar (issue #669)
+// ───────────────────────────────────────────────────────────────────────────
+
+/// `LET @A[i] = expr` on a local array binding must write the value and
+/// `@A[i]` must read it back.
+#[test]
+fn test_let_at_array_local_element_assignment() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF F()\n",
+        "  DIM @A[3]\n",
+        "  LET @A[1] = 10\n",
+        "  RETURN @A[1]\n",
+        "END\n",
+        "PUTDEC F()\n",
+    );
+    interp
+        .exec_source(src)
+        .expect("LET @A[1] = 10 should write 10 to element 1 of local array");
+    assert_eq!(interp.take_output(), "10");
+}
+
+/// `LET @A[I + 1] = expr` with an arithmetic index expression must write to
+/// the correct element.
+#[test]
+fn test_let_at_array_index_expression() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF F()\n",
+        "  DIM @A[3]\n",
+        "  VAR I = 1\n",
+        "  LET @A[I + 1] = 20\n",
+        "  RETURN @A[2]\n",
+        "END\n",
+        "PUTDEC F()\n",
+    );
+    interp
+        .exec_source(src)
+        .expect("LET @A[I + 1] = 20 should write 20 to element 2");
+    assert_eq!(interp.take_output(), "20");
+}
+
+/// `LET @A[i] = <arithmetic expr>` must evaluate the RHS before storing.
+#[test]
+fn test_let_at_array_rhs_expression() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF F()\n",
+        "  DIM @A[3]\n",
+        "  LET @A[1] = 10 + 20\n",
+        "  RETURN @A[1]\n",
+        "END\n",
+        "PUTDEC F()\n",
+    );
+    interp
+        .exec_source(src)
+        .expect("LET @A[1] = 10 + 20 should store 30");
+    assert_eq!(interp.take_output(), "30");
+}
+
+/// `LET @G[i] = expr` on a global array binding declared with `DIM @G[n]`
+/// at the top level must write the value when called from inside a DEF body.
+///
+/// Note: `LET` uses `COMPILE_LVALUE` which requires compile mode; top-level
+/// (execute-mode) `LET @G[i] = expr` is intentionally unsupported, matching
+/// the same constraint as top-level `LET V = expr` for scalar variables.
+#[test]
+fn test_let_at_array_global_element_assignment() {
+    let mut interp = Interpreter::new();
+    // DIM @G at top level; LET @G[i] inside DEF to stay in compile mode.
+    let src = concat!(
+        "DIM @G[3]\n",
+        "DEF F()\n",
+        "  LET @G[1] = 30\n",
+        "END\n",
+        "F\n",
+        "PUTDEC @G[1]\n",
+    );
+    interp
+        .exec_source(src)
+        .expect("LET @G[1] = 30 inside DEF should write 30 to element 1 of global array");
+    assert_eq!(interp.take_output(), "30");
+}
+
+/// `LET @A[i] = expr` must produce the same result as `SET &@A[i], expr`.
+#[test]
+fn test_let_at_array_equivalent_to_set_address() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF F()\n",
+        "  DIM @A[3]\n",
+        "  LET @A[2] = 99\n",
+        "  RETURN @A[2]\n",
+        "END\n",
+        "PUTDEC F()\n",
+    );
+    interp
+        .exec_source(src)
+        .expect("LET @A[2] = 99 should be equivalent to SET &@A[2], 99");
+    assert_eq!(interp.take_output(), "99");
+}
+
+/// `LET A = expr` scalar assignment must still work after adding array sugar.
+#[test]
+fn test_let_scalar_assignment_regression() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF F()\n",
+        "  VAR A\n",
+        "  LET A = 42\n",
+        "  RETURN A\n",
+        "END\n",
+        "PUTDEC F()\n",
+    );
+    interp
+        .exec_source(src)
+        .expect("LET A = 42 scalar assignment should still work");
+    assert_eq!(interp.take_output(), "42");
+}
+
+/// `SET &@A[i], expr` must continue to work after introducing `LET @A[i]`.
+#[test]
+fn test_set_at_array_address_regression() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF F()\n",
+        "  DIM @A[3]\n",
+        "  SET &@A[2], 99\n",
+        "  RETURN @A[2]\n",
+        "END\n",
+        "PUTDEC F()\n",
+    );
+    interp
+        .exec_source(src)
+        .expect("SET &@A[2], 99 should still work");
+    assert_eq!(interp.take_output(), "99");
+}
+
+/// `LET @A = expr` (missing brackets) must produce a compile-time error.
+#[test]
+fn test_let_at_array_missing_bracket_is_error() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF F()\n",
+        "  DIM @A[3]\n",
+        "  LET @A = 10\n",
+        "  RETURN 0\n",
+        "END\n",
+        "F\n",
+    );
+    interp
+        .exec_source(src)
+        .expect_err("LET @A = 10 without brackets should fail");
+}
+
+/// `LET @[1] = expr` (missing identifier after `@`) must produce a compile-time error.
+#[test]
+fn test_let_at_array_missing_ident_is_error() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF F()\n",
+        "  LET @[1] = 10\n",
+        "  RETURN 0\n",
+        "END\n",
+        "F\n",
+    );
+    interp
+        .exec_source(src)
+        .expect_err("LET @[1] = 10 without identifier should fail");
+}
+
+/// `LET @A[] = expr` (empty index) must produce a compile-time error.
+#[test]
+fn test_let_at_array_empty_index_is_error() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF F()\n",
+        "  DIM @A[3]\n",
+        "  LET @A[] = 10\n",
+        "  RETURN 0\n",
+        "END\n",
+        "F\n",
+    );
+    interp
+        .exec_source(src)
+        .expect_err("LET @A[] = 10 with empty index should fail");
+}
+
+/// `LET @A[1] = expr` on an undefined array binding must produce an error.
+#[test]
+fn test_let_at_array_undefined_binding_is_error() {
+    let mut interp = Interpreter::new();
+    let src = "LET @A[1] = 10\n";
+    interp
+        .exec_source(src)
+        .expect_err("LET @A[1] on undefined binding should fail");
+}
+
+/// `LET T[i] = expr` (tuple projection assignment) must remain unsupported.
+#[test]
+fn test_let_tuple_projection_assignment_is_error() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF F()\n",
+        "  VAR T = TUPLE(1, 2, 3)\n",
+        "  LET T[1] = 10\n",
+        "  RETURN 0\n",
+        "END\n",
+        "F\n",
+    );
+    interp
+        .exec_source(src)
+        .expect_err("LET T[1] = 10 tuple projection assignment should fail");
+}


### PR DESCRIPTION
## 概要

`LET @A[i] = expr` を `SET &@A[i], expr` と同等の syntax sugar として実装する。
`COMPILE_LVALUE` プリミティブを拡張し、LHS が `Token::At` の場合に `@A[i]` 形式の配列要素 lvalue として処理する。

## 変更内容

- `src/primitives.rs`: `compile_lvalue_prim` を修正し、先頭トークンが `Token::At` の場合に新規ヘルパー `compile_at_array_lvalue` へ委譲する分岐を追加
- `src/primitives.rs`: `compile_at_array_lvalue` ヘルパーを追加。`@A[i]` の LHS parse と emit sequence（`<array handle read>  <index expr>  ARRAY_ADDR`）を生成する
- `tests/tbx_lib_tests.rs`: 成功ケース・エラーケース・回帰テストを追加（計12テスト）

### emit sequence

```
LET @A[i] = expr
```

は次と同等のコードを emit する（新しい runtime primitive は追加しない）:

```
<array handle read>   -- LIT StackAddr/DictAddr + FETCH
<index expr>          -- compiled index expression
ARRAY_ADDR            -- pops (Array, index), pushes element address
<rhs expr>            -- compiled RHS expression
SET                   -- stores RHS into element address
```

### 制限事項

`LET`（`COMPILE_LVALUE`）は compile mode 専用であるため、`LET @G[i] = expr` をトップレベルで実行することはできない。これは既存の `LET V = expr` スカラー代入と同じ制約であり、DEF 内から global array binding を操作することで回避可能。

### テスト追加内容

成功ケース:
- local array element への代入
- 算術式をインデックスに使用
- 算術式を RHS に使用
- DEF 内から global array binding への代入
- `SET &@A[i], expr` と同等の結果になること

回帰テスト:
- `LET A = expr` スカラー代入が壊れていないこと
- `SET &@A[i], expr` が引き続き動作すること

エラーケース:
- `LET @A = expr`（bracket なし）→ compile-time error
- `LET @[1] = expr`（identifier なし）→ compile-time error
- `LET @A[] = expr`（空の index）→ compile-time error
- 未定義 binding → error
- tuple projection assignment `LET T[i] = expr` → error

Closes #669
