### PR TITLE
lib/tests と tbx_lib_tests.rs の旧配列アクセス構文を新構文へ移行する

### DIFF
--- a/lib/tests/test_array.tbx
+++ b/lib/tests/test_array.tbx
@@ -6,10 +6,10 @@ USE "lib/tests/helper.tbx"
 DEF MAKE_AND_READ()
   VAR A
   LET A = ARRAY(3)
-  SET &A(1), 10
-  SET &A(2), 20
-  SET &A(3), 30
-  RETURN A(1) + A(2) + A(3)
+  LET @A[1] = 10
+  LET @A[2] = 20
+  LET @A[3] = 30
+  RETURN @A[1] + @A[2] + @A[3]
 END
 ASSERT MAKE_AND_READ() = 60
 
@@ -19,7 +19,7 @@ DEF FIRST_ELEM_IS_NONE()
   VAR A
   LET A = ARRAY(5)
   # Cell::None is falsy, so this checks the initial value
-  IF A(1) = 0
+  IF @A[1] = 0
     RETURN 1
   ENDIF
   RETURN 0
@@ -35,9 +35,9 @@ DEF TWO_ARRAYS()
   VAR B
   LET A = ARRAY(2)
   LET B = ARRAY(2)
-  SET &A(1), 100
-  SET &B(1), 200
-  RETURN A(1) + B(1)
+  LET @A[1] = 100
+  LET @B[1] = 200
+  RETURN @A[1] + @B[1]
 END
 ASSERT TWO_ARRAYS() = 300
 
@@ -46,8 +46,8 @@ ASSERT TWO_ARRAYS() = 300
 DEF INNER()
   VAR A
   LET A = ARRAY(3)
-  SET &A(1), 42
-  RETURN A(1)
+  LET @A[1] = 42
+  RETURN @A[1]
 END
 
 DEF OUTER()
@@ -78,8 +78,8 @@ DEF SUM_ARRAY(N)
   LET I = 1
   LET S = 0
   WHILE I <= N
-    SET &A(I), (I - 1) * 2
-    LET S = S + A(I)
+    LET @A[I] = (I - 1) * 2
+    LET S = S + @A[I]
     LET I = I + 1
   ENDWH
   RETURN S

--- a/lib/tests/test_array_len.tbx
+++ b/lib/tests/test_array_len.tbx
@@ -26,12 +26,12 @@ DEF SUM_WITH_LEN(N)
   LET I = 1
   LET S = 0
   WHILE I <= N
-    SET &A(I), I
+    LET @A[I] = I
     LET I = I + 1
   ENDWH
   LET I = 1
   WHILE I <= ARRAY_LEN(A)
-    LET S = S + A(I)
+    LET S = S + @A[I]
     LET I = I + 1
   ENDWH
   RETURN S

--- a/lib/tests/test_return_ownership.tbx
+++ b/lib/tests/test_return_ownership.tbx
@@ -36,17 +36,17 @@ END
 DEF HMS_HOUR(T)
   VAR A
   LET A = HMS(T)
-  RETURN A(1)
+  RETURN @A[1]
 END
 DEF HMS_MIN(T)
   VAR A
   LET A = HMS(T)
-  RETURN A(2)
+  RETURN @A[2]
 END
 DEF HMS_SEC(T)
   VAR A
   LET A = HMS(T)
-  RETURN A(3)
+  RETURN @A[3]
 END
 ASSERT HMS_HOUR(3661) = 1
 ASSERT HMS_MIN(3661) = 1
@@ -66,9 +66,9 @@ END
 DEF CHECK_CHAINED_ARRAY()
   VAR R
   LET R = MAKE_ARRAY_OUTER()
-  IF R(1) = 10
-    IF R(2) = 20
-      IF R(3) = 30
+  IF @R[1] = 10
+    IF @R[2] = 20
+      IF @R[3] = 30
         RETURN 1
       ENDIF
     ENDIF
@@ -96,8 +96,8 @@ END
 DEF CHECK_RETURN_SECOND()
   VAR R
   LET R = RETURN_SECOND()
-  IF R(1) = 3
-    IF R(2) = 4
+  IF @R[1] = 3
+    IF @R[2] = 4
       RETURN 1
     ENDIF
   ENDIF

--- a/lib/tests/test_to_array.tbx
+++ b/lib/tests/test_to_array.tbx
@@ -6,7 +6,7 @@ USE "lib/tests/helper.tbx"
 DEF TO_ARRAY_SUM()
   VAR A
   LET A = TO_ARRAY(1, 2, 3)
-  RETURN A(1) + A(2) + A(3)
+  RETURN @A[1] + @A[2] + @A[3]
 END
 ASSERT TO_ARRAY_SUM() = 6
 
@@ -15,9 +15,9 @@ ASSERT TO_ARRAY_SUM() = 6
 DEF TO_ARRAY_ORDER()
   VAR A
   LET A = TO_ARRAY(10, 20, 30)
-  IF A(1) = 10
-    IF A(2) = 20
-      IF A(3) = 30
+  IF @A[1] = 10
+    IF @A[2] = 20
+      IF @A[3] = 30
         RETURN 1
       ENDIF
     ENDIF
@@ -40,7 +40,7 @@ ASSERT TO_ARRAY_EMPTY() = 99
 DEF TO_ARRAY_ONE()
   VAR A
   LET A = TO_ARRAY(42)
-  RETURN A(1)
+  RETURN @A[1]
 END
 ASSERT TO_ARRAY_ONE() = 42
 
@@ -49,18 +49,18 @@ ASSERT TO_ARRAY_ONE() = 42
 DEF TO_ARRAY_MUTATE()
   VAR A
   LET A = TO_ARRAY(1, 2, 3)
-  SET &A(2), 99
-  RETURN A(1) + A(2) + A(3)
+  SET &@A[2], 99
+  RETURN @A[1] + @A[2] + @A[3]
 END
 ASSERT TO_ARRAY_MUTATE() = 103
 
-# --- Top-level global array variable supports A(I) / &A(I) ---
+# --- Top-level global array variable supports @A[I] / &@A[I] ---
 
 VAR TOP_ARR
 SET &TOP_ARR, TO_ARRAY(10, 20)
-ASSERT TOP_ARR(2) = 20
-SET &TOP_ARR(2), 123
-ASSERT TOP_ARR(2) = 123
+ASSERT @TOP_ARR[2] = 20
+SET &@TOP_ARR[2], 123
+ASSERT @TOP_ARR[2] = 123
 
 # --- FROM_ARRAY: single-element array (expression context) ---
 # With exactly one element, FROM_ARRAY pushes one value, which behaves
@@ -101,9 +101,9 @@ ASSERT FROM_ARRAY_EMPTY_STMT() = 2
 DEF ROUNDTRIP()
   VAR A
   LET A = TO_ARRAY(100, 200, 300)
-  IF A(1) = 100
-    IF A(2) = 200
-      IF A(3) = 300
+  IF @A[1] = 100
+    IF @A[2] = 200
+      IF @A[3] = 300
         RETURN 1
       ENDIF
     ENDIF
@@ -122,10 +122,10 @@ DEF ARRAY_CONCAT_BASIC()
   LET B = TO_ARRAY(3, 4)
   LET C = ARRAY_CONCAT(A, B)
   IF ARRAY_LEN(C) = 4
-    IF C(1) = 1
-      IF C(2) = 2
-        IF C(3) = 3
-          IF C(4) = 4
+    IF @C[1] = 1
+      IF @C[2] = 2
+        IF @C[3] = 3
+          IF @C[4] = 4
             IF ARRAY_LEN(A) = 2
               IF ARRAY_LEN(B) = 2
                 RETURN 1
@@ -150,8 +150,8 @@ DEF ARRAY_CONCAT_EMPTY_LEFT()
   LET B = TO_ARRAY(9, 8)
   LET C = ARRAY_CONCAT(A, B)
   IF ARRAY_LEN(C) = 2
-    IF C(1) = 9
-      IF C(2) = 8
+    IF @C[1] = 9
+      IF @C[2] = 8
         RETURN 1
       ENDIF
     ENDIF

--- a/lib/tests/test_var_init.tbx
+++ b/lib/tests/test_var_init.tbx
@@ -62,10 +62,10 @@ ASSERT STR_INIT() = 5
 
 DEF ARRAY_INIT()
   VAR A = ARRAY(3)
-  SET &A(1), 10
-  SET &A(2), 20
-  SET &A(3), 30
-  RETURN A(1) + A(2) + A(3)
+  LET @A[1] = 10
+  LET @A[2] = 20
+  LET @A[3] = 30
+  RETURN @A[1] + @A[2] + @A[3]
 END
 ASSERT ARRAY_INIT() = 60
 

--- a/tests/tbx_lib_tests.rs
+++ b/tests/tbx_lib_tests.rs
@@ -110,7 +110,7 @@ fn test_array_index_zero_is_out_of_bounds() {
         .set_base_dir(base)
         .expect("CARGO_MANIFEST_DIR is always absolute");
     // Array indices are 1-based; index 0 must return ArrayIndexOutOfBounds.
-    let src = "DEF T()\n  VAR A\n  LET A = ARRAY(3)\n  RETURN A(0)\nEND\nT\n";
+    let src = "DEF T()\n  VAR A\n  LET A = ARRAY(3)\n  RETURN @A[0]\nEND\nT\n";
     let err = interp
         .exec_source(src)
         .expect_err("index 0 should be out of bounds");
@@ -129,7 +129,7 @@ fn test_array_index_zero_is_out_of_bounds() {
 // the string alive independently of any stack frame, so no per-source-lifetime
 // classification is needed.  Nested `Cell::Array` is still rejected.
 
-/// SET &A(1), STR("hello") inside a word must succeed (#591).
+/// SET &@A[1], STR("hello") inside a word must succeed (#591).
 /// STR() produces a runtime Rc<str>-backed string, which is now allowed as
 /// an array element.  The word is called without parentheses (statement form)
 /// because it has no return value.
@@ -137,18 +137,18 @@ fn test_array_index_zero_is_out_of_bounds() {
 fn test_set_runtime_str_into_array_is_allowed() {
     let mut interp = Interpreter::new();
     // Note: void DEF is called without parentheses (statement form).
-    let src = "DEF T()\n  VAR A\n  LET A = ARRAY(1)\n  SET &A(1), STR(\"hello\")\nEND\nT\n";
+    let src = "DEF T()\n  VAR A\n  LET A = ARRAY(1)\n  SET &@A[1], STR(\"hello\")\nEND\nT\n";
     interp
         .exec_source(src)
         .expect("storing runtime Str in array should succeed");
 }
 
-/// SET &A(1), "hello" (compile-time literal) must succeed (#591).
+/// SET &@A[1], "hello" (compile-time literal) must succeed (#591).
 /// Array indices are 1-based in TBX.
 #[test]
 fn test_set_literal_str_into_array_is_allowed() {
     let mut interp = Interpreter::new();
-    let src = "VAR A\nSET &A, ARRAY(1)\nSET &A(1), \"hello\"\nPUTSTR A(1)\n";
+    let src = "VAR A\nSET &A, ARRAY(1)\nSET &@A[1], \"hello\"\nPUTSTR @A[1]\n";
     interp
         .exec_source(src)
         .expect("storing string literal in array should succeed");
@@ -161,7 +161,7 @@ fn test_set_literal_str_into_array_is_allowed() {
 fn test_set_literal_str_into_array_inside_def_is_allowed() {
     let mut interp = Interpreter::new();
     let src =
-        "DEF MAKE()\n  VAR A\n  SET &A, ARRAY(1)\n  SET &A(1), \"inside\"\n  PUTSTR A(1)\nEND\nMAKE\n";
+        "DEF MAKE()\n  VAR A\n  SET &A, ARRAY(1)\n  SET &@A[1], \"inside\"\n  PUTSTR @A[1]\nEND\nMAKE\n";
     interp
         .exec_source(src)
         .expect("storing string literal in array inside DEF should succeed");
@@ -175,7 +175,7 @@ fn test_set_literal_str_into_array_inside_def_is_allowed() {
 fn test_set_runtime_str_into_global_array_survives_word_return() {
     let mut interp = Interpreter::new();
     // F is a void word; call it without parentheses to avoid DROP_TO_MARKER mismatch.
-    let src = "VAR A\nSET &A, ARRAY(1)\nDEF F()\n  SET &A(1), STR_CONCAT(\"foo\", \"bar\")\nEND\nF\nPUTSTR A(1)\n";
+    let src = "VAR A\nSET &A, ARRAY(1)\nDEF F()\n  SET &@A[1], STR_CONCAT(\"foo\", \"bar\")\nEND\nF\nPUTSTR @A[1]\n";
     interp
         .exec_source(src)
         .expect("storing runtime Str in global array should succeed");
@@ -188,7 +188,7 @@ fn test_set_runtime_str_into_global_array_survives_word_return() {
 fn test_set_runtime_str_into_frame_local_array_is_allowed() {
     let mut interp = Interpreter::new();
     // F is a void word; call it without parentheses to avoid DROP_TO_MARKER mismatch.
-    let src = "DEF F()\n  VAR A\n  SET &A, ARRAY(1)\n  SET &A(1), STR(\"hello\")\n  PUTSTR A(1)\nEND\nF\n";
+    let src = "DEF F()\n  VAR A\n  SET &A, ARRAY(1)\n  SET &@A[1], STR(\"hello\")\n  PUTSTR @A[1]\nEND\nF\n";
     interp
         .exec_source(src)
         .expect("storing runtime Str in frame-local array should succeed");
@@ -199,7 +199,7 @@ fn test_set_runtime_str_into_frame_local_array_is_allowed() {
 #[test]
 fn test_set_caller_owned_str_param_into_frame_local_array_is_allowed() {
     let mut interp = Interpreter::new();
-    let src = "DEF USE(S)\n  VAR A\n  SET &A, ARRAY(1)\n  SET &A(1), S\n  PUTSTR A(1)\nEND\nUSE(\"arg\")\n";
+    let src = "DEF USE(S)\n  VAR A\n  SET &A, ARRAY(1)\n  SET &@A[1], S\n  PUTSTR @A[1]\nEND\nUSE(\"arg\")\n";
     interp
         .exec_source(src)
         .expect("storing caller-owned Str param in frame-local array should succeed");
@@ -212,7 +212,8 @@ fn test_set_caller_owned_str_param_into_frame_local_array_is_allowed() {
 fn test_to_array_with_str_elements_is_allowed() {
     let mut interp = Interpreter::new();
     // Store TO_ARRAY result, read element 1 and 2 back via PUTSTR.
-    let src = "VAR A\nSET &A, TO_ARRAY(STR(\"alpha\"), STR(\"beta\"))\nPUTSTR A(1)\nPUTSTR A(2)\n";
+    let src =
+        "VAR A\nSET &A, TO_ARRAY(STR(\"alpha\"), STR(\"beta\"))\nPUTSTR @A[1]\nPUTSTR @A[2]\n";
     interp
         .exec_source(src)
         .expect("TO_ARRAY with Str elements should succeed");
@@ -225,7 +226,7 @@ fn test_str_ops_on_array_element_str() {
     let mut interp = Interpreter::new();
     // Use PUTSTR to exercise reading the element and passing it to string primitives.
     // STR_CONCAT output confirms the element was successfully read as Str.
-    let src = "VAR A\nSET &A, ARRAY(1)\nSET &A(1), \"hello\"\nPUTSTR STR_CONCAT(A(1), \"!\")\n";
+    let src = "VAR A\nSET &A, ARRAY(1)\nSET &@A[1], \"hello\"\nPUTSTR STR_CONCAT(@A[1], \"!\")\n";
     interp
         .exec_source(src)
         .expect("string ops on array element should succeed");
@@ -238,7 +239,7 @@ fn test_set_array_into_array_is_invalid_element_type() {
     let mut interp = Interpreter::new();
     // Create an outer array and a nested array, then try to store the inner in outer.
     let src =
-        "DEF T()\n  VAR A, B\n  LET A = ARRAY(3)\n  LET B = ARRAY(2)\n  SET &A(1), B\nEND\nT\n";
+        "DEF T()\n  VAR A, B\n  LET A = ARRAY(3)\n  LET B = ARRAY(2)\n  SET &@A[1], B\nEND\nT\n";
     let err = interp
         .exec_source(src)
         .expect_err("storing Array in array element should fail");
@@ -726,24 +727,24 @@ fn test_dim_global_size_expr_error_restores_vm_state() {
 // ---------------------------------------------------------------------------
 
 /// `@A[i]` on a local array binding declared with `DIM @A[n]` must return
-/// the value previously written with `SET &A(i), v`.
+/// the value previously written with `SET &@A[i], v`.
 #[test]
 fn test_at_array_local_index_read() {
     let mut interp = Interpreter::new();
     // DIM @A[3] creates a local array of 3 elements.
-    // SET &A(1), 10 writes 10 to element 1.
+    // SET &@A[1], 10 writes 10 to element 1.
     // RETURN @A[1] reads it back via the new @A[i] syntax.
     let src = concat!(
         "DEF F()\n",
         "  DIM @A[3]\n",
-        "  SET &A(1), 10\n",
+        "  SET &@A[1], 10\n",
         "  RETURN @A[1]\n",
         "END\n",
         "PUTDEC F()\n",
     );
     interp
         .exec_source(src)
-        .expect("@A[1] should read back the value written by SET &A(1), 10");
+        .expect("@A[1] should read back the value written by SET &@A[1], 10");
     assert_eq!(interp.take_output(), "10");
 }
 
@@ -752,11 +753,11 @@ fn test_at_array_local_index_read() {
 #[test]
 fn test_at_array_local_expr_index_read() {
     let mut interp = Interpreter::new();
-    // DIM @A[3] + SET &A(2), 20 + VAR I = 1 + RETURN @A[I + 1] == 20.
+    // DIM @A[3] + SET &@A[2], 20 + VAR I = 1 + RETURN @A[I + 1] == 20.
     let src = concat!(
         "DEF F()\n",
         "  DIM @A[3]\n",
-        "  SET &A(2), 20\n",
+        "  SET &@A[2], 20\n",
         "  VAR I = 1\n",
         "  RETURN @A[I + 1]\n",
         "END\n",
@@ -764,20 +765,20 @@ fn test_at_array_local_expr_index_read() {
     );
     interp
         .exec_source(src)
-        .expect("@A[I + 1] should read element 2 written by SET &A(2), 20");
+        .expect("@A[I + 1] should read element 2 written by SET &@A[2], 20");
     assert_eq!(interp.take_output(), "20");
 }
 
 /// `@G[i]` on a global array binding declared with `DIM @G[n]` at the top
-/// level must return the value previously written with `SET &G(i), v`.
+/// level must return the value previously written with `SET &@G[i], v`.
 #[test]
 fn test_at_array_global_index_read() {
     let mut interp = Interpreter::new();
-    // DIM @G[3] at top level + SET &G(1), 30 + PUTDEC @G[1] == 30.
-    let src = concat!("DIM @G[3]\n", "SET &G(1), 30\n", "PUTDEC @G[1]\n",);
+    // DIM @G[3] at top level + SET &@G[1], 30 + PUTDEC @G[1] == 30.
+    let src = concat!("DIM @G[3]\n", "SET &@G[1], 30\n", "PUTDEC @G[1]\n",);
     interp
         .exec_source(src)
-        .expect("@G[1] should read back the value written by SET &G(1), 30");
+        .expect("@G[1] should read back the value written by SET &@G[1], 30");
     assert_eq!(interp.take_output(), "30");
 }
 
@@ -852,24 +853,6 @@ fn test_set_at_array_second_element() {
         .exec_source(src)
         .expect("SET &@A[2], 99 should write 99 to element 2");
     assert_eq!(interp.take_output(), "99");
-}
-
-/// Existing `SET &A(i), v` syntax must still work after introducing `&@A[i]`.
-#[test]
-fn test_set_legacy_array_syntax_still_works() {
-    let mut interp = Interpreter::new();
-    let src = concat!(
-        "DEF F()\n",
-        "  DIM @A[3]\n",
-        "  SET &A(1), 10\n",
-        "  RETURN @A[1]\n",
-        "END\n",
-        "PUTDEC F()\n",
-    );
-    interp
-        .exec_source(src)
-        .expect("legacy SET &A(1) syntax should still work");
-    assert_eq!(interp.take_output(), "10");
 }
 
 /// `&@A` without brackets must produce a compile-time error.


### PR DESCRIPTION
## 概要

#672 の棚卸し結果に基づき、`lib/tests/` と `tests/tbx_lib_tests.rs` に残っていた旧配列アクセス構文 `A(i)` / `&A(i)` / `SET &A(i), expr` を正規構文 `@A[i]` / `&@A[i]` / `SET &@A[i], expr` / `LET @A[i] = expr` へ移行する。
コンパイラの旧構文実装分岐はまだ削除せず、テスト層のみの移行とする。

## 変更内容

- `lib/tests/test_array.tbx`: `SET &A(i)` / `A(i)` を `LET @A[i]` / `@A[i]` へ移行
- `lib/tests/test_array_len.tbx`: `SET &A(I)` / `A(I)` を `LET @A[I]` / `@A[I]` へ移行
- `lib/tests/test_to_array.tbx`: `A(i)` / `SET &A(i)` を `@A[i]` / `SET &@A[i]` / `LET @A[i]` へ移行し、旧構文互換性コメントを新構文ベースに更新
- `lib/tests/test_var_init.tbx`: `SET &A(i)` / `A(i)` を `LET @A[i]` / `@A[i]` へ移行
- `lib/tests/test_return_ownership.tbx`: `A(i)` を `@A[i]` へ移行
- `tests/tbx_lib_tests.rs`:
  - 旧構文互換テスト `test_set_legacy_array_syntax_still_works` を削除
  - 文字列配列テスト群の `SET &A(i)` / `A(i)` を `SET &@A[i]` / `@A[i]` へ移行
  - `test_array_index_zero_is_out_of_bounds` の `RETURN A(0)` を `RETURN @A[0]` へ移行
  - `test_at_array_*` テスト群の `SET &A(i)` / `SET &G(i)` を `SET &@A[i]` / `SET &@G[i]` へ移行

## 残存旧構文について

`rg` による残存確認の結果、誤検出（関数呼び出し・別文脈）以外に旧配列アクセス構文の残存はなし。
`src/interpreter.rs` 内テストの移行は後続 issue で扱う。

Closes #674
