### PR TITLE
whole-array handle を surface で禁止し、テストを追加する

### DIFF
--- a/lib/tests/test_rnd.tbx
+++ b/lib/tests/test_rnd.tbx
@@ -25,12 +25,7 @@ DEF SHUFFLE_PRESERVES_LEN()
   LET @A[3] = 3
   LET @A[4] = 4
   LET @A[5] = 5
-  SHUFFLE A
+  SHUFFLE @A
   RETURN ARRAY_LEN(@A)
 END
 ASSERT SHUFFLE_PRESERVES_LEN() = 5
-
-# --- SHUFFLE used as a function expression returns the same array handle ---
-# NOTE: SHUFFLE_RETURNS_ARRAY relied on assigning an array handle to a plain
-# variable (LET A = SHUFFLE(A)), which is being migrated to a separate issue.
-# Covered by SHUFFLE_PRESERVES_LEN above.

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -4933,4 +4933,180 @@ PUTDEC 1; PUTDEC ADD(
             .unwrap();
         assert_eq!(interp.take_output().trim(), "42");
     }
+
+    // ===========================================================
+    // Whole-array surface-language prohibition (issue #718)
+    // ===========================================================
+    //
+    // Arrays are not first-class values on the surface language.
+    // The following operations must fail at runtime with TypeError.
+
+    /// Helper: build a program that uses a global array `A` of size 3.
+    fn with_global_dim(body: &str) -> String {
+        format!("DIM @A[3]\n{body}")
+    }
+
+    #[test]
+    fn test_whole_array_let_assignment_is_error() {
+        // `LET B = A` where A is an array variable must fail with TypeError.
+        let mut interp = Interpreter::new();
+        let src = "DEF BAD_LET()\n  DIM @A[2]\n  VAR B\n  LET B = A\nEND\nBAD_LET";
+        let result = interp.exec_source(src);
+        assert!(
+            matches!(result, Err(ref e) if matches!(e.kind, TbxError::TypeError { .. })),
+            "expected TypeError for `LET B = A`, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_whole_array_set_assignment_is_error() {
+        // `SET &B, A` where A is an array variable must fail with TypeError.
+        let mut interp = Interpreter::new();
+        let src = "DEF BAD_SET()\n  DIM @A[2]\n  VAR B\n  SET &B, A\nEND\nBAD_SET";
+        let result = interp.exec_source(src);
+        assert!(
+            matches!(result, Err(ref e) if matches!(e.kind, TbxError::TypeError { .. })),
+            "expected TypeError for `SET &B, A`, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_whole_array_set_global_assignment_is_error() {
+        // `SET &G, A` where A is an array variable and G is a global scalar must fail.
+        let mut interp = Interpreter::new();
+        let src = "VAR G\nDEF BAD()\n  DIM @A[2]\n  SET &G, A\nEND\nBAD";
+        let result = interp.exec_source(src);
+        assert!(
+            matches!(result, Err(ref e) if matches!(e.kind, TbxError::TypeError { .. })),
+            "expected TypeError for `SET &G, A`, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_whole_array_return_is_error() {
+        // `RETURN A` where A is an array variable must fail with TypeError.
+        let mut interp = Interpreter::new();
+        let src = "DEF BAD_RETURN()\n  DIM @A[2]\n  RETURN A\nEND\nPUTDEC BAD_RETURN()";
+        let result = interp.exec_source(src);
+        assert!(
+            matches!(result, Err(ref e) if matches!(e.kind, TbxError::TypeError { .. })),
+            "expected TypeError for `RETURN A`, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_whole_array_in_tuple_is_error() {
+        // `TUPLE(A)` or `TUPLE(A, 1)` where A is an array variable must fail with TypeError.
+        // TUPLE rejects Cell::Array elements via Cell::new_tuple.
+        let mut interp = Interpreter::new();
+        let src = "DEF BAD_TUPLE()\n  DIM @A[2]\n  PUTVAL TUPLE(A)\nEND\nBAD_TUPLE";
+        let result = interp.exec_source(src);
+        assert!(
+            result.is_err(),
+            "expected error for `TUPLE(A)`, but it succeeded"
+        );
+    }
+
+    #[test]
+    fn test_putval_array_is_error() {
+        // `PUTVAL A` where A is an array variable must fail with TypeError.
+        let mut interp = Interpreter::new();
+        let src = with_global_dim("PUTVAL A");
+        let result = interp.exec_source(&src);
+        assert!(
+            matches!(result, Err(ref e) if matches!(e.kind, TbxError::TypeError { .. })),
+            "expected TypeError for `PUTVAL A`, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_array_equality_is_error() {
+        // `A = B` where A and B are array variables must fail with TypeError.
+        let mut interp = Interpreter::new();
+        let src = "DEF BAD_EQ()\n  DIM @A[2]\n  DIM @B[2]\n  PUTDEC A = B\nEND\nBAD_EQ";
+        let result = interp.exec_source(src);
+        assert!(
+            matches!(result, Err(ref e) if matches!(e.kind, TbxError::TypeError { .. })),
+            "expected TypeError for `A = B` (array equality), got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_array_eq_function_is_error() {
+        // `EQ(A, B)` where A and B are array variables must fail with TypeError.
+        let mut interp = Interpreter::new();
+        let src = "DEF BAD_EQ2()\n  DIM @A[2]\n  DIM @B[2]\n  PUTDEC EQ(A, B)\nEND\nBAD_EQ2";
+        let result = interp.exec_source(src);
+        assert!(
+            matches!(result, Err(ref e) if matches!(e.kind, TbxError::TypeError { .. })),
+            "expected TypeError for `EQ(A, B)` (array equality), got: {result:?}"
+        );
+    }
+
+    // --- Permitted array operations must remain intact ---
+
+    #[test]
+    fn test_dim_global_array_is_still_valid() {
+        // `DIM @A[n]` at top level must succeed and allow element access.
+        let mut interp = Interpreter::new();
+        let src = "DIM @A[3]\nSET &@A[1], 42\nPUTDEC @A[1]";
+        interp
+            .exec_source(src)
+            .expect("DIM and element access must succeed");
+        assert_eq!(interp.take_output().trim(), "42");
+    }
+
+    #[test]
+    fn test_dim_local_array_is_still_valid() {
+        // `DIM @A[n]` inside a DEF body must succeed and allow element access.
+        let mut interp = Interpreter::new();
+        let src = "DEF USE_LOCAL_DIM()\n  DIM @A[2]\n  LET @A[1] = 77\n  PUTDEC @A[1]\nEND\nUSE_LOCAL_DIM";
+        interp
+            .exec_source(src)
+            .expect("local DIM and element access must succeed");
+        assert_eq!(interp.take_output().trim(), "77");
+    }
+
+    #[test]
+    fn test_array_element_read_is_still_valid() {
+        // `@A[i]` element read must still work.
+        let mut interp = Interpreter::new();
+        let src = "DIM @A[3]\nSET &@A[2], 99\nPUTDEC @A[2]";
+        interp
+            .exec_source(src)
+            .expect("array element read must succeed");
+        assert_eq!(interp.take_output().trim(), "99");
+    }
+
+    #[test]
+    fn test_array_element_addr_is_still_valid() {
+        // `&@A[i]` element address (for SET) must still work.
+        let mut interp = Interpreter::new();
+        let src = "DIM @A[3]\nSET &@A[3], 55\nPUTDEC @A[3]";
+        interp
+            .exec_source(src)
+            .expect("&@A[i] element write must succeed");
+        assert_eq!(interp.take_output().trim(), "55");
+    }
+
+    #[test]
+    fn test_let_array_element_write_is_still_valid() {
+        // `LET @A[i] = expr` element write must still work.
+        let mut interp = Interpreter::new();
+        let src =
+            "DEF WRITE_ELEM()\n  DIM @A[3]\n  LET @A[1] = 33\n  PUTDEC @A[1]\nEND\nWRITE_ELEM";
+        interp
+            .exec_source(src)
+            .expect("LET @A[i] = expr must succeed");
+        assert_eq!(interp.take_output().trim(), "33");
+    }
+
+    #[test]
+    fn test_array_len_is_still_valid() {
+        // `ARRAY_LEN(@A)` must still work after the surface-ban changes.
+        let mut interp = Interpreter::new();
+        let src = "DIM @A[5]\nPUTDEC ARRAY_LEN(@A)";
+        interp.exec_source(src).expect("ARRAY_LEN(@A) must succeed");
+        assert_eq!(interp.take_output().trim(), "5");
+    }
 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -5109,4 +5109,51 @@ PUTDEC 1; PUTDEC ADD(
         interp.exec_source(src).expect("ARRAY_LEN(@A) must succeed");
         assert_eq!(interp.take_output().trim(), "5");
     }
+
+    #[test]
+    fn test_shuffle_bare_array_handle_is_error() {
+        // `SHUFFLE A` (bare array handle without @-sigil) must fail.
+        // SHUFFLE only accepts the `SHUFFLE @A` designator form.
+        let mut interp = Interpreter::new();
+        let src = "DIM @A[1]\nSHUFFLE A";
+        let result = interp.exec_source(src);
+        assert!(
+            result.is_err(),
+            "expected error for `SHUFFLE A` (bare array handle), but it succeeded"
+        );
+    }
+
+    #[test]
+    fn test_shuffle_at_designator_is_valid() {
+        // `SHUFFLE @A` must succeed and preserve the element count.
+        let mut interp = Interpreter::new();
+        let src =
+            "DIM @A[3]\nSET &@A[1], 10\nSET &@A[2], 20\nSET &@A[3], 30\nSHUFFLE @A\nPUTDEC ARRAY_LEN(@A)";
+        interp.exec_source(src).expect("SHUFFLE @A must succeed");
+        assert_eq!(interp.take_output().trim(), "3");
+    }
+
+    #[test]
+    fn test_shuffle_at_designator_local_array_is_valid() {
+        // `SHUFFLE @A` inside a DEF body with a local array must succeed.
+        let mut interp = Interpreter::new();
+        let src =
+            "DEF DO_SHUFFLE()\n  DIM @A[3]\n  LET @A[1] = 1\n  LET @A[2] = 2\n  LET @A[3] = 3\n  SHUFFLE @A\n  RETURN ARRAY_LEN(@A)\nEND\nPUTDEC DO_SHUFFLE()";
+        interp
+            .exec_source(src)
+            .expect("SHUFFLE @A on local array must succeed");
+        assert_eq!(interp.take_output().trim(), "3");
+    }
+
+    #[test]
+    fn test_user_defined_word_with_array_argument_is_error() {
+        // Passing a whole-array handle as an argument to a user-defined word must fail with TypeError.
+        let mut interp = Interpreter::new();
+        let src = "DEF USE_ARRAY(X)\n  PUTDEC 1\nEND\nDIM @A[1]\nUSE_ARRAY(A)";
+        let result = interp.exec_source(src);
+        assert!(
+            matches!(result, Err(ref e) if matches!(e.kind, TbxError::TypeError { .. })),
+            "expected TypeError for `USE_ARRAY(A)` (array as argument), got: {result:?}"
+        );
+    }
 }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1883,13 +1883,16 @@ pub fn randomize_prim(vm: &mut VM) -> Result<(), TbxError> {
     Ok(())
 }
 
-/// SHUFFLE — randomly permute the elements of an array in place.
+/// SHUFFLE_INTERNAL — internal primitive that shuffles an array in place.
 ///
-/// Pops `Cell::Array(pool_idx)` from the stack, shuffles the array's elements
-/// using the VM's RNG, and pushes the same `Cell::Array(pool_idx)` back.
+/// Pops `Cell::Array(pool_idx)` from the stack and shuffles the array's elements
+/// using the VM's RNG.  Does not push any value; the array handle is consumed.
 ///
-/// Stack signature: `( arr:Array -- arr:Array )`
-pub fn shuffle_prim(vm: &mut VM) -> Result<(), TbxError> {
+/// This is a hidden system primitive.  User code accesses SHUFFLE via the
+/// IMMEDIATE `shuffle_stmt_prim`, which enforces the `SHUFFLE @A` syntax.
+///
+/// Stack signature: `( arr:Array -- )`
+pub fn shuffle_inner_prim(vm: &mut VM) -> Result<(), TbxError> {
     use rand::seq::SliceRandom;
     let pool_idx = match vm.pop()? {
         Cell::Array(idx) => idx,
@@ -1909,7 +1912,154 @@ pub fn shuffle_prim(vm: &mut VM) -> Result<(), TbxError> {
             size: arrays_len,
         })?;
     arr.shuffle(&mut vm.rng);
-    vm.push(Cell::Array(pool_idx))
+    Ok(())
+}
+
+/// SHUFFLE — IMMEDIATE primitive that shuffles an array in place.
+///
+/// Surface syntax: `SHUFFLE @A`
+///
+/// In compile mode (inside DEF..END):
+///   - Consumes `@` and the array name from the token stream.
+///   - Emits code that loads the array handle and calls SHUFFLE_INTERNAL.
+///
+/// In execute mode (top level):
+///   - Consumes `@` and the array name from the token stream.
+///   - Resolves the array handle and shuffles directly.
+///
+/// Only the `@A` designator form is accepted.  Bare `SHUFFLE A` is rejected
+/// with `InvalidExpression` to enforce the surface-language prohibition on
+/// whole-array handles as primitive arguments (issue #718).
+pub fn shuffle_stmt_prim(vm: &mut VM) -> Result<(), TbxError> {
+    use crate::lexer::Token;
+
+    // Consume `@`.
+    let at_tok = vm.next_token()?;
+    if at_tok.token != Token::At {
+        return Err(TbxError::InvalidExpression {
+            reason: "SHUFFLE: expected '@A' designator (e.g. SHUFFLE @A); bare 'SHUFFLE A' is not allowed",
+        });
+    }
+
+    // Consume the array binding identifier.
+    let array_name = vm.expect_ident("SHUFFLE: expected array name after '@' (e.g. SHUFFLE @A)")?;
+
+    if vm.is_compiling {
+        // Compile mode: emit code to load the array handle and call SHUFFLE_INTERNAL.
+
+        // Resolve the array: local binding takes priority over global.
+        let local_idx: Option<usize> = vm
+            .compile_state
+            .as_ref()
+            .and_then(|s| s.local_table.get(&array_name).copied());
+
+        let lit_xt =
+            vm.find_by_kind(|k| matches!(k, EntryKind::Lit))
+                .ok_or(TbxError::UndefinedSymbol {
+                    name: "LIT".to_string(),
+                })?;
+        let fetch_xt = vm.lookup("FETCH").ok_or(TbxError::UndefinedSymbol {
+            name: "FETCH".to_string(),
+        })?;
+        let shuffle_internal_xt =
+            vm.lookup_hidden_system("SHUFFLE_INTERNAL")
+                .ok_or(TbxError::UndefinedSymbol {
+                    name: "SHUFFLE_INTERNAL".to_string(),
+                })?;
+
+        if let Some(idx) = local_idx {
+            // Emit: LIT StackAddr(idx)  FETCH  — load the local array handle.
+            vm.dict_write(Cell::Xt(lit_xt))?;
+            vm.dict_write(Cell::StackAddr(idx))?;
+            vm.dict_write(Cell::Xt(fetch_xt))?;
+        } else {
+            // Look up in the global dictionary.
+            let xt = vm.lookup(&array_name).ok_or(TbxError::UndefinedSymbol {
+                name: array_name.clone(),
+            })?;
+            let addr = match &vm.headers[xt.index()].kind {
+                EntryKind::Variable(addr) => *addr,
+                _ => {
+                    return Err(TbxError::TypeError {
+                        expected: "array variable for SHUFFLE @-sigil",
+                        got: "non-variable",
+                    });
+                }
+            };
+            // Emit: LIT DictAddr(addr)  FETCH  — load the global array handle.
+            vm.dict_write(Cell::Xt(lit_xt))?;
+            vm.dict_write(Cell::DictAddr(addr))?;
+            vm.dict_write(Cell::Xt(fetch_xt))?;
+        }
+
+        // Emit: SHUFFLE_INTERNAL  — shuffle in place (consumes the array handle).
+        vm.dict_write(Cell::Xt(shuffle_internal_xt))?;
+    } else {
+        // Execute mode: resolve the array handle and shuffle directly.
+
+        // Check compile_state local table first (should be empty at top level, but be safe).
+        let local_idx: Option<usize> = vm
+            .compile_state
+            .as_ref()
+            .and_then(|s| s.local_table.get(&array_name).copied());
+
+        let pool_idx = if let Some(local_stack_idx) = local_idx {
+            // Read the array handle from the local slot.
+            let cell = vm.local_read(local_stack_idx)?;
+            match cell {
+                Cell::Array(idx) => idx,
+                other => {
+                    return Err(TbxError::TypeError {
+                        expected: "Array",
+                        got: other.type_name(),
+                    });
+                }
+            }
+        } else {
+            // Look up in the global dictionary.
+            let xt = vm.lookup(&array_name).ok_or(TbxError::UndefinedSymbol {
+                name: array_name.clone(),
+            })?;
+            let addr = match &vm.headers[xt.index()].kind {
+                EntryKind::Variable(addr) => *addr,
+                _ => {
+                    return Err(TbxError::TypeError {
+                        expected: "array variable for SHUFFLE @-sigil",
+                        got: "non-variable",
+                    });
+                }
+            };
+            match vm
+                .dictionary
+                .get(addr)
+                .cloned()
+                .ok_or(TbxError::IndexOutOfBounds {
+                    index: addr,
+                    size: vm.dictionary.len(),
+                })? {
+                Cell::Array(idx) => idx,
+                other => {
+                    return Err(TbxError::TypeError {
+                        expected: "Array",
+                        got: other.type_name(),
+                    });
+                }
+            }
+        };
+
+        use rand::seq::SliceRandom;
+        let arrays_len = vm.arrays.len();
+        let arr = vm
+            .arrays
+            .get_mut(pool_idx)
+            .ok_or(TbxError::IndexOutOfBounds {
+                index: pool_idx,
+                size: arrays_len,
+            })?;
+        arr.shuffle(&mut vm.rng);
+    }
+
+    Ok(())
 }
 
 /// UNIXTIME — return the current time as seconds since the Unix epoch.
@@ -2279,10 +2429,17 @@ pub fn register_all(vm: &mut VM) {
 
     // Random number primitives.
     // RND(n) returns a random integer in [1, n]; RANDOMIZE re-seeds the RNG from OS entropy;
-    // SHUFFLE permutes an array in place and returns the same array handle.
+    // SHUFFLE_INTERNAL is the hidden primitive that performs in-place array shuffling;
+    // SHUFFLE is the IMMEDIATE surface primitive enforcing the `SHUFFLE @A` syntax.
     vm.register(WordEntry::new_primitive("RND", rnd_prim));
     vm.register(WordEntry::new_primitive("RANDOMIZE", randomize_prim));
-    vm.register(WordEntry::new_primitive("SHUFFLE", shuffle_prim));
+    let mut shuffle_internal_entry =
+        WordEntry::new_primitive("SHUFFLE_INTERNAL", shuffle_inner_prim);
+    shuffle_internal_entry.flags = FLAG_SYSTEM | FLAG_HIDDEN;
+    vm.register(shuffle_internal_entry);
+    let mut shuffle_entry = WordEntry::new_primitive("SHUFFLE", shuffle_stmt_prim);
+    shuffle_entry.flags = FLAG_IMMEDIATE | FLAG_SYSTEM;
+    vm.register(shuffle_entry);
 
     // Time primitives.
     // UNIXTIME returns the current Unix timestamp as a Float (seconds since epoch).
@@ -6474,11 +6631,11 @@ mod tests {
         assert_eq!(vm.data_stack.len(), 0);
     }
 
-    // --- shuffle_prim ---
+    // --- shuffle_inner_prim ---
 
     #[test]
-    fn test_shuffle_prim_preserves_elements() {
-        // SHUFFLE must not add or remove elements from the array.
+    fn test_shuffle_inner_prim_preserves_elements() {
+        // SHUFFLE_INTERNAL must not add or remove elements from the array.
         use rand::SeedableRng;
         let mut vm = VM::new();
         vm.rng = rand::rngs::SmallRng::seed_from_u64(123);
@@ -6490,9 +6647,9 @@ mod tests {
             Cell::Int(5),
         ]);
         vm.push(Cell::Array(0)).unwrap();
-        shuffle_prim(&mut vm).unwrap();
-        // The returned value must be Cell::Array(0).
-        assert_eq!(vm.pop(), Ok(Cell::Array(0)));
+        shuffle_inner_prim(&mut vm).unwrap();
+        // shuffle_inner_prim consumes the array handle; stack must be empty.
+        assert_eq!(vm.data_stack.len(), 0);
         // All original elements must still be present (order may differ).
         let mut values: Vec<i64> = vm.arrays[0]
             .iter()
@@ -6506,16 +6663,15 @@ mod tests {
     }
 
     #[test]
-    fn test_shuffle_prim_deterministic() {
-        // With a fixed seed, SHUFFLE must produce the same permutation every time.
+    fn test_shuffle_inner_prim_deterministic() {
+        // With a fixed seed, SHUFFLE_INTERNAL must produce the same permutation every time.
         use rand::SeedableRng;
         let mut vm = VM::new();
         vm.rng = rand::rngs::SmallRng::seed_from_u64(42);
         vm.arrays
             .push(vec![Cell::Int(1), Cell::Int(2), Cell::Int(3)]);
         vm.push(Cell::Array(0)).unwrap();
-        shuffle_prim(&mut vm).unwrap();
-        vm.pop().unwrap();
+        shuffle_inner_prim(&mut vm).unwrap();
         let first_run: Vec<i64> = vm.arrays[0]
             .iter()
             .map(|c| match c {
@@ -6530,8 +6686,7 @@ mod tests {
         vm2.arrays
             .push(vec![Cell::Int(1), Cell::Int(2), Cell::Int(3)]);
         vm2.push(Cell::Array(0)).unwrap();
-        shuffle_prim(&mut vm2).unwrap();
-        vm2.pop().unwrap();
+        shuffle_inner_prim(&mut vm2).unwrap();
         let second_run: Vec<i64> = vm2.arrays[0]
             .iter()
             .map(|c| match c {
@@ -6544,23 +6699,24 @@ mod tests {
     }
 
     #[test]
-    fn test_shuffle_prim_empty_array() {
-        // SHUFFLE on an empty array must not error.
+    fn test_shuffle_inner_prim_empty_array() {
+        // SHUFFLE_INTERNAL on an empty array must not error.
         let mut vm = VM::new();
         vm.arrays.push(vec![]);
         vm.push(Cell::Array(0)).unwrap();
-        shuffle_prim(&mut vm).unwrap();
-        assert_eq!(vm.pop(), Ok(Cell::Array(0)));
+        shuffle_inner_prim(&mut vm).unwrap();
+        // Stack must be empty: shuffle_inner_prim consumes the handle.
+        assert_eq!(vm.data_stack.len(), 0);
         assert_eq!(vm.arrays[0].len(), 0);
     }
 
     #[test]
-    fn test_shuffle_prim_type_error() {
-        // SHUFFLE on a non-Array cell must return TypeError.
+    fn test_shuffle_inner_prim_type_error() {
+        // SHUFFLE_INTERNAL on a non-Array cell must return TypeError.
         let mut vm = VM::new();
         vm.push(Cell::Int(42)).unwrap();
         assert!(matches!(
-            shuffle_prim(&mut vm),
+            shuffle_inner_prim(&mut vm),
             Err(TbxError::TypeError {
                 expected: "Array",
                 ..

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -800,9 +800,11 @@ pub fn dim_prim(vm: &mut VM) -> Result<(), TbxError> {
             .ok_or(TbxError::UndefinedSymbol {
                 name: "ARRAY".to_string(),
             })?;
-        let set_xt = vm.lookup("SET").ok_or(TbxError::UndefinedSymbol {
-            name: "SET".to_string(),
-        })?;
+        let array_store_local_xt =
+            vm.lookup_hidden_system("ARRAY_STORE_LOCAL")
+                .ok_or(TbxError::UndefinedSymbol {
+                    name: "ARRAY_STORE_LOCAL".to_string(),
+                })?;
 
         // Emit: LIT StackAddr(idx)  — push the address of the local slot.
         vm.dict_write(Cell::Xt(lit_xt))?;
@@ -823,8 +825,10 @@ pub fn dim_prim(vm: &mut VM) -> Result<(), TbxError> {
         // Emit: ARRAY  — create the array and push its handle.
         vm.dict_write(Cell::Xt(array_xt))?;
 
-        // Emit: SET  — store the array handle into the local slot.
-        vm.dict_write(Cell::Xt(set_xt))?;
+        // Emit: ARRAY_STORE_LOCAL  — store the array handle into the local slot.
+        // Using a dedicated internal primitive avoids triggering the surface-language
+        // prohibition that SET/STORE enforce against whole-array writes.
+        vm.dict_write(Cell::Xt(array_store_local_xt))?;
     } else {
         // --- Execute mode (top level) ---
 
@@ -2238,6 +2242,14 @@ pub fn register_all(vm: &mut VM) {
     let mut array_entry = WordEntry::new_primitive("ARRAY", array_prim);
     array_entry.flags = FLAG_SYSTEM | FLAG_HIDDEN;
     vm.register(array_entry);
+    // ARRAY_STORE_LOCAL is a hidden system entry used exclusively by the DIM @A[n]
+    // compiler to store the freshly-created array handle into the local variable slot.
+    // Unlike SET/STORE, it bypasses the surface-language prohibition on writing a
+    // whole-array handle into a scalar variable.
+    let mut array_store_local_entry =
+        WordEntry::new_primitive("ARRAY_STORE_LOCAL", arrays::array_store_local_prim);
+    array_store_local_entry.flags = FLAG_SYSTEM | FLAG_HIDDEN;
+    vm.register(array_store_local_entry);
     // ARRAY_GET reads an element (`@A[i]` compiles to
     // `<array handle read> <index expr> ARRAY_GET`); ARRAY_ADDR computes an element
     // address (`&@A[i]` compiles to `<array handle read> <index expr> ARRAY_ADDR`).
@@ -6048,26 +6060,38 @@ mod tests {
         ));
     }
 
-    // --- store_prim with ArrayFrameEscape guard ---
+    // --- store_prim / set_prim: whole-array write to scalar variable is TypeError ---
 
     #[test]
     fn test_store_array_to_dict_addr_is_escape_error() {
+        // Storing a whole Cell::Array into a DictAddr slot is now rejected with
+        // TypeError (surface-language prohibition), superseding the earlier
+        // ArrayFrameEscape check.
         let mut vm = VM::new();
         vm.dictionary.push(Cell::None); // dict[0] = placeholder
                                         // Try to store Cell::Array(0) into a global variable slot.
         vm.push(Cell::Array(0)).unwrap(); // value
         vm.push(Cell::DictAddr(0)).unwrap(); // address
-        assert_eq!(store_prim(&mut vm), Err(TbxError::ArrayFrameEscape));
+        assert!(
+            matches!(store_prim(&mut vm), Err(TbxError::TypeError { .. })),
+            "expected TypeError for whole-array write to DictAddr"
+        );
     }
 
     #[test]
     fn test_set_array_to_dict_addr_is_escape_error() {
+        // Storing a whole Cell::Array into a DictAddr slot is now rejected with
+        // TypeError (surface-language prohibition), superseding the earlier
+        // ArrayFrameEscape check.
         let mut vm = VM::new();
         vm.dictionary.push(Cell::None); // dict[0] = placeholder
                                         // set_prim: stack is [..., addr, value]
         vm.push(Cell::DictAddr(0)).unwrap(); // address
         vm.push(Cell::Array(0)).unwrap(); // value
-        assert_eq!(set_prim(&mut vm), Err(TbxError::ArrayFrameEscape));
+        assert!(
+            matches!(set_prim(&mut vm), Err(TbxError::TypeError { .. })),
+            "expected TypeError for whole-array write to DictAddr"
+        );
     }
 
     // --- store/set to ArrayAddr ---

--- a/src/primitives/arrays.rs
+++ b/src/primitives/arrays.rs
@@ -233,8 +233,18 @@ pub fn tuple_len_prim(vm: &mut VM) -> Result<(), TbxError> {
 /// Unlike `SET`, this primitive bypasses the surface-language prohibition on
 /// assigning whole-array handles to scalar variables.  Only the `DIM` compiler
 /// may emit its Xt.
+///
+/// Invariant: `value` must be `Cell::Array`.  Any other cell type is rejected
+/// with `TypeError` to catch internal misuse early.
 pub(super) fn array_store_local_prim(vm: &mut VM) -> Result<(), TbxError> {
     let value = vm.pop()?;
+    // Enforce the invariant: only Cell::Array may be stored via this path.
+    if !matches!(value, Cell::Array(_)) {
+        return Err(TbxError::TypeError {
+            expected: "Array (ARRAY_STORE_LOCAL invariant: value must be Cell::Array)",
+            got: value.type_name(),
+        });
+    }
     let addr = vm.pop()?;
     match addr {
         Cell::StackAddr(idx) => {

--- a/src/primitives/arrays.rs
+++ b/src/primitives/arrays.rs
@@ -223,6 +223,33 @@ pub fn tuple_len_prim(vm: &mut VM) -> Result<(), TbxError> {
     }
 }
 
+/// ARRAY_STORE_LOCAL — store an array handle into a local (StackAddr) variable slot.
+///
+/// This is an internal system primitive used exclusively by the `DIM @A[n]` compiler
+/// to initialise a local array binding.  It is intentionally hidden from user code.
+///
+/// Stack convention: `[..., StackAddr(idx), Cell::Array(pool_idx)]` → ARRAY_STORE_LOCAL → `[...]`
+///
+/// Unlike `SET`, this primitive bypasses the surface-language prohibition on
+/// assigning whole-array handles to scalar variables.  Only the `DIM` compiler
+/// may emit its Xt.
+pub(super) fn array_store_local_prim(vm: &mut VM) -> Result<(), TbxError> {
+    let value = vm.pop()?;
+    let addr = vm.pop()?;
+    match addr {
+        Cell::StackAddr(idx) => {
+            vm.local_write(idx, value)?;
+        }
+        _ => {
+            return Err(TbxError::TypeError {
+                expected: "StackAddr for ARRAY_STORE_LOCAL",
+                got: "non-StackAddr",
+            });
+        }
+    }
+    Ok(())
+}
+
 /// ARRAY_LEN — return the length of an array.
 ///
 /// Pops `Cell::Array(pool_idx)` from the stack and pushes the number of elements

--- a/src/primitives/compare.rs
+++ b/src/primitives/compare.rs
@@ -15,9 +15,18 @@ use crate::vm::VM;
 /// EQ — equality comparison. Pushes Bool(true) if the two top values are equal.
 /// Int/Float mixed pairs are compared by promoting Int to Float.
 /// All other pairs, including two Cell::Str values, use Cell's PartialEq.
+///
+/// `Cell::Array` operands are rejected with a TypeError: arrays are not
+/// first-class values on the surface language and may not be compared.
 pub fn eq_prim(vm: &mut VM) -> Result<(), TbxError> {
     let b = vm.pop()?;
     let a = vm.pop()?;
+    if matches!(a, Cell::Array(_)) || matches!(b, Cell::Array(_)) {
+        return Err(TbxError::TypeError {
+            expected: "non-array value",
+            got: "Array",
+        });
+    }
     let result = match (&a, &b) {
         (Cell::Int(x), Cell::Float(y)) => (*x as f64) == *y,
         (Cell::Float(x), Cell::Int(y)) => *x == (*y as f64),
@@ -30,9 +39,18 @@ pub fn eq_prim(vm: &mut VM) -> Result<(), TbxError> {
 /// NEQ — inequality comparison. Pushes Bool(true) if the two top values are not equal.
 /// Int/Float mixed pairs are compared by promoting Int to Float.
 /// All other pairs, including two Cell::Str values, use Cell's PartialEq.
+///
+/// `Cell::Array` operands are rejected with a TypeError: arrays are not
+/// first-class values on the surface language and may not be compared.
 pub fn neq_prim(vm: &mut VM) -> Result<(), TbxError> {
     let b = vm.pop()?;
     let a = vm.pop()?;
+    if matches!(a, Cell::Array(_)) || matches!(b, Cell::Array(_)) {
+        return Err(TbxError::TypeError {
+            expected: "non-array value",
+            got: "Array",
+        });
+    }
     let result = match (&a, &b) {
         (Cell::Int(x), Cell::Float(y)) => (*x as f64) != *y,
         (Cell::Float(x), Cell::Int(y)) => *x != (*y as f64),

--- a/src/primitives/memory.rs
+++ b/src/primitives/memory.rs
@@ -103,19 +103,39 @@ pub fn fetch_prim(vm: &mut VM) -> Result<(), TbxError> {
     }
 }
 
+/// Check that `value` is not a whole-array handle being written to a scalar variable.
+///
+/// `Cell::Array` is forbidden as a value in scalar variable writes (`DictAddr` or
+/// `StackAddr` destinations).  Arrays are not first-class values on the surface
+/// language; only element-level access via `Cell::ArrayAddr` is permitted.
+fn check_scalar_write_value(value: &Cell) -> Result<(), TbxError> {
+    if matches!(value, Cell::Array(_)) {
+        return Err(TbxError::TypeError {
+            expected: "non-array value for scalar variable write",
+            got: "Array",
+        });
+    }
+    Ok(())
+}
+
 /// STORE — pop addr (top) then value (below), and store value at addr.
 ///
 /// Stack convention: `[..., value, addr]` → STORE → `[...]`
+///
+/// Storing a whole `Cell::Array` into a scalar variable (`DictAddr` or `StackAddr`)
+/// is rejected with a TypeError; element-level writes via `Cell::ArrayAddr` are allowed.
 pub fn store_prim(vm: &mut VM) -> Result<(), TbxError> {
     let addr = vm.pop()?;
     let value = vm.pop()?;
     match addr {
         Cell::DictAddr(a) => {
+            check_scalar_write_value(&value)?;
             check_dict_reference_write(vm, &value)?;
             vm.dict_write_at(a, value)?;
             Ok(())
         }
         Cell::StackAddr(a) => {
+            check_scalar_write_value(&value)?;
             vm.local_write(a, value)?;
             Ok(())
         }
@@ -134,16 +154,21 @@ pub fn store_prim(vm: &mut VM) -> Result<(), TbxError> {
 /// Designed for the `SET &var, value` statement pattern where `&var` is
 /// pushed before `value` (left-to-right argument evaluation via comma).
 /// Stack convention: `[..., addr, value]` → SET → `[...]`
+///
+/// Storing a whole `Cell::Array` into a scalar variable (`DictAddr` or `StackAddr`)
+/// is rejected with a TypeError; element-level writes via `Cell::ArrayAddr` are allowed.
 pub fn set_prim(vm: &mut VM) -> Result<(), TbxError> {
     let value = vm.pop()?;
     let addr = vm.pop()?;
     match addr {
         Cell::DictAddr(a) => {
+            check_scalar_write_value(&value)?;
             check_dict_reference_write(vm, &value)?;
             vm.dict_write_at(a, value)?;
             Ok(())
         }
         Cell::StackAddr(a) => {
+            check_scalar_write_value(&value)?;
             vm.local_write(a, value)?;
             Ok(())
         }
@@ -304,16 +329,18 @@ mod tests {
     /// the VM is currently executing inside a Call frame (not top-level).
     #[test]
     fn test_store_frame_local_array_to_dict_errors() {
+        // Storing a whole Cell::Array into a DictAddr slot is now always rejected
+        // with TypeError, regardless of frame context.  (Previously it was
+        // ArrayFrameEscape for frame-local arrays; the earlier check was
+        // superseded by the surface-level prohibition on whole-array writes.)
         let mut vm = VM::new();
 
         // Allocate a dictionary slot for the target variable.
         vm.dictionary.push(Cell::None);
         vm.dp = 1;
 
-        // Create the frame-local array; global_array_pool_len stays at 0.
         let frame_local_idx = vm.arrays.len();
         vm.arrays.push(vec![Cell::Int(7)]);
-        // global_array_pool_len = 0 means pool_idx 0 is not global.
 
         // Simulate a Call frame so is_executing_top_level() returns false.
         vm.return_stack.push(ReturnFrame::TopLevel);
@@ -331,18 +358,17 @@ mod tests {
 
         let result = store_prim(&mut vm);
         assert!(
-            matches!(result, Err(TbxError::ArrayFrameEscape)),
-            "expected ArrayFrameEscape, got {:?}",
+            matches!(result, Err(TbxError::TypeError { .. })),
+            "expected TypeError for whole-array write, got {:?}",
             result
         );
     }
 
-    /// Verify that storing a top-level Cell::Array into a dictionary slot promotes
-    /// global_array_pool_len to cover the stored array.
+    /// Verify that storing a top-level Cell::Array into a dictionary slot is now
+    /// rejected with TypeError.
     ///
-    /// When execution is at the top level (only a TopLevel sentinel on the return
-    /// stack), STORE must promote the array to the global region instead of
-    /// returning an error.
+    /// Arrays are not first-class surface values; storing a whole array handle
+    /// into a scalar variable is forbidden regardless of the execution context.
     #[test]
     fn test_store_top_level_array_to_dict_promotes_global_boundary() {
         let mut vm = VM::new();
@@ -351,7 +377,6 @@ mod tests {
         vm.dictionary.push(Cell::None);
         vm.dp = 1;
 
-        // Create the array at top level; global_array_pool_len starts at 0.
         let top_level_idx = vm.arrays.len();
         vm.arrays.push(vec![Cell::Int(99)]);
 
@@ -362,16 +387,11 @@ mod tests {
         vm.push(Cell::Array(top_level_idx)).unwrap();
         vm.push(Cell::DictAddr(0)).unwrap();
 
-        store_prim(&mut vm).unwrap();
-
-        // The global boundary must have been promoted to cover top_level_idx.
+        let result = store_prim(&mut vm);
         assert!(
-            vm.global_array_pool_len > top_level_idx,
-            "expected global_array_pool_len > {}, got {}",
-            top_level_idx,
-            vm.global_array_pool_len
+            matches!(result, Err(TbxError::TypeError { .. })),
+            "expected TypeError for whole-array write at top level, got {:?}",
+            result
         );
-        // The dictionary slot must now hold the array handle.
-        assert_eq!(vm.dictionary[0], Cell::Array(top_level_idx));
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -870,6 +870,18 @@ impl VM {
                             if self.data_stack.len() < arity {
                                 return Err(TbxError::StackUnderflow);
                             }
+                            // Arrays are not first-class surface values; passing a
+                            // whole-array handle as an argument to a user-defined word
+                            // is not supported (issue #718).
+                            let arg_start = self.data_stack.len() - arity;
+                            for cell in &self.data_stack[arg_start..] {
+                                if matches!(cell, Cell::Array(_)) {
+                                    return Err(TbxError::TypeError {
+                                        expected: "non-array argument to user-defined word",
+                                        got: "Array",
+                                    });
+                                }
+                            }
                             if self.return_stack.len() >= MAX_RETURN_STACK_DEPTH {
                                 return Err(TbxError::ReturnStackOverflow {
                                     depth: self.return_stack.len(),

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -923,48 +923,23 @@ impl VM {
                     }
                 }
                 EntryKind::ReturnVal => {
-                    // Determine the array frame boundary before popping the return
-                    // value, so we can detect whether the array belongs to the
-                    // current frame.
-                    let array_frame_boundary = match self.return_stack.last() {
-                        Some(ReturnFrame::Call {
-                            saved_array_pool_len,
-                            ..
-                        }) => *saved_array_pool_len,
+                    // Check that the current frame is a proper call frame (not top level).
+                    match self.return_stack.last() {
+                        Some(ReturnFrame::Call { .. }) => {}
                         Some(ReturnFrame::TopLevel) => {
                             return Err(TbxError::InvalidReturn);
                         }
                         None => return Err(TbxError::StackUnderflow),
                     };
-                    let mut retval = self.pop()?;
-                    // Ownership transfer for frame-local Cell::Array:
-                    // If the returned array was created in this frame
-                    // (pool_idx >= array_frame_boundary), swap it to the
-                    // boundary slot and mark it for preservation.
-                    // Array elements are guaranteed to be Int/Float/Bool/None
-                    // (no nested references), so no recursive check is needed.
-                    // `Cell::Str` is `Rc<str>`-backed and needs no swap.
-                    let array_transferred = if let Cell::Array(pool_idx) = &retval {
-                        if *pool_idx >= array_frame_boundary {
-                            // Bounds check before swap: both indices must be valid.
-                            // pool_idx >= array_frame_boundary is already confirmed;
-                            // checking pool_idx < arrays.len() implies array_frame_boundary
-                            // is also in range.
-                            if *pool_idx >= self.arrays.len() {
-                                return Err(TbxError::IndexOutOfBounds {
-                                    index: *pool_idx,
-                                    size: self.arrays.len(),
-                                });
-                            }
-                            self.arrays.swap(*pool_idx, array_frame_boundary);
-                            retval = Cell::Array(array_frame_boundary);
-                            true
-                        } else {
-                            false
-                        }
-                    } else {
-                        false
-                    };
+                    let retval = self.pop()?;
+                    // Arrays are not first-class surface values; returning a whole
+                    // array handle from a word is not supported.
+                    if matches!(retval, Cell::Array(_)) {
+                        return Err(TbxError::TypeError {
+                            expected: "non-array return value",
+                            got: "Array",
+                        });
+                    }
                     match self.return_stack.pop().ok_or(TbxError::StackUnderflow)? {
                         ReturnFrame::Call {
                             callee_xt: _,
@@ -975,11 +950,8 @@ impl VM {
                         } => {
                             self.data_stack.truncate(self.bp);
                             // Truncate the array pool back to the saved boundary.
-                            // If ownership was transferred, the returned value now sits
-                            // at `saved_array_pool_len` (the boundary slot), so we keep
-                            // exactly one extra entry beyond the boundary.
-                            let array_keep = saved_array_pool_len + usize::from(array_transferred);
-                            self.arrays.truncate(array_keep);
+                            // Arrays are not returnable, so no ownership transfer occurs.
+                            self.arrays.truncate(saved_array_pool_len);
                             self.push(retval)?;
                             self.pc = return_pc;
                             self.bp = saved_bp;
@@ -2919,15 +2891,18 @@ mod tests {
 
     #[test]
     fn test_array_frame_escape_via_store_to_dict_is_error() {
-        // Verify that STORE of a Cell::Array into a global variable produces ArrayFrameEscape.
+        // Verify that SET &G, A (where A is an array variable) is now rejected with
+        // TypeError.  Arrays are not first-class surface values; the whole-array
+        // handle may not be assigned to a scalar variable.  (Previously, frame-local
+        // arrays produced ArrayFrameEscape; the prohibition is now broader.)
         let result = run_source(
             "VAR G\n\
              DEF BAD_STORE()\n  DIM @A[2]\n  SET &G, A\nEND\n\
              BAD_STORE",
         );
         assert!(
-            matches!(result, Err(crate::error::TbxError::ArrayFrameEscape)),
-            "expected ArrayFrameEscape, got: {result:?}"
+            matches!(result, Err(crate::error::TbxError::TypeError { .. })),
+            "expected TypeError for whole-array write to global var, got: {result:?}"
         );
     }
 
@@ -2989,8 +2964,9 @@ mod tests {
 
     #[test]
     fn test_global_array_stored_via_store_prim() {
-        // A global array (pool_idx < global_array_pool_len) can be stored into a
-        // dictionary slot by store_prim without triggering ArrayFrameEscape.
+        // Storing a whole Cell::Array into a DictAddr slot is now rejected with
+        // TypeError regardless of whether the array is "global" or not.
+        // Arrays are not first-class surface values; this write path is forbidden.
         let mut vm = VM::new();
         vm.arrays.push(vec![Cell::Int(0); 5]);
         vm.global_array_pool_len = 1; // mark pool[0] as global
@@ -3001,19 +2977,19 @@ mod tests {
 
         let arr = Cell::Array(0);
         // store_prim pops addr first, then value; so push value then addr.
-        vm.push(arr.clone()).unwrap();
+        vm.push(arr).unwrap();
         vm.push(Cell::DictAddr(slot)).unwrap();
         let result = crate::primitives::store_prim(&mut vm);
         assert!(
-            result.is_ok(),
-            "store_prim should allow global array: {result:?}"
+            matches!(result, Err(TbxError::TypeError { .. })),
+            "expected TypeError for whole-array write: {result:?}"
         );
-        assert_eq!(vm.dict_read(slot).unwrap(), arr);
     }
 
     #[test]
     fn test_global_array_stored_via_set_prim() {
-        // set_prim (SET &var, value) also accepts a global array.
+        // Storing a whole Cell::Array into a DictAddr slot via set_prim is now
+        // rejected with TypeError.  Arrays are not first-class surface values.
         let mut vm = VM::new();
         vm.arrays.push(vec![Cell::Int(0); 3]);
         vm.global_array_pool_len = 1;
@@ -3024,33 +3000,33 @@ mod tests {
         let arr = Cell::Array(0);
         // set_prim pops value first, then addr (stack: [..., addr, value]).
         vm.push(Cell::DictAddr(slot)).unwrap();
-        vm.push(arr.clone()).unwrap();
+        vm.push(arr).unwrap();
         let result = crate::primitives::set_prim(&mut vm);
         assert!(
-            result.is_ok(),
-            "set_prim should allow global array: {result:?}"
+            matches!(result, Err(TbxError::TypeError { .. })),
+            "expected TypeError for whole-array write: {result:?}"
         );
-        assert_eq!(vm.dict_read(slot).unwrap(), arr);
     }
 
     #[test]
     fn test_word_array_store_to_global_var_is_still_error() {
-        // Arrays created inside a word must still not escape via a global VAR.
-        // global_array_pool_len = 0 (default), so all arrays created in words are frame-local.
+        // SET &gvar, a (where a is a local array variable) is now rejected with
+        // TypeError.  Arrays are not first-class surface values; the whole-array
+        // handle may not be assigned to a scalar variable.
         let result = run_source(
             "VAR gvar\n\
              DEF BAD()\n  DIM @a[3]\n  SET &gvar, a\nEND\n\
              BAD",
         );
         assert!(
-            matches!(result, Err(crate::error::TbxError::ArrayFrameEscape)),
-            "expected ArrayFrameEscape, got: {result:?}"
+            matches!(result, Err(crate::error::TbxError::TypeError { .. })),
+            "expected TypeError for whole-array write to global var, got: {result:?}"
         );
     }
 
     #[test]
     fn test_non_global_array_store_rejected_by_store_prim() {
-        // An array with pool_idx >= global_array_pool_len must still be rejected.
+        // Storing any Cell::Array into a DictAddr slot is now rejected with TypeError.
         let mut vm = VM::new();
         vm.arrays.push(vec![Cell::Int(0); 5]);
         // global_array_pool_len stays 0, so pool[0] is NOT global.
@@ -3063,55 +3039,28 @@ mod tests {
         vm.push(Cell::DictAddr(slot)).unwrap();
         let result = crate::primitives::store_prim(&mut vm);
         assert!(
-            matches!(result, Err(TbxError::ArrayFrameEscape)),
-            "expected ArrayFrameEscape, got: {result:?}"
+            matches!(result, Err(TbxError::TypeError { .. })),
+            "expected TypeError for whole-array write, got: {result:?}"
         );
     }
 
     #[test]
-    fn test_global_array_returnable_from_word() {
-        // A global array (pool_idx < saved_array_pool_len of the CALL frame) can
-        // be returned from a word without triggering ArrayFrameEscape.
+    fn test_global_array_not_returnable_from_word() {
+        // Arrays are not first-class surface values; RETURN_VAL now rejects any
+        // Cell::Array return value with TypeError, regardless of whether the array
+        // is "global" or frame-local.
         //
-        // The ReturnVal check uses `frame_boundary = saved_array_pool_len` of the
-        // current CALL frame.  A global array created before the call has
-        // pool_idx < saved_array_pool_len, so it is safe to return.
-        let mut vm = VM::new();
-
-        // Insert a "global" array at pool slot 0.
-        vm.arrays.push(vec![Cell::Int(99); 3]);
-        // Simulate that TopLevel exit has already promoted it.
-        vm.global_array_pool_len = 1;
-
-        // Simulate a CALL frame where saved_array_pool_len = 1 (the array already
-        // existed when the word was called).
-        vm.return_stack.push(ReturnFrame::TopLevel);
-        vm.return_stack.push(ReturnFrame::Call {
-            callee_xt: Xt(0),
-            return_pc: 0,
-            saved_bp: 0,
-            saved_array_pool_len: 1,
-            actual_arity: 0,
-        });
-
-        // Push the global array as the return value.
-        vm.push(Cell::Array(0)).unwrap();
-
-        // Mimic the ReturnVal boundary check: frame_boundary = 1, pool_idx = 0 < 1 → OK.
-        let frame_boundary = match vm.return_stack.last().unwrap() {
-            ReturnFrame::Call {
-                saved_array_pool_len,
-                ..
-            } => *saved_array_pool_len,
-            _ => panic!("unexpected frame"),
-        };
-        let retval = vm.pop().unwrap();
-        if let Cell::Array(pool_idx) = &retval {
-            assert!(
-                *pool_idx < frame_boundary,
-                "global array should pass ReturnVal check"
-            );
-        }
+        // This test verifies that run_source produces a TypeError when a word
+        // attempts to return a global array.
+        let result = run_source(
+            "DIM @G[3]\n\
+             DEF RETURN_ARRAY()\n  RETURN G\nEND\n\
+             PUTDEC RETURN_ARRAY()",
+        );
+        assert!(
+            matches!(result, Err(crate::error::TbxError::TypeError { .. })),
+            "expected TypeError for whole-array return, got: {result:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 概要

Array は surface language 上では first-class value ではないため、whole-array handle を surface で使う操作（`LET B = A`・`SET &B, A`・`RETURN A`・`TUPLE(A)`・`PUTVAL A`・`A = B`）を runtime TypeError で拒否する実装を追加する。

## 変更内容

### 禁止ロジック

- **`EQ` / `NEQ`** (`src/primitives/compare.rs`): どちらかのオペランドが `Cell::Array` の場合に `TypeError` を返すチェックを追加
- **`SET` / `STORE`** (`src/primitives/memory.rs`): `DictAddr` または `StackAddr` 宛への `Cell::Array` 書き込みを `TypeError` で拒否する `check_scalar_write_value` ヘルパーを追加
- **`RETURN_VAL`** (`src/vm.rs`): 返り値が `Cell::Array` の場合に `TypeError` を返すチェックを追加。配列 ownership transfer コードは削除

### DIM @A[n] との両立

`DIM @A[n]` のローカル配列コンパイルは内部で `SET StackAddr(idx), Cell::Array(pool_idx)` を生成していた。`SET` に禁止チェックを入れると `DIM` が壊れるため、専用の内部システムプリミティブ `ARRAY_STORE_LOCAL` を追加し、`dim_prim` のコンパイル時コード生成で `SET` の代わりに使用する。

- `src/primitives/arrays.rs`: `array_store_local_prim` 関数を追加
- `src/primitives.rs`: `ARRAY_STORE_LOCAL` を `FLAG_SYSTEM | FLAG_HIDDEN` で登録、`dim_prim` のローカル配列 emit で `SET` → `ARRAY_STORE_LOCAL` に変更

### テスト

- 既存テスト群（`ArrayFrameEscape` を期待していたもの）を `TypeError` 期待に更新
- `src/interpreter.rs` に以下のテストを追加：
  - `test_whole_array_let_assignment_is_error` — `LET B = A` が TypeError になること
  - `test_whole_array_set_assignment_is_error` — `SET &B, A` が TypeError になること
  - `test_whole_array_set_global_assignment_is_error` — `SET &G, A`（グローバル変数）が TypeError になること
  - `test_whole_array_return_is_error` — `RETURN A` が TypeError になること
  - `test_whole_array_in_tuple_is_error` — `TUPLE(A)` がエラーになること
  - `test_putval_array_is_error` — `PUTVAL A` が TypeError になること
  - `test_array_equality_is_error` — `A = B`（配列equality）が TypeError になること
  - `test_array_eq_function_is_error` — `EQ(A, B)` が TypeError になること
  - `test_dim_global_array_is_still_valid` — `DIM @A[n]` とelement accessが継続動作すること
  - `test_dim_local_array_is_still_valid` — ローカル `DIM @A[n]` が継続動作すること
  - `test_array_element_read_is_still_valid` — `@A[i]` 読み出しが継続動作すること
  - `test_array_element_addr_is_still_valid` — `&@A[i]` 経由の書き込みが継続動作すること
  - `test_let_array_element_write_is_still_valid` — `LET @A[i] = expr` が継続動作すること
  - `test_array_len_is_still_valid` — `ARRAY_LEN(@A)` が継続動作すること

Closes #718
