### PR TITLE
expr.rs から旧 A(i) 配列要素値アクセス分岐を削除する

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -26,7 +26,6 @@ enum OpItem {
     /// Left-parenthesis sentinel. Carries optional call metadata.
     ///
     /// `call` is `Some(LParenCall::Function(xt, arity))` for a function call,
-    /// `Some(LParenCall::Array)` for an array index expression,
     /// and `None` for a plain grouping parenthesis.
     LParen { call: Option<LParenCall> },
     /// Comma-as-binary-operator used outside of function calls (precedence 11).
@@ -41,9 +40,6 @@ enum OpItem {
 enum LParenCall {
     /// Function call: execution token and current argument arity count.
     Function(Xt, usize),
-    /// Array index access: the Cell::Array handle is already on the output stack.
-    /// On closing `)`, emit ARRAY_GET (index is on top, handle is below).
-    Array,
 }
 
 // ---------------------------------------------------------------------------
@@ -161,29 +157,8 @@ impl<'a> ExprCompiler<'a> {
                     // Check local variable table first — locals shadow globals.
                     if let Some(local_idx) = self.local_table.and_then(|lt| lt.get(&name)).copied()
                     {
-                        // Peek ahead: local variable followed by `(` means array element access.
-                        let next_is_lparen = tokens
-                            .get(i + 1)
-                            .map(|st| matches!(st.token, Token::LParen))
-                            .unwrap_or(false);
-
-                        if next_is_lparen {
-                            // Array element read: A(I)
-                            // 1. Load the Cell::Array handle from the local slot.
-                            emit_local_read(&mut output, local_idx, self.vm)?;
-                            // 2. Open an array-index paren frame marked as Array
-                            //    to distinguish it from a regular function call paren.
-                            op_stack.push(OpItem::LParen {
-                                call: Some(LParenCall::Array),
-                            });
-                            i += 1; // consume '('
-                            prev_was_operand = false;
-                        } else {
-                            emit_local_read(&mut output, local_idx, self.vm)?;
-                            prev_was_operand = true;
-                            i += 1;
-                            continue;
-                        }
+                        emit_local_read(&mut output, local_idx, self.vm)?;
+                        prev_was_operand = true;
                         i += 1;
                         continue;
                     }
@@ -213,23 +188,6 @@ impl<'a> ExprCompiler<'a> {
                             .get(i + 2)
                             .map(|st| matches!(st.token, Token::RParen))
                             .unwrap_or(false);
-
-                        if !next_is_rparen {
-                            if let EntryKind::Variable(addr) = &self.vm.headers[xt.index()].kind {
-                                let lparen_pos = i + 1;
-                                let (index_toks, close_pos) =
-                                    parse_array_index_tokens(tokens, lparen_pos)?;
-                                emit_var_read(&mut output, *addr, self.vm)?;
-                                let index_cells = self.compile_expr(index_toks)?;
-                                output.extend(index_cells);
-                                let array_get_xt = require_xt(self.vm, "ARRAY_GET")?;
-                                output.push(Cell::Xt(array_get_xt));
-                                i = close_pos;
-                                prev_was_operand = true;
-                                i += 1;
-                                continue;
-                            }
-                        }
 
                         if next_is_rparen {
                             // Zero-argument call: emit based on entry kind.
@@ -524,13 +482,6 @@ impl<'a> ExprCompiler<'a> {
                                 &mut self.patch_offsets,
                             )?;
                         }
-                        Some(OpItem::LParen {
-                            call: Some(LParenCall::Array),
-                        }) => {
-                            // Emit ARRAY_GET: stack is [..., Cell::Array, index] → value.
-                            let array_get_xt = require_xt(self.vm, "ARRAY_GET")?;
-                            output.push(Cell::Xt(array_get_xt));
-                        }
                         _ => {
                             // Plain grouping paren — nothing extra to emit.
                         }
@@ -588,24 +539,11 @@ impl<'a> ExprCompiler<'a> {
                 // -------------------------------------------------------
                 Token::Comma => {
                     // A comma is an argument separator when the nearest enclosing
-                    // parenthesis belongs to a function call (not an array index).
+                    // parenthesis belongs to a function call.
                     let nearest_lparen = op_stack
                         .iter()
                         .rev()
                         .find(|op| matches!(op, OpItem::LParen { .. }));
-
-                    // Local array index expressions must be a single expression — commas
-                    // are not allowed inside array subscripts.
-                    if matches!(
-                        nearest_lparen,
-                        Some(OpItem::LParen {
-                            call: Some(LParenCall::Array)
-                        })
-                    ) {
-                        return Err(TbxError::InvalidExpression {
-                            reason: "array index must be a single expression: use NAME(index)",
-                        });
-                    }
 
                     let in_func_call = matches!(
                         nearest_lparen,
@@ -1167,32 +1105,6 @@ mod tests {
         assert_eq!(result.len(), 2);
         assert_eq!(result[0], Cell::Xt(lit_xt));
         assert_eq!(result[1], Cell::DictAddr(0));
-    }
-
-    #[test]
-    fn test_global_array_element_read() {
-        let mut vm = make_vm();
-        vm.dict_write(Cell::Int(0)).unwrap();
-        vm.register(WordEntry::new_variable("A", 0));
-
-        let tokens = lex("A(2)");
-        let result = ExprCompiler::new(&mut vm).compile_expr(&tokens).unwrap();
-
-        let lit_xt = vm.lookup("LIT").unwrap();
-        let fetch_xt = vm.lookup("FETCH").unwrap();
-        let array_get_xt = vm.lookup("ARRAY_GET").unwrap();
-
-        assert_eq!(
-            result,
-            vec![
-                Cell::Xt(lit_xt),
-                Cell::DictAddr(0),
-                Cell::Xt(fetch_xt),
-                Cell::Xt(lit_xt),
-                Cell::Int(2),
-                Cell::Xt(array_get_xt),
-            ]
-        );
     }
 
     #[test]

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1438,8 +1438,8 @@ mod tests {
         let src = "\
 VAR A
 SET &A, TO_ARRAY(10, 20)
-SET &A(2), 123
-PUTDEC A(2)";
+SET &@A[2], 123
+PUTDEC @A[2]";
         interp.exec_source(src).unwrap();
         assert_eq!(interp.take_output(), "123");
     }
@@ -1450,7 +1450,7 @@ PUTDEC A(2)";
         let src = "\
 VAR A
 SET &A, TO_ARRAY(10, 20)
-PUTDEC A(2)";
+PUTDEC @A[2]";
         interp.exec_source(src).unwrap();
         assert_eq!(interp.take_output(), "20");
     }
@@ -1466,7 +1466,7 @@ SET &A, TO_ARRAY(
 )
 PUTDEC ARRAY_LEN(A)
 PUTSTR \":\"
-PUTDEC A(3)";
+PUTDEC @A[3]";
         interp.exec_source(src).unwrap();
         assert_eq!(interp.take_output(), "4:30");
     }
@@ -4752,7 +4752,7 @@ SET &A, TO_ARRAY(
 )
 PUTDEC ARRAY_LEN(A)
 PUTSTR \":\"
-PUTDEC A(3)";
+PUTDEC @A[3]";
         interp.compile_program(src).unwrap();
         assert_eq!(interp.take_output(), "4:30");
     }
@@ -4846,7 +4846,7 @@ SET &A, TO_ARRAY(
   3
 )
 PUTDEC ARRAY_LEN(A)
-PUTDEC A(2)";
+PUTDEC @A[2]";
 
         let mut interp1 = Interpreter::new();
         interp1.exec_source(src).unwrap();

--- a/tests/tbx_lib_tests.rs
+++ b/tests/tbx_lib_tests.rs
@@ -121,6 +121,33 @@ fn test_array_index_zero_is_out_of_bounds() {
 }
 
 // ---------------------------------------------------------------------------
+// Negative test: legacy A(i) array value access syntax must not work (#676)
+// ---------------------------------------------------------------------------
+
+/// `A(i)` must no longer be usable as an array value access expression.
+///
+/// The `A(i)` syntax for reading array elements has been removed in favour of
+/// the `@A[i]` sigil syntax.  A global variable `A` followed by `(index)` no
+/// longer compiles as an array element read; it is interpreted as a function
+/// call on a variable, which fails at runtime with a type error.
+#[test]
+fn test_legacy_global_array_paren_syntax_is_not_array_access() {
+    let mut interp = Interpreter::new();
+    // Set up a global array and attempt to read element 2 using the old syntax.
+    let src = "VAR A\nSET &A, TO_ARRAY(10, 20)\nPUTDEC A(2)\n";
+    let err = interp
+        .exec_source(src)
+        .expect_err("A(i) must not work as array value access");
+    // The error occurs because the variable handle (DictAddr) ends up where a
+    // number is expected — it is NOT silently returning 20.
+    let msg = err.to_string();
+    assert!(
+        !msg.is_empty(),
+        "A(i) must produce an error, not succeed silently"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Array element string tests (issue #591, D-4: Rc<str> liberation)
 // ---------------------------------------------------------------------------
 //

--- a/tests/tbx_lib_tests.rs
+++ b/tests/tbx_lib_tests.rs
@@ -147,6 +147,28 @@ fn test_legacy_global_array_paren_syntax_is_not_array_access() {
     );
 }
 
+/// `A(i)` must no longer be usable as an array value access expression for
+/// local variables either.
+///
+/// When `A` is a local variable holding an array, `A(i)` used to read element
+/// `i`.  That path has been removed; `A(i)` is now parsed as a function call,
+/// which fails at runtime with a type error.
+#[test]
+fn test_legacy_local_array_paren_syntax_is_not_array_access() {
+    let mut interp = Interpreter::new();
+    // Define a function that sets up a local array and attempts to read
+    // element 1 using the old A(i) syntax.
+    let src = "DEF F()\n  VAR A\n  LET A = ARRAY(3)\n  LET @A[1] = 10\n  RETURN A(1)\nEND\nF()\n";
+    let err = interp
+        .exec_source(src)
+        .expect_err("A(i) must not work as local array value access");
+    let msg = err.to_string();
+    assert!(
+        !msg.is_empty(),
+        "A(i) must produce an error for local variables, not succeed silently"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Array element string tests (issue #591, D-4: Rc<str> liberation)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## 概要

`src/expr.rs` から旧 `A(i)` 配列要素値アクセスのコンパイラ分岐を削除する。
配列要素の読み取りは `@A[i]` シジル構文に統一され、`A(i)` 構文は廃止とする。

## 変更内容

- `src/expr.rs`: ローカル変数 `A(i)` value access コンパイラ分岐を削除
- `src/expr.rs`: グローバル変数 `A(i)` value access コンパイラ分岐を削除
- `src/expr.rs`: `LParenCall::Array` variant および関連する dead code（match arm・comma チェック）を削除
- `src/expr.rs`: unit test `test_global_array_element_read` を削除
- `tests/tbx_lib_tests.rs`: `A(i)` が array access として動作しないことを確認する negative integration test (`test_legacy_global_array_paren_syntax_is_not_array_access`) を追加
- `src/interpreter.rs`: 旧 `A(i)` 構文を使っていた既存テスト5件を `@A[i]` 構文へ移行

なお以下はこの issue のスコープ外として変更しない:
- `&A(i)` address access 分岐
- `parse_array_index_tokens` 関数

Closes #676
