### PR TITLE
ArrayRef に ptr_eq ポインタ同一性ヘルパーを追加する

### DIFF
--- a/src/array_ref.rs
+++ b/src/array_ref.rs
@@ -69,6 +69,28 @@ impl ArrayRef {
         self.inner.borrow().get(idx).cloned()
     }
 
+    /// Return `true` if `self` and `other` point to the same Rc allocation.
+    ///
+    /// This is **pointer identity**, not content equality.  Two `ArrayRef`
+    /// values that hold identical element sequences but were created
+    /// independently will return `false`.  Only clones that share the same
+    /// underlying `Rc` allocation return `true`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use tbx::array_ref::ArrayRef;
+    /// # use tbx::cell::Cell;
+    /// let a = ArrayRef::new(vec![Cell::Int(1)]);
+    /// let b = a.clone();                         // same allocation
+    /// let c = ArrayRef::new(vec![Cell::Int(1)]); // different allocation
+    /// assert!(a.ptr_eq(&b));
+    /// assert!(!a.ptr_eq(&c));
+    /// ```
+    pub fn ptr_eq(&self, other: &Self) -> bool {
+        Rc::ptr_eq(&self.inner, &other.inner)
+    }
+
     /// Write `value` into position `idx`.
     ///
     /// Returns `Err(TbxError::ArrayIndexOutOfBounds)` if `idx >= len`.
@@ -172,5 +194,19 @@ mod tests {
         let ar = ArrayRef::new(vec![Cell::Int(1), Cell::Int(2)]);
         let s = format!("{:?}", ar);
         assert!(s.starts_with("ArrayRef("));
+    }
+
+    #[test]
+    fn ptr_eq_clone_is_true() {
+        let a = ArrayRef::new(vec![Cell::Int(1), Cell::Int(2)]);
+        let b = a.clone();
+        assert!(a.ptr_eq(&b));
+    }
+
+    #[test]
+    fn ptr_eq_independent_same_content_is_false() {
+        let a = ArrayRef::new(vec![Cell::Int(1), Cell::Int(2)]);
+        let b = ArrayRef::new(vec![Cell::Int(1), Cell::Int(2)]);
+        assert!(!a.ptr_eq(&b));
     }
 }


### PR DESCRIPTION
## 概要

`ArrayRef` に `Rc::ptr_eq` を用いたポインタ同一性ヘルパー `ptr_eq` を追加する。
これは content equality ではなく、同一 Rc allocation を指しているかの判定メソッドである。

## 変更内容

- `ArrayRef::ptr_eq(&self, other: &Self) -> bool` を追加（`Rc::ptr_eq` 委譲）
- doc comment にポインタ同一性と content equality の違いを明記
- doc example を含む doctest を追加
- unit test を2件追加
  - clone した `ArrayRef` 同士は `ptr_eq == true`
  - 別々に作った同内容の `ArrayRef` 同士は `ptr_eq == false`

Closes #725
