### PR TITLE
Cell::Array(usize) を Cell::Array(ArrayRef) へ移行する

### DIFF
--- a/src/array_ref.rs
+++ b/src/array_ref.rs
@@ -58,6 +58,28 @@ impl ArrayRef {
         self.inner.borrow().get(idx).cloned()
     }
 
+    /// Return `true` if `self` and `other` share the same underlying `Rc` allocation.
+    ///
+    /// This is pointer identity, not content equality.  Content equality semantics
+    /// for arrays are deferred to a follow-up issue.
+    pub fn ptr_eq(&self, other: &Self) -> bool {
+        Rc::ptr_eq(&self.inner, &other.inner)
+    }
+
+    /// Apply a mutable closure to the underlying `Vec<Cell>`.
+    ///
+    /// The `borrow_mut()` guard is held only for the duration of the closure and
+    /// is dropped before this function returns.  No `RefMut` escapes the call.
+    ///
+    /// Use this for in-place mutations (e.g. shuffle) where the element-level
+    /// `set()` API is insufficient.
+    pub fn with_mut<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(&mut Vec<Cell>) -> R,
+    {
+        f(&mut self.inner.borrow_mut())
+    }
+
     /// Write `value` into position `idx`.
     ///
     /// Returns `Err(TbxError::ArrayIndexOutOfBounds)` if `idx >= len`.

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -1,3 +1,4 @@
+use crate::array_ref::ArrayRef;
 use crate::error::TbxError;
 
 /// An entry on the compile-time stack (`VM::compile_stack`).
@@ -84,29 +85,22 @@ pub enum Cell {
     Xt(Xt),
     /// Boolean value for logical/comparison operations
     Bool(bool),
-    /// Array handle — index into `VM::arrays` (the array pool).
+    /// Array handle — an Rc-backed shared mutable container.
     ///
-    /// Created by the `ARRAY(N)` primitive.  The pool entry at this index holds
-    /// a `Vec<Cell>` of length N.
+    /// Created by the `ARRAY(N)` / `DIM @A[N]` construct.  The `ArrayRef`
+    /// wraps `Rc<RefCell<Vec<Cell>>>`, so cloning a `Cell::Array` is cheap
+    /// (reference-count bump) and all clones share the same underlying storage.
     ///
-    /// Arrays come in three flavours:
-    /// - **Frame-local arrays** (`pool_idx >= saved_array_pool_len` of the current call
-    ///   frame) are owned by that frame.  On EXIT they are freed; on RETURN_VAL the
-    ///   returned array is moved to the frame-boundary slot via ownership transfer
-    ///   (swap + truncate) so it survives the pool cleanup.
-    /// - **Global arrays** (`pool_idx < vm.global_array_pool_len`) are created
-    ///   at the top level (outside any `DEF..END`) and are never freed.  They
-    ///   may safely be stored in `VARIABLE` slots and shared across word calls.
-    /// - **Caller-owned arrays** (`pool_idx < saved_array_pool_len` of the current
-    ///   call frame but not globally permanent) were created before the call; they
-    ///   can be returned without modification.
+    /// Arrays also maintain a parallel entry in `VM::arrays` (the pool) so that
+    /// `Cell::ArrayAddr { pool_idx, elem_idx }` can still locate the storage
+    /// by index.  When `ArrayAddr` is migrated to `(ArrayRef, elem_idx)` in a
+    /// follow-up issue, the pool entries and the associated lifetime logic
+    /// (`saved_array_pool_len`, `global_array_pool_len`, `ArrayFrameEscape`)
+    /// will be removed.
     ///
     /// Array elements may be any scalar type (`Int`, `Float`, `Bool`, `None`,
     /// or `Str`).  Nested `Array` handles are rejected at write time.
-    /// Because `Cell::Str` is `Rc<str>`-backed (#588 / #591), storing a string
-    /// in an array element stores/shares the `Rc` handle; no pool-index
-    /// lifetime tracking is needed.
-    Array(usize),
+    Array(ArrayRef),
     /// Immutable reference-counted string handle (`Rc<str>`).
     ///
     /// Created by string primitives such as `STR`, `STR_CONCAT`, etc., and by
@@ -169,7 +163,7 @@ impl std::fmt::Display for Cell {
             Cell::StackAddr(a) => write!(f, "stack:{}", a),
             Cell::Xt(x) => write!(f, "xt:{}", x.0),
             Cell::Bool(b) => write!(f, "{}", b),
-            Cell::Array(idx) => write!(f, "<array:{}>", idx),
+            Cell::Array(_) => write!(f, "<array>"),
             Cell::Str(s) => write!(f, "{}", s),
             Cell::ArrayAddr { pool_idx, elem_idx } => {
                 write!(f, "<arrayaddr:{}[{}]>", pool_idx, elem_idx)
@@ -245,10 +239,10 @@ impl Cell {
         }
     }
 
-    /// Returns the pool index if this cell is `Array`, otherwise `None`.
-    pub fn as_array_index(&self) -> Option<usize> {
-        if let Cell::Array(idx) = self {
-            Some(*idx)
+    /// Returns a reference to the `ArrayRef` if this cell is `Array`, otherwise `None`.
+    pub fn as_array_ref(&self) -> Option<&ArrayRef> {
+        if let Cell::Array(ar) = self {
+            Some(ar)
         } else {
             None
         }
@@ -346,7 +340,9 @@ impl PartialEq for Cell {
             (Cell::Xt(a), Cell::Xt(b)) => a == b,
             (Cell::Bool(a), Cell::Bool(b)) => a == b,
             (Cell::None, Cell::None) => true,
-            (Cell::Array(a), Cell::Array(b)) => a == b,
+            // Array equality: Rc pointer identity only.
+            // Content equality semantics are deferred to a follow-up issue.
+            (Cell::Array(a), Cell::Array(b)) => a.ptr_eq(b),
             // Content equality: two Str cells are equal when their underlying
             // string contents match.  (Previously this was an index comparison
             // when `Cell::Str` was `usize`; `Rc<str>` derives `PartialEq` from
@@ -443,8 +439,8 @@ mod tests {
 
     #[test]
     fn test_display_array() {
-        assert_eq!(Cell::Array(0).to_string(), "<array:0>");
-        assert_eq!(Cell::Array(42).to_string(), "<array:42>");
+        let ar = ArrayRef::new(vec![]);
+        assert_eq!(Cell::Array(ar).to_string(), "<array>");
         assert_eq!(
             Cell::ArrayAddr {
                 pool_idx: 3,
@@ -505,7 +501,7 @@ mod tests {
         assert_eq!(Cell::Xt(Xt(0)).type_name(), "Xt");
         assert_eq!(Cell::Bool(false).type_name(), "Bool");
         assert_eq!(Cell::None.type_name(), "None");
-        assert_eq!(Cell::Array(0).type_name(), "Array");
+        assert_eq!(Cell::Array(ArrayRef::new(vec![])).type_name(), "Array");
         assert_eq!(Cell::string("hello").type_name(), "Str");
     }
 
@@ -606,7 +602,7 @@ mod tests {
     #[test]
     fn tuple_element_type_rejection() {
         // Cell::Array is a forbidden element type
-        let result = Cell::new_tuple(vec![Cell::Array(0)]);
+        let result = Cell::new_tuple(vec![Cell::Array(ArrayRef::new(vec![]))]);
         assert!(result.is_err());
         // Cell::Tuple (nested) is forbidden
         let inner = Cell::new_tuple(vec![Cell::Int(1)]).unwrap();
@@ -630,7 +626,7 @@ mod tests {
         assert!(!Cell::Float(0.0).is_truthy());
         // non-Int/Bool/Float variants are falsy
         assert!(!Cell::None.is_truthy());
-        assert!(!Cell::Array(0).is_truthy());
+        assert!(!Cell::Array(ArrayRef::new(vec![])).is_truthy());
         assert!(!Cell::DictAddr(1).is_truthy());
         assert!(!Cell::StackAddr(1).is_truthy());
     }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -898,15 +898,20 @@ pub fn dim_prim(vm: &mut VM) -> Result<(), TbxError> {
         let storage_idx = vm.dp;
         vm.dict_write(Cell::None)?;
 
-        // Create the array in the array pool.
+        // Create the array using ArrayRef (Rc-backed shared mutable container).
+        let ar = crate::array_ref::ArrayRef::new(vec![Cell::None; size]);
+
+        // Register in vm.arrays so that Cell::ArrayAddr can locate this array
+        // by pool_idx.  This registration will be removed when ArrayAddr is
+        // migrated to (ArrayRef, elem_idx) in a follow-up issue.
         let pool_idx = vm.arrays.len();
-        vm.arrays.push(vec![Cell::None; size]);
+        vm.arrays.push(ar.clone());
 
         // Promote to the global array region so it persists across word calls.
         vm.global_array_pool_len = vm.global_array_pool_len.max(pool_idx + 1);
 
         // Store the array handle in the variable slot.
-        vm.dict_write_at(storage_idx, Cell::Array(pool_idx))?;
+        vm.dict_write_at(storage_idx, Cell::Array(ar))?;
 
         // Register the variable in the dictionary.
         let entry = crate::dict::WordEntry::new_variable(&name, storage_idx);
@@ -1881,14 +1886,14 @@ pub fn randomize_prim(vm: &mut VM) -> Result<(), TbxError> {
 
 /// SHUFFLE — randomly permute the elements of an array in place.
 ///
-/// Pops `Cell::Array(pool_idx)` from the stack, shuffles the array's elements
-/// using the VM's RNG, and pushes the same `Cell::Array(pool_idx)` back.
+/// Pops `Cell::Array(ArrayRef)` from the stack, shuffles the array's elements
+/// using the VM's RNG, and pushes the same `Cell::Array(ArrayRef)` back.
 ///
 /// Stack signature: `( arr:Array -- arr:Array )`
 pub fn shuffle_prim(vm: &mut VM) -> Result<(), TbxError> {
     use rand::seq::SliceRandom;
-    let pool_idx = match vm.pop()? {
-        Cell::Array(idx) => idx,
+    let ar = match vm.pop()? {
+        Cell::Array(ar) => ar,
         other => {
             return Err(TbxError::TypeError {
                 expected: "Array",
@@ -1896,16 +1901,10 @@ pub fn shuffle_prim(vm: &mut VM) -> Result<(), TbxError> {
             })
         }
     };
-    let arrays_len = vm.arrays.len();
-    let arr = vm
-        .arrays
-        .get_mut(pool_idx)
-        .ok_or(TbxError::IndexOutOfBounds {
-            index: pool_idx,
-            size: arrays_len,
-        })?;
-    arr.shuffle(&mut vm.rng);
-    vm.push(Cell::Array(pool_idx))
+    // Borrow the inner Vec mutably for the duration of the shuffle only.
+    // with_mut() ensures the borrow_mut guard does not escape the closure.
+    ar.with_mut(|v| v.shuffle(&mut vm.rng));
+    vm.push(Cell::Array(ar))
 }
 
 /// UNIXTIME — return the current time as seconds since the Unix epoch.
@@ -2284,8 +2283,22 @@ pub fn register_all(vm: &mut VM) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::array_ref::ArrayRef;
     use crate::cell::{Cell, CompileEntry};
     use crate::constants::MAX_DICTIONARY_CELLS;
+
+    /// Create a new `ArrayRef` from the given elements, register it in `vm.arrays`,
+    /// push `Cell::Array(ArrayRef)` onto the data stack, and return the `pool_idx`.
+    ///
+    /// This helper mirrors the pattern used by `array_prim` / `dim_prim` so that
+    /// unit tests can set up arrays without duplicating the two-step push.
+    fn push_new_array(vm: &mut VM, elems: Vec<Cell>) -> usize {
+        let pool_idx = vm.arrays.len();
+        let ar = ArrayRef::new(elems);
+        vm.arrays.push(ar.clone());
+        vm.push(Cell::Array(ar)).unwrap();
+        pool_idx
+    }
 
     // --- drop_prim ---
 
@@ -3517,8 +3530,7 @@ mod tests {
     #[test]
     fn test_putval_array_error() {
         let mut vm = VM::new();
-        vm.arrays.push(vec![Cell::None; 3]);
-        vm.push(Cell::Array(0)).unwrap();
+        push_new_array(&mut vm, vec![Cell::None; 3]);
         assert!(matches!(
             putval_prim(&mut vm),
             Err(TbxError::TypeError { .. })
@@ -5959,9 +5971,7 @@ mod tests {
     fn test_array_get_prim_reads_element() {
         // User index 1 maps to internal index 0.
         let mut vm = VM::new();
-        vm.arrays
-            .push(vec![Cell::Int(10), Cell::Int(20), Cell::Int(30)]);
-        vm.push(Cell::Array(0)).unwrap();
+        push_new_array(&mut vm, vec![Cell::Int(10), Cell::Int(20), Cell::Int(30)]);
         vm.push(Cell::Int(1)).unwrap();
         array_get_prim(&mut vm).unwrap();
         assert_eq!(vm.pop(), Ok(Cell::Int(10)));
@@ -5971,9 +5981,7 @@ mod tests {
     fn test_array_get_prim_reads_second_element() {
         // User index 2 maps to internal index 1.
         let mut vm = VM::new();
-        vm.arrays
-            .push(vec![Cell::Int(10), Cell::Int(20), Cell::Int(30)]);
-        vm.push(Cell::Array(0)).unwrap();
+        push_new_array(&mut vm, vec![Cell::Int(10), Cell::Int(20), Cell::Int(30)]);
         vm.push(Cell::Int(2)).unwrap();
         array_get_prim(&mut vm).unwrap();
         assert_eq!(vm.pop(), Ok(Cell::Int(20)));
@@ -5982,8 +5990,7 @@ mod tests {
     #[test]
     fn test_array_get_prim_out_of_bounds() {
         let mut vm = VM::new();
-        vm.arrays.push(vec![Cell::Int(1)]);
-        vm.push(Cell::Array(0)).unwrap();
+        push_new_array(&mut vm, vec![Cell::Int(1)]);
         vm.push(Cell::Int(5)).unwrap();
         assert!(matches!(
             array_get_prim(&mut vm),
@@ -5995,8 +6002,7 @@ mod tests {
     fn test_array_get_prim_zero_index_is_out_of_bounds() {
         // Index 0 is invalid in 1-based indexing.
         let mut vm = VM::new();
-        vm.arrays.push(vec![Cell::Int(1)]);
-        vm.push(Cell::Array(0)).unwrap();
+        push_new_array(&mut vm, vec![Cell::Int(1)]);
         vm.push(Cell::Int(0)).unwrap();
         assert!(matches!(
             array_get_prim(&mut vm),
@@ -6007,8 +6013,7 @@ mod tests {
     #[test]
     fn test_array_get_prim_negative_index() {
         let mut vm = VM::new();
-        vm.arrays.push(vec![Cell::Int(1)]);
-        vm.push(Cell::Array(0)).unwrap();
+        push_new_array(&mut vm, vec![Cell::Int(1)]);
         vm.push(Cell::Int(-1)).unwrap();
         assert!(matches!(
             array_get_prim(&mut vm),
@@ -6022,14 +6027,13 @@ mod tests {
     fn test_array_addr_prim_pushes_array_addr() {
         // User index 1 maps to internal elem_idx 0.
         let mut vm = VM::new();
-        vm.arrays.push(vec![Cell::Int(0), Cell::Int(0)]);
-        vm.push(Cell::Array(0)).unwrap();
+        let pool_idx = push_new_array(&mut vm, vec![Cell::Int(0), Cell::Int(0)]);
         vm.push(Cell::Int(1)).unwrap();
         array_addr_prim(&mut vm).unwrap();
         assert_eq!(
             vm.pop(),
             Ok(Cell::ArrayAddr {
-                pool_idx: 0,
+                pool_idx,
                 elem_idx: 0
             })
         );
@@ -6039,8 +6043,7 @@ mod tests {
     fn test_array_addr_prim_zero_index_is_out_of_bounds() {
         // Index 0 is invalid in 1-based indexing.
         let mut vm = VM::new();
-        vm.arrays.push(vec![Cell::Int(0), Cell::Int(0)]);
-        vm.push(Cell::Array(0)).unwrap();
+        push_new_array(&mut vm, vec![Cell::Int(0), Cell::Int(0)]);
         vm.push(Cell::Int(0)).unwrap();
         assert!(matches!(
             array_addr_prim(&mut vm),
@@ -6054,8 +6057,24 @@ mod tests {
     fn test_store_array_to_dict_addr_is_escape_error() {
         let mut vm = VM::new();
         vm.dictionary.push(Cell::None); // dict[0] = placeholder
-                                        // Try to store Cell::Array(0) into a global variable slot.
-        vm.push(Cell::Array(0)).unwrap(); // value
+                                        // Try to store Cell::Array into a global variable slot.
+                                        // An array not in vm.arrays and not at top level triggers ArrayFrameEscape.
+        let ar = ArrayRef::new(vec![]);
+        vm.arrays.push(ar.clone());
+        // global_array_pool_len = 0: not global; no Call frame but also not TopLevel
+        // (empty return_stack means is_executing_top_level() returns false for this case).
+        // Actually with no return_stack push, is_executing_top_level() checks the last frame.
+        // Let's use a Call frame to ensure it's not top-level.
+        use crate::cell::{ReturnFrame, Xt};
+        vm.return_stack.push(ReturnFrame::TopLevel);
+        vm.return_stack.push(ReturnFrame::Call {
+            callee_xt: Xt(0),
+            return_pc: 0,
+            saved_bp: 0,
+            saved_array_pool_len: 0,
+            actual_arity: 0,
+        });
+        vm.push(Cell::Array(ar)).unwrap(); // value
         vm.push(Cell::DictAddr(0)).unwrap(); // address
         assert_eq!(store_prim(&mut vm), Err(TbxError::ArrayFrameEscape));
     }
@@ -6064,9 +6083,20 @@ mod tests {
     fn test_set_array_to_dict_addr_is_escape_error() {
         let mut vm = VM::new();
         vm.dictionary.push(Cell::None); // dict[0] = placeholder
-                                        // set_prim: stack is [..., addr, value]
+        let ar = ArrayRef::new(vec![]);
+        vm.arrays.push(ar.clone());
+        use crate::cell::{ReturnFrame, Xt};
+        vm.return_stack.push(ReturnFrame::TopLevel);
+        vm.return_stack.push(ReturnFrame::Call {
+            callee_xt: Xt(0),
+            return_pc: 0,
+            saved_bp: 0,
+            saved_array_pool_len: 0,
+            actual_arity: 0,
+        });
+        // set_prim: stack is [..., addr, value]
         vm.push(Cell::DictAddr(0)).unwrap(); // address
-        vm.push(Cell::Array(0)).unwrap(); // value
+        vm.push(Cell::Array(ar)).unwrap(); // value
         assert_eq!(set_prim(&mut vm), Err(TbxError::ArrayFrameEscape));
     }
 
@@ -6075,29 +6105,33 @@ mod tests {
     #[test]
     fn test_store_to_array_addr() {
         let mut vm = VM::new();
-        vm.arrays.push(vec![Cell::None, Cell::None]);
+        let ar = ArrayRef::new(vec![Cell::None, Cell::None]);
+        let pool_idx = vm.arrays.len();
+        vm.arrays.push(ar);
         vm.push(Cell::Int(99)).unwrap();
         vm.push(Cell::ArrayAddr {
-            pool_idx: 0,
+            pool_idx,
             elem_idx: 1,
         })
         .unwrap();
         store_prim(&mut vm).unwrap();
-        assert_eq!(vm.arrays[0][1], Cell::Int(99));
+        assert_eq!(vm.arrays[pool_idx].get_cloned(1), Some(Cell::Int(99)));
     }
 
     #[test]
     fn test_set_to_array_addr() {
         let mut vm = VM::new();
-        vm.arrays.push(vec![Cell::None, Cell::None]);
+        let ar = ArrayRef::new(vec![Cell::None, Cell::None]);
+        let pool_idx = vm.arrays.len();
+        vm.arrays.push(ar);
         vm.push(Cell::ArrayAddr {
-            pool_idx: 0,
+            pool_idx,
             elem_idx: 0,
         })
         .unwrap();
         vm.push(Cell::Int(42)).unwrap();
         set_prim(&mut vm).unwrap();
-        assert_eq!(vm.arrays[0][0], Cell::Int(42));
+        assert_eq!(vm.arrays[pool_idx].get_cloned(0), Some(Cell::Int(42)));
     }
 
     // --- array element write: Cell::Str (D-4: Rc<str> liberation, #591) ---
@@ -6111,77 +6145,100 @@ mod tests {
     fn test_set_str_to_array_element_is_allowed() {
         // Cell::Str(Rc<str>) written through SET must succeed (#591).
         let mut vm = VM::new();
-        vm.arrays.push(vec![Cell::None]);
+        let ar = ArrayRef::new(vec![Cell::None]);
+        let pool_idx = vm.arrays.len();
+        vm.arrays.push(ar);
         vm.push(Cell::ArrayAddr {
-            pool_idx: 0,
+            pool_idx,
             elem_idx: 0,
         })
         .unwrap();
         vm.push(Cell::string("hello")).unwrap();
         set_prim(&mut vm).unwrap();
-        assert_eq!(vm.arrays[0][0], Cell::string("hello"));
+        assert_eq!(
+            vm.arrays[pool_idx].get_cloned(0),
+            Some(Cell::string("hello"))
+        );
     }
 
     #[test]
     fn test_store_str_to_array_element_is_allowed() {
         // Same as the SET path above, exercised through STORE (#591).
         let mut vm = VM::new();
-        vm.arrays.push(vec![Cell::None]);
+        let ar = ArrayRef::new(vec![Cell::None]);
+        let pool_idx = vm.arrays.len();
+        vm.arrays.push(ar);
         vm.push(Cell::string("world")).unwrap();
         vm.push(Cell::ArrayAddr {
-            pool_idx: 0,
+            pool_idx,
             elem_idx: 0,
         })
         .unwrap();
         store_prim(&mut vm).unwrap();
-        assert_eq!(vm.arrays[0][0], Cell::string("world"));
+        assert_eq!(
+            vm.arrays[pool_idx].get_cloned(0),
+            Some(Cell::string("world"))
+        );
     }
 
     #[test]
     fn test_set_str_to_global_array_element_is_allowed() {
         // Storing a Str into a global array (global_array_pool_len covers it) must succeed.
         let mut vm = VM::new();
-        vm.arrays.push(vec![Cell::None]);
+        let ar = ArrayRef::new(vec![Cell::None]);
+        let pool_idx = vm.arrays.len();
+        vm.arrays.push(ar);
         vm.global_array_pool_len = 1; // mark as global
         vm.push(Cell::ArrayAddr {
-            pool_idx: 0,
+            pool_idx,
             elem_idx: 0,
         })
         .unwrap();
         vm.push(Cell::string("global")).unwrap();
         set_prim(&mut vm).unwrap();
-        assert_eq!(vm.arrays[0][0], Cell::string("global"));
+        assert_eq!(
+            vm.arrays[pool_idx].get_cloned(0),
+            Some(Cell::string("global"))
+        );
     }
 
     #[test]
     fn test_set_str_to_frame_local_array_element_is_allowed() {
         // Storing a Str into a frame-local array must succeed (#591).
         let mut vm = VM::new();
-        vm.arrays.push(vec![Cell::None]);
+        let ar = ArrayRef::new(vec![Cell::None]);
+        let pool_idx = vm.arrays.len();
+        vm.arrays.push(ar);
         // global_array_pool_len = 0 (default) → array is frame-local
         vm.push(Cell::ArrayAddr {
-            pool_idx: 0,
+            pool_idx,
             elem_idx: 0,
         })
         .unwrap();
         vm.push(Cell::string("frame-local")).unwrap();
         set_prim(&mut vm).unwrap();
-        assert_eq!(vm.arrays[0][0], Cell::string("frame-local"));
+        assert_eq!(
+            vm.arrays[pool_idx].get_cloned(0),
+            Some(Cell::string("frame-local"))
+        );
     }
 
     #[test]
     fn test_set_nested_array_to_array_element_is_invalid_array_element() {
         // Cell::Array must always be rejected as an array element.
         let mut vm = VM::new();
-        vm.arrays.push(vec![Cell::None]); // pool_idx = 0: target array
-        vm.arrays.push(vec![Cell::None]); // pool_idx = 1: value to store
+        let target_ar = ArrayRef::new(vec![Cell::None]);
+        let target_pool_idx = vm.arrays.len();
+        vm.arrays.push(target_ar);
         vm.global_array_pool_len = 2; // both are global
         vm.push(Cell::ArrayAddr {
-            pool_idx: 0,
+            pool_idx: target_pool_idx,
             elem_idx: 0,
         })
         .unwrap();
-        vm.push(Cell::Array(1)).unwrap();
+        // Create a nested array as the value (not registered in pool for simplicity).
+        let nested_ar = ArrayRef::new(vec![Cell::None]);
+        vm.push(Cell::Array(nested_ar)).unwrap();
         assert_eq!(
             set_prim(&mut vm),
             Err(TbxError::InvalidArrayElement { got: "Array" })
@@ -6193,9 +6250,11 @@ mod tests {
     #[test]
     fn test_fetch_array_addr() {
         let mut vm = VM::new();
-        vm.arrays.push(vec![Cell::Int(77)]);
+        let ar = ArrayRef::new(vec![Cell::Int(77)]);
+        let pool_idx = vm.arrays.len();
+        vm.arrays.push(ar);
         vm.push(Cell::ArrayAddr {
-            pool_idx: 0,
+            pool_idx,
             elem_idx: 0,
         })
         .unwrap();
@@ -6273,8 +6332,7 @@ mod tests {
     fn test_to_tuple_prim_rejects_array() {
         // Cell::Array is a forbidden tuple element type.
         let mut vm = VM::new();
-        vm.arrays.push(vec![Cell::Int(1)]);
-        vm.push(Cell::Array(0)).unwrap();
+        push_new_array(&mut vm, vec![Cell::Int(1)]);
         vm.push(Cell::Int(1)).unwrap(); // arity
         assert!(matches!(
             to_tuple_prim(&mut vm),
@@ -6359,8 +6417,7 @@ mod tests {
     fn test_array_len_prim_basic() {
         // ARRAY_LEN on a 5-element array must return 5.
         let mut vm = VM::new();
-        vm.arrays.push(vec![Cell::None; 5]);
-        vm.push(Cell::Array(0)).unwrap();
+        push_new_array(&mut vm, vec![Cell::None; 5]);
         array_len_prim(&mut vm).unwrap();
         assert_eq!(vm.pop(), Ok(Cell::Int(5)));
     }
@@ -6369,8 +6426,7 @@ mod tests {
     fn test_array_len_prim_one_element() {
         // ARRAY_LEN on a 1-element array must return 1.
         let mut vm = VM::new();
-        vm.arrays.push(vec![Cell::None]);
-        vm.push(Cell::Array(0)).unwrap();
+        push_new_array(&mut vm, vec![Cell::None]);
         array_len_prim(&mut vm).unwrap();
         assert_eq!(vm.pop(), Ok(Cell::Int(1)));
     }
@@ -6458,22 +6514,27 @@ mod tests {
         use rand::SeedableRng;
         let mut vm = VM::new();
         vm.rng = rand::rngs::SmallRng::seed_from_u64(123);
-        vm.arrays.push(vec![
-            Cell::Int(1),
-            Cell::Int(2),
-            Cell::Int(3),
-            Cell::Int(4),
-            Cell::Int(5),
-        ]);
-        vm.push(Cell::Array(0)).unwrap();
+        let pool_idx = push_new_array(
+            &mut vm,
+            vec![
+                Cell::Int(1),
+                Cell::Int(2),
+                Cell::Int(3),
+                Cell::Int(4),
+                Cell::Int(5),
+            ],
+        );
         shuffle_prim(&mut vm).unwrap();
-        // The returned value must be Cell::Array(0).
-        assert_eq!(vm.pop(), Ok(Cell::Array(0)));
+        // The returned value must be a Cell::Array sharing the same Rc.
+        let returned = vm.pop().unwrap();
+        assert!(
+            matches!(&returned, Cell::Array(ar) if ar.ptr_eq(&vm.arrays[pool_idx])),
+            "returned Cell::Array must share Rc with pool entry"
+        );
         // All original elements must still be present (order may differ).
-        let mut values: Vec<i64> = vm.arrays[0]
-            .iter()
-            .map(|c| match c {
-                Cell::Int(n) => *n,
+        let mut values: Vec<i64> = (0..5)
+            .map(|i| match vm.arrays[pool_idx].get_cloned(i).unwrap() {
+                Cell::Int(n) => n,
                 _ => panic!("unexpected cell type"),
             })
             .collect();
@@ -6487,15 +6548,12 @@ mod tests {
         use rand::SeedableRng;
         let mut vm = VM::new();
         vm.rng = rand::rngs::SmallRng::seed_from_u64(42);
-        vm.arrays
-            .push(vec![Cell::Int(1), Cell::Int(2), Cell::Int(3)]);
-        vm.push(Cell::Array(0)).unwrap();
+        let pool_idx = push_new_array(&mut vm, vec![Cell::Int(1), Cell::Int(2), Cell::Int(3)]);
         shuffle_prim(&mut vm).unwrap();
         vm.pop().unwrap();
-        let first_run: Vec<i64> = vm.arrays[0]
-            .iter()
-            .map(|c| match c {
-                Cell::Int(n) => *n,
+        let first_run: Vec<i64> = (0..3)
+            .map(|i| match vm.arrays[pool_idx].get_cloned(i).unwrap() {
+                Cell::Int(n) => n,
                 _ => panic!("unexpected cell type"),
             })
             .collect();
@@ -6503,15 +6561,12 @@ mod tests {
         // Reset and run again with the same seed.
         let mut vm2 = VM::new();
         vm2.rng = rand::rngs::SmallRng::seed_from_u64(42);
-        vm2.arrays
-            .push(vec![Cell::Int(1), Cell::Int(2), Cell::Int(3)]);
-        vm2.push(Cell::Array(0)).unwrap();
+        let pool_idx2 = push_new_array(&mut vm2, vec![Cell::Int(1), Cell::Int(2), Cell::Int(3)]);
         shuffle_prim(&mut vm2).unwrap();
         vm2.pop().unwrap();
-        let second_run: Vec<i64> = vm2.arrays[0]
-            .iter()
-            .map(|c| match c {
-                Cell::Int(n) => *n,
+        let second_run: Vec<i64> = (0..3)
+            .map(|i| match vm2.arrays[pool_idx2].get_cloned(i).unwrap() {
+                Cell::Int(n) => n,
                 _ => panic!("unexpected cell type"),
             })
             .collect();
@@ -6523,11 +6578,14 @@ mod tests {
     fn test_shuffle_prim_empty_array() {
         // SHUFFLE on an empty array must not error.
         let mut vm = VM::new();
-        vm.arrays.push(vec![]);
-        vm.push(Cell::Array(0)).unwrap();
+        let pool_idx = push_new_array(&mut vm, vec![]);
         shuffle_prim(&mut vm).unwrap();
-        assert_eq!(vm.pop(), Ok(Cell::Array(0)));
-        assert_eq!(vm.arrays[0].len(), 0);
+        let returned = vm.pop().unwrap();
+        assert!(
+            matches!(&returned, Cell::Array(ar) if ar.ptr_eq(&vm.arrays[pool_idx])),
+            "returned Cell::Array must share Rc with pool entry"
+        );
+        assert_eq!(vm.arrays[pool_idx].len(), 0);
     }
 
     #[test]

--- a/src/primitives/arrays.rs
+++ b/src/primitives/arrays.rs
@@ -1,3 +1,4 @@
+use crate::array_ref::ArrayRef;
 use crate::cell::Cell;
 use crate::error::TbxError;
 use crate::vm::VM;
@@ -17,8 +18,9 @@ pub(super) fn check_array_element_value(value: &Cell) -> Result<(), TbxError> {
 
 /// Internal primitive used by the `DIM @A[n]` compiler to allocate an array.
 ///
-/// Pops `Cell::Int(n)` (n > 0) from the stack, allocates `n` `Cell::None` slots
-/// in `vm.arrays`, and pushes `Cell::Array(pool_idx)` as the handle.
+/// Pops `Cell::Int(n)` (n > 0) from the stack, creates an `ArrayRef` with `n`
+/// `Cell::None` slots, registers it in `vm.arrays` for `ArrayAddr` compatibility,
+/// and pushes `Cell::Array(ArrayRef)` as the handle.
 ///
 /// This function is NOT registered as a user-facing surface primitive.
 /// It is registered under a hidden system entry so that `dim_prim` can emit its
@@ -31,9 +33,12 @@ pub(super) fn array_prim(vm: &mut VM) -> Result<(), TbxError> {
         });
     }
     let size = n as usize;
-    let idx = vm.arrays.len();
-    vm.arrays.push(vec![Cell::None; size]);
-    vm.push(Cell::Array(idx))?;
+    let ar = ArrayRef::new(vec![Cell::None; size]);
+    // Register in vm.arrays so that Cell::ArrayAddr can locate this array by
+    // pool_idx.  This will be removed when ArrayAddr is migrated to
+    // (ArrayRef, elem_idx) in a follow-up issue.
+    vm.arrays.push(ar.clone());
+    vm.push(Cell::Array(ar))?;
     Ok(())
 }
 
@@ -68,17 +73,17 @@ pub fn to_tuple_prim(vm: &mut VM) -> Result<(), TbxError> {
 
 /// ARRAY_GET — read an element from an array.
 ///
-/// Stack: `[..., Cell::Array(pool_idx), Cell::Int(elem_idx)]` → `value`
+/// Stack: `[..., Cell::Array(ArrayRef), Cell::Int(elem_idx)]` → `value`
 ///
 /// This is the VM-level primitive that `@A[i]` compiles to.  The expression
 /// compiler lowers `@A[i]` to: `<array handle read>  <index expr>  ARRAY_GET`.
 ///
 /// Array indices are 1-based from the user's perspective: valid range is `1..=N`.
-/// The index is translated to 0-based internally before accessing the Vec.
+/// The index is translated to 0-based internally before accessing the storage.
 pub fn array_get_prim(vm: &mut VM) -> Result<(), TbxError> {
     let elem_idx_raw = vm.pop_int()?;
-    let pool_idx = match vm.pop()? {
-        Cell::Array(idx) => idx,
+    let ar = match vm.pop()? {
+        Cell::Array(ar) => ar,
         other => {
             return Err(TbxError::TypeError {
                 expected: "Array",
@@ -86,11 +91,7 @@ pub fn array_get_prim(vm: &mut VM) -> Result<(), TbxError> {
             })
         }
     };
-    let arr = vm.arrays.get(pool_idx).ok_or(TbxError::IndexOutOfBounds {
-        index: pool_idx,
-        size: vm.arrays.len(),
-    })?;
-    let size = arr.len();
+    let size = ar.len();
     // Translate 1-based user index to 0-based internal index.
     // Index 0 or negative is out of bounds.
     if elem_idx_raw < 1 {
@@ -106,14 +107,19 @@ pub fn array_get_prim(vm: &mut VM) -> Result<(), TbxError> {
             size,
         });
     }
-    let value = arr[elem_idx].clone();
+    let value = ar
+        .get_cloned(elem_idx)
+        .ok_or(TbxError::ArrayIndexOutOfBounds {
+            index: elem_idx_raw,
+            size,
+        })?;
     vm.push(value)?;
     Ok(())
 }
 
 /// ARRAY_ADDR — compute the address of an array element.
 ///
-/// Stack: `[..., Cell::Array(pool_idx), Cell::Int(elem_idx)]` → `Cell::ArrayAddr { pool_idx, elem_idx }`
+/// Stack: `[..., Cell::Array(ArrayRef), Cell::Int(elem_idx)]` → `Cell::ArrayAddr { pool_idx, elem_idx }`
 ///
 /// This is the VM-level primitive that `&@A[i]` compiles to.  The expression
 /// compiler lowers `&@A[i]` to: `<array handle read>  <index expr>  ARRAY_ADDR`.
@@ -122,10 +128,15 @@ pub fn array_get_prim(vm: &mut VM) -> Result<(), TbxError> {
 ///
 /// Array indices are 1-based from the user's perspective: valid range is `1..=N`.
 /// The index is translated to 0-based internally before storing in `Cell::ArrayAddr`.
+///
+/// NOTE: `Cell::ArrayAddr` still uses `pool_idx` to locate the array in
+/// `VM::arrays`.  The `ArrayRef` is used only for bounds checking here.
+/// When `ArrayAddr` is migrated to `(ArrayRef, elem_idx)` in a follow-up issue,
+/// the `pool_idx` lookup will be removed.
 pub fn array_addr_prim(vm: &mut VM) -> Result<(), TbxError> {
     let elem_idx_raw = vm.pop_int()?;
-    let pool_idx = match vm.pop()? {
-        Cell::Array(idx) => idx,
+    let ar = match vm.pop()? {
+        Cell::Array(ar) => ar,
         other => {
             return Err(TbxError::TypeError {
                 expected: "Array",
@@ -133,12 +144,7 @@ pub fn array_addr_prim(vm: &mut VM) -> Result<(), TbxError> {
             })
         }
     };
-    // Validate bounds at address-computation time.
-    let arr = vm.arrays.get(pool_idx).ok_or(TbxError::IndexOutOfBounds {
-        index: pool_idx,
-        size: vm.arrays.len(),
-    })?;
-    let size = arr.len();
+    let size = ar.len();
     // Translate 1-based user index to 0-based internal index.
     // Index 0 or negative is out of bounds.
     if elem_idx_raw < 1 {
@@ -154,6 +160,18 @@ pub fn array_addr_prim(vm: &mut VM) -> Result<(), TbxError> {
             size,
         });
     }
+    // Locate the pool_idx by finding the matching ArrayRef in vm.arrays.
+    // This lookup is O(n) but arrays are small and this path is only used for
+    // &@A[i] address-of operations.  The pool_idx lookup will be eliminated
+    // when ArrayAddr is migrated to (ArrayRef, elem_idx).
+    let pool_idx =
+        vm.arrays
+            .iter()
+            .position(|entry| entry.ptr_eq(&ar))
+            .ok_or(TbxError::InvalidArgument {
+                message: "ARRAY_ADDR: array not found in pool (possible use-after-free)"
+                    .to_string(),
+            })?;
     vm.push(Cell::ArrayAddr { pool_idx, elem_idx })?;
     Ok(())
 }
@@ -225,13 +243,13 @@ pub fn tuple_len_prim(vm: &mut VM) -> Result<(), TbxError> {
 
 /// ARRAY_LEN — return the length of an array.
 ///
-/// Pops `Cell::Array(pool_idx)` from the stack and pushes the number of elements
+/// Pops `Cell::Array(ArrayRef)` from the stack and pushes the number of elements
 /// as `Cell::Int`.
 ///
-/// Stack: `[..., Cell::Array(pool_idx)]` → `Cell::Int(len)`
+/// Stack: `[..., Cell::Array(ArrayRef)]` → `Cell::Int(len)`
 pub fn array_len_prim(vm: &mut VM) -> Result<(), TbxError> {
-    let pool_idx = match vm.pop()? {
-        Cell::Array(idx) => idx,
+    let ar = match vm.pop()? {
+        Cell::Array(ar) => ar,
         other => {
             return Err(TbxError::TypeError {
                 expected: "Array",
@@ -239,11 +257,7 @@ pub fn array_len_prim(vm: &mut VM) -> Result<(), TbxError> {
             })
         }
     };
-    let arr = vm.arrays.get(pool_idx).ok_or(TbxError::IndexOutOfBounds {
-        index: pool_idx,
-        size: vm.arrays.len(),
-    })?;
-    let len = arr.len() as i64;
+    let len = ar.len() as i64;
     vm.push(Cell::Int(len))?;
     Ok(())
 }

--- a/src/primitives/memory.rs
+++ b/src/primitives/memory.rs
@@ -1,14 +1,15 @@
+use crate::array_ref::ArrayRef;
 use crate::cell::Cell;
 use crate::error::TbxError;
 use crate::vm::VM;
 
-/// Extract the array pool index from a `Cell::Array`.
+/// Return the `ArrayRef` if `cell` is `Cell::Array`, otherwise `None`.
 ///
-/// Returns `None` for any cell that is not `Cell::Array`.  `Cell::Str` is
-/// `Rc<str>`-backed and has no VM-managed pool index.
-fn array_pool_idx_from_cell(cell: &Cell) -> Option<usize> {
+/// This helper is used by STORE / SET to detect when an array handle is being
+/// written to a dictionary slot, so the frame-escape check can be applied.
+fn array_ref_from_cell(cell: &Cell) -> Option<&ArrayRef> {
     match cell {
-        Cell::Array(idx) => Some(*idx),
+        Cell::Array(ar) => Some(ar),
         _ => None,
     }
 }
@@ -22,16 +23,26 @@ fn promote_array_pool_idx_to_global(vm: &mut VM, pool_idx: usize) {
 }
 
 fn check_dict_reference_write(vm: &mut VM, value: &Cell) -> Result<(), TbxError> {
-    let Some(pool_idx) = array_pool_idx_from_cell(value) else {
+    let Some(ar) = array_ref_from_cell(value) else {
         return Ok(());
     };
 
-    if is_global_array_pool_idx(vm, pool_idx) {
-        return Ok(());
+    // Find the pool_idx for this ArrayRef.  If it is not registered in the
+    // pool at all, treat it as non-global (conservative: will return Err below
+    // if inside a call frame).
+    let pool_idx = vm.arrays.iter().position(|entry| entry.ptr_eq(ar));
+
+    if let Some(idx) = pool_idx {
+        if is_global_array_pool_idx(vm, idx) {
+            return Ok(());
+        }
     }
 
     if vm.is_executing_top_level() {
-        promote_array_pool_idx_to_global(vm, pool_idx);
+        // Promote to global if possible.
+        if let Some(idx) = pool_idx {
+            promote_array_pool_idx_to_global(vm, idx);
+        }
         return Ok(());
     }
 
@@ -45,24 +56,18 @@ fn write_array_element(
     elem_idx: usize,
     value: Cell,
 ) -> Result<(), TbxError> {
-    // Validate before get_mut() to avoid borrow conflicts.
+    // Validate before borrowing to avoid borrow conflicts.
     super::arrays::check_array_element_value(&value)?;
     let pool_size = vm.arrays.len();
-    let arr = vm
+    let ar = vm
         .arrays
-        .get_mut(pool_idx)
+        .get(pool_idx)
         .ok_or(TbxError::IndexOutOfBounds {
             index: pool_idx,
             size: pool_size,
-        })?;
-    let size = arr.len();
-    if elem_idx >= size {
-        return Err(TbxError::ArrayIndexOutOfBounds {
-            index: elem_idx as i64,
-            size,
-        });
-    }
-    arr[elem_idx] = value;
+        })?
+        .clone();
+    ar.set(elem_idx, value)?;
     Ok(())
 }
 
@@ -81,18 +86,28 @@ pub fn fetch_prim(vm: &mut VM) -> Result<(), TbxError> {
             Ok(())
         }
         Cell::ArrayAddr { pool_idx, elem_idx } => {
-            let arr = vm.arrays.get(pool_idx).ok_or(TbxError::IndexOutOfBounds {
-                index: pool_idx,
-                size: vm.arrays.len(),
-            })?;
-            let size = arr.len();
+            let pool_size = vm.arrays.len();
+            let ar = vm
+                .arrays
+                .get(pool_idx)
+                .ok_or(TbxError::IndexOutOfBounds {
+                    index: pool_idx,
+                    size: pool_size,
+                })?
+                .clone();
+            let size = ar.len();
             if elem_idx >= size {
                 return Err(TbxError::ArrayIndexOutOfBounds {
                     index: elem_idx as i64,
                     size,
                 });
             }
-            let value = arr[elem_idx].clone();
+            let value = ar
+                .get_cloned(elem_idx)
+                .ok_or(TbxError::ArrayIndexOutOfBounds {
+                    index: elem_idx as i64,
+                    size,
+                })?;
             vm.push(value)?;
             Ok(())
         }
@@ -160,23 +175,32 @@ pub fn set_prim(vm: &mut VM) -> Result<(), TbxError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::array_ref::ArrayRef;
     use crate::cell::{Cell, ReturnFrame, Xt};
 
+    /// Helper to create a one-element pool entry and push Cell::Array for tests
+    /// that still exercise the pool-index path (ARRAY_ADDR / STORE / FETCH).
+    fn push_pooled_array(vm: &mut VM, elems: Vec<Cell>) -> usize {
+        let pool_idx = vm.arrays.len();
+        let ar = ArrayRef::new(elems);
+        vm.arrays.push(ar.clone());
+        vm.push(Cell::Array(ar)).unwrap();
+        pool_idx
+    }
+
     #[test]
-    fn test_array_pool_idx_from_cell_array_only() {
-        // array_pool_idx_from_cell returns Some only for Cell::Array;
-        // Cell::Str is Rc<str>-backed and has no array pool index.
-        assert_eq!(array_pool_idx_from_cell(&Cell::Array(3)), Some(3));
-        assert_eq!(array_pool_idx_from_cell(&Cell::string("hello")), None);
-        assert_eq!(
-            array_pool_idx_from_cell(&Cell::ArrayAddr {
-                pool_idx: 1,
-                elem_idx: 2,
-            }),
-            None
-        );
-        assert_eq!(array_pool_idx_from_cell(&Cell::DictAddr(0)), None);
-        assert_eq!(array_pool_idx_from_cell(&Cell::StackAddr(0)), None);
+    fn test_array_ref_from_cell_array_only() {
+        // array_ref_from_cell returns Some only for Cell::Array.
+        let ar = ArrayRef::new(vec![Cell::Int(3)]);
+        assert!(array_ref_from_cell(&Cell::Array(ar)).is_some());
+        assert!(array_ref_from_cell(&Cell::string("hello")).is_none());
+        assert!(array_ref_from_cell(&Cell::DictAddr(0)).is_none());
+        assert!(array_ref_from_cell(&Cell::StackAddr(0)).is_none());
+        assert!(array_ref_from_cell(&Cell::ArrayAddr {
+            pool_idx: 1,
+            elem_idx: 2
+        })
+        .is_none());
     }
 
     #[test]
@@ -204,11 +228,10 @@ mod tests {
         let mut vm = VM::new();
 
         // Create a one-element array with initial value Cell::None.
-        let pool_idx = vm.arrays.len();
-        vm.arrays.push(vec![Cell::None]);
+        let pool_idx = push_pooled_array(&mut vm, vec![Cell::None]);
 
-        // Push array handle and 1-based index, then call ARRAY_ADDR.
-        vm.push(Cell::Array(pool_idx)).unwrap();
+        // Push 1-based index, then call ARRAY_ADDR.
+        // Note: push_pooled_array already pushed Cell::Array on the stack.
         vm.push(Cell::Int(1)).unwrap();
         array_addr_prim(&mut vm).unwrap();
 
@@ -224,8 +247,8 @@ mod tests {
 
         store_prim(&mut vm).unwrap();
 
-        // Verify the array element was updated.
-        assert_eq!(vm.arrays[pool_idx][0], new_value);
+        // Verify the array element was updated via the pool entry.
+        assert_eq!(vm.arrays[pool_idx].get_cloned(0), Some(new_value.clone()));
 
         // Now FETCH: push the ArrayAddr again and call fetch_prim.
         vm.push(Cell::ArrayAddr {
@@ -246,14 +269,15 @@ mod tests {
 
         // Outer array — the target element.
         let outer_idx = vm.arrays.len();
-        vm.arrays.push(vec![Cell::None]);
+        let outer_ar = ArrayRef::new(vec![Cell::None]);
+        vm.arrays.push(outer_ar);
 
         // Inner array — the value to be (illegally) stored.
-        let inner_idx = vm.arrays.len();
-        vm.arrays.push(vec![Cell::Int(1)]);
+        let inner_ar = ArrayRef::new(vec![Cell::Int(1)]);
+        let inner_cell = Cell::Array(inner_ar);
 
         // STORE convention: push value then addr.
-        vm.push(Cell::Array(inner_idx)).unwrap();
+        vm.push(inner_cell).unwrap();
         vm.push(Cell::ArrayAddr {
             pool_idx: outer_idx,
             elem_idx: 0,
@@ -275,11 +299,12 @@ mod tests {
 
         // Target array.
         let outer_idx = vm.arrays.len();
-        vm.arrays.push(vec![Cell::None]);
+        let outer_ar = ArrayRef::new(vec![Cell::None]);
+        vm.arrays.push(outer_ar);
 
         // Value array (nested).
-        let inner_idx = vm.arrays.len();
-        vm.arrays.push(vec![Cell::Int(1)]);
+        let inner_ar = ArrayRef::new(vec![Cell::Int(1)]);
+        let inner_cell = Cell::Array(inner_ar);
 
         // SET convention: push addr then value.
         vm.push(Cell::ArrayAddr {
@@ -287,7 +312,7 @@ mod tests {
             elem_idx: 0,
         })
         .unwrap();
-        vm.push(Cell::Array(inner_idx)).unwrap();
+        vm.push(inner_cell).unwrap();
 
         let result = set_prim(&mut vm);
         assert!(
@@ -311,8 +336,8 @@ mod tests {
         vm.dp = 1;
 
         // Create the frame-local array; global_array_pool_len stays at 0.
-        let frame_local_idx = vm.arrays.len();
-        vm.arrays.push(vec![Cell::Int(7)]);
+        let ar = ArrayRef::new(vec![Cell::Int(7)]);
+        vm.arrays.push(ar.clone());
         // global_array_pool_len = 0 means pool_idx 0 is not global.
 
         // Simulate a Call frame so is_executing_top_level() returns false.
@@ -326,7 +351,7 @@ mod tests {
         });
 
         // STORE convention: push value then addr.
-        vm.push(Cell::Array(frame_local_idx)).unwrap();
+        vm.push(Cell::Array(ar)).unwrap();
         vm.push(Cell::DictAddr(0)).unwrap();
 
         let result = store_prim(&mut vm);
@@ -352,14 +377,16 @@ mod tests {
         vm.dp = 1;
 
         // Create the array at top level; global_array_pool_len starts at 0.
+        let top_level_ar = ArrayRef::new(vec![Cell::Int(99)]);
         let top_level_idx = vm.arrays.len();
-        vm.arrays.push(vec![Cell::Int(99)]);
+        vm.arrays.push(top_level_ar.clone());
 
         // Simulate top-level execution: only a TopLevel sentinel on the return stack.
         vm.return_stack.push(ReturnFrame::TopLevel);
 
         // STORE convention: push value then addr.
-        vm.push(Cell::Array(top_level_idx)).unwrap();
+        let arr_cell = Cell::Array(top_level_ar);
+        vm.push(arr_cell.clone()).unwrap();
         vm.push(Cell::DictAddr(0)).unwrap();
 
         store_prim(&mut vm).unwrap();
@@ -372,6 +399,15 @@ mod tests {
             vm.global_array_pool_len
         );
         // The dictionary slot must now hold the array handle.
-        assert_eq!(vm.dictionary[0], Cell::Array(top_level_idx));
+        // Use ptr_eq to compare since ArrayRef equality is pointer-based.
+        let stored = vm.dict_read(0).unwrap();
+        if let (Cell::Array(stored_ar), Cell::Array(orig_ar)) = (&stored, &arr_cell) {
+            assert!(
+                stored_ar.ptr_eq(orig_ar),
+                "stored ArrayRef must be the same Rc"
+            );
+        } else {
+            panic!("expected Cell::Array in dictionary slot, got {:?}", stored);
+        }
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1,3 +1,4 @@
+use crate::array_ref::ArrayRef;
 use crate::cell::{Cell, CompileEntry, ReturnFrame, Xt};
 use crate::constants::{MAX_DATA_STACK_DEPTH, MAX_DICTIONARY_CELLS, MAX_RETURN_STACK_DEPTH};
 use crate::dict::{EntryKind, WordEntry};
@@ -166,13 +167,22 @@ pub struct VM {
     /// Drained by `exec_immediate_word` in the interpreter, which calls
     /// `exec_source` on the file content.
     pub(crate) pending_use_path: Option<String>,
-    /// Array pool: indexed by `Cell::Array(usize)` values.
+    /// Array pool: indexed by `Cell::ArrayAddr::pool_idx` values.
     ///
-    /// Each entry is a `Vec<Cell>` created by the `ARRAY(N)` primitive.
+    /// Each entry is an `ArrayRef` (Rc-backed shared mutable container).
+    /// `Cell::Array(ArrayRef)` holds an `Rc::clone` of the same `ArrayRef`,
+    /// so mutation through either path is reflected in both.
+    ///
     /// On every word EXIT or RETURN_VAL, the pool is truncated back to the
     /// length saved in `ReturnFrame::Call::saved_array_pool_len`, freeing all
-    /// arrays allocated within that call.
-    pub arrays: Vec<Vec<Cell>>,
+    /// pool entries allocated within that call.
+    ///
+    /// NOTE: `VM::arrays` is kept for `Cell::ArrayAddr` compatibility while
+    /// `ArrayAddr` still holds a `pool_idx`.  When `ArrayAddr` is migrated to
+    /// `(ArrayRef, elem_idx)` in a follow-up issue, this pool and the
+    /// associated lifetime logic (`saved_array_pool_len`,
+    /// `global_array_pool_len`, `ArrayFrameEscape`) can be removed.
+    pub arrays: Vec<ArrayRef>,
     /// Length of the "global" (persistent) region of `arrays`.
     ///
     /// Arrays at indices `0..global_array_pool_len` were created at the top
@@ -923,48 +933,27 @@ impl VM {
                     }
                 }
                 EntryKind::ReturnVal => {
-                    // Determine the array frame boundary before popping the return
-                    // value, so we can detect whether the array belongs to the
-                    // current frame.
-                    let array_frame_boundary = match self.return_stack.last() {
-                        Some(ReturnFrame::Call {
-                            saved_array_pool_len,
-                            ..
-                        }) => *saved_array_pool_len,
+                    // Validate the return stack before popping the return value.
+                    match self.return_stack.last() {
+                        Some(ReturnFrame::Call { .. }) => {}
                         Some(ReturnFrame::TopLevel) => {
                             return Err(TbxError::InvalidReturn);
                         }
                         None => return Err(TbxError::StackUnderflow),
                     };
-                    let mut retval = self.pop()?;
-                    // Ownership transfer for frame-local Cell::Array:
-                    // If the returned array was created in this frame
-                    // (pool_idx >= array_frame_boundary), swap it to the
-                    // boundary slot and mark it for preservation.
-                    // Array elements are guaranteed to be Int/Float/Bool/None
-                    // (no nested references), so no recursive check is needed.
-                    // `Cell::Str` is `Rc<str>`-backed and needs no swap.
-                    let array_transferred = if let Cell::Array(pool_idx) = &retval {
-                        if *pool_idx >= array_frame_boundary {
-                            // Bounds check before swap: both indices must be valid.
-                            // pool_idx >= array_frame_boundary is already confirmed;
-                            // checking pool_idx < arrays.len() implies array_frame_boundary
-                            // is also in range.
-                            if *pool_idx >= self.arrays.len() {
-                                return Err(TbxError::IndexOutOfBounds {
-                                    index: *pool_idx,
-                                    size: self.arrays.len(),
-                                });
-                            }
-                            self.arrays.swap(*pool_idx, array_frame_boundary);
-                            retval = Cell::Array(array_frame_boundary);
-                            true
-                        } else {
-                            false
-                        }
-                    } else {
-                        false
-                    };
+                    let retval = self.pop()?;
+                    // `Cell::Array(ArrayRef)` is Rc-backed: the storage survives
+                    // pool truncation because the Rc reference count stays > 0 as
+                    // long as the Cell::Array handle exists on the stack or in a
+                    // variable.  No swap-and-preserve is needed.
+                    //
+                    // NOTE: vm.arrays is still truncated to free pool entries that
+                    // are no longer reachable via any Cell::Array.  This matters for
+                    // Cell::ArrayAddr compatibility: pool entries that belong to the
+                    // current frame should not be accessible by pool_idx after the
+                    // call returns.  Full removal of the pool and the lifetime checks
+                    // (ArrayFrameEscape / saved_array_pool_len / global_array_pool_len)
+                    // is deferred to the follow-up issue that migrates ArrayAddr.
                     match self.return_stack.pop().ok_or(TbxError::StackUnderflow)? {
                         ReturnFrame::Call {
                             callee_xt: _,
@@ -975,11 +964,9 @@ impl VM {
                         } => {
                             self.data_stack.truncate(self.bp);
                             // Truncate the array pool back to the saved boundary.
-                            // If ownership was transferred, the returned value now sits
-                            // at `saved_array_pool_len` (the boundary slot), so we keep
-                            // exactly one extra entry beyond the boundary.
-                            let array_keep = saved_array_pool_len + usize::from(array_transferred);
-                            self.arrays.truncate(array_keep);
+                            // The returned Cell::Array (if any) holds an Rc clone and
+                            // remains valid even after the pool entry is dropped.
+                            self.arrays.truncate(saved_array_pool_len);
                             self.push(retval)?;
                             self.pc = return_pc;
                             self.bp = saved_bp;
@@ -3033,14 +3020,15 @@ mod tests {
         // A global array (pool_idx < global_array_pool_len) can be stored into a
         // dictionary slot by store_prim without triggering ArrayFrameEscape.
         let mut vm = VM::new();
-        vm.arrays.push(vec![Cell::Int(0); 5]);
+        let ar = crate::array_ref::ArrayRef::new(vec![Cell::Int(0); 5]);
+        vm.arrays.push(ar.clone());
         vm.global_array_pool_len = 1; // mark pool[0] as global
 
         // Allocate a dictionary slot.
         let slot = vm.dp;
         vm.dict_write(Cell::None).unwrap();
 
-        let arr = Cell::Array(0);
+        let arr = Cell::Array(ar.clone());
         // store_prim pops addr first, then value; so push value then addr.
         vm.push(arr.clone()).unwrap();
         vm.push(Cell::DictAddr(slot)).unwrap();
@@ -3049,20 +3037,26 @@ mod tests {
             result.is_ok(),
             "store_prim should allow global array: {result:?}"
         );
-        assert_eq!(vm.dict_read(slot).unwrap(), arr);
+        // Verify the stored cell is a Cell::Array sharing the same Rc.
+        let stored = vm.dict_read(slot).unwrap();
+        assert!(
+            matches!(&stored, Cell::Array(stored_ar) if stored_ar.ptr_eq(&ar)),
+            "stored array must share Rc with original"
+        );
     }
 
     #[test]
     fn test_global_array_stored_via_set_prim() {
         // set_prim (SET &var, value) also accepts a global array.
         let mut vm = VM::new();
-        vm.arrays.push(vec![Cell::Int(0); 3]);
+        let ar = crate::array_ref::ArrayRef::new(vec![Cell::Int(0); 3]);
+        vm.arrays.push(ar.clone());
         vm.global_array_pool_len = 1;
 
         let slot = vm.dp;
         vm.dict_write(Cell::None).unwrap();
 
-        let arr = Cell::Array(0);
+        let arr = Cell::Array(ar.clone());
         // set_prim pops value first, then addr (stack: [..., addr, value]).
         vm.push(Cell::DictAddr(slot)).unwrap();
         vm.push(arr.clone()).unwrap();
@@ -3071,7 +3065,11 @@ mod tests {
             result.is_ok(),
             "set_prim should allow global array: {result:?}"
         );
-        assert_eq!(vm.dict_read(slot).unwrap(), arr);
+        let stored = vm.dict_read(slot).unwrap();
+        assert!(
+            matches!(&stored, Cell::Array(stored_ar) if stored_ar.ptr_eq(&ar)),
+            "stored array must share Rc with original"
+        );
     }
 
     #[test]
@@ -3093,14 +3091,25 @@ mod tests {
     fn test_non_global_array_store_rejected_by_store_prim() {
         // An array with pool_idx >= global_array_pool_len must still be rejected.
         let mut vm = VM::new();
-        vm.arrays.push(vec![Cell::Int(0); 5]);
+        let ar = crate::array_ref::ArrayRef::new(vec![Cell::Int(0); 5]);
+        vm.arrays.push(ar.clone());
         // global_array_pool_len stays 0, so pool[0] is NOT global.
 
         let slot = vm.dp;
         vm.dict_write(Cell::None).unwrap();
 
+        // Simulate a Call frame so is_executing_top_level() returns false.
+        vm.return_stack.push(ReturnFrame::TopLevel);
+        vm.return_stack.push(ReturnFrame::Call {
+            callee_xt: Xt(0),
+            return_pc: 0,
+            saved_bp: 0,
+            saved_array_pool_len: 0,
+            actual_arity: 0,
+        });
+
         // store_prim pops addr first, then value; so push value then addr.
-        vm.push(Cell::Array(0)).unwrap();
+        vm.push(Cell::Array(ar)).unwrap();
         vm.push(Cell::DictAddr(slot)).unwrap();
         let result = crate::primitives::store_prim(&mut vm);
         assert!(
@@ -3111,48 +3120,17 @@ mod tests {
 
     #[test]
     fn test_global_array_returnable_from_word() {
-        // A global array (pool_idx < saved_array_pool_len of the CALL frame) can
-        // be returned from a word without triggering ArrayFrameEscape.
-        //
-        // The ReturnVal check uses `frame_boundary = saved_array_pool_len` of the
-        // current CALL frame.  A global array created before the call has
-        // pool_idx < saved_array_pool_len, so it is safe to return.
-        let mut vm = VM::new();
-
-        // Insert a "global" array at pool slot 0.
-        vm.arrays.push(vec![Cell::Int(99); 3]);
-        // Simulate that TopLevel exit has already promoted it.
-        vm.global_array_pool_len = 1;
-
-        // Simulate a CALL frame where saved_array_pool_len = 1 (the array already
-        // existed when the word was called).
-        vm.return_stack.push(ReturnFrame::TopLevel);
-        vm.return_stack.push(ReturnFrame::Call {
-            callee_xt: Xt(0),
-            return_pc: 0,
-            saved_bp: 0,
-            saved_array_pool_len: 1,
-            actual_arity: 0,
-        });
-
-        // Push the global array as the return value.
-        vm.push(Cell::Array(0)).unwrap();
-
-        // Mimic the ReturnVal boundary check: frame_boundary = 1, pool_idx = 0 < 1 → OK.
-        let frame_boundary = match vm.return_stack.last().unwrap() {
-            ReturnFrame::Call {
-                saved_array_pool_len,
-                ..
-            } => *saved_array_pool_len,
-            _ => panic!("unexpected frame"),
-        };
-        let retval = vm.pop().unwrap();
-        if let Cell::Array(pool_idx) = &retval {
-            assert!(
-                *pool_idx < frame_boundary,
-                "global array should pass ReturnVal check"
-            );
-        }
+        // A global array can be returned from a word.
+        // Since Cell::Array(ArrayRef) is Rc-backed, the array stays alive after
+        // the pool is truncated. This test verifies the high-level behavior via
+        // run_source rather than testing pool_idx arithmetic directly.
+        let result = run_source(
+            "DIM @G[3]\n\
+             DEF GET_GLOBAL()\n  RETURN G\nEND\n\
+             PUTDEC ARRAY_LEN(GET_GLOBAL())",
+        );
+        assert!(result.is_ok(), "expected success, got: {result:?}");
+        assert_eq!(result.unwrap().trim(), "3");
     }
 
     #[test]
@@ -3283,11 +3261,11 @@ mod tests {
 
     #[test]
     fn test_array_pool_len_after_ownership_transfer() {
-        // After a word returns its local array, the transferred array occupies the
-        // boundary slot in the caller's pool.  At the top level, when the TopLevel
-        // frame is popped, all remaining pool entries are promoted to the global
-        // region (global_array_pool_len is advanced to arrays.len()), so the pool
-        // is NOT empty — it contains exactly the one promoted array.
+        // Since Cell::Array is now Rc-backed (ArrayRef), returning a frame-local
+        // array no longer requires swapping pool entries.  The pool is truncated
+        // back to the frame boundary on return, so vm.arrays.len() == 0 after the
+        // top-level call completes.  The returned Cell::Array keeps the storage
+        // alive via its Rc — verified by the PUTDEC ARRAY_LEN assertion.
         let mut interp = crate::interpreter::Interpreter::new();
         interp
             .exec_source(
@@ -3295,16 +3273,12 @@ mod tests {
                  PUTDEC ARRAY_LEN(GIVE_ARRAY())",
             )
             .expect("exec_source failed");
-        // The returned array is now promoted to global; pool has exactly 1 entry.
+        // The top-level DROP_TO_MARKER discards the returned Cell::Array, so the
+        // pool is empty after the statement completes.
         assert_eq!(
             interp.vm().arrays.len(),
-            1,
-            "array pool should contain exactly the one promoted (returned) array"
-        );
-        assert_eq!(
-            interp.vm().global_array_pool_len,
-            1,
-            "global_array_pool_len should reflect the promoted array"
+            0,
+            "array pool should be empty after the Rc-backed returned array is discarded"
         );
     }
 


### PR DESCRIPTION
## 概要

`Cell::Array(usize)` を `Cell::Array(ArrayRef)` へ移行し、配列の内部表現を pool index から Rc-backed shared mutable container handle へ変更する。
これにより、array creation / read / len の基本 path が `ArrayRef` ベースとなる。

## 変更内容

### コア変更
- `Cell::Array(usize)` → `Cell::Array(ArrayRef)` へ variant を変更
- `ArrayRef` に `ptr_eq` / `with_mut` メソッドを追加
- `Cell::as_array_index()` を `Cell::as_array_ref()` へ置き換え
- `Cell::Array` の `PartialEq` を pointer identity (`Rc::ptr_eq`) ベースへ変更（equality の最終仕様は後続 issue で決定）
- `Cell::Array` の `Display` を `<array>` に変更（pool_idx の概念がなくなったため）

### array creation path
- `array_prim`（hidden ARRAY primitive）: `ArrayRef::new(...)` で storage を作成し、`vm.arrays.push(ar.clone())` で pool にも登録する
- `dim_prim` execute mode: 同様に `ArrayRef::new(...)` ベースへ移行

### primitive の移行
- `ARRAY_LEN`: `ArrayRef::len()` ベースへ（pool index 不要）
- `ARRAY_GET`: `ArrayRef::get_cloned()` ベースへ（pool index 不要）
- `ARRAY_ADDR`: `ArrayRef` で境界チェックを行い、`vm.arrays.iter().position(ptr_eq)` で pool_idx を探索する
- `FETCH` / `STORE` / `SET` の `ArrayAddr` path: `ArrayRef::get_cloned()` / `ArrayRef::set()` ベースへ
- `shuffle_prim`: `ArrayRef::with_mut()` ベースへ

### VM 内部変更
- `VM::arrays` を `Vec<Vec<Cell>>` から `Vec<ArrayRef>` へ変更
- `RETURN_VAL` の ownership transfer swap ロジックを削除（`Cell::Array(ArrayRef)` は Rc ベースなので truncate 後も生き続ける）

### nested Array 禁止の維持
- `check_array_element_value` は `Cell::Array(_)` を引き続き拒否する

## 残存している VM::arrays pool と lifetime logic について

以下は今 issue の非目標として意図的に残している：

| 残存物 | 理由 |
|---|---|
| `VM::arrays: Vec<ArrayRef>` | `Cell::ArrayAddr { pool_idx, elem_idx }` が pool_idx でアクセスするため |
| `saved_array_pool_len` / `global_array_pool_len` | `ArrayAddr` を通じた lifetime 管理に必要 |
| `ArrayFrameEscape` の check_dict_reference_write | `global_array_pool_len` ベースのチェックを継続 |

### ARRAY_ADDR の互換レイヤー
`array_addr_prim` は `Cell::Array(ArrayRef)` を受け取り、`vm.arrays.iter().position(ptr_eq)` で対応する pool_idx を O(n) で探索する。
この探索は配列数が少ない実用的なケースでは問題ないが、将来的には `ArrayAddr` を `(ArrayRef, elem_idx)` へ移行することで解消される。

### 後続 issue 化の方針

1. `ArrayAddr` を `(ArrayRef, elem_idx)` へ移行する
2. `VM::arrays` pool と関連する lifetime 管理（`saved_array_pool_len` / `global_array_pool_len` / `ArrayFrameEscape` / pool truncate on EXIT）を撤去する
3. `Cell::Array` の equality / `Debug` / display / `PUTVAL` の最終仕様を決定する
4. 旧 pool lifetime tests / docs / comments を整理する

Closes #714
