### PR TITLE
VM::arrays の型を Vec<Vec<Cell>> から Vec<ArrayRef> へ移行する

### DIFF
--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1,3 +1,4 @@
+use crate::array_ref::ArrayRef;
 use crate::cell::{Cell, CompileEntry};
 use crate::constants::MAX_DICTIONARY_CELLS;
 use crate::dict::{EntryKind, WordEntry, FLAG_HIDDEN, FLAG_IMMEDIATE, FLAG_SYSTEM};
@@ -905,7 +906,7 @@ pub fn dim_prim(vm: &mut VM) -> Result<(), TbxError> {
 
         // Create the array in the array pool.
         let pool_idx = vm.arrays.len();
-        vm.arrays.push(vec![Cell::None; size]);
+        vm.arrays.push(ArrayRef::new(vec![Cell::None; size]));
 
         // Promote to the global array region so it persists across word calls.
         vm.global_array_pool_len = vm.global_array_pool_len.max(pool_idx + 1);
@@ -3506,7 +3507,7 @@ mod tests {
     #[test]
     fn test_putval_array_error() {
         let mut vm = VM::new();
-        vm.arrays.push(vec![Cell::None; 3]);
+        vm.arrays.push(ArrayRef::new(vec![Cell::None; 3]));
         vm.push(Cell::Array(0)).unwrap();
         assert!(matches!(
             putval_prim(&mut vm),
@@ -5948,8 +5949,11 @@ mod tests {
     fn test_array_get_prim_reads_element() {
         // User index 1 maps to internal index 0.
         let mut vm = VM::new();
-        vm.arrays
-            .push(vec![Cell::Int(10), Cell::Int(20), Cell::Int(30)]);
+        vm.arrays.push(ArrayRef::new(vec![
+            Cell::Int(10),
+            Cell::Int(20),
+            Cell::Int(30),
+        ]));
         vm.push(Cell::Array(0)).unwrap();
         vm.push(Cell::Int(1)).unwrap();
         array_get_prim(&mut vm).unwrap();
@@ -5960,8 +5964,11 @@ mod tests {
     fn test_array_get_prim_reads_second_element() {
         // User index 2 maps to internal index 1.
         let mut vm = VM::new();
-        vm.arrays
-            .push(vec![Cell::Int(10), Cell::Int(20), Cell::Int(30)]);
+        vm.arrays.push(ArrayRef::new(vec![
+            Cell::Int(10),
+            Cell::Int(20),
+            Cell::Int(30),
+        ]));
         vm.push(Cell::Array(0)).unwrap();
         vm.push(Cell::Int(2)).unwrap();
         array_get_prim(&mut vm).unwrap();
@@ -5971,7 +5978,7 @@ mod tests {
     #[test]
     fn test_array_get_prim_out_of_bounds() {
         let mut vm = VM::new();
-        vm.arrays.push(vec![Cell::Int(1)]);
+        vm.arrays.push(ArrayRef::new(vec![Cell::Int(1)]));
         vm.push(Cell::Array(0)).unwrap();
         vm.push(Cell::Int(5)).unwrap();
         assert!(matches!(
@@ -5984,7 +5991,7 @@ mod tests {
     fn test_array_get_prim_zero_index_is_out_of_bounds() {
         // Index 0 is invalid in 1-based indexing.
         let mut vm = VM::new();
-        vm.arrays.push(vec![Cell::Int(1)]);
+        vm.arrays.push(ArrayRef::new(vec![Cell::Int(1)]));
         vm.push(Cell::Array(0)).unwrap();
         vm.push(Cell::Int(0)).unwrap();
         assert!(matches!(
@@ -5996,7 +6003,7 @@ mod tests {
     #[test]
     fn test_array_get_prim_negative_index() {
         let mut vm = VM::new();
-        vm.arrays.push(vec![Cell::Int(1)]);
+        vm.arrays.push(ArrayRef::new(vec![Cell::Int(1)]));
         vm.push(Cell::Array(0)).unwrap();
         vm.push(Cell::Int(-1)).unwrap();
         assert!(matches!(
@@ -6011,7 +6018,8 @@ mod tests {
     fn test_array_addr_prim_pushes_array_addr() {
         // User index 1 maps to internal elem_idx 0.
         let mut vm = VM::new();
-        vm.arrays.push(vec![Cell::Int(0), Cell::Int(0)]);
+        vm.arrays
+            .push(ArrayRef::new(vec![Cell::Int(0), Cell::Int(0)]));
         vm.push(Cell::Array(0)).unwrap();
         vm.push(Cell::Int(1)).unwrap();
         array_addr_prim(&mut vm).unwrap();
@@ -6028,7 +6036,8 @@ mod tests {
     fn test_array_addr_prim_zero_index_is_out_of_bounds() {
         // Index 0 is invalid in 1-based indexing.
         let mut vm = VM::new();
-        vm.arrays.push(vec![Cell::Int(0), Cell::Int(0)]);
+        vm.arrays
+            .push(ArrayRef::new(vec![Cell::Int(0), Cell::Int(0)]));
         vm.push(Cell::Array(0)).unwrap();
         vm.push(Cell::Int(0)).unwrap();
         assert!(matches!(
@@ -6077,7 +6086,7 @@ mod tests {
     #[test]
     fn test_store_to_array_addr() {
         let mut vm = VM::new();
-        vm.arrays.push(vec![Cell::None, Cell::None]);
+        vm.arrays.push(ArrayRef::new(vec![Cell::None, Cell::None]));
         vm.push(Cell::Int(99)).unwrap();
         vm.push(Cell::ArrayAddr {
             pool_idx: 0,
@@ -6085,13 +6094,13 @@ mod tests {
         })
         .unwrap();
         store_prim(&mut vm).unwrap();
-        assert_eq!(vm.arrays[0][1], Cell::Int(99));
+        assert_eq!(vm.arrays[0].get_cloned(1), Some(Cell::Int(99)));
     }
 
     #[test]
     fn test_set_to_array_addr() {
         let mut vm = VM::new();
-        vm.arrays.push(vec![Cell::None, Cell::None]);
+        vm.arrays.push(ArrayRef::new(vec![Cell::None, Cell::None]));
         vm.push(Cell::ArrayAddr {
             pool_idx: 0,
             elem_idx: 0,
@@ -6099,7 +6108,7 @@ mod tests {
         .unwrap();
         vm.push(Cell::Int(42)).unwrap();
         set_prim(&mut vm).unwrap();
-        assert_eq!(vm.arrays[0][0], Cell::Int(42));
+        assert_eq!(vm.arrays[0].get_cloned(0), Some(Cell::Int(42)));
     }
 
     // --- array element write: Cell::Str (D-4: Rc<str> liberation, #591) ---
@@ -6113,7 +6122,7 @@ mod tests {
     fn test_set_str_to_array_element_is_allowed() {
         // Cell::Str(Rc<str>) written through SET must succeed (#591).
         let mut vm = VM::new();
-        vm.arrays.push(vec![Cell::None]);
+        vm.arrays.push(ArrayRef::new(vec![Cell::None]));
         vm.push(Cell::ArrayAddr {
             pool_idx: 0,
             elem_idx: 0,
@@ -6121,14 +6130,14 @@ mod tests {
         .unwrap();
         vm.push(Cell::string("hello")).unwrap();
         set_prim(&mut vm).unwrap();
-        assert_eq!(vm.arrays[0][0], Cell::string("hello"));
+        assert_eq!(vm.arrays[0].get_cloned(0), Some(Cell::string("hello")));
     }
 
     #[test]
     fn test_store_str_to_array_element_is_allowed() {
         // Same as the SET path above, exercised through STORE (#591).
         let mut vm = VM::new();
-        vm.arrays.push(vec![Cell::None]);
+        vm.arrays.push(ArrayRef::new(vec![Cell::None]));
         vm.push(Cell::string("world")).unwrap();
         vm.push(Cell::ArrayAddr {
             pool_idx: 0,
@@ -6136,14 +6145,14 @@ mod tests {
         })
         .unwrap();
         store_prim(&mut vm).unwrap();
-        assert_eq!(vm.arrays[0][0], Cell::string("world"));
+        assert_eq!(vm.arrays[0].get_cloned(0), Some(Cell::string("world")));
     }
 
     #[test]
     fn test_set_str_to_global_array_element_is_allowed() {
         // Storing a Str into a global array (global_array_pool_len covers it) must succeed.
         let mut vm = VM::new();
-        vm.arrays.push(vec![Cell::None]);
+        vm.arrays.push(ArrayRef::new(vec![Cell::None]));
         vm.global_array_pool_len = 1; // mark as global
         vm.push(Cell::ArrayAddr {
             pool_idx: 0,
@@ -6152,14 +6161,14 @@ mod tests {
         .unwrap();
         vm.push(Cell::string("global")).unwrap();
         set_prim(&mut vm).unwrap();
-        assert_eq!(vm.arrays[0][0], Cell::string("global"));
+        assert_eq!(vm.arrays[0].get_cloned(0), Some(Cell::string("global")));
     }
 
     #[test]
     fn test_set_str_to_frame_local_array_element_is_allowed() {
         // Storing a Str into a frame-local array must succeed (#591).
         let mut vm = VM::new();
-        vm.arrays.push(vec![Cell::None]);
+        vm.arrays.push(ArrayRef::new(vec![Cell::None]));
         // global_array_pool_len = 0 (default) → array is frame-local
         vm.push(Cell::ArrayAddr {
             pool_idx: 0,
@@ -6168,15 +6177,18 @@ mod tests {
         .unwrap();
         vm.push(Cell::string("frame-local")).unwrap();
         set_prim(&mut vm).unwrap();
-        assert_eq!(vm.arrays[0][0], Cell::string("frame-local"));
+        assert_eq!(
+            vm.arrays[0].get_cloned(0),
+            Some(Cell::string("frame-local"))
+        );
     }
 
     #[test]
     fn test_set_nested_array_to_array_element_is_invalid_array_element() {
         // Cell::Array must always be rejected as an array element.
         let mut vm = VM::new();
-        vm.arrays.push(vec![Cell::None]); // pool_idx = 0: target array
-        vm.arrays.push(vec![Cell::None]); // pool_idx = 1: value to store
+        vm.arrays.push(ArrayRef::new(vec![Cell::None])); // pool_idx = 0: target array
+        vm.arrays.push(ArrayRef::new(vec![Cell::None])); // pool_idx = 1: value to store
         vm.global_array_pool_len = 2; // both are global
         vm.push(Cell::ArrayAddr {
             pool_idx: 0,
@@ -6195,7 +6207,7 @@ mod tests {
     #[test]
     fn test_fetch_array_addr() {
         let mut vm = VM::new();
-        vm.arrays.push(vec![Cell::Int(77)]);
+        vm.arrays.push(ArrayRef::new(vec![Cell::Int(77)]));
         vm.push(Cell::ArrayAddr {
             pool_idx: 0,
             elem_idx: 0,
@@ -6275,7 +6287,7 @@ mod tests {
     fn test_to_tuple_prim_rejects_array() {
         // Cell::Array is a forbidden tuple element type.
         let mut vm = VM::new();
-        vm.arrays.push(vec![Cell::Int(1)]);
+        vm.arrays.push(ArrayRef::new(vec![Cell::Int(1)]));
         vm.push(Cell::Array(0)).unwrap();
         vm.push(Cell::Int(1)).unwrap(); // arity
         assert!(matches!(
@@ -6361,7 +6373,7 @@ mod tests {
     fn test_array_len_prim_basic() {
         // ARRAY_LEN on a 5-element array must return 5.
         let mut vm = VM::new();
-        vm.arrays.push(vec![Cell::None; 5]);
+        vm.arrays.push(ArrayRef::new(vec![Cell::None; 5]));
         vm.push(Cell::Array(0)).unwrap();
         array_len_prim(&mut vm).unwrap();
         assert_eq!(vm.pop(), Ok(Cell::Int(5)));
@@ -6371,7 +6383,7 @@ mod tests {
     fn test_array_len_prim_one_element() {
         // ARRAY_LEN on a 1-element array must return 1.
         let mut vm = VM::new();
-        vm.arrays.push(vec![Cell::None]);
+        vm.arrays.push(ArrayRef::new(vec![Cell::None]));
         vm.push(Cell::Array(0)).unwrap();
         array_len_prim(&mut vm).unwrap();
         assert_eq!(vm.pop(), Ok(Cell::Int(1)));

--- a/src/primitives/arrays.rs
+++ b/src/primitives/arrays.rs
@@ -1,3 +1,4 @@
+use crate::array_ref::ArrayRef;
 use crate::cell::Cell;
 use crate::error::TbxError;
 use crate::vm::VM;
@@ -32,7 +33,8 @@ pub(super) fn array_prim(vm: &mut VM) -> Result<(), TbxError> {
     }
     let size = n as usize;
     let idx = vm.arrays.len();
-    vm.arrays.push(vec![Cell::None; size]);
+    let ar = ArrayRef::new(vec![Cell::None; size]);
+    vm.arrays.push(ar);
     vm.push(Cell::Array(idx))?;
     Ok(())
 }
@@ -128,11 +130,11 @@ pub fn array_get_prim(vm: &mut VM) -> Result<(), TbxError> {
             })
         }
     };
-    let arr = vm.arrays.get(pool_idx).ok_or(TbxError::IndexOutOfBounds {
+    let ar = vm.arrays.get(pool_idx).ok_or(TbxError::IndexOutOfBounds {
         index: pool_idx,
         size: vm.arrays.len(),
     })?;
-    let size = arr.len();
+    let size = ar.len();
     // Translate 1-based user index to 0-based internal index.
     // Index 0 or negative is out of bounds.
     if elem_idx_raw < 1 {
@@ -148,7 +150,12 @@ pub fn array_get_prim(vm: &mut VM) -> Result<(), TbxError> {
             size,
         });
     }
-    let value = arr[elem_idx].clone();
+    let value = ar
+        .get_cloned(elem_idx)
+        .ok_or(TbxError::ArrayIndexOutOfBounds {
+            index: elem_idx_raw,
+            size,
+        })?;
     vm.push(value)?;
     Ok(())
 }
@@ -176,11 +183,11 @@ pub fn array_addr_prim(vm: &mut VM) -> Result<(), TbxError> {
         }
     };
     // Validate bounds at address-computation time.
-    let arr = vm.arrays.get(pool_idx).ok_or(TbxError::IndexOutOfBounds {
+    let ar = vm.arrays.get(pool_idx).ok_or(TbxError::IndexOutOfBounds {
         index: pool_idx,
         size: vm.arrays.len(),
     })?;
-    let size = arr.len();
+    let size = ar.len();
     // Translate 1-based user index to 0-based internal index.
     // Index 0 or negative is out of bounds.
     if elem_idx_raw < 1 {
@@ -289,11 +296,11 @@ pub fn array_len_prim(vm: &mut VM) -> Result<(), TbxError> {
             })
         }
     };
-    let arr = vm.arrays.get(pool_idx).ok_or(TbxError::IndexOutOfBounds {
+    let ar = vm.arrays.get(pool_idx).ok_or(TbxError::IndexOutOfBounds {
         index: pool_idx,
         size: vm.arrays.len(),
     })?;
-    let len = arr.len() as i64;
+    let len = ar.len() as i64;
     vm.push(Cell::Int(len))?;
     Ok(())
 }

--- a/src/primitives/memory.rs
+++ b/src/primitives/memory.rs
@@ -24,25 +24,18 @@ fn write_array_element(
     elem_idx: usize,
     value: Cell,
 ) -> Result<(), TbxError> {
-    // Validate before get_mut() to avoid borrow conflicts.
+    // Validate element type before touching the array.
     super::arrays::check_array_element_value(&value)?;
     let pool_size = vm.arrays.len();
-    let arr = vm
+    let ar = vm
         .arrays
-        .get_mut(pool_idx)
+        .get(pool_idx)
         .ok_or(TbxError::IndexOutOfBounds {
             index: pool_idx,
             size: pool_size,
-        })?;
-    let size = arr.len();
-    if elem_idx >= size {
-        return Err(TbxError::ArrayIndexOutOfBounds {
-            index: elem_idx as i64,
-            size,
-        });
-    }
-    arr[elem_idx] = value;
-    Ok(())
+        })?
+        .clone();
+    ar.set(elem_idx, value)
 }
 
 /// FETCH — fetch a value from an address and push it onto the stack.
@@ -60,18 +53,21 @@ pub fn fetch_prim(vm: &mut VM) -> Result<(), TbxError> {
             Ok(())
         }
         Cell::ArrayAddr { pool_idx, elem_idx } => {
-            let arr = vm.arrays.get(pool_idx).ok_or(TbxError::IndexOutOfBounds {
-                index: pool_idx,
-                size: vm.arrays.len(),
-            })?;
-            let size = arr.len();
-            if elem_idx >= size {
-                return Err(TbxError::ArrayIndexOutOfBounds {
+            let ar = vm
+                .arrays
+                .get(pool_idx)
+                .ok_or(TbxError::IndexOutOfBounds {
+                    index: pool_idx,
+                    size: vm.arrays.len(),
+                })?
+                .clone();
+            let size = ar.len();
+            let value = ar
+                .get_cloned(elem_idx)
+                .ok_or(TbxError::ArrayIndexOutOfBounds {
                     index: elem_idx as i64,
                     size,
-                });
-            }
-            let value = arr[elem_idx].clone();
+                })?;
             vm.push(value)?;
             Ok(())
         }
@@ -164,7 +160,8 @@ mod tests {
 
         // Create a one-element array with initial value Cell::None.
         let pool_idx = vm.arrays.len();
-        vm.arrays.push(vec![Cell::None]);
+        vm.arrays
+            .push(crate::array_ref::ArrayRef::new(vec![Cell::None]));
 
         // Push array handle and 1-based index, then call ARRAY_ADDR.
         vm.push(Cell::Array(pool_idx)).unwrap();
@@ -184,7 +181,7 @@ mod tests {
         store_prim(&mut vm).unwrap();
 
         // Verify the array element was updated.
-        assert_eq!(vm.arrays[pool_idx][0], new_value);
+        assert_eq!(vm.arrays[pool_idx].get_cloned(0), Some(new_value.clone()));
 
         // Now FETCH: push the ArrayAddr again and call fetch_prim.
         vm.push(Cell::ArrayAddr {
@@ -205,11 +202,13 @@ mod tests {
 
         // Outer array — the target element.
         let outer_idx = vm.arrays.len();
-        vm.arrays.push(vec![Cell::None]);
+        vm.arrays
+            .push(crate::array_ref::ArrayRef::new(vec![Cell::None]));
 
         // Inner array — the value to be (illegally) stored.
         let inner_idx = vm.arrays.len();
-        vm.arrays.push(vec![Cell::Int(1)]);
+        vm.arrays
+            .push(crate::array_ref::ArrayRef::new(vec![Cell::Int(1)]));
 
         // STORE convention: push value then addr.
         vm.push(Cell::Array(inner_idx)).unwrap();
@@ -234,11 +233,13 @@ mod tests {
 
         // Target array.
         let outer_idx = vm.arrays.len();
-        vm.arrays.push(vec![Cell::None]);
+        vm.arrays
+            .push(crate::array_ref::ArrayRef::new(vec![Cell::None]));
 
         // Value array (nested).
         let inner_idx = vm.arrays.len();
-        vm.arrays.push(vec![Cell::Int(1)]);
+        vm.arrays
+            .push(crate::array_ref::ArrayRef::new(vec![Cell::Int(1)]));
 
         // SET convention: push addr then value.
         vm.push(Cell::ArrayAddr {
@@ -267,7 +268,8 @@ mod tests {
         vm.dp = 1;
 
         let pool_idx = vm.arrays.len();
-        vm.arrays.push(vec![Cell::Int(7)]);
+        vm.arrays
+            .push(crate::array_ref::ArrayRef::new(vec![Cell::Int(7)]));
 
         // STORE convention: push value then addr.
         vm.push(Cell::Array(pool_idx)).unwrap();
@@ -293,7 +295,8 @@ mod tests {
         vm.bp = 0;
 
         let pool_idx = vm.arrays.len();
-        vm.arrays.push(vec![Cell::Int(3)]);
+        vm.arrays
+            .push(crate::array_ref::ArrayRef::new(vec![Cell::Int(3)]));
 
         // STORE convention: push value then addr.
         vm.push(Cell::Array(pool_idx)).unwrap();
@@ -316,7 +319,8 @@ mod tests {
         vm.dp = 1;
 
         let pool_idx = vm.arrays.len();
-        vm.arrays.push(vec![Cell::Int(5)]);
+        vm.arrays
+            .push(crate::array_ref::ArrayRef::new(vec![Cell::Int(5)]));
 
         // SET convention: push addr then value.
         vm.push(Cell::DictAddr(0)).unwrap();
@@ -339,7 +343,8 @@ mod tests {
         vm.bp = 0;
 
         let pool_idx = vm.arrays.len();
-        vm.arrays.push(vec![Cell::Int(2)]);
+        vm.arrays
+            .push(crate::array_ref::ArrayRef::new(vec![Cell::Int(2)]));
 
         // SET convention: push addr then value.
         vm.push(Cell::StackAddr(0)).unwrap();

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1,3 +1,4 @@
+use crate::array_ref::ArrayRef;
 use crate::cell::{Cell, CompileEntry, ReturnFrame, Xt};
 use crate::constants::{MAX_DATA_STACK_DEPTH, MAX_DICTIONARY_CELLS, MAX_RETURN_STACK_DEPTH};
 use crate::dict::{EntryKind, WordEntry};
@@ -168,11 +169,18 @@ pub struct VM {
     pub(crate) pending_use_path: Option<String>,
     /// Array pool: indexed by `Cell::Array(usize)` values.
     ///
-    /// Each entry is a `Vec<Cell>` created by the `ARRAY(N)` primitive.
+    /// Each entry is an `ArrayRef` handle created by the `ARRAY(N)` primitive.
     /// On every word EXIT or RETURN_VAL, the pool is truncated back to the
     /// length saved in `ReturnFrame::Call::saved_array_pool_len`, freeing all
     /// arrays allocated within that call.
-    pub arrays: Vec<Vec<Cell>>,
+    ///
+    /// # Ownership note
+    ///
+    /// `VM::arrays` is the **compatibility registry** for pool-index-to-`ArrayRef`
+    /// mapping.  It is not the final owner of array data in the long term: once
+    /// `Cell::Array` is evolved to hold an `ArrayRef` directly, this registry will
+    /// become redundant and may be removed.
+    pub arrays: Vec<ArrayRef>,
     /// Length of the "global" (persistent) region of `arrays`.
     ///
     /// Arrays at indices `0..global_array_pool_len` were created at the top
@@ -3007,7 +3015,8 @@ mod tests {
         // regardless of whether the array is in the global pool region.
         // (Surface-level SET / STORE never allow whole-array handle writes.)
         let mut vm = VM::new();
-        vm.arrays.push(vec![Cell::Int(0); 5]);
+        vm.arrays
+            .push(crate::array_ref::ArrayRef::new(vec![Cell::Int(0); 5]));
         vm.global_array_pool_len = 1; // mark pool[0] as global
 
         let slot = vm.dp;
@@ -3028,7 +3037,8 @@ mod tests {
     fn test_global_array_stored_via_set_prim() {
         // set_prim must also reject Cell::Array written to a DictAddr slot.
         let mut vm = VM::new();
-        vm.arrays.push(vec![Cell::Int(0); 3]);
+        vm.arrays
+            .push(crate::array_ref::ArrayRef::new(vec![Cell::Int(0); 3]));
         vm.global_array_pool_len = 1;
 
         let slot = vm.dp;
@@ -3066,7 +3076,8 @@ mod tests {
     fn test_non_global_array_store_rejected_by_store_prim() {
         // An array handle written to a DictAddr must always be rejected by store_prim.
         let mut vm = VM::new();
-        vm.arrays.push(vec![Cell::Int(0); 5]);
+        vm.arrays
+            .push(crate::array_ref::ArrayRef::new(vec![Cell::Int(0); 5]));
         // global_array_pool_len stays 0, so pool[0] is NOT global.
 
         let slot = vm.dp;
@@ -3093,7 +3104,8 @@ mod tests {
         let mut vm = VM::new();
 
         // Insert a "global" array at pool slot 0.
-        vm.arrays.push(vec![Cell::Int(99); 3]);
+        vm.arrays
+            .push(crate::array_ref::ArrayRef::new(vec![Cell::Int(99); 3]));
         // Simulate that TopLevel exit has already promoted it.
         vm.global_array_pool_len = 1;
 


### PR DESCRIPTION
## 概要

`VM::arrays` の型を `Vec<Vec<Cell>>` から `Vec<ArrayRef>` へ移行する。
`ArrayRef` の `get_cloned` / `set` / `len` API を通じて配列要素にアクセスするようにし、
将来的に `Cell::Array` が `ArrayRef` を直接保持する設計変更への足掛かりとする。

## 変更内容

- `vm.rs`: `pub arrays` フィールドの型を `Vec<ArrayRef>` に変更。`ArrayRef` を import し、フィールドのコメントに「互換性レジストリであり最終的な owner ではない」旨を記述
- `primitives/arrays.rs`: `array_prim` で `ArrayRef::new` を使って配列を生成。`array_get_prim` / `array_addr_prim` / `array_len_prim` を `ArrayRef::get_cloned` / `len` API に切り替え
- `primitives/memory.rs`: `write_array_element` を `ArrayRef::set` に切り替え。`fetch_prim` の `ArrayAddr` ブランチを `ArrayRef::get_cloned` に切り替え
- `primitives.rs`: DIM 配列グローバル変数生成箇所を `ArrayRef::new` に更新。テストコードの `vm.arrays.push(vec![...])` / `vm.arrays[i][j]` を `ArrayRef` API に更新

Closes #726
