### PR TITLE
旧構文 A(i) がARRAY_GETをemitしないことを確認する

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1007,6 +1007,26 @@ mod tests {
         assert_eq!(result[2], Cell::Xt(fetch_xt));
     }
 
+    #[test]
+    fn test_legacy_global_array_element_read_not_emitted() {
+        let mut vm = make_vm();
+        vm.dict_write(Cell::Int(0)).unwrap();
+        vm.register(WordEntry::new_variable("A", 0));
+
+        let array_get_xt = vm.lookup("ARRAY_GET").unwrap();
+
+        let tokens = lex("A(2)");
+        let result = ExprCompiler::new(&mut vm).compile_expr(&tokens);
+
+        if let Ok(cells) = result {
+            assert!(
+                !cells.contains(&Cell::Xt(array_get_xt)),
+                "A(i) must not emit ARRAY_GET: {cells:?}"
+            );
+        }
+        // Compilation failure is also acceptable.
+    }
+
     // ------------------------------------------------------------------
     // Test 5: address-of operator &A
     // ------------------------------------------------------------------


### PR DESCRIPTION
概要
Refs #680 の Phase 10-e / 方針 1 の補強として、旧 `A(i)` 配列要素 value access が compiler emit 上も復活していないことを確認するテストを追加する。

変更内容
test_legacy_global_array_element_read_not_emittedを追加

補足
issue #680 の「旧構文が誤って `ARRAY_GET` を emit しない」完了条件を補強する。