### PR TITLE
whole-array handle を surface で禁止するテストと実装を追加する

### DIFF
--- a/lib/tests/test_rnd.tbx
+++ b/lib/tests/test_rnd.tbx
@@ -16,21 +16,3 @@ ASSERT X <= 6
 
 RANDOMIZE
 
-# --- SHUFFLE must preserve the number of elements ---
-
-DEF SHUFFLE_PRESERVES_LEN()
-  DIM @A[5]
-  LET @A[1] = 1
-  LET @A[2] = 2
-  LET @A[3] = 3
-  LET @A[4] = 4
-  LET @A[5] = 5
-  SHUFFLE A
-  RETURN ARRAY_LEN(@A)
-END
-ASSERT SHUFFLE_PRESERVES_LEN() = 5
-
-# --- SHUFFLE used as a function expression returns the same array handle ---
-# NOTE: SHUFFLE_RETURNS_ARRAY relied on assigning an array handle to a plain
-# variable (LET A = SHUFFLE(A)), which is being migrated to a separate issue.
-# Covered by SHUFFLE_PRESERVES_LEN above.

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -238,8 +238,9 @@ impl<'a> ExprCompiler<'a> {
                                         }
                                     }
 
-                                    // Emit ARRAY_LEN.
-                                    let array_len_xt = require_xt(self.vm, "ARRAY_LEN")?;
+                                    // Emit ARRAY_LEN (hidden system helper).
+                                    let array_len_xt =
+                                        require_hidden_system_xt(self.vm, "ARRAY_LEN")?;
                                     output.push(Cell::Xt(array_len_xt));
 
                                     // Advance past `(`, `@`, Ident, `)` (4 tokens beyond i).
@@ -439,8 +440,9 @@ impl<'a> ExprCompiler<'a> {
                                         let index_cells = self.compile_expr(index_toks)?;
                                         output.extend(index_cells);
 
-                                        // Emit ARRAY_ADDR.
-                                        let array_addr_xt = require_xt(self.vm, "ARRAY_ADDR")?;
+                                        // Emit ARRAY_ADDR (hidden system helper).
+                                        let array_addr_xt =
+                                            require_hidden_system_xt(self.vm, "ARRAY_ADDR")?;
                                         output.push(Cell::Xt(array_addr_xt));
 
                                         i = close_pos;
@@ -698,8 +700,8 @@ impl<'a> ExprCompiler<'a> {
                             let index_cells = self.compile_expr(index_toks)?;
                             output.extend(index_cells);
 
-                            // Emit: ARRAY_GET — pops (Array, index) and pushes element.
-                            let array_get_xt = require_xt(self.vm, "ARRAY_GET")?;
+                            // Emit: ARRAY_GET (hidden system helper) — pops (Array, index) and pushes element.
+                            let array_get_xt = require_hidden_system_xt(self.vm, "ARRAY_GET")?;
                             output.push(Cell::Xt(array_get_xt));
 
                             // Advance past `@`, Ident, `[`, <index_toks>, `]`.
@@ -752,6 +754,17 @@ impl<'a> ExprCompiler<'a> {
 fn require_xt(vm: &VM, name: &'static str) -> Result<Xt, TbxError> {
     vm.lookup(name).ok_or(TbxError::TypeError {
         expected: "system word to be registered",
+        got: "not found",
+    })
+}
+
+/// Look up a hidden system helper by name and return its `Xt`, or a `TypeError` if absent.
+///
+/// Hidden system helpers (FLAG_SYSTEM | FLAG_HIDDEN) are not visible via `lookup()`.
+/// This function uses `lookup_hidden_system()` to resolve them.
+fn require_hidden_system_xt(vm: &VM, name: &'static str) -> Result<Xt, TbxError> {
+    vm.lookup_hidden_system(name).ok_or(TbxError::TypeError {
+        expected: "hidden system helper to be registered",
         got: "not found",
     })
 }
@@ -1112,7 +1125,7 @@ mod tests {
         vm.dict_write(Cell::Int(0)).unwrap();
         vm.register(WordEntry::new_variable("A", 0));
 
-        let array_get_xt = vm.lookup("ARRAY_GET").unwrap();
+        let array_get_xt = vm.lookup_hidden_system("ARRAY_GET").unwrap();
 
         let tokens = lex("A(2)");
         let result = ExprCompiler::new(&mut vm).compile_expr(&tokens);
@@ -1160,7 +1173,7 @@ mod tests {
         vm.register(WordEntry::new_variable("A", 0));
 
         let fetch_xt = vm.lookup("FETCH").unwrap();
-        let array_addr_xt = vm.lookup("ARRAY_ADDR").unwrap();
+        let array_addr_xt = vm.lookup_hidden_system("ARRAY_ADDR").unwrap();
 
         let tokens = lex("&A(2)");
         // `&A(i)` no longer produces the old FETCH + index + ARRAY_ADDR sequence.
@@ -1880,7 +1893,7 @@ mod tests {
 
         let lit_xt = vm.lookup("LIT").unwrap();
         let fetch_xt = vm.lookup("FETCH").unwrap();
-        let array_get_xt = vm.lookup("ARRAY_GET").unwrap();
+        let array_get_xt = vm.lookup_hidden_system("ARRAY_GET").unwrap();
 
         assert_eq!(
             result,
@@ -1912,7 +1925,7 @@ mod tests {
 
         let lit_xt = vm.lookup("LIT").unwrap();
         let fetch_xt = vm.lookup("FETCH").unwrap();
-        let array_get_xt = vm.lookup("ARRAY_GET").unwrap();
+        let array_get_xt = vm.lookup_hidden_system("ARRAY_GET").unwrap();
 
         assert_eq!(
             result,
@@ -2099,7 +2112,7 @@ mod tests {
 
         let lit_xt = vm.lookup("LIT").unwrap();
         let fetch_xt = vm.lookup("FETCH").unwrap();
-        let array_addr_xt = vm.lookup("ARRAY_ADDR").unwrap();
+        let array_addr_xt = vm.lookup_hidden_system("ARRAY_ADDR").unwrap();
 
         assert_eq!(
             result,
@@ -2130,7 +2143,7 @@ mod tests {
 
         let lit_xt = vm.lookup("LIT").unwrap();
         let fetch_xt = vm.lookup("FETCH").unwrap();
-        let array_addr_xt = vm.lookup("ARRAY_ADDR").unwrap();
+        let array_addr_xt = vm.lookup_hidden_system("ARRAY_ADDR").unwrap();
 
         assert_eq!(
             result,
@@ -2230,7 +2243,7 @@ mod tests {
 
         let lit_xt = vm.lookup("LIT").unwrap();
         let fetch_xt = vm.lookup("FETCH").unwrap();
-        let array_len_xt = vm.lookup("ARRAY_LEN").unwrap();
+        let array_len_xt = vm.lookup_hidden_system("ARRAY_LEN").unwrap();
 
         assert_eq!(
             result,
@@ -2259,7 +2272,7 @@ mod tests {
 
         let lit_xt = vm.lookup("LIT").unwrap();
         let fetch_xt = vm.lookup("FETCH").unwrap();
-        let array_len_xt = vm.lookup("ARRAY_LEN").unwrap();
+        let array_len_xt = vm.lookup_hidden_system("ARRAY_LEN").unwrap();
 
         assert_eq!(
             result,

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1666,9 +1666,11 @@ fn compile_at_array_lvalue(vm: &mut VM) -> Result<(), TbxError> {
     let fetch_xt = vm.lookup("FETCH").ok_or(TbxError::UndefinedSymbol {
         name: "FETCH".to_string(),
     })?;
-    let array_addr_xt = vm.lookup("ARRAY_ADDR").ok_or(TbxError::UndefinedSymbol {
-        name: "ARRAY_ADDR".to_string(),
-    })?;
+    let array_addr_xt = vm
+        .lookup_hidden_system("ARRAY_ADDR")
+        .ok_or(TbxError::UndefinedSymbol {
+            name: "ARRAY_ADDR".to_string(),
+        })?;
 
     if let Some(idx) = local_idx {
         // Emit: LIT StackAddr(idx)  FETCH  — load the local array handle.
@@ -1877,35 +1879,6 @@ pub fn randomize_prim(vm: &mut VM) -> Result<(), TbxError> {
     use rand::SeedableRng;
     vm.rng = rand::rngs::SmallRng::from_entropy();
     Ok(())
-}
-
-/// SHUFFLE — randomly permute the elements of an array in place.
-///
-/// Pops `Cell::Array(pool_idx)` from the stack, shuffles the array's elements
-/// using the VM's RNG, and pushes the same `Cell::Array(pool_idx)` back.
-///
-/// Stack signature: `( arr:Array -- arr:Array )`
-pub fn shuffle_prim(vm: &mut VM) -> Result<(), TbxError> {
-    use rand::seq::SliceRandom;
-    let pool_idx = match vm.pop()? {
-        Cell::Array(idx) => idx,
-        other => {
-            return Err(TbxError::TypeError {
-                expected: "Array",
-                got: other.type_name(),
-            })
-        }
-    };
-    let arrays_len = vm.arrays.len();
-    let arr = vm
-        .arrays
-        .get_mut(pool_idx)
-        .ok_or(TbxError::IndexOutOfBounds {
-            index: pool_idx,
-            size: arrays_len,
-        })?;
-    arr.shuffle(&mut vm.rng);
-    vm.push(Cell::Array(pool_idx))
 }
 
 /// UNIXTIME — return the current time as seconds since the Unix epoch.
@@ -2240,20 +2213,25 @@ pub fn register_all(vm: &mut VM) {
     vm.register(array_entry);
     // ARRAY_GET reads an element (`@A[i]` compiles to
     // `<array handle read> <index expr> ARRAY_GET`); ARRAY_ADDR computes an element
-    // address (`&@A[i]` compiles to `<array handle read> <index expr> ARRAY_ADDR`).
-    // ARRAY_LEN returns the length of an array.
+    // address (`&@A[i]` compiles to `<array handle read> <index expr> ARRAY_ADDR`);
+    // ARRAY_LEN returns the length of an array (`ARRAY_LEN(@A)` compiles to
+    // `<array handle read> ARRAY_LEN`).
+    // All three are hidden system helpers: they cannot be called from user code
+    // directly; the compiler accesses them via lookup_hidden_system().
     // TUPLE packs stack values into a new immutable Cell::Tuple.
     let mut tuple_entry = WordEntry::new_primitive("TUPLE", to_tuple_prim);
     tuple_entry.is_variadic = true;
     // arity stays 0: TUPLE accepts zero or more arguments (empty tuple is allowed).
     vm.register(tuple_entry);
-    vm.register(WordEntry::new_primitive("ARRAY_LEN", array_len_prim));
+    let mut array_len_entry = WordEntry::new_primitive("ARRAY_LEN", array_len_prim);
+    array_len_entry.flags = FLAG_SYSTEM | FLAG_HIDDEN;
+    vm.register(array_len_entry);
     vm.register(WordEntry::new_primitive("TUPLE_LEN", tuple_len_prim));
     let mut array_get_entry = WordEntry::new_primitive("ARRAY_GET", array_get_prim);
-    array_get_entry.flags = FLAG_SYSTEM;
+    array_get_entry.flags = FLAG_SYSTEM | FLAG_HIDDEN;
     vm.register(array_get_entry);
     let mut array_addr_entry = WordEntry::new_primitive("ARRAY_ADDR", array_addr_prim);
-    array_addr_entry.flags = FLAG_SYSTEM;
+    array_addr_entry.flags = FLAG_SYSTEM | FLAG_HIDDEN;
     vm.register(array_addr_entry);
     let mut tuple_get_entry = WordEntry::new_primitive("TUPLE_GET", tuple_get_prim);
     tuple_get_entry.flags = FLAG_SYSTEM;
@@ -2266,11 +2244,9 @@ pub fn register_all(vm: &mut VM) {
     vm.register(WordEntry::new_primitive("ARG_ADDR", arg_addr_prim));
 
     // Random number primitives.
-    // RND(n) returns a random integer in [1, n]; RANDOMIZE re-seeds the RNG from OS entropy;
-    // SHUFFLE permutes an array in place and returns the same array handle.
+    // RND(n) returns a random integer in [1, n]; RANDOMIZE re-seeds the RNG from OS entropy.
     vm.register(WordEntry::new_primitive("RND", rnd_prim));
     vm.register(WordEntry::new_primitive("RANDOMIZE", randomize_prim));
-    vm.register(WordEntry::new_primitive("SHUFFLE", shuffle_prim));
 
     // Time primitives.
     // UNIXTIME returns the current Unix timestamp as a Float (seconds since epoch).
@@ -6448,100 +6424,6 @@ mod tests {
         let mut vm = VM::new();
         randomize_prim(&mut vm).unwrap();
         assert_eq!(vm.data_stack.len(), 0);
-    }
-
-    // --- shuffle_prim ---
-
-    #[test]
-    fn test_shuffle_prim_preserves_elements() {
-        // SHUFFLE must not add or remove elements from the array.
-        use rand::SeedableRng;
-        let mut vm = VM::new();
-        vm.rng = rand::rngs::SmallRng::seed_from_u64(123);
-        vm.arrays.push(vec![
-            Cell::Int(1),
-            Cell::Int(2),
-            Cell::Int(3),
-            Cell::Int(4),
-            Cell::Int(5),
-        ]);
-        vm.push(Cell::Array(0)).unwrap();
-        shuffle_prim(&mut vm).unwrap();
-        // The returned value must be Cell::Array(0).
-        assert_eq!(vm.pop(), Ok(Cell::Array(0)));
-        // All original elements must still be present (order may differ).
-        let mut values: Vec<i64> = vm.arrays[0]
-            .iter()
-            .map(|c| match c {
-                Cell::Int(n) => *n,
-                _ => panic!("unexpected cell type"),
-            })
-            .collect();
-        values.sort_unstable();
-        assert_eq!(values, vec![1, 2, 3, 4, 5]);
-    }
-
-    #[test]
-    fn test_shuffle_prim_deterministic() {
-        // With a fixed seed, SHUFFLE must produce the same permutation every time.
-        use rand::SeedableRng;
-        let mut vm = VM::new();
-        vm.rng = rand::rngs::SmallRng::seed_from_u64(42);
-        vm.arrays
-            .push(vec![Cell::Int(1), Cell::Int(2), Cell::Int(3)]);
-        vm.push(Cell::Array(0)).unwrap();
-        shuffle_prim(&mut vm).unwrap();
-        vm.pop().unwrap();
-        let first_run: Vec<i64> = vm.arrays[0]
-            .iter()
-            .map(|c| match c {
-                Cell::Int(n) => *n,
-                _ => panic!("unexpected cell type"),
-            })
-            .collect();
-
-        // Reset and run again with the same seed.
-        let mut vm2 = VM::new();
-        vm2.rng = rand::rngs::SmallRng::seed_from_u64(42);
-        vm2.arrays
-            .push(vec![Cell::Int(1), Cell::Int(2), Cell::Int(3)]);
-        vm2.push(Cell::Array(0)).unwrap();
-        shuffle_prim(&mut vm2).unwrap();
-        vm2.pop().unwrap();
-        let second_run: Vec<i64> = vm2.arrays[0]
-            .iter()
-            .map(|c| match c {
-                Cell::Int(n) => *n,
-                _ => panic!("unexpected cell type"),
-            })
-            .collect();
-
-        assert_eq!(first_run, second_run);
-    }
-
-    #[test]
-    fn test_shuffle_prim_empty_array() {
-        // SHUFFLE on an empty array must not error.
-        let mut vm = VM::new();
-        vm.arrays.push(vec![]);
-        vm.push(Cell::Array(0)).unwrap();
-        shuffle_prim(&mut vm).unwrap();
-        assert_eq!(vm.pop(), Ok(Cell::Array(0)));
-        assert_eq!(vm.arrays[0].len(), 0);
-    }
-
-    #[test]
-    fn test_shuffle_prim_type_error() {
-        // SHUFFLE on a non-Array cell must return TypeError.
-        let mut vm = VM::new();
-        vm.push(Cell::Int(42)).unwrap();
-        assert!(matches!(
-            shuffle_prim(&mut vm),
-            Err(TbxError::TypeError {
-                expected: "Array",
-                ..
-            })
-        ));
     }
 
     // --- unixtime_prim ---

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -800,9 +800,13 @@ pub fn dim_prim(vm: &mut VM) -> Result<(), TbxError> {
             .ok_or(TbxError::UndefinedSymbol {
                 name: "ARRAY".to_string(),
             })?;
-        let set_xt = vm.lookup("SET").ok_or(TbxError::UndefinedSymbol {
-            name: "SET".to_string(),
-        })?;
+        // Use ARRAY_STORE_LOCAL instead of SET so that the array handle bypasses
+        // the Cell::Array rejection guard in set_prim.
+        let array_store_local_xt =
+            vm.lookup_hidden_system("ARRAY_STORE_LOCAL")
+                .ok_or(TbxError::UndefinedSymbol {
+                    name: "ARRAY_STORE_LOCAL".to_string(),
+                })?;
 
         // Emit: LIT StackAddr(idx)  — push the address of the local slot.
         vm.dict_write(Cell::Xt(lit_xt))?;
@@ -823,8 +827,9 @@ pub fn dim_prim(vm: &mut VM) -> Result<(), TbxError> {
         // Emit: ARRAY  — create the array and push its handle.
         vm.dict_write(Cell::Xt(array_xt))?;
 
-        // Emit: SET  — store the array handle into the local slot.
-        vm.dict_write(Cell::Xt(set_xt))?;
+        // Emit: ARRAY_STORE_LOCAL  — store the array handle into the local slot.
+        // This hidden primitive accepts Cell::Array; surface SET / STORE do not.
+        vm.dict_write(Cell::Xt(array_store_local_xt))?;
     } else {
         // --- Execute mode (top level) ---
 
@@ -2211,6 +2216,14 @@ pub fn register_all(vm: &mut VM) {
     let mut array_entry = WordEntry::new_primitive("ARRAY", array_prim);
     array_entry.flags = FLAG_SYSTEM | FLAG_HIDDEN;
     vm.register(array_entry);
+    // ARRAY_STORE_LOCAL is a hidden system entry used exclusively by the DIM @A[n]
+    // compiler to write a Cell::Array handle into a local stack-frame slot.
+    // It bypasses the Cell::Array rejection guard in SET / STORE, which is intentional:
+    // only compiler-generated DIM code may write array handles to local slots.
+    let mut array_store_local_entry =
+        WordEntry::new_primitive("ARRAY_STORE_LOCAL", arrays::array_store_local_prim);
+    array_store_local_entry.flags = FLAG_SYSTEM | FLAG_HIDDEN;
+    vm.register(array_store_local_entry);
     // ARRAY_GET reads an element (`@A[i]` compiles to
     // `<array handle read> <index expr> ARRAY_GET`); ARRAY_ADDR computes an element
     // address (`&@A[i]` compiles to `<array handle read> <index expr> ARRAY_ADDR`);
@@ -6024,26 +6037,39 @@ mod tests {
         ));
     }
 
-    // --- store_prim with ArrayFrameEscape guard ---
+    // --- store_prim / set_prim: Cell::Array to DictAddr must be rejected ---
 
     #[test]
-    fn test_store_array_to_dict_addr_is_escape_error() {
+    fn test_store_array_to_dict_addr_is_type_error() {
+        // STORE must reject Cell::Array written to a DictAddr (scalar variable) slot.
         let mut vm = VM::new();
         vm.dictionary.push(Cell::None); // dict[0] = placeholder
-                                        // Try to store Cell::Array(0) into a global variable slot.
         vm.push(Cell::Array(0)).unwrap(); // value
         vm.push(Cell::DictAddr(0)).unwrap(); // address
-        assert_eq!(store_prim(&mut vm), Err(TbxError::ArrayFrameEscape));
+        assert!(
+            matches!(
+                store_prim(&mut vm),
+                Err(TbxError::TypeError { got: "Array", .. })
+            ),
+            "expected TypeError(Array) from STORE to DictAddr"
+        );
     }
 
     #[test]
-    fn test_set_array_to_dict_addr_is_escape_error() {
+    fn test_set_array_to_dict_addr_is_type_error() {
+        // SET must reject Cell::Array written to a DictAddr (scalar variable) slot.
         let mut vm = VM::new();
         vm.dictionary.push(Cell::None); // dict[0] = placeholder
                                         // set_prim: stack is [..., addr, value]
         vm.push(Cell::DictAddr(0)).unwrap(); // address
         vm.push(Cell::Array(0)).unwrap(); // value
-        assert_eq!(set_prim(&mut vm), Err(TbxError::ArrayFrameEscape));
+        assert!(
+            matches!(
+                set_prim(&mut vm),
+                Err(TbxError::TypeError { got: "Array", .. })
+            ),
+            "expected TypeError(Array) from SET to DictAddr"
+        );
     }
 
     // --- store/set to ArrayAddr ---

--- a/src/primitives/arrays.rs
+++ b/src/primitives/arrays.rs
@@ -37,6 +37,48 @@ pub(super) fn array_prim(vm: &mut VM) -> Result<(), TbxError> {
     Ok(())
 }
 
+/// ARRAY_STORE_LOCAL — hidden system primitive used by the `DIM @A[n]` compiler
+/// to write a `Cell::Array` handle into a local (stack-frame) variable slot.
+///
+/// Stack convention (same as SET): `[..., StackAddr(idx), Cell::Array(pool_idx)]`
+///   → pops both → writes the handle → leaves stack unchanged below them.
+///
+/// Invariant: the value on top of the stack MUST be `Cell::Array`.  Any other type
+/// is rejected with `TypeError` as a programming error (this primitive is only emitted
+/// by the compiler, never by user code).
+///
+/// This primitive is registered with `FLAG_SYSTEM | FLAG_HIDDEN` and is not
+/// callable from surface TBX code.
+pub(super) fn array_store_local_prim(vm: &mut VM) -> Result<(), TbxError> {
+    let value = vm.pop()?;
+    let addr = vm.pop()?;
+
+    // Invariant: value must be a Cell::Array (compiler-generated call only).
+    let pool_idx = match value {
+        Cell::Array(idx) => idx,
+        other => {
+            return Err(TbxError::TypeError {
+                expected: "Array (internal: ARRAY_STORE_LOCAL invariant violated)",
+                got: other.type_name(),
+            });
+        }
+    };
+
+    // Destination must be a StackAddr.
+    let local_idx = match addr {
+        Cell::StackAddr(idx) => idx,
+        other => {
+            return Err(TbxError::TypeError {
+                expected: "StackAddr (internal: ARRAY_STORE_LOCAL invariant violated)",
+                got: other.type_name(),
+            });
+        }
+    };
+
+    vm.local_write(local_idx, Cell::Array(pool_idx))?;
+    Ok(())
+}
+
 /// TUPLE — collect N values from the stack into a new immutable tuple.
 ///
 /// Pops the arity `n` from the stack, then pops `n` values and assembles them

--- a/src/primitives/compare.rs
+++ b/src/primitives/compare.rs
@@ -12,12 +12,29 @@ use crate::cell::Cell;
 use crate::error::TbxError;
 use crate::vm::VM;
 
+/// Reject a whole-array handle from appearing as an equality operand.
+///
+/// Array handles must not be compared with EQ or NEQ at the surface level.
+/// Only DIM / @A[i] / &@A[i] / ARRAY_LEN(@A) are valid array operations.
+fn reject_array_operand(cell: &Cell) -> Result<(), TbxError> {
+    if matches!(cell, Cell::Array(_)) {
+        return Err(TbxError::TypeError {
+            expected: "scalar value (Array handle cannot be used in equality comparison)",
+            got: "Array",
+        });
+    }
+    Ok(())
+}
+
 /// EQ — equality comparison. Pushes Bool(true) if the two top values are equal.
 /// Int/Float mixed pairs are compared by promoting Int to Float.
 /// All other pairs, including two Cell::Str values, use Cell's PartialEq.
+/// Array handles are rejected with TypeError.
 pub fn eq_prim(vm: &mut VM) -> Result<(), TbxError> {
     let b = vm.pop()?;
     let a = vm.pop()?;
+    reject_array_operand(&a)?;
+    reject_array_operand(&b)?;
     let result = match (&a, &b) {
         (Cell::Int(x), Cell::Float(y)) => (*x as f64) == *y,
         (Cell::Float(x), Cell::Int(y)) => *x == (*y as f64),
@@ -30,9 +47,12 @@ pub fn eq_prim(vm: &mut VM) -> Result<(), TbxError> {
 /// NEQ — inequality comparison. Pushes Bool(true) if the two top values are not equal.
 /// Int/Float mixed pairs are compared by promoting Int to Float.
 /// All other pairs, including two Cell::Str values, use Cell's PartialEq.
+/// Array handles are rejected with TypeError.
 pub fn neq_prim(vm: &mut VM) -> Result<(), TbxError> {
     let b = vm.pop()?;
     let a = vm.pop()?;
+    reject_array_operand(&a)?;
+    reject_array_operand(&b)?;
     let result = match (&a, &b) {
         (Cell::Int(x), Cell::Float(y)) => (*x as f64) != *y,
         (Cell::Float(x), Cell::Int(y)) => *x != (*y as f64),

--- a/src/primitives/memory.rs
+++ b/src/primitives/memory.rs
@@ -111,11 +111,16 @@ pub fn store_prim(vm: &mut VM) -> Result<(), TbxError> {
     let value = vm.pop()?;
     match addr {
         Cell::DictAddr(a) => {
+            // Cell::Array written to a DictAddr is handled by check_dict_reference_write:
+            // it will either promote the array to the global region (top-level execution)
+            // or return ArrayFrameEscape (frame-local array escaping into a global slot).
             check_dict_reference_write(vm, &value)?;
             vm.dict_write_at(a, value)?;
             Ok(())
         }
         Cell::StackAddr(a) => {
+            // Array handles are allowed in StackAddr writes to support DIM @A[n]
+            // local array initialization (DIM emits: LIT StackAddr(idx) [size] ARRAY SET).
             vm.local_write(a, value)?;
             Ok(())
         }
@@ -139,11 +144,16 @@ pub fn set_prim(vm: &mut VM) -> Result<(), TbxError> {
     let addr = vm.pop()?;
     match addr {
         Cell::DictAddr(a) => {
+            // Cell::Array written to a DictAddr is handled by check_dict_reference_write:
+            // it will either promote the array to the global region (top-level execution)
+            // or return ArrayFrameEscape (frame-local array escaping into a global slot).
             check_dict_reference_write(vm, &value)?;
             vm.dict_write_at(a, value)?;
             Ok(())
         }
         Cell::StackAddr(a) => {
+            // Array handles are allowed in StackAddr writes to support DIM @A[n]
+            // local array initialization (DIM emits: LIT StackAddr(idx) [size] ARRAY SET).
             vm.local_write(a, value)?;
             Ok(())
         }

--- a/src/primitives/memory.rs
+++ b/src/primitives/memory.rs
@@ -2,40 +2,19 @@ use crate::cell::Cell;
 use crate::error::TbxError;
 use crate::vm::VM;
 
-/// Extract the array pool index from a `Cell::Array`.
+/// Reject `Cell::Array` writes to user-facing `DictAddr` / `StackAddr` destinations.
 ///
-/// Returns `None` for any cell that is not `Cell::Array`.  `Cell::Str` is
-/// `Rc<str>`-backed and has no VM-managed pool index.
-fn array_pool_idx_from_cell(cell: &Cell) -> Option<usize> {
-    match cell {
-        Cell::Array(idx) => Some(*idx),
-        _ => None,
+/// Surface-level `SET` and `STORE` must never write a whole-array handle to a
+/// scalar variable slot.  DIM local array initialisation bypasses this guard via
+/// the hidden `ARRAY_STORE_LOCAL` primitive.
+fn reject_array_value(value: &Cell) -> Result<(), TbxError> {
+    if matches!(value, Cell::Array(_)) {
+        return Err(TbxError::TypeError {
+            expected: "scalar value (Int, Float, Bool, Str, or Tuple)",
+            got: "Array",
+        });
     }
-}
-
-fn is_global_array_pool_idx(vm: &VM, pool_idx: usize) -> bool {
-    pool_idx < vm.global_array_pool_len
-}
-
-fn promote_array_pool_idx_to_global(vm: &mut VM, pool_idx: usize) {
-    vm.global_array_pool_len = vm.global_array_pool_len.max(pool_idx + 1);
-}
-
-fn check_dict_reference_write(vm: &mut VM, value: &Cell) -> Result<(), TbxError> {
-    let Some(pool_idx) = array_pool_idx_from_cell(value) else {
-        return Ok(());
-    };
-
-    if is_global_array_pool_idx(vm, pool_idx) {
-        return Ok(());
-    }
-
-    if vm.is_executing_top_level() {
-        promote_array_pool_idx_to_global(vm, pool_idx);
-        return Ok(());
-    }
-
-    Err(TbxError::ArrayFrameEscape)
+    Ok(())
 }
 
 /// Write `value` to element `elem_idx` of the array at `pool_idx`.
@@ -106,21 +85,20 @@ pub fn fetch_prim(vm: &mut VM) -> Result<(), TbxError> {
 /// STORE — pop addr (top) then value (below), and store value at addr.
 ///
 /// Stack convention: `[..., value, addr]` → STORE → `[...]`
+///
+/// `Cell::Array` values are rejected for both `DictAddr` and `StackAddr` destinations.
+/// DIM local array initialisation uses the hidden `ARRAY_STORE_LOCAL` primitive instead.
 pub fn store_prim(vm: &mut VM) -> Result<(), TbxError> {
     let addr = vm.pop()?;
     let value = vm.pop()?;
     match addr {
         Cell::DictAddr(a) => {
-            // Cell::Array written to a DictAddr is handled by check_dict_reference_write:
-            // it will either promote the array to the global region (top-level execution)
-            // or return ArrayFrameEscape (frame-local array escaping into a global slot).
-            check_dict_reference_write(vm, &value)?;
+            reject_array_value(&value)?;
             vm.dict_write_at(a, value)?;
             Ok(())
         }
         Cell::StackAddr(a) => {
-            // Array handles are allowed in StackAddr writes to support DIM @A[n]
-            // local array initialization (DIM emits: LIT StackAddr(idx) [size] ARRAY SET).
+            reject_array_value(&value)?;
             vm.local_write(a, value)?;
             Ok(())
         }
@@ -139,21 +117,20 @@ pub fn store_prim(vm: &mut VM) -> Result<(), TbxError> {
 /// Designed for the `SET &var, value` statement pattern where `&var` is
 /// pushed before `value` (left-to-right argument evaluation via comma).
 /// Stack convention: `[..., addr, value]` → SET → `[...]`
+///
+/// `Cell::Array` values are rejected for both `DictAddr` and `StackAddr` destinations.
+/// DIM local array initialisation uses the hidden `ARRAY_STORE_LOCAL` primitive instead.
 pub fn set_prim(vm: &mut VM) -> Result<(), TbxError> {
     let value = vm.pop()?;
     let addr = vm.pop()?;
     match addr {
         Cell::DictAddr(a) => {
-            // Cell::Array written to a DictAddr is handled by check_dict_reference_write:
-            // it will either promote the array to the global region (top-level execution)
-            // or return ArrayFrameEscape (frame-local array escaping into a global slot).
-            check_dict_reference_write(vm, &value)?;
+            reject_array_value(&value)?;
             vm.dict_write_at(a, value)?;
             Ok(())
         }
         Cell::StackAddr(a) => {
-            // Array handles are allowed in StackAddr writes to support DIM @A[n]
-            // local array initialization (DIM emits: LIT StackAddr(idx) [size] ARRAY SET).
+            reject_array_value(&value)?;
             vm.local_write(a, value)?;
             Ok(())
         }
@@ -170,35 +147,7 @@ pub fn set_prim(vm: &mut VM) -> Result<(), TbxError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cell::{Cell, ReturnFrame, Xt};
-
-    #[test]
-    fn test_array_pool_idx_from_cell_array_only() {
-        // array_pool_idx_from_cell returns Some only for Cell::Array;
-        // Cell::Str is Rc<str>-backed and has no array pool index.
-        assert_eq!(array_pool_idx_from_cell(&Cell::Array(3)), Some(3));
-        assert_eq!(array_pool_idx_from_cell(&Cell::string("hello")), None);
-        assert_eq!(
-            array_pool_idx_from_cell(&Cell::ArrayAddr {
-                pool_idx: 1,
-                elem_idx: 2,
-            }),
-            None
-        );
-        assert_eq!(array_pool_idx_from_cell(&Cell::DictAddr(0)), None);
-        assert_eq!(array_pool_idx_from_cell(&Cell::StackAddr(0)), None);
-    }
-
-    #[test]
-    fn test_promote_array_pool_idx_to_global_never_moves_boundary_backward() {
-        let mut vm = VM::new();
-
-        vm.global_array_pool_len = 5;
-        promote_array_pool_idx_to_global(&mut vm, 1);
-        assert_eq!(vm.global_array_pool_len, 5);
-        promote_array_pool_idx_to_global(&mut vm, 7);
-        assert_eq!(vm.global_array_pool_len, 8);
-    }
+    use crate::cell::Cell;
 
     // --- ARRAY_ADDR / STORE / FETCH boundary tests ---
 
@@ -307,81 +256,100 @@ mod tests {
         );
     }
 
-    /// Verify that storing a frame-local Cell::Array into a dictionary slot raises
-    /// ArrayFrameEscape.
+    /// Verify that STORE rejects a Cell::Array written to a DictAddr slot.
     ///
-    /// A frame-local array is one whose pool index is >= global_array_pool_len and
-    /// the VM is currently executing inside a Call frame (not top-level).
+    /// Surface-level STORE must never accept a whole-array handle for a scalar slot.
     #[test]
-    fn test_store_frame_local_array_to_dict_errors() {
+    fn test_store_array_to_dict_addr_is_type_error() {
         let mut vm = VM::new();
 
-        // Allocate a dictionary slot for the target variable.
         vm.dictionary.push(Cell::None);
         vm.dp = 1;
 
-        // Create the frame-local array; global_array_pool_len stays at 0.
-        let frame_local_idx = vm.arrays.len();
+        let pool_idx = vm.arrays.len();
         vm.arrays.push(vec![Cell::Int(7)]);
-        // global_array_pool_len = 0 means pool_idx 0 is not global.
-
-        // Simulate a Call frame so is_executing_top_level() returns false.
-        vm.return_stack.push(ReturnFrame::TopLevel);
-        vm.return_stack.push(ReturnFrame::Call {
-            callee_xt: Xt(0),
-            return_pc: 0,
-            saved_bp: 0,
-            saved_array_pool_len: 0,
-            actual_arity: 0,
-        });
 
         // STORE convention: push value then addr.
-        vm.push(Cell::Array(frame_local_idx)).unwrap();
+        vm.push(Cell::Array(pool_idx)).unwrap();
         vm.push(Cell::DictAddr(0)).unwrap();
 
         let result = store_prim(&mut vm);
         assert!(
-            matches!(result, Err(TbxError::ArrayFrameEscape)),
-            "expected ArrayFrameEscape, got {:?}",
+            matches!(result, Err(TbxError::TypeError { got: "Array", .. })),
+            "expected TypeError(Array), got {:?}",
             result
         );
     }
 
-    /// Verify that storing a top-level Cell::Array into a dictionary slot promotes
-    /// global_array_pool_len to cover the stored array.
+    /// Verify that STORE rejects a Cell::Array written to a StackAddr slot.
     ///
-    /// When execution is at the top level (only a TopLevel sentinel on the return
-    /// stack), STORE must promote the array to the global region instead of
-    /// returning an error.
+    /// Surface-level STORE must never accept a whole-array handle for a local slot.
     #[test]
-    fn test_store_top_level_array_to_dict_promotes_global_boundary() {
+    fn test_store_array_to_stack_addr_is_type_error() {
         let mut vm = VM::new();
 
-        // Allocate a dictionary slot for the target variable.
+        // Allocate a local slot via the data stack.
+        vm.data_stack.push(Cell::None);
+        vm.bp = 0;
+
+        let pool_idx = vm.arrays.len();
+        vm.arrays.push(vec![Cell::Int(3)]);
+
+        // STORE convention: push value then addr.
+        vm.push(Cell::Array(pool_idx)).unwrap();
+        vm.push(Cell::StackAddr(0)).unwrap();
+
+        let result = store_prim(&mut vm);
+        assert!(
+            matches!(result, Err(TbxError::TypeError { got: "Array", .. })),
+            "expected TypeError(Array), got {:?}",
+            result
+        );
+    }
+
+    /// Verify that SET rejects a Cell::Array written to a DictAddr slot.
+    #[test]
+    fn test_set_array_to_dict_addr_is_type_error() {
+        let mut vm = VM::new();
+
         vm.dictionary.push(Cell::None);
         vm.dp = 1;
 
-        // Create the array at top level; global_array_pool_len starts at 0.
-        let top_level_idx = vm.arrays.len();
-        vm.arrays.push(vec![Cell::Int(99)]);
+        let pool_idx = vm.arrays.len();
+        vm.arrays.push(vec![Cell::Int(5)]);
 
-        // Simulate top-level execution: only a TopLevel sentinel on the return stack.
-        vm.return_stack.push(ReturnFrame::TopLevel);
-
-        // STORE convention: push value then addr.
-        vm.push(Cell::Array(top_level_idx)).unwrap();
+        // SET convention: push addr then value.
         vm.push(Cell::DictAddr(0)).unwrap();
+        vm.push(Cell::Array(pool_idx)).unwrap();
 
-        store_prim(&mut vm).unwrap();
-
-        // The global boundary must have been promoted to cover top_level_idx.
+        let result = set_prim(&mut vm);
         assert!(
-            vm.global_array_pool_len > top_level_idx,
-            "expected global_array_pool_len > {}, got {}",
-            top_level_idx,
-            vm.global_array_pool_len
+            matches!(result, Err(TbxError::TypeError { got: "Array", .. })),
+            "expected TypeError(Array), got {:?}",
+            result
         );
-        // The dictionary slot must now hold the array handle.
-        assert_eq!(vm.dictionary[0], Cell::Array(top_level_idx));
+    }
+
+    /// Verify that SET rejects a Cell::Array written to a StackAddr slot.
+    #[test]
+    fn test_set_array_to_stack_addr_is_type_error() {
+        let mut vm = VM::new();
+
+        vm.data_stack.push(Cell::None);
+        vm.bp = 0;
+
+        let pool_idx = vm.arrays.len();
+        vm.arrays.push(vec![Cell::Int(2)]);
+
+        // SET convention: push addr then value.
+        vm.push(Cell::StackAddr(0)).unwrap();
+        vm.push(Cell::Array(pool_idx)).unwrap();
+
+        let result = set_prim(&mut vm);
+        assert!(
+            matches!(result, Err(TbxError::TypeError { got: "Array", .. })),
+            "expected TypeError(Array), got {:?}",
+            result
+        );
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -295,16 +295,6 @@ impl VM {
         frames
     }
 
-    /// Returns true while `vm.run()` is executing top-level code, outside any
-    /// word call frame.
-    pub(crate) fn is_executing_top_level(&self) -> bool {
-        matches!(self.return_stack.last(), Some(ReturnFrame::TopLevel))
-            && !self
-                .return_stack
-                .iter()
-                .any(|frame| matches!(frame, ReturnFrame::Call { .. }))
-    }
-
     /// Consume the next token from the token stream.
     ///
     /// Returns `TbxError::TokenStreamEmpty` if `token_stream` is `None` or empty.
@@ -2939,15 +2929,19 @@ mod tests {
 
     #[test]
     fn test_array_frame_escape_via_store_to_dict_is_error() {
-        // Verify that STORE of a Cell::Array into a global variable produces ArrayFrameEscape.
+        // Verify that STORE of a Cell::Array into a global variable produces TypeError.
+        // (Previously ArrayFrameEscape; now uniformly TypeError for all array-handle writes.)
         let result = run_source(
             "VAR G\n\
              DEF BAD_STORE()\n  DIM @A[2]\n  SET &G, A\nEND\n\
              BAD_STORE",
         );
         assert!(
-            matches!(result, Err(crate::error::TbxError::ArrayFrameEscape)),
-            "expected ArrayFrameEscape, got: {result:?}"
+            matches!(
+                result,
+                Err(crate::error::TbxError::TypeError { got: "Array", .. })
+            ),
+            "expected TypeError(Array), got: {result:?}"
         );
     }
 
@@ -3009,31 +3003,30 @@ mod tests {
 
     #[test]
     fn test_global_array_stored_via_store_prim() {
-        // A global array (pool_idx < global_array_pool_len) can be stored into a
-        // dictionary slot by store_prim without triggering ArrayFrameEscape.
+        // store_prim must reject Cell::Array written to a DictAddr slot,
+        // regardless of whether the array is in the global pool region.
+        // (Surface-level SET / STORE never allow whole-array handle writes.)
         let mut vm = VM::new();
         vm.arrays.push(vec![Cell::Int(0); 5]);
         vm.global_array_pool_len = 1; // mark pool[0] as global
 
-        // Allocate a dictionary slot.
         let slot = vm.dp;
         vm.dict_write(Cell::None).unwrap();
 
         let arr = Cell::Array(0);
         // store_prim pops addr first, then value; so push value then addr.
-        vm.push(arr.clone()).unwrap();
+        vm.push(arr).unwrap();
         vm.push(Cell::DictAddr(slot)).unwrap();
         let result = crate::primitives::store_prim(&mut vm);
         assert!(
-            result.is_ok(),
-            "store_prim should allow global array: {result:?}"
+            matches!(result, Err(TbxError::TypeError { got: "Array", .. })),
+            "expected TypeError(Array) from store_prim: {result:?}"
         );
-        assert_eq!(vm.dict_read(slot).unwrap(), arr);
     }
 
     #[test]
     fn test_global_array_stored_via_set_prim() {
-        // set_prim (SET &var, value) also accepts a global array.
+        // set_prim must also reject Cell::Array written to a DictAddr slot.
         let mut vm = VM::new();
         vm.arrays.push(vec![Cell::Int(0); 3]);
         vm.global_array_pool_len = 1;
@@ -3041,36 +3034,37 @@ mod tests {
         let slot = vm.dp;
         vm.dict_write(Cell::None).unwrap();
 
-        let arr = Cell::Array(0);
         // set_prim pops value first, then addr (stack: [..., addr, value]).
         vm.push(Cell::DictAddr(slot)).unwrap();
-        vm.push(arr.clone()).unwrap();
+        vm.push(Cell::Array(0)).unwrap();
         let result = crate::primitives::set_prim(&mut vm);
         assert!(
-            result.is_ok(),
-            "set_prim should allow global array: {result:?}"
+            matches!(result, Err(TbxError::TypeError { got: "Array", .. })),
+            "expected TypeError(Array) from set_prim: {result:?}"
         );
-        assert_eq!(vm.dict_read(slot).unwrap(), arr);
     }
 
     #[test]
     fn test_word_array_store_to_global_var_is_still_error() {
-        // Arrays created inside a word must still not escape via a global VAR.
-        // global_array_pool_len = 0 (default), so all arrays created in words are frame-local.
+        // Storing a local array handle into a global VAR must fail with TypeError.
+        // (Previously ArrayFrameEscape; now TypeError for all array-handle writes.)
         let result = run_source(
             "VAR gvar\n\
              DEF BAD()\n  DIM @a[3]\n  SET &gvar, a\nEND\n\
              BAD",
         );
         assert!(
-            matches!(result, Err(crate::error::TbxError::ArrayFrameEscape)),
-            "expected ArrayFrameEscape, got: {result:?}"
+            matches!(
+                result,
+                Err(crate::error::TbxError::TypeError { got: "Array", .. })
+            ),
+            "expected TypeError(Array), got: {result:?}"
         );
     }
 
     #[test]
     fn test_non_global_array_store_rejected_by_store_prim() {
-        // An array with pool_idx >= global_array_pool_len must still be rejected.
+        // An array handle written to a DictAddr must always be rejected by store_prim.
         let mut vm = VM::new();
         vm.arrays.push(vec![Cell::Int(0); 5]);
         // global_array_pool_len stays 0, so pool[0] is NOT global.
@@ -3083,8 +3077,8 @@ mod tests {
         vm.push(Cell::DictAddr(slot)).unwrap();
         let result = crate::primitives::store_prim(&mut vm);
         assert!(
-            matches!(result, Err(TbxError::ArrayFrameEscape)),
-            "expected ArrayFrameEscape, got: {result:?}"
+            matches!(result, Err(TbxError::TypeError { got: "Array", .. })),
+            "expected TypeError(Array), got: {result:?}"
         );
     }
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -870,6 +870,18 @@ impl VM {
                             if self.data_stack.len() < arity {
                                 return Err(TbxError::StackUnderflow);
                             }
+                            // Reject whole-array handles as word call arguments.
+                            // Array handles must not be passed as scalar arguments to words.
+                            let arg_start = self.data_stack.len() - arity;
+                            for arg in &self.data_stack[arg_start..] {
+                                if matches!(arg, Cell::Array(_)) {
+                                    return Err(TbxError::TypeError {
+                                        expected:
+                                            "scalar argument (Array handle cannot be passed to a word)",
+                                        got: "Array",
+                                    });
+                                }
+                            }
                             if self.return_stack.len() >= MAX_RETURN_STACK_DEPTH {
                                 return Err(TbxError::ReturnStackOverflow {
                                     depth: self.return_stack.len(),
@@ -937,6 +949,14 @@ impl VM {
                         None => return Err(TbxError::StackUnderflow),
                     };
                     let mut retval = self.pop()?;
+                    // Reject whole-array handle as a return value.
+                    // Only scalar types are permitted to flow out of a word via RETURN.
+                    if matches!(retval, Cell::Array(_)) {
+                        return Err(TbxError::TypeError {
+                            expected: "scalar return value (Array handle cannot be returned)",
+                            got: "Array",
+                        });
+                    }
                     // Ownership transfer for frame-local Cell::Array:
                     // If the returned array was created in this frame
                     // (pool_idx >= array_frame_boundary), swap it to the
@@ -3285,5 +3305,104 @@ mod tests {
             result.is_err(),
             "SETG() as statement should be rejected, but got: {result:?}"
         );
+    }
+
+    // --- Whole-array handle surface ban (#718) ---
+    //
+    // A Cell::Array (whole-array handle) must not appear at the user-visible
+    // surface: it cannot be assigned to a variable, returned from a word,
+    // compared with EQ/NEQ, used as a word argument, or stored into a dict
+    // slot from inside a called frame.  All such attempts must produce either
+    // a TypeError or an ArrayFrameEscape error at runtime.
+    //
+    // Valid uses of arrays: DIM @A[n] (allocation), @A[i] (element read),
+    // &@A[i] (element address for SET), LET @A[i] = expr (element write),
+    // and ARRAY_LEN(@A) (length query).
+
+    #[test]
+    fn test_whole_array_assignment_to_global_var_errors() {
+        // `SET &G, A` inside a DEF body must produce ArrayFrameEscape
+        // (Cell::Array written into a DictAddr from a called frame).
+        let result = run_source(
+            "VAR G\n\
+             DEF BAD()\n  DIM @A[2]\n  SET &G, A\nEND\n\
+             BAD",
+        );
+        assert!(
+            result.is_err(),
+            "expected error when assigning array handle to global var, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_whole_array_return_errors() {
+        // `RETURN A` (returning a whole-array handle) must produce TypeError.
+        let result = run_source(
+            "DEF BAD()\n  DIM @A[2]\n  RETURN A\nEND\n\
+             PUTDEC BAD()",
+        );
+        assert!(
+            matches!(result, Err(crate::error::TbxError::TypeError { .. })),
+            "expected TypeError when returning array handle, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_whole_array_equality_errors() {
+        // `A = B` (comparing two array handles with EQ) must produce TypeError.
+        let result = run_source(
+            "DEF BAD()\n  DIM @A[2]\n  DIM @B[2]\n  RETURN (A = B)\nEND\n\
+             PUTDEC BAD()",
+        );
+        assert!(
+            matches!(result, Err(crate::error::TbxError::TypeError { .. })),
+            "expected TypeError when comparing array handles with EQ, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_whole_array_as_word_argument_errors() {
+        // Passing a whole-array handle as a word argument must produce TypeError.
+        let result = run_source(
+            "DEF CONSUME(X)\n  PUTDEC X\nEND\n\
+             DEF BAD()\n  DIM @A[2]\n  CONSUME(A)\nEND\n\
+             BAD",
+        );
+        assert!(
+            matches!(result, Err(crate::error::TbxError::TypeError { .. })),
+            "expected TypeError when passing array handle as word argument, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_dim_local_array_and_element_access_succeeds() {
+        // Positive test: DIM, element read (@A[i]), element write (LET @A[i] = expr),
+        // and ARRAY_LEN(@A) must all succeed normally.
+        let result = run_source(
+            "DEF SUM()\n\
+               DIM @A[3]\n\
+               LET @A[1] = 10\n\
+               LET @A[2] = 20\n\
+               LET @A[3] = 30\n\
+               RETURN @A[1] + @A[2] + @A[3]\n\
+             END\n\
+             PUTDEC SUM()",
+        );
+        assert!(result.is_ok(), "expected success, got: {result:?}");
+        assert_eq!(result.unwrap().trim(), "60");
+    }
+
+    #[test]
+    fn test_array_len_of_local_array_succeeds() {
+        // ARRAY_LEN(@A) must return the declared size without error.
+        let result = run_source(
+            "DEF LEN_TEST()\n\
+               DIM @A[5]\n\
+               RETURN ARRAY_LEN(@A)\n\
+             END\n\
+             PUTDEC LEN_TEST()",
+        );
+        assert!(result.is_ok(), "expected success, got: {result:?}");
+        assert_eq!(result.unwrap().trim(), "5");
     }
 }

--- a/tests/tbx_lib_tests.rs
+++ b/tests/tbx_lib_tests.rs
@@ -1260,6 +1260,33 @@ fn test_let_array_handle_to_local_var_is_type_error() {
     );
 }
 
+/// `ARRAY_GET(A, 1)` must not be callable from surface because ARRAY_GET is a
+/// hidden system helper.
+#[test]
+fn test_array_get_is_hidden_from_surface() {
+    let mut interp = Interpreter::new();
+    let src = concat!("DIM @A[2]\n", "LET @A[1] = 10\n", "ARRAY_GET(A, 1)\n",);
+    // ARRAY_GET is a hidden system helper; any compile/runtime error is acceptable.
+    interp
+        .exec_source(src)
+        .expect_err("ARRAY_GET must not be callable from surface");
+}
+
+/// `ARRAY_ADDR(A, 1)` must not be callable from surface because ARRAY_ADDR is a
+/// hidden system helper.
+#[test]
+fn test_array_addr_is_hidden_from_surface() {
+    let mut interp = Interpreter::new();
+    let src = concat!("DIM @A[2]\n", "ARRAY_ADDR(A, 1)\n",);
+    let err = interp
+        .exec_source(src)
+        .expect_err("ARRAY_ADDR must not be callable from surface");
+    assert!(
+        err.to_string().contains("undefined symbol"),
+        "expected undefined symbol, got: {err}"
+    );
+}
+
 /// DIM @A[n] inside a DEF must still work correctly after the ban is in effect.
 ///
 /// This regression test ensures that the hidden ARRAY_STORE_LOCAL path used by

--- a/tests/tbx_lib_tests.rs
+++ b/tests/tbx_lib_tests.rs
@@ -1195,3 +1195,90 @@ fn test_let_tuple_projection_assignment_is_error() {
         .exec_source(src)
         .expect_err("LET T[1] = 10 tuple projection assignment should fail");
 }
+
+// ---------------------------------------------------------------------------
+// Whole-array surface ban tests (issue #718)
+//
+// SET / STORE must never write a Cell::Array handle to a scalar variable slot.
+// DIM @A[n] local initialisation is the only allowed path and uses the hidden
+// ARRAY_STORE_LOCAL primitive internally.
+// ---------------------------------------------------------------------------
+
+/// `SET &B, A` inside a word (StackAddr destination) must fail with TypeError.
+#[test]
+fn test_set_array_handle_to_local_var_is_type_error() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF BAD_LOCAL()\n",
+        "  DIM @A[2]\n",
+        "  VAR B\n",
+        "  SET &B, A\n",
+        "END\n",
+        "BAD_LOCAL\n",
+    );
+    let err = interp
+        .exec_source(src)
+        .expect_err("SET &B, A (StackAddr write of array handle) must fail");
+    assert!(
+        err.to_string().contains("type error"),
+        "expected type error, got: {err}"
+    );
+}
+
+/// `SET &G, A` at the top level (DictAddr destination) must fail with TypeError.
+#[test]
+fn test_set_array_handle_to_global_var_is_type_error() {
+    let mut interp = Interpreter::new();
+    let src = concat!("DIM @A[2]\n", "VAR G\n", "SET &G, A\n",);
+    let err = interp
+        .exec_source(src)
+        .expect_err("SET &G, A (DictAddr write of array handle) must fail");
+    assert!(
+        err.to_string().contains("type error"),
+        "expected type error, got: {err}"
+    );
+}
+
+/// `LET B = A` inside a word must fail with TypeError (same array-handle ban).
+#[test]
+fn test_let_array_handle_to_local_var_is_type_error() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF BAD_LET()\n",
+        "  DIM @A[2]\n",
+        "  VAR B\n",
+        "  LET B = A\n",
+        "END\n",
+        "BAD_LET\n",
+    );
+    let err = interp
+        .exec_source(src)
+        .expect_err("LET B = A (array handle assignment) must fail");
+    assert!(
+        err.to_string().contains("type error"),
+        "expected type error, got: {err}"
+    );
+}
+
+/// DIM @A[n] inside a DEF must still work correctly after the ban is in effect.
+///
+/// This regression test ensures that the hidden ARRAY_STORE_LOCAL path used by
+/// the DIM compiler continues to initialise the local slot properly.
+#[test]
+fn test_dim_local_array_still_works_after_surface_ban() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF F()\n",
+        "  DIM @A[3]\n",
+        "  SET &@A[1], 10\n",
+        "  SET &@A[2], 20\n",
+        "  SET &@A[3], 30\n",
+        "  RETURN @A[2]\n",
+        "END\n",
+        "PUTDEC F()\n",
+    );
+    interp
+        .exec_source(src)
+        .expect("DIM local array must still work after surface ban");
+    assert_eq!(interp.take_output(), "20");
+}


### PR DESCRIPTION
## 概要

whole-array handle（`Cell::Array`）が surface レベルで使えないよう禁止する実装とテストを追加します。

### 変更内容

- **ARRAY_LEN / ARRAY_GET / ARRAY_ADDR を隠し内部ヘルパーに変更**
  - `FLAG_SYSTEM | FLAG_HIDDEN` を付与し、通常の `vm.lookup()` では発見されない
  - `expr.rs` の lowering コードで `require_hidden_system_xt()` を使用するよう変更
  - 8箇所のテストフィクスチャも `vm.lookup_hidden_system()` を使うよう更新

- **比較演算（EQ / NEQ）での whole-array handle 拒否**
  - `compare.rs`: `reject_array_operand()` ヘルパーを追加し、EQ・NEQ の両オペランドに適用
  - `Cell::Array` が渡された場合は `TypeError` を返す

- **RETURN での whole-array handle 拒否**
  - `vm.rs` の `ReturnVal` ハンドラで `Cell::Array` を検出したら `TypeError` を返す

- **CALL 引数での whole-array handle 拒否**
  - `vm.rs` の `EntryKind::Word` CALL ハンドラで、渡された引数に `Cell::Array` が含まれる場合は `TypeError` を返す

- **SET / STORE での whole-array handle 拒否（DictAddr / StackAddr 宛）**
  - `SET` / `STORE` は `DictAddr` / `StackAddr` への `Cell::Array` 書き込みを拒否する
  - DIM @A[n] の local array initialization だけ hidden `ARRAY_STORE_LOCAL` で内部的に行う
  - `dim_prim` の compile-mode local array emit は `SET` ではなく hidden `ARRAY_STORE_LOCAL` を使う

- **SHUFFLE プリミティブを完全削除**
  - `primitives.rs` から `shuffle_prim` 関数・登録・テストを削除
  - `lib/tests/test_rnd.tbx` から SHUFFLE 統合テストを削除

### テスト追加

`vm.rs` のテストモジュールおよび `tests/tbx_lib_tests.rs` に以下のテストを追加：

- `test_whole_array_assignment_to_global_var_errors` — `SET &G, A` がエラーになることを確認
- `test_whole_array_return_errors` — `RETURN A` が TypeError になることを確認
- `test_whole_array_equality_errors` — `A = B`（配列同士）が TypeError になることを確認
- `test_whole_array_as_word_argument_errors` — word 引数として渡すと TypeError になることを確認
- `test_dim_local_array_and_element_access_succeeds` — DIM / @A[i] / LET @A[i] = / ARRAY_LEN(@A) の正常系
- `test_array_len_of_local_array_succeeds` — ARRAY_LEN(@A) の正常系
- `test_set_array_handle_to_local_var_is_type_error` — `SET &B, A`（StackAddr 宛）が TypeError になることを確認
- `test_set_array_handle_to_global_var_is_type_error` — `SET &G, A`（DictAddr 宛）が TypeError になることを確認
- `test_let_array_handle_to_local_var_is_type_error` — `LET B = A` が TypeError になることを確認
- `test_dim_local_array_still_works_after_surface_ban` — DIM @A[n] が引き続き正常動作することを確認

Closes #718