### PR TITLE
expr.rs から旧 &A(i) 配列要素アドレスアクセス分岐を削除する

### DIFF
--- a/src/cell.rs
+++ b/src/cell.rs
@@ -123,7 +123,7 @@ pub enum Cell {
     Str(std::rc::Rc<str>),
     /// Address of an element in an array.
     ///
-    /// Produced by the `&A(I)` construct where `A` holds a `Cell::Array`.
+    /// Produced by the `&@A[i]` construct where `A` holds a `Cell::Array`.
     /// Used by `FETCH`, `STORE`, and `SET` to read/write individual elements.
     ArrayAddr {
         /// Index into `VM::arrays` (the array pool).

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -256,31 +256,10 @@ impl<'a> ExprCompiler<'a> {
                                 if let Some(local_idx) =
                                     self.local_table.and_then(|lt| lt.get(&name)).copied()
                                 {
-                                    // Is this an array element address: &A(I)?
-                                    let lparen_pos = i + 1;
-                                    if tokens
-                                        .get(lparen_pos)
-                                        .map(|st| matches!(st.token, Token::LParen))
-                                        .unwrap_or(false)
-                                    {
-                                        // Array address-of: &A(I)
-                                        let (index_toks, close_pos) =
-                                            parse_array_index_tokens(tokens, lparen_pos)?;
-                                        // 1. Load the Cell::Array handle.
-                                        emit_local_read(&mut output, local_idx, self.vm)?;
-                                        // 2. Compile the index expression.
-                                        let index_cells = self.compile_expr(index_toks)?;
-                                        output.extend(index_cells);
-                                        // 3. Emit ARRAY_ADDR.
-                                        let array_addr_xt = require_xt(self.vm, "ARRAY_ADDR")?;
-                                        output.push(Cell::Xt(array_addr_xt));
-                                        i = close_pos;
-                                    } else {
-                                        // Simple local variable address: &A (StackAddr).
-                                        let xt_lit = require_xt(self.vm, "LIT")?;
-                                        output.push(Cell::Xt(xt_lit));
-                                        output.push(Cell::StackAddr(local_idx));
-                                    }
+                                    // Simple local variable address: &A (StackAddr).
+                                    let xt_lit = require_xt(self.vm, "LIT")?;
+                                    output.push(Cell::Xt(xt_lit));
+                                    output.push(Cell::StackAddr(local_idx));
                                 } else {
                                     let xt = self
                                         .vm
@@ -290,27 +269,10 @@ impl<'a> ExprCompiler<'a> {
                                         })?;
                                     match &self.vm.headers[xt.index()].kind {
                                         EntryKind::Variable(addr) => {
-                                            let lparen_pos = i + 1;
-                                            if tokens
-                                                .get(lparen_pos)
-                                                .map(|st| matches!(st.token, Token::LParen))
-                                                .unwrap_or(false)
-                                            {
-                                                let (index_toks, close_pos) =
-                                                    parse_array_index_tokens(tokens, lparen_pos)?;
-                                                emit_var_read(&mut output, *addr, self.vm)?;
-                                                let index_cells = self.compile_expr(index_toks)?;
-                                                output.extend(index_cells);
-                                                let array_addr_xt =
-                                                    require_xt(self.vm, "ARRAY_ADDR")?;
-                                                output.push(Cell::Xt(array_addr_xt));
-                                                i = close_pos;
-                                            } else {
-                                                // Emit address only — no FETCH.
-                                                let xt_lit = require_xt(self.vm, "LIT")?;
-                                                output.push(Cell::Xt(xt_lit));
-                                                output.push(Cell::DictAddr(*addr));
-                                            }
+                                            // Emit address only — no FETCH.
+                                            let xt_lit = require_xt(self.vm, "LIT")?;
+                                            output.push(Cell::Xt(xt_lit));
+                                            output.push(Cell::DictAddr(*addr));
                                         }
                                         _ => {
                                             return Err(TbxError::TypeError {
@@ -739,47 +701,6 @@ fn parse_at_index_tokens(
     Ok((index_toks, close_pos))
 }
 
-/// Find the index of the matching closing `)` for an already-consumed `(`.
-///
-/// `tokens[start..]` is the content after the opening `(`.  Returns the index
-/// in `tokens` of the first `)` at depth 0 (accounting for nested parentheses),
-/// or `None` if no such `)` exists.
-fn find_matching_rparen(tokens: &[SpannedToken], start: usize) -> Option<usize> {
-    let mut depth = 0usize;
-    for (j, st) in tokens.iter().enumerate().skip(start) {
-        match &st.token {
-            Token::LParen => depth += 1,
-            Token::RParen => {
-                if depth == 0 {
-                    return Some(j);
-                }
-                depth -= 1;
-            }
-            _ => {}
-        }
-    }
-    None
-}
-
-/// Return the tokens inside `(` `)` of an array index expression and the
-/// position of the matching closing parenthesis.
-fn parse_array_index_tokens(
-    tokens: &[SpannedToken],
-    lparen_pos: usize,
-) -> Result<(&[SpannedToken], usize), TbxError> {
-    let idx_start = lparen_pos + 1;
-    let close_pos = find_matching_rparen(tokens, idx_start).ok_or(TbxError::InvalidExpression {
-        reason: "missing ')' in array index expression",
-    })?;
-    let index_toks = &tokens[idx_start..close_pos];
-    if index_toks.is_empty() {
-        return Err(TbxError::InvalidExpression {
-            reason: "array index expression must not be empty: use NAME(index)",
-        });
-    }
-    Ok((index_toks, close_pos))
-}
-
 /// Emit `Xt(LIT)` followed by `value` onto `output`.
 fn emit_lit(output: &mut Vec<Cell>, value: Cell, vm: &VM) -> Result<(), TbxError> {
     let xt = require_xt(vm, "LIT")?;
@@ -1107,30 +1028,36 @@ mod tests {
         assert_eq!(result[1], Cell::DictAddr(0));
     }
 
+    /// `&A(i)` must no longer compile as an array element address (#671).
+    ///
+    /// The `&A(i)` syntax for array element addresses has been removed in
+    /// favour of `&@A[i]`.  After `&A` is handled as a plain variable address,
+    /// the compiler no longer emits `FETCH` + index + `ARRAY_ADDR`.  This test
+    /// verifies that the old six-cell sequence is no longer produced.
     #[test]
-    fn test_address_of_global_array_element() {
+    fn test_legacy_address_of_global_array_element_not_emitted() {
         let mut vm = make_vm();
         vm.dict_write(Cell::Int(0)).unwrap();
         vm.register(WordEntry::new_variable("A", 0));
 
-        let tokens = lex("&A(2)");
-        let result = ExprCompiler::new(&mut vm).compile_expr(&tokens).unwrap();
-
-        let lit_xt = vm.lookup("LIT").unwrap();
         let fetch_xt = vm.lookup("FETCH").unwrap();
         let array_addr_xt = vm.lookup("ARRAY_ADDR").unwrap();
 
-        assert_eq!(
-            result,
-            vec![
-                Cell::Xt(lit_xt),
-                Cell::DictAddr(0),
-                Cell::Xt(fetch_xt),
-                Cell::Xt(lit_xt),
-                Cell::Int(2),
-                Cell::Xt(array_addr_xt),
-            ]
-        );
+        let tokens = lex("&A(2)");
+        // `&A(i)` no longer produces the old FETCH + index + ARRAY_ADDR sequence.
+        // Whatever the compiler produces, it must not contain ARRAY_ADDR.
+        let result = ExprCompiler::new(&mut vm).compile_expr(&tokens);
+        if let Ok(cells) = result {
+            assert!(
+                !cells.contains(&Cell::Xt(array_addr_xt)),
+                "&A(i) must not emit ARRAY_ADDR: {cells:?}"
+            );
+            assert!(
+                !cells.contains(&Cell::Xt(fetch_xt)),
+                "&A(i) must not emit FETCH after &A: {cells:?}"
+            );
+        }
+        // Compilation failure is also acceptable.
     }
 
     // ------------------------------------------------------------------

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -2230,7 +2230,7 @@ pub fn register_all(vm: &mut VM) {
 
     // Array primitives.
     // ARRAY creates an array; ARRAY_GET reads an element; ARRAY_ADDR computes
-    // an element address (used internally by the expression compiler for `A(I)` and `&A(I)`).
+    // an element address (used internally by the expression compiler for `&@A[i]`).
     // TO_ARRAY packs stack values into a new array; FROM_ARRAY expands one onto the stack.
     // ARRAY_LEN returns the length of an array; ARRAY_CONCAT concatenates two arrays.
     // TUPLE packs stack values into a new immutable Cell::Tuple.

--- a/tests/tbx_lib_tests.rs
+++ b/tests/tbx_lib_tests.rs
@@ -173,62 +173,36 @@ fn test_legacy_local_array_paren_syntax_is_not_array_access() {
 // Negative test: legacy &A(i) array element address syntax must not work (#671)
 // ---------------------------------------------------------------------------
 
-/// `&A(i)` must no longer be usable as an array element address expression.
+/// `SET &A(i), value` for a global variable must be rejected.
 ///
 /// The `&A(i)` syntax for writing array elements via SET has been removed in
-/// favour of `&@A[i]`.  When `SET &A(i), value` is compiled, `&A` is treated
-/// as a plain variable address and the `(i)` part is parsed separately, so the
-/// resulting code either fails to compile, fails at runtime, or does not write
-/// to the expected array element.
-///
-/// This test verifies that the value 99 does not end up in element index 1 of
-/// the array after the old-syntax write attempt.  We confirm this by
-/// subsequently reading back the element with the new `@A[1]` syntax.
+/// favour of `&@A[i]`.  This test confirms that the legacy syntax now results
+/// in a compile-time or runtime error.
 #[test]
 fn test_legacy_global_array_paren_addr_syntax_is_not_array_addr_access() {
     let mut interp = Interpreter::new();
-    // Prepare the array in a separate step so we know it is set up correctly.
+    let src = "VAR A\nSET &A, TO_ARRAY(10, 20)\nSET &A(1), 99\n";
     interp
-        .exec_source("VAR A\nSET &A, TO_ARRAY(10, 20)\n")
-        .expect("array setup must succeed");
-
-    // Now attempt the legacy write.  Either it errors (expected), or succeeds
-    // without actually writing to the correct element (also acceptable).
-    let write_result = interp.exec_source("SET &A(1), 99\n");
-
-    if write_result.is_ok() {
-        // If the write "succeeded", the element must still hold 20 (unchanged).
-        let mut interp2 = Interpreter::new();
-        // Re-run the full setup + read in a fresh interpreter to avoid
-        // interference from the failed write attempt above.
-        interp2
-            .exec_source("VAR A\nSET &A, TO_ARRAY(10, 20)\nSET &A(1), 99\n")
-            .ok(); // ignore errors
-                   // We cannot capture PUTDEC output here, so this branch is informational.
-    } else {
-        // Compile-time or runtime error is the expected (and preferred) outcome.
-    }
+        .exec_source(src)
+        .expect_err("SET &A(i) for global variable must fail");
 }
 
-/// `SET &A(i), value` using a local variable must not write to the array element.
+/// `SET &A(i), value` using a local variable must be rejected.
 ///
-/// When `A` is a local variable holding an array, `SET &A(i), value` used to
-/// write to element `i`.  That path has been removed; the statement either
-/// errors or does not affect the array element at the expected index.
+/// The `&A(i)` syntax for writing array elements via SET has been removed in
+/// favour of `&@A[i]`.  This test confirms that the legacy syntax now results
+/// in a compile-time or runtime error.
 #[test]
 fn test_legacy_local_array_paren_addr_syntax_is_not_array_addr_access() {
     let mut interp = Interpreter::new();
     // Define a function that sets up a local array and attempts to write
-    // element 0 using the old `SET &A(i), value` syntax.
-    let src =
-        "DEF F()\n  VAR A\n  LET A = ARRAY(3)\n  LET @A[0] = 10\n  SET &A(0), 99\n  RETURN @A[0]\nEND\nF()\n";
+    // element 1 using the old `SET &A(i), value` syntax.
+    let src = "DEF F()\n  VAR A\n  LET A = ARRAY(3)\n  SET &A(1), 99\n  RETURN @A[1]\nEND\nF()\n";
     // Either compilation or runtime must fail — &A(i) no longer writes to
-    // an array element.  Silent success returning 99 is not acceptable.
-    let result = interp.exec_source(src);
-    assert!(
-        result.is_err(),
-        "SET &A(i) for local variable must fail; it must not silently write to the array element"
-    );
+    // an array element.
+    interp
+        .exec_source(src)
+        .expect_err("SET &A(i) for local variable must fail");
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/tbx_lib_tests.rs
+++ b/tests/tbx_lib_tests.rs
@@ -170,6 +170,68 @@ fn test_legacy_local_array_paren_syntax_is_not_array_access() {
 }
 
 // ---------------------------------------------------------------------------
+// Negative test: legacy &A(i) array element address syntax must not work (#671)
+// ---------------------------------------------------------------------------
+
+/// `&A(i)` must no longer be usable as an array element address expression.
+///
+/// The `&A(i)` syntax for writing array elements via SET has been removed in
+/// favour of `&@A[i]`.  When `SET &A(i), value` is compiled, `&A` is treated
+/// as a plain variable address and the `(i)` part is parsed separately, so the
+/// resulting code either fails to compile, fails at runtime, or does not write
+/// to the expected array element.
+///
+/// This test verifies that the value 99 does not end up in element index 1 of
+/// the array after the old-syntax write attempt.  We confirm this by
+/// subsequently reading back the element with the new `@A[1]` syntax.
+#[test]
+fn test_legacy_global_array_paren_addr_syntax_is_not_array_addr_access() {
+    let mut interp = Interpreter::new();
+    // Prepare the array in a separate step so we know it is set up correctly.
+    interp
+        .exec_source("VAR A\nSET &A, TO_ARRAY(10, 20)\n")
+        .expect("array setup must succeed");
+
+    // Now attempt the legacy write.  Either it errors (expected), or succeeds
+    // without actually writing to the correct element (also acceptable).
+    let write_result = interp.exec_source("SET &A(1), 99\n");
+
+    if write_result.is_ok() {
+        // If the write "succeeded", the element must still hold 20 (unchanged).
+        let mut interp2 = Interpreter::new();
+        // Re-run the full setup + read in a fresh interpreter to avoid
+        // interference from the failed write attempt above.
+        interp2
+            .exec_source("VAR A\nSET &A, TO_ARRAY(10, 20)\nSET &A(1), 99\n")
+            .ok(); // ignore errors
+                   // We cannot capture PUTDEC output here, so this branch is informational.
+    } else {
+        // Compile-time or runtime error is the expected (and preferred) outcome.
+    }
+}
+
+/// `SET &A(i), value` using a local variable must not write to the array element.
+///
+/// When `A` is a local variable holding an array, `SET &A(i), value` used to
+/// write to element `i`.  That path has been removed; the statement either
+/// errors or does not affect the array element at the expected index.
+#[test]
+fn test_legacy_local_array_paren_addr_syntax_is_not_array_addr_access() {
+    let mut interp = Interpreter::new();
+    // Define a function that sets up a local array and attempts to write
+    // element 0 using the old `SET &A(i), value` syntax.
+    let src =
+        "DEF F()\n  VAR A\n  LET A = ARRAY(3)\n  LET @A[0] = 10\n  SET &A(0), 99\n  RETURN @A[0]\nEND\nF()\n";
+    // Either compilation or runtime must fail — &A(i) no longer writes to
+    // an array element.  Silent success returning 99 is not acceptable.
+    let result = interp.exec_source(src);
+    assert!(
+        result.is_err(),
+        "SET &A(i) for local variable must fail; it must not silently write to the array element"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Array element string tests (issue #591, D-4: Rc<str> liberation)
 // ---------------------------------------------------------------------------
 //


### PR DESCRIPTION
## 概要

issue #671 Phase 10-d / 10-e として、`src/expr.rs` に残っていた `&A(i)` 配列要素アドレスアクセスのコンパイラ分岐を削除し、旧構文が動作しないことを確認する negative test を追加する。

## 変更内容

- `src/expr.rs`: `&A(i)` を配列要素アドレスとして処理するローカル変数・グローバル変数の両分岐を削除し、`&A` はスカラー変数アドレスのみを返すよう変更
- `src/expr.rs`: 削除した分岐でのみ使用されていた `parse_array_index_tokens` 関数と `find_matching_rparen` 関数を削除
- `src/expr.rs`: `test_address_of_global_array_element`（旧構文が動作することを確認するテスト）を、`&A(i)` が `ARRAY_ADDR` 命令を生成しないことを確認する negative unit test に置き換える
- `tests/tbx_lib_tests.rs`: `&A(i)` を使った場合にエラーまたは配列への書き込みが行われないことを確認する negative integration test を追加
- `src/cell.rs`: `ArrayAddr` バリアントのコメント中の旧構文 `&A(I)` を `&@A[i]` に更新
- `src/primitives.rs`: `ARRAY_ADDR` の説明コメント中の旧構文 `A(I)` / `&A(I)` を `&@A[i]` に更新

## 壊さなかったもの

- `&A`（スカラー変数のアドレス）は引き続き動作する
- `&@A[i]`（配列要素アドレス）は引き続き動作する
- `SET &@A[i], expr` は引き続き動作する
- `LET @A[i] = expr` は引き続き動作する
- `F(i)` 関数呼び出しは引き続き動作する

Closes #678