### PR TITLE
TUPLE_LEN primitive を追加する

### DIFF
--- a/lib/tests/test_tuple_len.tbx
+++ b/lib/tests/test_tuple_len.tbx
@@ -1,0 +1,26 @@
+# lib/tests/test_tuple_len.tbx — TBX tests for TUPLE_LEN
+USE "lib/tests/helper.tbx"
+
+# --- TUPLE_LEN: empty tuple returns 0 ---
+
+ASSERT TUPLE_LEN(TUPLE()) = 0
+
+# --- TUPLE_LEN: multi-element tuple returns length ---
+
+ASSERT TUPLE_LEN(TUPLE(1, 2, 3)) = 3
+
+# --- TUPLE_LEN: tuple stored in a variable ---
+
+DEF LEN_FROM_VAR()
+  VAR T
+  LET T = TUPLE(10, 20, 30, 40)
+  RETURN TUPLE_LEN(T)
+END
+ASSERT LEN_FROM_VAR() = 4
+
+# --- TUPLE_LEN: tuple returned from a function ---
+
+DEF MAKE_PAIR()
+  RETURN TUPLE(7, 8)
+END
+ASSERT TUPLE_LEN(MAKE_PAIR()) = 2

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -2248,6 +2248,7 @@ pub fn register_all(vm: &mut VM) {
     // arity stays 0: TUPLE accepts zero or more arguments (empty tuple is allowed).
     vm.register(tuple_entry);
     vm.register(WordEntry::new_primitive("ARRAY_LEN", array_len_prim));
+    vm.register(WordEntry::new_primitive("TUPLE_LEN", tuple_len_prim));
     let mut array_get_entry = WordEntry::new_primitive("ARRAY_GET", array_get_prim);
     array_get_entry.flags = FLAG_SYSTEM;
     vm.register(array_get_entry);

--- a/src/primitives/arrays.rs
+++ b/src/primitives/arrays.rs
@@ -204,6 +204,25 @@ pub fn tuple_get_prim(vm: &mut VM) -> Result<(), TbxError> {
     Ok(())
 }
 
+/// TUPLE_LEN — return the number of elements in a tuple.
+///
+/// Pops `Cell::Tuple(elems)` from the stack and pushes the element count as `Cell::Int`.
+/// Returns `TbxError::TypeError` if the top of the stack is not a `Cell::Tuple`.
+///
+/// Stack: `[..., Cell::Tuple(elems)]` → `Cell::Int(len)`
+pub fn tuple_len_prim(vm: &mut VM) -> Result<(), TbxError> {
+    match vm.pop()? {
+        Cell::Tuple(elems) => {
+            vm.push(Cell::Int(elems.len() as i64))?;
+            Ok(())
+        }
+        other => Err(TbxError::TypeError {
+            expected: "Tuple",
+            got: other.type_name(),
+        }),
+    }
+}
+
 /// ARRAY_LEN — return the length of an array.
 ///
 /// Pops `Cell::Array(pool_idx)` from the stack and pushes the number of elements
@@ -232,6 +251,52 @@ pub fn array_len_prim(vm: &mut VM) -> Result<(), TbxError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- tuple_len_prim ---
+
+    #[test]
+    fn test_tuple_len_prim_empty() {
+        // An empty tuple must return 0.
+        let mut vm = VM::new();
+        let tuple = Cell::new_tuple(vec![]).unwrap();
+        vm.push(tuple).unwrap();
+        tuple_len_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Int(0)));
+    }
+
+    #[test]
+    fn test_tuple_len_prim_one_element() {
+        // A one-element tuple must return 1.
+        let mut vm = VM::new();
+        let tuple = Cell::new_tuple(vec![Cell::Int(42)]).unwrap();
+        vm.push(tuple).unwrap();
+        tuple_len_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Int(1)));
+    }
+
+    #[test]
+    fn test_tuple_len_prim_multi_element() {
+        // A three-element tuple must return 3.
+        let mut vm = VM::new();
+        let tuple = Cell::new_tuple(vec![Cell::Int(1), Cell::Int(2), Cell::Int(3)]).unwrap();
+        vm.push(tuple).unwrap();
+        tuple_len_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Int(3)));
+    }
+
+    #[test]
+    fn test_tuple_len_prim_non_tuple_returns_type_error() {
+        // A non-Tuple value must produce a TypeError.
+        let mut vm = VM::new();
+        vm.push(Cell::Int(99)).unwrap();
+        assert!(matches!(
+            tuple_len_prim(&mut vm),
+            Err(TbxError::TypeError {
+                expected: "Tuple",
+                ..
+            })
+        ));
+    }
 
     // --- tuple_get_prim ---
 


### PR DESCRIPTION
## 概要

`Cell::Tuple` の要素数を返す `TUPLE_LEN` primitive を追加した。
`ARRAY_LEN` と対称な設計で、tuple 以外を渡すと `TypeError` を返す。

## 変更内容

- `src/primitives/arrays.rs` — `tuple_len_prim` 関数を追加し、Rust unit tests 4ケースを追加した
- `src/primitives.rs` — `TUPLE_LEN` を primitive として登録した
- `lib/tests/test_tuple_len.tbx` — TBX integration test 4ケースを追加した（empty tuple、multi-element tuple、変数経由、関数戻り値経由）

Closes #709
