### PR TITLE
旧 A(i) が ARRAY_GET を emit しないことを確認する

### DIFF
--- a/tests/expr_legacy_array_syntax_tests.rs
+++ b/tests/expr_legacy_array_syntax_tests.rs
@@ -1,0 +1,37 @@
+use tbx::cell::Cell;
+use tbx::dict::WordEntry;
+use tbx::expr::ExprCompiler;
+use tbx::lexer::{Lexer, SpannedToken, Token};
+
+fn lex(src: &str) -> Vec<SpannedToken> {
+    let mut lx = Lexer::new(src);
+    let mut out = Vec::new();
+    loop {
+        let st = lx.next_token();
+        match &st.token {
+            Token::Eof | Token::Newline => break,
+            _ => out.push(st),
+        }
+    }
+    out
+}
+
+#[test]
+fn test_legacy_global_array_element_read_not_emitted() {
+    let mut vm = tbx::init_vm();
+    vm.dict_write(Cell::Int(0)).unwrap();
+    vm.register(WordEntry::new_variable("A", 0));
+
+    let array_get_xt = vm.lookup("ARRAY_GET").unwrap();
+
+    let tokens = lex("A(2)");
+    let result = ExprCompiler::new(&mut vm).compile_expr(&tokens);
+
+    if let Ok(cells) = result {
+        assert!(
+            !cells.contains(&Cell::Xt(array_get_xt)),
+            "A(i) must not emit ARRAY_GET: {cells:?}"
+        );
+    }
+    // Compilation failure is also acceptable.
+}


### PR DESCRIPTION
## 概要

Refs #680 の Phase 10-e / 方針 1 の補強として、旧 `A(i)` 配列要素 value access が compiler emit 上も復活していないことを確認するテストを追加する。

## 変更内容

- `tests/expr_legacy_array_syntax_tests.rs` を追加
- global variable `A` に対する旧構文 `A(2)` を `ExprCompiler` で compile し、結果が `ARRAY_GET` を含まないことを確認
- compile error になる場合も許容し、少なくとも旧 `A(i)` array value access として `ARRAY_GET` を emit しないことを固定

## 補足

当初の推奨位置は `src/expr.rs` の unit test module 内だったが、この PR では公開 API 経由の integration test として追加している。検証対象は同じく `ExprCompiler` の emit であり、#680 の「旧構文が誤って `ARRAY_GET` を emit しない」完了条件を補強する。