### PR TITLE
ARRAY / TO_ARRAY / FROM_ARRAY を surface primitive から撤去する

### DIFF
--- a/lib/basic.tbx
+++ b/lib/basic.tbx
@@ -410,7 +410,7 @@ DEF PRINT(...)
   ENDWH
 END
 
-# return Time array (Hour, Minute, Second) in JST
+# return Time tuple (Hour, Minute, Second) in JST
 DEF HMS(T)
-  RETURN TO_ARRAY((HOUR(T) + 9) % 24, MINUTE(T), INT(SECOND(T)))
+  RETURN TUPLE((HOUR(T) + 9) % 24, MINUTE(T), INT(SECOND(T)))
 END

--- a/lib/tests/test_array.tbx
+++ b/lib/tests/test_array.tbx
@@ -83,3 +83,18 @@ ASSERT SUM_ARRAY(5) = 20
 
 DIM @A[1]
 ASSERT ARRAY_LEN(A) = 1
+
+# --- User-defined word named ARRAY must not shadow the hidden system ARRAY ---
+# DIM @A[n] must continue to use the hidden system ARRAY entry even when a
+# user-visible word named ARRAY exists in the dictionary.
+
+DEF ARRAY()
+  RETURN 999
+END
+
+DEF DIM_WITH_USER_ARRAY_DEFINED()
+  DIM @B[2]
+  RETURN ARRAY_LEN(B)
+END
+
+ASSERT DIM_WITH_USER_ARRAY_DEFINED() = 2

--- a/lib/tests/test_var_init.tbx
+++ b/lib/tests/test_var_init.tbx
@@ -58,10 +58,10 @@ DEF STR_INIT()
 END
 ASSERT STR_INIT() = 5
 
-# --- VAR with ARRAY initializer ---
+# --- DIM @A[n] array creation and element access ---
 
 DEF ARRAY_INIT()
-  VAR A = ARRAY(3)
+  DIM @A[3]
   LET @A[1] = 10
   LET @A[2] = 20
   LET @A[3] = 30

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1433,45 +1433,6 @@ mod tests {
     }
 
     #[test]
-    fn test_exec_source_top_level_global_array_element_set() {
-        let mut interp = Interpreter::new();
-        let src = "\
-VAR A
-SET &A, TO_ARRAY(10, 20)
-SET &@A[2], 123
-PUTDEC @A[2]";
-        interp.exec_source(src).unwrap();
-        assert_eq!(interp.take_output(), "123");
-    }
-
-    #[test]
-    fn test_exec_source_top_level_global_array_element_read() {
-        let mut interp = Interpreter::new();
-        let src = "\
-VAR A
-SET &A, TO_ARRAY(10, 20)
-PUTDEC @A[2]";
-        interp.exec_source(src).unwrap();
-        assert_eq!(interp.take_output(), "20");
-    }
-
-    #[test]
-    fn test_exec_source_multiline_to_array() {
-        let mut interp = Interpreter::new();
-        let src = "\
-VAR A
-SET &A, TO_ARRAY(
-  10, 20,
-  30, 40
-)
-PUTDEC ARRAY_LEN(A)
-PUTSTR \":\"
-PUTDEC @A[3]";
-        interp.exec_source(src).unwrap();
-        assert_eq!(interp.take_output(), "4:30");
-    }
-
-    #[test]
     fn test_exec_source_multiline_str_concat() {
         let mut interp = Interpreter::new();
         let src = "\
@@ -2876,7 +2837,7 @@ PUTDEC 99
     #[test]
     fn test_compile_program_top_level_array_store_to_global_var() {
         let mut interp = Interpreter::new();
-        let src = "VAR A\nSET &A, ARRAY(1)\nPUTDEC ARRAY_LEN(A)";
+        let src = "DIM @A[1]\nPUTDEC ARRAY_LEN(A)";
         interp.compile_program(src).unwrap();
         assert_eq!(interp.take_output(), "1");
     }
@@ -2894,14 +2855,8 @@ PUTSTR S"#;
     #[test]
     fn test_compile_program_word_can_copy_top_level_array_global() {
         let mut interp = Interpreter::new();
-        let src = r#"VAR A
-VAR B
-DEF COPY_ARRAY()
-  SET &B, A
-END
-SET &A, ARRAY(1)
-COPY_ARRAY
-PUTDEC ARRAY_LEN(B)"#;
+        let src =
+            "DIM @A[1]\nVAR B\nDEF COPY_ARRAY()\n  SET &B, A\nEND\nCOPY_ARRAY\nPUTDEC ARRAY_LEN(B)";
         interp.compile_program(src).unwrap();
         assert_eq!(interp.take_output(), "1");
     }
@@ -4741,23 +4696,6 @@ END";
     // --- compile_program: StatementReader-based multi-line expression support (issue #520) ---
 
     #[test]
-    fn test_compile_program_multiline_to_array() {
-        // compile_program must handle multi-line TO_ARRAY(...) at ground level.
-        let mut interp = Interpreter::new();
-        let src = "\
-VAR A
-SET &A, TO_ARRAY(
-  10, 20,
-  30, 40
-)
-PUTDEC ARRAY_LEN(A)
-PUTSTR \":\"
-PUTDEC @A[3]";
-        interp.compile_program(src).unwrap();
-        assert_eq!(interp.take_output(), "4:30");
-    }
-
-    #[test]
     fn test_compile_program_multiline_str_concat() {
         // compile_program must handle multi-line STR_CONCAT(...) at ground level.
         let mut interp = Interpreter::new();
@@ -4832,35 +4770,6 @@ SHOW 0";
             .compile_program("PUTDEC 7")
             .expect("interpreter should be reusable after reader error rollback");
         assert_eq!(interp.take_output(), "7");
-    }
-
-    #[test]
-    fn test_compile_program_and_exec_source_same_multiline_boundary() {
-        // exec_source and compile_program must produce identical results for the
-        // same multi-line expression.  This verifies that the StatementReader-based
-        // migration has not introduced a boundary difference.
-        let src = "\
-VAR A
-SET &A, TO_ARRAY(
-  1, 2,
-  3
-)
-PUTDEC ARRAY_LEN(A)
-PUTDEC @A[2]";
-
-        let mut interp1 = Interpreter::new();
-        interp1.exec_source(src).unwrap();
-        let out1 = interp1.take_output();
-
-        let mut interp2 = Interpreter::new();
-        interp2.compile_program(src).unwrap();
-        let out2 = interp2.take_output();
-
-        assert_eq!(
-            out1, out2,
-            "exec_source and compile_program must produce the same output for multi-line expressions"
-        );
-        assert_eq!(out1, "32");
     }
 
     #[test]

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -796,7 +796,7 @@ pub fn dim_prim(vm: &mut VM) -> Result<(), TbxError> {
                     name: "LIT".to_string(),
                 })?;
         let array_xt = vm
-            .lookup_including_hidden("ARRAY")
+            .lookup_hidden_system("ARRAY")
             .ok_or(TbxError::UndefinedSymbol {
                 name: "ARRAY".to_string(),
             })?;
@@ -2233,7 +2233,7 @@ pub fn register_all(vm: &mut VM) {
     // Array primitives.
     // ARRAY is a hidden system entry used internally by the DIM @A[n] compiler.
     // It is NOT a user-facing surface primitive; user code uses DIM @A[n] instead.
-    // dim_prim looks this up via vm.lookup_including_hidden("ARRAY") to emit its Xt
+    // dim_prim looks this up via vm.lookup_hidden_system("ARRAY") to emit its Xt
     // into the compiled word body.
     let mut array_entry = WordEntry::new_primitive("ARRAY", array_prim);
     array_entry.flags = FLAG_SYSTEM | FLAG_HIDDEN;

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1,6 +1,6 @@
 use crate::cell::{Cell, CompileEntry};
 use crate::constants::MAX_DICTIONARY_CELLS;
-use crate::dict::{EntryKind, WordEntry, FLAG_IMMEDIATE, FLAG_SYSTEM};
+use crate::dict::{EntryKind, WordEntry, FLAG_HIDDEN, FLAG_IMMEDIATE, FLAG_SYSTEM};
 use crate::error::TbxError;
 use crate::expr::ExprCompiler;
 use crate::vm::{CompileState, VM};
@@ -795,9 +795,11 @@ pub fn dim_prim(vm: &mut VM) -> Result<(), TbxError> {
                 .ok_or(TbxError::UndefinedSymbol {
                     name: "LIT".to_string(),
                 })?;
-        let array_xt = vm.lookup("ARRAY").ok_or(TbxError::UndefinedSymbol {
-            name: "ARRAY".to_string(),
-        })?;
+        let array_xt = vm
+            .lookup_including_hidden("ARRAY")
+            .ok_or(TbxError::UndefinedSymbol {
+                name: "ARRAY".to_string(),
+            })?;
         let set_xt = vm.lookup("SET").ok_or(TbxError::UndefinedSymbol {
             name: "SET".to_string(),
         })?;
@@ -2229,22 +2231,22 @@ pub fn register_all(vm: &mut VM) {
     ));
 
     // Array primitives.
-    // ARRAY creates an array; ARRAY_GET reads an element (`@A[i]` compiles to
+    // ARRAY is a hidden system entry used internally by the DIM @A[n] compiler.
+    // It is NOT a user-facing surface primitive; user code uses DIM @A[n] instead.
+    // dim_prim looks this up via vm.lookup_including_hidden("ARRAY") to emit its Xt
+    // into the compiled word body.
+    let mut array_entry = WordEntry::new_primitive("ARRAY", array_prim);
+    array_entry.flags = FLAG_SYSTEM | FLAG_HIDDEN;
+    vm.register(array_entry);
+    // ARRAY_GET reads an element (`@A[i]` compiles to
     // `<array handle read> <index expr> ARRAY_GET`); ARRAY_ADDR computes an element
     // address (`&@A[i]` compiles to `<array handle read> <index expr> ARRAY_ADDR`).
-    // TO_ARRAY packs stack values into a new array; FROM_ARRAY expands one onto the stack.
     // ARRAY_LEN returns the length of an array.
     // TUPLE packs stack values into a new immutable Cell::Tuple.
-    let mut to_array_entry = WordEntry::new_primitive("TO_ARRAY", to_array_prim);
-    to_array_entry.is_variadic = true;
-    // arity stays 0: TO_ARRAY accepts zero or more arguments.
-    vm.register(to_array_entry);
     let mut tuple_entry = WordEntry::new_primitive("TUPLE", to_tuple_prim);
     tuple_entry.is_variadic = true;
     // arity stays 0: TUPLE accepts zero or more arguments (empty tuple is allowed).
     vm.register(tuple_entry);
-    vm.register(WordEntry::new_primitive("FROM_ARRAY", from_array_prim));
-    vm.register(WordEntry::new_primitive("ARRAY", array_prim));
     vm.register(WordEntry::new_primitive("ARRAY_LEN", array_len_prim));
     let mut array_get_entry = WordEntry::new_primitive("ARRAY_GET", array_get_prim);
     array_get_entry.flags = FLAG_SYSTEM;
@@ -3514,8 +3516,8 @@ mod tests {
     #[test]
     fn test_putval_array_error() {
         let mut vm = VM::new();
-        vm.push(Cell::Int(3)).unwrap();
-        array_prim(&mut vm).unwrap();
+        vm.arrays.push(vec![Cell::None; 3]);
+        vm.push(Cell::Array(0)).unwrap();
         assert!(matches!(
             putval_prim(&mut vm),
             Err(TbxError::TypeError { .. })
@@ -5950,63 +5952,6 @@ mod tests {
         assert!(vm.output_buffer.is_empty());
     }
 
-    // --- array_prim ---
-
-    #[test]
-    fn test_array_prim_creates_array() {
-        let mut vm = VM::new();
-        vm.push(Cell::Int(3)).unwrap();
-        array_prim(&mut vm).unwrap();
-        // Stack should contain Cell::Array(0) — first pool slot.
-        assert_eq!(vm.pop(), Ok(Cell::Array(0)));
-        // The pool should have one entry of length 3.
-        assert_eq!(vm.arrays.len(), 1);
-        assert_eq!(vm.arrays[0].len(), 3);
-    }
-
-    #[test]
-    fn test_array_prim_initialises_to_none() {
-        let mut vm = VM::new();
-        vm.push(Cell::Int(2)).unwrap();
-        array_prim(&mut vm).unwrap();
-        vm.pop().unwrap(); // discard handle
-        assert_eq!(vm.arrays[0][0], Cell::None);
-        assert_eq!(vm.arrays[0][1], Cell::None);
-    }
-
-    #[test]
-    fn test_array_prim_size_zero_returns_error() {
-        let mut vm = VM::new();
-        vm.push(Cell::Int(0)).unwrap();
-        assert!(matches!(
-            array_prim(&mut vm),
-            Err(TbxError::InvalidArgument { .. })
-        ));
-    }
-
-    #[test]
-    fn test_array_prim_negative_size_returns_error() {
-        let mut vm = VM::new();
-        vm.push(Cell::Int(-1)).unwrap();
-        assert!(matches!(
-            array_prim(&mut vm),
-            Err(TbxError::InvalidArgument { .. })
-        ));
-    }
-
-    #[test]
-    fn test_array_prim_multiple_arrays_get_distinct_indices() {
-        let mut vm = VM::new();
-        vm.push(Cell::Int(2)).unwrap();
-        array_prim(&mut vm).unwrap();
-        vm.push(Cell::Int(4)).unwrap();
-        array_prim(&mut vm).unwrap();
-        let second = vm.pop().unwrap();
-        let first = vm.pop().unwrap();
-        assert_eq!(first, Cell::Array(0));
-        assert_eq!(second, Cell::Array(1));
-    }
-
     // --- array_get_prim ---
 
     #[test]
@@ -6257,84 +6202,6 @@ mod tests {
         assert_eq!(vm.pop(), Ok(Cell::Int(77)));
     }
 
-    // --- to_array_prim ---
-
-    #[test]
-    fn test_to_array_prim_basic() {
-        // Stack: [1, 2, 3, Int(3)] → Cell::Array(0) with elems [1, 2, 3]
-        let mut vm = VM::new();
-        vm.push(Cell::Int(1)).unwrap();
-        vm.push(Cell::Int(2)).unwrap();
-        vm.push(Cell::Int(3)).unwrap();
-        vm.push(Cell::Int(3)).unwrap(); // arity
-        to_array_prim(&mut vm).unwrap();
-        assert_eq!(vm.pop(), Ok(Cell::Array(0)));
-        assert_eq!(vm.arrays[0], vec![Cell::Int(1), Cell::Int(2), Cell::Int(3)]);
-    }
-
-    #[test]
-    fn test_to_array_prim_empty() {
-        // Stack: [Int(0)] → Cell::Array(0) with empty vec
-        let mut vm = VM::new();
-        vm.push(Cell::Int(0)).unwrap(); // arity = 0
-        to_array_prim(&mut vm).unwrap();
-        assert_eq!(vm.pop(), Ok(Cell::Array(0)));
-        assert!(vm.arrays[0].is_empty());
-    }
-
-    #[test]
-    fn test_to_array_prim_single_element() {
-        // Stack: [Int(42), Int(1)] → Cell::Array(0) with elems [42]
-        let mut vm = VM::new();
-        vm.push(Cell::Int(42)).unwrap();
-        vm.push(Cell::Int(1)).unwrap(); // arity
-        to_array_prim(&mut vm).unwrap();
-        assert_eq!(vm.pop(), Ok(Cell::Array(0)));
-        assert_eq!(vm.arrays[0], vec![Cell::Int(42)]);
-    }
-
-    #[test]
-    fn test_to_array_prim_preserves_order() {
-        // Ensure push order: first arg (10) → index 0, last arg (30) → index 2.
-        let mut vm = VM::new();
-        vm.push(Cell::Int(10)).unwrap();
-        vm.push(Cell::Int(20)).unwrap();
-        vm.push(Cell::Int(30)).unwrap();
-        vm.push(Cell::Int(3)).unwrap(); // arity
-        to_array_prim(&mut vm).unwrap();
-        let _ = vm.pop().unwrap(); // discard Cell::Array handle
-        assert_eq!(vm.arrays[0][0], Cell::Int(10));
-        assert_eq!(vm.arrays[0][1], Cell::Int(20));
-        assert_eq!(vm.arrays[0][2], Cell::Int(30));
-    }
-
-    #[test]
-    fn test_to_array_prim_negative_arity_returns_error() {
-        let mut vm = VM::new();
-        vm.push(Cell::Int(-1)).unwrap(); // negative arity
-        assert!(matches!(
-            to_array_prim(&mut vm),
-            Err(TbxError::InvalidArgument { .. })
-        ));
-    }
-
-    #[test]
-    fn test_to_array_prim_multiple_calls_get_distinct_pool_indices() {
-        let mut vm = VM::new();
-        // First call: TO_ARRAY(1) → Array(0)
-        vm.push(Cell::Int(1)).unwrap();
-        vm.push(Cell::Int(1)).unwrap();
-        to_array_prim(&mut vm).unwrap();
-        // Second call: TO_ARRAY(2) → Array(1)
-        vm.push(Cell::Int(2)).unwrap();
-        vm.push(Cell::Int(1)).unwrap();
-        to_array_prim(&mut vm).unwrap();
-        let second = vm.pop().unwrap();
-        let first = vm.pop().unwrap();
-        assert_eq!(first, Cell::Array(0));
-        assert_eq!(second, Cell::Array(1));
-    }
-
     // --- to_tuple_prim ---
 
     #[test]
@@ -6431,62 +6298,6 @@ mod tests {
         vm.push(Cell::Int(0)).unwrap(); // arity = 0
         to_tuple_prim(&mut vm).unwrap();
         assert_eq!(vm.pop(), Ok(Cell::Tuple(vec![])));
-    }
-
-    // --- from_array_prim ---
-
-    #[test]
-    fn test_from_array_prim_pushes_elements_in_order() {
-        // Array [7, 8, 9]: FROM_ARRAY should push 7, 8, 9 (7 first, 9 last/top).
-        let mut vm = VM::new();
-        vm.arrays
-            .push(vec![Cell::Int(7), Cell::Int(8), Cell::Int(9)]);
-        vm.push(Cell::Array(0)).unwrap();
-        from_array_prim(&mut vm).unwrap();
-        // Stack should now be [7, 8, 9] (top = 9).
-        assert_eq!(vm.pop(), Ok(Cell::Int(9)));
-        assert_eq!(vm.pop(), Ok(Cell::Int(8)));
-        assert_eq!(vm.pop(), Ok(Cell::Int(7)));
-    }
-
-    #[test]
-    fn test_from_array_prim_empty_array_pushes_nothing() {
-        let mut vm = VM::new();
-        vm.arrays.push(vec![]);
-        let stack_depth_before = vm.data_stack.len();
-        vm.push(Cell::Array(0)).unwrap();
-        from_array_prim(&mut vm).unwrap();
-        // Stack depth must be equal to before (the handle was consumed, nothing added).
-        assert_eq!(vm.data_stack.len(), stack_depth_before);
-    }
-
-    #[test]
-    fn test_from_array_prim_type_error_on_non_array() {
-        // Passing an Int where Array is expected must return TypeError.
-        let mut vm = VM::new();
-        vm.push(Cell::Int(42)).unwrap();
-        assert!(matches!(
-            from_array_prim(&mut vm),
-            Err(TbxError::TypeError {
-                expected: "Array",
-                ..
-            })
-        ));
-    }
-
-    #[test]
-    fn test_from_array_prim_to_array_roundtrip() {
-        // TO_ARRAY then FROM_ARRAY must restore the original elements.
-        let mut vm = VM::new();
-        vm.push(Cell::Int(100)).unwrap();
-        vm.push(Cell::Int(200)).unwrap();
-        vm.push(Cell::Int(300)).unwrap();
-        vm.push(Cell::Int(3)).unwrap(); // arity
-        to_array_prim(&mut vm).unwrap(); // → Cell::Array(0) on stack
-        from_array_prim(&mut vm).unwrap(); // consume Array, push 100, 200, 300
-        assert_eq!(vm.pop(), Ok(Cell::Int(300)));
-        assert_eq!(vm.pop(), Ok(Cell::Int(200)));
-        assert_eq!(vm.pop(), Ok(Cell::Int(100)));
     }
 
     // --- int_prim ---

--- a/src/primitives/arrays.rs
+++ b/src/primitives/arrays.rs
@@ -15,31 +15,25 @@ pub(super) fn check_array_element_value(value: &Cell) -> Result<(), TbxError> {
     }
 }
 
-/// TO_ARRAY — collect N values from the stack into a new array.
+/// Internal primitive used by the `DIM @A[n]` compiler to allocate an array.
 ///
-/// The returned `Cell::Array` is bound to the current frame and must not escape.
-/// TO_ARRAY with zero arguments (`TO_ARRAY()`) produces an empty array.
-pub fn to_array_prim(vm: &mut VM) -> Result<(), TbxError> {
-    // Pop the arity pushed by the compiler.
+/// Pops `Cell::Int(n)` (n > 0) from the stack, allocates `n` `Cell::None` slots
+/// in `vm.arrays`, and pushes `Cell::Array(pool_idx)` as the handle.
+///
+/// This function is NOT registered as a user-facing surface primitive.
+/// It is registered under a hidden system entry so that `dim_prim` can emit its
+/// Xt into the compiled word body at compile time.
+pub(super) fn array_prim(vm: &mut VM) -> Result<(), TbxError> {
     let n = vm.pop_int()?;
-    if n < 0 {
+    if n <= 0 {
         return Err(TbxError::InvalidArgument {
-            message: format!("TO_ARRAY arity must be non-negative, got {n}"),
+            message: format!("ARRAY size must be positive, got {n}"),
         });
     }
-    let count = n as usize;
-    // Pop `count` values in reverse order, then reverse to restore original order.
-    let mut elems: Vec<Cell> = Vec::with_capacity(count);
-    for _ in 0..count {
-        let elem = vm.pop()?;
-        // Reject nested arrays; Cell::Str(Rc<str>) is now allowed (#591).
-        check_array_element_value(&elem)?;
-        elems.push(elem);
-    }
-    elems.reverse();
-    let pool_idx = vm.arrays.len();
-    vm.arrays.push(elems);
-    vm.push(Cell::Array(pool_idx))?;
+    let size = n as usize;
+    let idx = vm.arrays.len();
+    vm.arrays.push(vec![Cell::None; size]);
+    vm.push(Cell::Array(idx))?;
     Ok(())
 }
 
@@ -69,58 +63,6 @@ pub fn to_tuple_prim(vm: &mut VM) -> Result<(), TbxError> {
     // Cell::new_tuple validates element types and returns an error for forbidden types.
     let tuple = Cell::new_tuple(elems)?;
     vm.push(tuple)?;
-    Ok(())
-}
-
-/// FROM_ARRAY — expand an array onto the stack.
-///
-/// Pops `Cell::Array(pool_idx)` from the stack and pushes every element of the
-/// array onto the stack in order (index 0 first).
-///
-/// Stack before call: `[Cell::Array(pool_idx)]`
-/// Stack after call:  `[elem0, elem1, ..., elem(n-1)]`
-pub fn from_array_prim(vm: &mut VM) -> Result<(), TbxError> {
-    let pool_idx = match vm.pop()? {
-        Cell::Array(idx) => idx,
-        other => {
-            return Err(TbxError::TypeError {
-                expected: "Array",
-                got: other.type_name(),
-            })
-        }
-    };
-    let elems = vm
-        .arrays
-        .get(pool_idx)
-        .ok_or(TbxError::IndexOutOfBounds {
-            index: pool_idx,
-            size: vm.arrays.len(),
-        })?
-        .clone();
-    for elem in elems {
-        vm.push(elem)?;
-    }
-    Ok(())
-}
-
-/// ARRAY — create an array of N elements and push its handle onto the stack.
-///
-/// Pops `Cell::Int(n)` from the stack (n > 0), pushes `n` `Cell::None` elements
-/// into `vm.arrays`, and pushes `Cell::Array(pool_idx)` as the handle.
-///
-/// Arrays created inside a word are bound to that stack frame and freed automatically
-/// when the owning word returns (EXIT/RETURN_VAL truncates the pool).
-pub fn array_prim(vm: &mut VM) -> Result<(), TbxError> {
-    let n = vm.pop_int()?;
-    if n <= 0 {
-        return Err(TbxError::InvalidArgument {
-            message: format!("ARRAY size must be positive, got {n}"),
-        });
-    }
-    let size = n as usize;
-    let idx = vm.arrays.len();
-    vm.arrays.push(vec![Cell::None; size]);
-    vm.push(Cell::Array(idx))?;
     Ok(())
 }
 
@@ -290,7 +232,6 @@ pub fn array_len_prim(vm: &mut VM) -> Result<(), TbxError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cell::Cell;
 
     // --- tuple_get_prim ---
 
@@ -360,38 +301,5 @@ mod tests {
                 ..
             })
         ));
-    }
-
-    // --- to_array_prim ---
-
-    /// Verify that TO_ARRAY accepts Cell::Str(Rc<str>) as an array element.
-    ///
-    /// Cell::Str is Rc<str>-backed (#591); storing a string in an array element
-    /// is allowed because the Rc handle keeps the string alive independently of
-    /// any stack frame.  This test confirms that to_array_prim does not reject
-    /// Cell::Str values with InvalidArrayElement.
-    #[test]
-    fn test_to_array_accepts_str_elements() {
-        let mut vm = VM::new();
-
-        // Push two string elements followed by the arity.
-        vm.push(Cell::string("hello")).unwrap();
-        vm.push(Cell::string("world")).unwrap();
-        vm.push(Cell::Int(2)).unwrap();
-
-        to_array_prim(&mut vm).unwrap();
-
-        // The resulting Cell::Array handle should be on the stack.
-        let result = vm.pop().unwrap();
-        let pool_idx = match result {
-            Cell::Array(idx) => idx,
-            other => panic!("expected Cell::Array, got {:?}", other),
-        };
-
-        // The array pool entry must contain the two string elements in order.
-        let arr = &vm.arrays[pool_idx];
-        assert_eq!(arr.len(), 2);
-        assert_eq!(arr[0], Cell::string("hello"));
-        assert_eq!(arr[1], Cell::string("world"));
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -440,6 +440,25 @@ impl VM {
         None
     }
 
+    /// Like `lookup`, but also finds entries with `FLAG_HIDDEN` set.
+    ///
+    /// This is used by compiler primitives (e.g. `dim_prim`) that need to resolve
+    /// internal system words that are hidden from user-level name lookup.
+    pub(crate) fn lookup_including_hidden(&self, name: &str) -> Option<Xt> {
+        let mut current = self.latest;
+        while let Some(xt) = current {
+            if xt.index() >= self.headers.len() {
+                break;
+            }
+            let entry = &self.headers[xt.index()];
+            if entry.name == name {
+                return Some(xt);
+            }
+            current = entry.prev;
+        }
+        None
+    }
+
     /// Push a value onto the data stack.
     ///
     /// # Errors
@@ -2826,7 +2845,7 @@ mod tests {
         // run_source creates a fresh Interpreter (and therefore a fresh VM), so we
         // check the absence of errors rather than the pool length directly.
         let result = run_source(
-            "DEF HAS_ARRAY()\n  VAR A\n  LET A = ARRAY(3)\n  RETURN 1\nEND\n\
+            "DEF HAS_ARRAY()\n  DIM @A[3]\n  RETURN 1\nEND\n\
              PUTDEC HAS_ARRAY()",
         );
         assert_eq!(
@@ -2841,7 +2860,7 @@ mod tests {
         // Verify that returning a frame-local Cell::Array via RETURN_VAL succeeds
         // (ownership transfer instead of escape error).
         let result = run_source(
-            "DEF MAKE_ARRAY()\n  VAR A\n  LET A = ARRAY(3)\n  RETURN A\nEND\n\
+            "DEF MAKE_ARRAY()\n  DIM @A[3]\n  RETURN A\nEND\n\
              PUTDEC ARRAY_LEN(MAKE_ARRAY())",
         );
         assert!(result.is_ok(), "expected success, got: {result:?}");
@@ -2865,7 +2884,7 @@ mod tests {
         // Verify that ownership transfer works across multiple call levels:
         // OUTER calls INNER which returns an array, then OUTER returns it.
         let result = run_source(
-            "DEF INNER()\n  VAR A\n  LET A = TO_ARRAY(10, 20, 30)\n  RETURN A\nEND\n\
+            "DEF INNER()\n  DIM @A[3]\n  RETURN A\nEND\n\
              DEF OUTER()\n  VAR B\n  LET B = INNER()\n  RETURN B\nEND\n\
              PUTDEC ARRAY_LEN(OUTER())",
         );
@@ -2894,7 +2913,7 @@ mod tests {
         // no swap occurs and the result is valid.
         let result = run_source(
             "DEF PASS_THROUGH(A)\n  RETURN A\nEND\n\
-             DEF CALLER()\n  VAR B\n  LET B = TO_ARRAY(1, 2, 3)\n  RETURN PASS_THROUGH(B)\nEND\n\
+             DEF CALLER()\n  DIM @B[3]\n  RETURN PASS_THROUGH(B)\nEND\n\
              PUTDEC ARRAY_LEN(CALLER())",
         );
         assert!(result.is_ok(), "expected success, got: {result:?}");
@@ -2906,7 +2925,7 @@ mod tests {
         // Verify that STORE of a Cell::Array into a global variable produces ArrayFrameEscape.
         let result = run_source(
             "VAR G\n\
-             DEF BAD_STORE()\n  VAR A\n  LET A = ARRAY(2)\n  SET &G, A\nEND\n\
+             DEF BAD_STORE()\n  DIM @A[2]\n  SET &G, A\nEND\n\
              BAD_STORE",
         );
         assert!(
@@ -3023,7 +3042,7 @@ mod tests {
         // global_array_pool_len = 0 (default), so all arrays created in words are frame-local.
         let result = run_source(
             "VAR gvar\n\
-             DEF BAD()\n  VAR a\n  LET a = ARRAY(3)\n  SET &gvar, a\nEND\n\
+             DEF BAD()\n  DIM @a[3]\n  SET &gvar, a\nEND\n\
              BAD",
         );
         assert!(
@@ -3140,7 +3159,7 @@ mod tests {
         let mut interp = crate::interpreter::Interpreter::new();
         interp
             .exec_source(
-                "DEF MAKE_AND_DROP()\n  VAR A\n  LET A = ARRAY(5)\n  RETURN 42\nEND\n\
+                "DEF MAKE_AND_DROP()\n  DIM @A[5]\n  RETURN 42\nEND\n\
                  PUTDEC MAKE_AND_DROP()",
             )
             .expect("exec_source failed");
@@ -3234,7 +3253,7 @@ mod tests {
         let mut interp = crate::interpreter::Interpreter::new();
         interp
             .exec_source(
-                "DEF GIVE_ARRAY()\n  VAR A\n  LET A = TO_ARRAY(1,2,3)\n  RETURN A\nEND\n\
+                "DEF GIVE_ARRAY()\n  DIM @A[3]\n  RETURN A\nEND\n\
                  PUTDEC ARRAY_LEN(GIVE_ARRAY())",
             )
             .expect("exec_source failed");

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -440,18 +440,22 @@ impl VM {
         None
     }
 
-    /// Like `lookup`, but also finds entries with `FLAG_HIDDEN` set.
+    /// Returns the first entry that is **both** `FLAG_HIDDEN` and `FLAG_SYSTEM`
+    /// and has the given name.
     ///
     /// This is used by compiler primitives (e.g. `dim_prim`) that need to resolve
-    /// internal system words that are hidden from user-level name lookup.
-    pub(crate) fn lookup_including_hidden(&self, name: &str) -> Option<Xt> {
+    /// internal system words that are hidden from user-level name lookup, without
+    /// accidentally matching a user-defined word of the same name.
+    pub(crate) fn lookup_hidden_system(&self, name: &str) -> Option<Xt> {
         let mut current = self.latest;
         while let Some(xt) = current {
             if xt.index() >= self.headers.len() {
                 break;
             }
             let entry = &self.headers[xt.index()];
-            if entry.name == name {
+            let is_hidden = entry.flags & crate::dict::FLAG_HIDDEN != 0;
+            let is_system = entry.flags & crate::dict::FLAG_SYSTEM != 0;
+            if entry.name == name && is_hidden && is_system {
                 return Some(xt);
             }
             current = entry.prev;
@@ -1333,6 +1337,40 @@ mod tests {
         // With self_word=None, finds neither.
         assert_eq!(vm.lookup_including_self("FACT", None), None);
         assert_eq!(vm.lookup_including_self("HELPER", None), None);
+    }
+
+    #[test]
+    fn test_lookup_hidden_system_returns_only_hidden_system_entry() {
+        // lookup_hidden_system must return an entry only when both FLAG_HIDDEN and
+        // FLAG_SYSTEM are set.  A user-visible word with the same name must not be
+        // returned, even if it is more recently registered.
+        use crate::dict::{FLAG_HIDDEN, FLAG_SYSTEM};
+        let mut vm = VM::new();
+        crate::primitives::register_all(&mut vm);
+
+        // Locate the built-in hidden+system ARRAY entry registered by register_all.
+        let system_xt = vm.lookup_hidden_system("ARRAY").unwrap();
+
+        // Register a plain (visible, non-system) user word named "ARRAY".
+        vm.register(WordEntry::new_word("ARRAY", 999));
+        let user_xt = vm.lookup("ARRAY").unwrap();
+        assert_ne!(user_xt, system_xt);
+
+        // lookup_hidden_system must still return the hidden system entry, not the user word.
+        assert_eq!(vm.lookup_hidden_system("ARRAY"), Some(system_xt));
+
+        // Register a hidden-only (non-system) word — must not be returned.
+        vm.register(WordEntry::new_word("ARRAY", 888));
+        vm.headers.last_mut().unwrap().flags |= FLAG_HIDDEN;
+        assert_eq!(vm.lookup_hidden_system("ARRAY"), Some(system_xt));
+
+        // Register a system-only (non-hidden) word — must not be returned.
+        vm.register(WordEntry::new_word("ARRAY", 777));
+        vm.headers.last_mut().unwrap().flags |= FLAG_SYSTEM;
+        assert_eq!(vm.lookup_hidden_system("ARRAY"), Some(system_xt));
+
+        // A name that does not exist must return None.
+        assert_eq!(vm.lookup_hidden_system("NO_SUCH_WORD"), None);
     }
 
     #[test]

--- a/tests/tbx_lib_tests.rs
+++ b/tests/tbx_lib_tests.rs
@@ -110,7 +110,7 @@ fn test_array_index_zero_is_out_of_bounds() {
         .set_base_dir(base)
         .expect("CARGO_MANIFEST_DIR is always absolute");
     // Array indices are 1-based; index 0 must return ArrayIndexOutOfBounds.
-    let src = "DEF T()\n  VAR A\n  LET A = ARRAY(3)\n  RETURN @A[0]\nEND\nT\n";
+    let src = "DEF T()\n  DIM @A[3]\n  RETURN @A[0]\nEND\nT\n";
     let err = interp
         .exec_source(src)
         .expect_err("index 0 should be out of bounds");
@@ -134,7 +134,7 @@ fn test_array_index_zero_is_out_of_bounds() {
 fn test_legacy_global_array_paren_syntax_is_not_array_access() {
     let mut interp = Interpreter::new();
     // Set up a global array and attempt to read element 2 using the old syntax.
-    let src = "VAR A\nSET &A, TO_ARRAY(10, 20)\nPUTDEC A(2)\n";
+    let src = "DIM @A[2]\nLET @A[1] = 10\nLET @A[2] = 20\nPUTDEC A(2)\n";
     let err = interp
         .exec_source(src)
         .expect_err("A(i) must not work as array value access");
@@ -158,7 +158,7 @@ fn test_legacy_local_array_paren_syntax_is_not_array_access() {
     let mut interp = Interpreter::new();
     // Define a function that sets up a local array and attempts to read
     // element 1 using the old A(i) syntax.
-    let src = "DEF F()\n  VAR A\n  LET A = ARRAY(3)\n  LET @A[1] = 10\n  RETURN A(1)\nEND\nF()\n";
+    let src = "DEF F()\n  DIM @A[3]\n  LET @A[1] = 10\n  RETURN A(1)\nEND\nF()\n";
     let err = interp
         .exec_source(src)
         .expect_err("A(i) must not work as local array value access");
@@ -181,7 +181,7 @@ fn test_legacy_local_array_paren_syntax_is_not_array_access() {
 #[test]
 fn test_legacy_global_array_paren_addr_syntax_is_not_array_addr_access() {
     let mut interp = Interpreter::new();
-    let src = "VAR A\nSET &A, TO_ARRAY(10, 20)\nSET &A(1), 99\n";
+    let src = "DIM @A[2]\nLET @A[1] = 10\nLET @A[2] = 20\nSET &A(1), 99\n";
     interp
         .exec_source(src)
         .expect_err("SET &A(i) for global variable must fail");
@@ -197,7 +197,7 @@ fn test_legacy_local_array_paren_addr_syntax_is_not_array_addr_access() {
     let mut interp = Interpreter::new();
     // Define a function that sets up a local array and attempts to write
     // element 1 using the old `SET &A(i), value` syntax.
-    let src = "DEF F()\n  VAR A\n  LET A = ARRAY(3)\n  SET &A(1), 99\n  RETURN @A[1]\nEND\nF()\n";
+    let src = "DEF F()\n  DIM @A[3]\n  SET &A(1), 99\n  RETURN @A[1]\nEND\nF()\n";
     // Either compilation or runtime must fail — &A(i) no longer writes to
     // an array element.
     interp
@@ -222,7 +222,7 @@ fn test_legacy_local_array_paren_addr_syntax_is_not_array_addr_access() {
 fn test_set_runtime_str_into_array_is_allowed() {
     let mut interp = Interpreter::new();
     // Note: void DEF is called without parentheses (statement form).
-    let src = "DEF T()\n  VAR A\n  LET A = ARRAY(1)\n  SET &@A[1], STR(\"hello\")\nEND\nT\n";
+    let src = "DEF T()\n  DIM @A[1]\n  SET &@A[1], STR(\"hello\")\nEND\nT\n";
     interp
         .exec_source(src)
         .expect("storing runtime Str in array should succeed");
@@ -233,7 +233,7 @@ fn test_set_runtime_str_into_array_is_allowed() {
 #[test]
 fn test_set_literal_str_into_array_is_allowed() {
     let mut interp = Interpreter::new();
-    let src = "VAR A\nSET &A, ARRAY(1)\nSET &@A[1], \"hello\"\nPUTSTR @A[1]\n";
+    let src = "DIM @A[1]\nSET &@A[1], \"hello\"\nPUTSTR @A[1]\n";
     interp
         .exec_source(src)
         .expect("storing string literal in array should succeed");
@@ -245,8 +245,7 @@ fn test_set_literal_str_into_array_is_allowed() {
 #[test]
 fn test_set_literal_str_into_array_inside_def_is_allowed() {
     let mut interp = Interpreter::new();
-    let src =
-        "DEF MAKE()\n  VAR A\n  SET &A, ARRAY(1)\n  SET &@A[1], \"inside\"\n  PUTSTR @A[1]\nEND\nMAKE\n";
+    let src = "DEF MAKE()\n  DIM @A[1]\n  SET &@A[1], \"inside\"\n  PUTSTR @A[1]\nEND\nMAKE\n";
     interp
         .exec_source(src)
         .expect("storing string literal in array inside DEF should succeed");
@@ -260,7 +259,8 @@ fn test_set_literal_str_into_array_inside_def_is_allowed() {
 fn test_set_runtime_str_into_global_array_survives_word_return() {
     let mut interp = Interpreter::new();
     // F is a void word; call it without parentheses to avoid DROP_TO_MARKER mismatch.
-    let src = "VAR A\nSET &A, ARRAY(1)\nDEF F()\n  SET &@A[1], STR_CONCAT(\"foo\", \"bar\")\nEND\nF\nPUTSTR @A[1]\n";
+    let src =
+        "DIM @A[1]\nDEF F()\n  SET &@A[1], STR_CONCAT(\"foo\", \"bar\")\nEND\nF\nPUTSTR @A[1]\n";
     interp
         .exec_source(src)
         .expect("storing runtime Str in global array should succeed");
@@ -273,7 +273,7 @@ fn test_set_runtime_str_into_global_array_survives_word_return() {
 fn test_set_runtime_str_into_frame_local_array_is_allowed() {
     let mut interp = Interpreter::new();
     // F is a void word; call it without parentheses to avoid DROP_TO_MARKER mismatch.
-    let src = "DEF F()\n  VAR A\n  SET &A, ARRAY(1)\n  SET &@A[1], STR(\"hello\")\n  PUTSTR @A[1]\nEND\nF\n";
+    let src = "DEF F()\n  DIM @A[1]\n  SET &@A[1], STR(\"hello\")\n  PUTSTR @A[1]\nEND\nF\n";
     interp
         .exec_source(src)
         .expect("storing runtime Str in frame-local array should succeed");
@@ -284,24 +284,22 @@ fn test_set_runtime_str_into_frame_local_array_is_allowed() {
 #[test]
 fn test_set_caller_owned_str_param_into_frame_local_array_is_allowed() {
     let mut interp = Interpreter::new();
-    let src = "DEF USE(S)\n  VAR A\n  SET &A, ARRAY(1)\n  SET &@A[1], S\n  PUTSTR @A[1]\nEND\nUSE(\"arg\")\n";
+    let src = "DEF USE(S)\n  DIM @A[1]\n  SET &@A[1], S\n  PUTSTR @A[1]\nEND\nUSE(\"arg\")\n";
     interp
         .exec_source(src)
         .expect("storing caller-owned Str param in frame-local array should succeed");
     assert_eq!(interp.take_output(), "arg");
 }
 
-/// TO_ARRAY(STR("a"), STR("b")) must now succeed (#591); the results can be
-/// read back via array indexing.
+/// Str values can be stored in array elements and read back (#591).
 #[test]
 fn test_to_array_with_str_elements_is_allowed() {
     let mut interp = Interpreter::new();
-    // Store TO_ARRAY result, read element 1 and 2 back via PUTSTR.
-    let src =
-        "VAR A\nSET &A, TO_ARRAY(STR(\"alpha\"), STR(\"beta\"))\nPUTSTR @A[1]\nPUTSTR @A[2]\n";
+    // Create an array and store string elements; read back via PUTSTR.
+    let src = "DIM @A[2]\nSET &@A[1], STR(\"alpha\")\nSET &@A[2], STR(\"beta\")\nPUTSTR @A[1]\nPUTSTR @A[2]\n";
     interp
         .exec_source(src)
-        .expect("TO_ARRAY with Str elements should succeed");
+        .expect("storing Str elements in array should succeed");
     assert_eq!(interp.take_output(), "alphabeta");
 }
 
@@ -311,7 +309,7 @@ fn test_str_ops_on_array_element_str() {
     let mut interp = Interpreter::new();
     // Use PUTSTR to exercise reading the element and passing it to string primitives.
     // STR_CONCAT output confirms the element was successfully read as Str.
-    let src = "VAR A\nSET &A, ARRAY(1)\nSET &@A[1], \"hello\"\nPUTSTR STR_CONCAT(@A[1], \"!\")\n";
+    let src = "DIM @A[1]\nSET &@A[1], \"hello\"\nPUTSTR STR_CONCAT(@A[1], \"!\")\n";
     interp
         .exec_source(src)
         .expect("string ops on array element should succeed");
@@ -323,8 +321,7 @@ fn test_str_ops_on_array_element_str() {
 fn test_set_array_into_array_is_invalid_element_type() {
     let mut interp = Interpreter::new();
     // Create an outer array and a nested array, then try to store the inner in outer.
-    let src =
-        "DEF T()\n  VAR A, B\n  LET A = ARRAY(3)\n  LET B = ARRAY(2)\n  SET &@A[1], B\nEND\nT\n";
+    let src = "DEF T()\n  DIM @A[3]\n  DIM @B[2]\n  SET &@A[1], B\nEND\nT\n";
     let err = interp
         .exec_source(src)
         .expect_err("storing Array in array element should fail");
@@ -406,7 +403,7 @@ fn test_duplicate_local_var_with_init_then_no_init_is_error() {
 #[test]
 fn test_tuple_with_array_element_is_invalid() {
     let mut interp = Interpreter::new();
-    let src = "DEF T()\n  VAR A\n  LET A = ARRAY(3)\n  RETURN TUPLE(A)\nEND\nT\n";
+    let src = "DEF T()\n  DIM @A[3]\n  RETURN TUPLE(A)\nEND\nT\n";
     let err = interp
         .exec_source(src)
         .expect_err("TUPLE(Array) should fail with invalid tuple element error");


### PR DESCRIPTION
## 概要

`ARRAY` / `TO_ARRAY` / `FROM_ARRAY` を surface primitive から撤去し、不要になった実装・ユニットテスト・コメントを削除する。`array_prim` は `DIM @A[n]` コンパイラが内部で使うため、隠しシステムエントリとして維持する。

## 変更内容

- `src/primitives/arrays.rs`: `to_array_prim` / `from_array_prim` を削除。`array_prim` は `pub(super)` の内部専用関数として残し、DIMコンパイラの内部用であることをdocコメントに明記
- `src/primitives.rs`: `TO_ARRAY` / `FROM_ARRAY` の `vm.register` を削除。`ARRAY` を `FLAG_SYSTEM | FLAG_HIDDEN` フラグ付きで登録（ユーザーコードから参照不可）。`dim_prim` が `vm.lookup_including_hidden("ARRAY")` でXtを取得するよう変更
- `src/vm.rs`: `lookup_including_hidden` メソッドを追加（FLAG_HIDDENエントリも検索）。`TO_ARRAY` / `ARRAY` に依存していたテストを `DIM @A[n]` 構文で書き換え
- `src/interpreter.rs`: `TO_ARRAY` / `ARRAY` に依存していたテストを削除または `DIM @A[n]` で書き換え
- `tests/tbx_lib_tests.rs`: `TO_ARRAY` / `ARRAY` に依存していたテストを `DIM @A[n]` 構文で書き換え
- `lib/basic.tbx`: `HMS` 関数を `TO_ARRAY(...)` から `TUPLE(...)` に変更
- `lib/tests/test_var_init.tbx`: `VAR A = ARRAY(n)` を `DIM @A[n]` に変更

## 残したもの

- `ARRAY_GET` / `ARRAY_ADDR` / `ARRAY_LEN` / `TUPLE` / `TUPLE_GET` は維持
- `Cell::Array` enum variant は削除せず内部ストレージハンドルとして維持
- `check_array_element_value` は `memory.rs` から参照されているため維持

Closes #703
