### PR TITLE
value aggregate 用途の TO_ARRAY テストを TUPLE ベースへ移行する

### DIFF
--- a/lib/tests/test_return_ownership.tbx
+++ b/lib/tests/test_return_ownership.tbx
@@ -1,5 +1,5 @@
 # lib/tests/test_return_ownership.tbx
-# TBX tests for ownership transfer of Cell::Str and Cell::Array via RETURN.
+# TBX tests for ownership transfer of Cell::Str and Cell::Array/Tuple via RETURN.
 USE "lib/tests/helper.tbx"
 
 # --- Cell::Str ownership transfer ---
@@ -25,79 +25,91 @@ VAR TOP_LEVEL_STR
 SET &TOP_LEVEL_STR, STR_CONCAT("foo", "bar")
 ASSERT STR_EQ(TOP_LEVEL_STR, "foobar")
 
-# --- Cell::Array ownership transfer ---
+# --- Cell::Tuple ownership transfer ---
 
-# A word that creates an array locally and returns it;
-# verify length and specific elements via helper words.
+# A word that creates a tuple locally and returns it;
+# verify specific elements via helper words.
 DEF HMS(T)
-  RETURN TO_ARRAY(T / 3600, (T / 60) % 60, T % 60)
+  RETURN TUPLE(T / 3600, (T / 60) % 60, T % 60)
 END
 
 DEF HMS_HOUR(T)
-  VAR A
-  LET A = HMS(T)
-  RETURN @A[1]
+  VAR H
+  LET H = HMS(T)
+  RETURN H[1]
 END
 DEF HMS_MIN(T)
-  VAR A
-  LET A = HMS(T)
-  RETURN @A[2]
+  VAR H
+  LET H = HMS(T)
+  RETURN H[2]
 END
 DEF HMS_SEC(T)
-  VAR A
-  LET A = HMS(T)
-  RETURN @A[3]
+  VAR H
+  LET H = HMS(T)
+  RETURN H[3]
 END
 ASSERT HMS_HOUR(3661) = 1
 ASSERT HMS_MIN(3661) = 1
 ASSERT HMS_SEC(3661) = 1
 
-# Chained array RETURN (OUTER calls INNER and returns the result directly).
-DEF MAKE_ARRAY_INNER()
-  RETURN TO_ARRAY(10, 20, 30)
+# Chained tuple RETURN (OUTER calls INNER and returns the result directly).
+DEF MAKE_TUPLE_INNER()
+  RETURN TUPLE(10, 20, 30)
 END
 
-DEF MAKE_ARRAY_OUTER()
-  VAR B
-  LET B = MAKE_ARRAY_INNER()
-  RETURN B
+DEF MAKE_TUPLE_OUTER()
+  VAR T
+  LET T = MAKE_TUPLE_INNER()
+  RETURN T
 END
 
-DEF CHECK_CHAINED_ARRAY()
+DEF CHECK_CHAINED_TUPLE()
   VAR R
-  LET R = MAKE_ARRAY_OUTER()
-  IF @R[1] = 10
-    IF @R[2] = 20
-      IF @R[3] = 30
+  LET R = MAKE_TUPLE_OUTER()
+  IF R[1] = 10
+    IF R[2] = 20
+      IF R[3] = 30
         RETURN 1
       ENDIF
     ENDIF
   ENDIF
   RETURN 0
 END
-ASSERT CHECK_CHAINED_ARRAY() = 1
+ASSERT CHECK_CHAINED_TUPLE() = 1
 
-# ARRAY_LEN on a returned frame-local array.
+# A word that returns a 3-element tuple; verify all elements.
 DEF MAKE_THREE()
-  RETURN TO_ARRAY(1, 2, 3)
+  RETURN TUPLE(1, 2, 3)
 END
-ASSERT ARRAY_LEN(MAKE_THREE()) = 3
+DEF CHECK_MAKE_THREE()
+  VAR T
+  LET T = MAKE_THREE()
+  IF T[1] = 1
+    IF T[2] = 2
+      IF T[3] = 3
+        RETURN 1
+      ENDIF
+    ENDIF
+  ENDIF
+  RETURN 0
+END
+ASSERT CHECK_MAKE_THREE() = 1
 
-# A word that creates multiple local arrays but returns only one;
-# the non-returned array is freed and the returned one is valid.
+# A word that creates multiple local tuples but returns only one;
+# the non-returned tuple is freed and the returned one is valid.
 DEF RETURN_SECOND()
   VAR A
   VAR B
-  LET A = TO_ARRAY(1, 2)
-  LET B = TO_ARRAY(3, 4)
+  LET A = TUPLE(1, 2)
+  LET B = TUPLE(3, 4)
   RETURN B
 END
 
 DEF CHECK_RETURN_SECOND()
   VAR R
   LET R = RETURN_SECOND()
-  IF @R[1] = 3
-    IF @R[2] = 4
+  IF R[1] = 3
+    IF R[2] = 4
       RETURN 1
     ENDIF
   ENDIF

--- a/lib/tests/test_to_array.tbx
+++ b/lib/tests/test_to_array.tbx
@@ -1,48 +1,48 @@
 # lib/tests/test_to_array.tbx — TBX tests for TO_ARRAY and FROM_ARRAY primitives
 USE "lib/tests/helper.tbx"
 
-# --- TO_ARRAY: basic creation and element access ---
+# --- TUPLE: basic creation and element sum (value aggregate) ---
 
-DEF TO_ARRAY_SUM()
-  VAR A
-  LET A = TO_ARRAY(1, 2, 3)
-  RETURN @A[1] + @A[2] + @A[3]
+DEF TUPLE_SUM()
+  VAR T
+  LET T = TUPLE(1, 2, 3)
+  RETURN T[1] + T[2] + T[3]
 END
-ASSERT TO_ARRAY_SUM() = 6
+ASSERT TUPLE_SUM() = 6
 
-# --- TO_ARRAY: element order is preserved (first arg -> index 1) ---
+# --- TUPLE: element order is preserved (first arg -> index 1) ---
 
-DEF TO_ARRAY_ORDER()
-  VAR A
-  LET A = TO_ARRAY(10, 20, 30)
-  IF @A[1] = 10
-    IF @A[2] = 20
-      IF @A[3] = 30
+DEF TUPLE_ORDER()
+  VAR T
+  LET T = TUPLE(10, 20, 30)
+  IF T[1] = 10
+    IF T[2] = 20
+      IF T[3] = 30
         RETURN 1
       ENDIF
     ENDIF
   ENDIF
   RETURN 0
 END
-ASSERT TO_ARRAY_ORDER() = 1
+ASSERT TUPLE_ORDER() = 1
 
-# --- TO_ARRAY: empty array (zero arguments) does not crash ---
+# --- TUPLE: empty tuple (zero arguments) does not crash ---
 
-DEF TO_ARRAY_EMPTY()
-  VAR A
-  LET A = TO_ARRAY()
+DEF TUPLE_EMPTY_AGG()
+  VAR T
+  LET T = TUPLE()
   RETURN 99
 END
-ASSERT TO_ARRAY_EMPTY() = 99
+ASSERT TUPLE_EMPTY_AGG() = 99
 
-# --- TO_ARRAY: single element ---
+# --- TUPLE: single element ---
 
-DEF TO_ARRAY_ONE()
-  VAR A
-  LET A = TO_ARRAY(42)
-  RETURN @A[1]
+DEF TUPLE_ONE()
+  VAR T
+  LET T = TUPLE(42)
+  RETURN T[1]
 END
-ASSERT TO_ARRAY_ONE() = 42
+ASSERT TUPLE_ONE() = 42
 
 # --- TO_ARRAY: elements can be mutated via SET ---
 
@@ -96,21 +96,21 @@ DEF FROM_ARRAY_EMPTY_STMT()
 END
 ASSERT FROM_ARRAY_EMPTY_STMT() = 2
 
-# --- Round-trip: TO_ARRAY -> element read -> matches original values ---
+# --- TUPLE round-trip: element read matches original values ---
 
-DEF ROUNDTRIP()
-  VAR A
-  LET A = TO_ARRAY(100, 200, 300)
-  IF @A[1] = 100
-    IF @A[2] = 200
-      IF @A[3] = 300
+DEF TUPLE_ROUNDTRIP()
+  VAR T
+  LET T = TUPLE(100, 200, 300)
+  IF T[1] = 100
+    IF T[2] = 200
+      IF T[3] = 300
         RETURN 1
       ENDIF
     ENDIF
   ENDIF
   RETURN 0
 END
-ASSERT ROUNDTRIP() = 1
+ASSERT TUPLE_ROUNDTRIP() = 1
 
 # --- ARRAY_CONCAT: concatenate arrays without mutating inputs ---
 


### PR DESCRIPTION
## 概要

`TO_ARRAY(...)` を immutable/value aggregate として使っていたテストを `TUPLE(...)` + `T[i]` 構文へ移行する。mutable storage テスト・`FROM_ARRAY` テスト・`ARRAY_LEN`/`ARRAY_CONCAT` 依存テストは今回のスコープ外として変更しない。

## 変更内容

### lib/tests/test_to_array.tbx

- `TO_ARRAY_SUM` → `TUPLE_SUM`（`TUPLE(1, 2, 3)` + `T[i]` で要素合計）
- `TO_ARRAY_ORDER` → `TUPLE_ORDER`（要素順序の保持確認）
- `TO_ARRAY_EMPTY` → `TUPLE_EMPTY_AGG`（空 tuple でクラッシュしないことを確認）
- `TO_ARRAY_ONE` → `TUPLE_ONE`（単一要素 tuple のアクセス）
- `ROUNDTRIP` → `TUPLE_ROUNDTRIP`（要素読み出しが元の値と一致することを確認）
- mutable storage テスト（`TO_ARRAY_MUTATE`, `TOP_ARR`）・`FROM_ARRAY` テスト・`ARRAY_CONCAT` テストは変更なし

### lib/tests/test_return_ownership.tbx

- `HMS` → `TUPLE(T / 3600, ...)` を返し、`H[1]` / `H[2]` / `H[3]` でアクセス
- `MAKE_ARRAY_INNER` / `MAKE_ARRAY_OUTER` → `MAKE_TUPLE_INNER` / `MAKE_TUPLE_OUTER` に改名
- `CHECK_CHAINED_ARRAY` → `CHECK_CHAINED_TUPLE` に改名、`R[i]` でアクセス
- `MAKE_THREE` → `TUPLE(1, 2, 3)` を返す形に変更、`ARRAY_LEN` アサーションを `CHECK_MAKE_THREE` で要素値確認に変更
- `RETURN_SECOND` → `TUPLE(1, 2)` / `TUPLE(3, 4)` を使用、`R[i]` でアクセス

Closes #691
