### PR TITLE
Cell::Array の内部表現を usize から ArrayRef に変更する

### DIFF
--- a/src/cell.rs
+++ b/src/cell.rs
@@ -1,3 +1,4 @@
+use crate::array_ref::ArrayRef;
 use crate::error::TbxError;
 
 /// An entry on the compile-time stack (`VM::compile_stack`).
@@ -84,7 +85,7 @@ pub enum Cell {
     Xt(Xt),
     /// Boolean value for logical/comparison operations
     Bool(bool),
-    /// Array handle — index into `VM::arrays` (the array pool).
+    /// Array handle — an `ArrayRef` (Rc-backed shared mutable storage).
     ///
     /// **Internal representation only.**  `Cell::Array` is NOT a surface
     /// first-class array value.  It is an implementation artefact that moves
@@ -96,27 +97,20 @@ pub enum Cell {
     /// `PUTVAL A`, `A = B`, `EQ(A, B)`.  See `blueprint-language.md` §配列の
     /// surface policy for the complete list.
     ///
-    /// Created by the `ARRAY(N)` primitive.  The pool entry at this index holds
-    /// a `Vec<Cell>` of length N.
+    /// Created by the `ARRAY(N)` primitive.  The underlying `ArrayRef` holds
+    /// `Rc<RefCell<Vec<Cell>>>` storage of length N.
     ///
-    /// Arrays come in three flavours:
-    /// - **Frame-local arrays** (`pool_idx >= saved_array_pool_len` of the current call
-    ///   frame) are owned by that frame.  On EXIT they are freed; on RETURN_VAL the
-    ///   returned array is moved to the frame-boundary slot via ownership transfer
-    ///   (swap + truncate) so it survives the pool cleanup.
-    /// - **Global arrays** (`pool_idx < vm.global_array_pool_len`) are created
-    ///   at the top level (outside any `DEF..END`) and are never freed.  They
-    ///   may safely be stored in `VARIABLE` slots and shared across word calls.
-    /// - **Caller-owned arrays** (`pool_idx < saved_array_pool_len` of the current
-    ///   call frame but not globally permanent) were created before the call; they
-    ///   can be returned without modification.
+    /// `VM::arrays` serves as a compatibility registry for lifetime management:
+    /// frame-local arrays are truncated from the pool on EXIT / RETURN_VAL to
+    /// bound reachable `Rc` clones, even though the `Rc` itself could outlive
+    /// the entry if a reference escaped (the surface ban prevents that).
     ///
     /// Array elements may be any scalar type (`Int`, `Float`, `Bool`, `None`,
     /// or `Str`).  Nested `Array` handles are rejected at write time.
     /// Because `Cell::Str` is `Rc<str>`-backed (#588 / #591), storing a string
     /// in an array element stores/shares the `Rc` handle; no pool-index
     /// lifetime tracking is needed.
-    Array(usize),
+    Array(ArrayRef),
     /// Immutable reference-counted string handle (`Rc<str>`).
     ///
     /// Created by string primitives such as `STR`, `STR_CONCAT`, etc., and by
@@ -179,7 +173,7 @@ impl std::fmt::Display for Cell {
             Cell::StackAddr(a) => write!(f, "stack:{}", a),
             Cell::Xt(x) => write!(f, "xt:{}", x.0),
             Cell::Bool(b) => write!(f, "{}", b),
-            Cell::Array(idx) => write!(f, "<array:{}>", idx),
+            Cell::Array(_) => write!(f, "<array>"),
             Cell::Str(s) => write!(f, "{}", s),
             Cell::ArrayAddr { pool_idx, elem_idx } => {
                 write!(f, "<arrayaddr:{}[{}]>", pool_idx, elem_idx)
@@ -255,10 +249,10 @@ impl Cell {
         }
     }
 
-    /// Returns the pool index if this cell is `Array`, otherwise `None`.
-    pub fn as_array_index(&self) -> Option<usize> {
-        if let Cell::Array(idx) = self {
-            Some(*idx)
+    /// Returns a clone of the `ArrayRef` if this cell is `Array`, otherwise `None`.
+    pub fn as_array_ref(&self) -> Option<ArrayRef> {
+        if let Cell::Array(ar) = self {
+            Some(ar.clone())
         } else {
             None
         }
@@ -356,7 +350,11 @@ impl PartialEq for Cell {
             (Cell::Xt(a), Cell::Xt(b)) => a == b,
             (Cell::Bool(a), Cell::Bool(b)) => a == b,
             (Cell::None, Cell::None) => true,
-            (Cell::Array(a), Cell::Array(b)) => a == b,
+            // Pointer identity, not content equality.
+            // `Cell::Array` is an internal representation, not a surface value;
+            // this `PartialEq` arm exists only for internal tests and diagnostics,
+            // not to expose surface array equality semantics.
+            (Cell::Array(a), Cell::Array(b)) => a.ptr_eq(b),
             // Content equality: two Str cells are equal when their underlying
             // string contents match.  (Previously this was an index comparison
             // when `Cell::Str` was `usize`; `Rc<str>` derives `PartialEq` from
@@ -453,8 +451,8 @@ mod tests {
 
     #[test]
     fn test_display_array() {
-        assert_eq!(Cell::Array(0).to_string(), "<array:0>");
-        assert_eq!(Cell::Array(42).to_string(), "<array:42>");
+        let ar = ArrayRef::new(vec![]);
+        assert_eq!(Cell::Array(ar).to_string(), "<array>");
         assert_eq!(
             Cell::ArrayAddr {
                 pool_idx: 3,
@@ -515,7 +513,7 @@ mod tests {
         assert_eq!(Cell::Xt(Xt(0)).type_name(), "Xt");
         assert_eq!(Cell::Bool(false).type_name(), "Bool");
         assert_eq!(Cell::None.type_name(), "None");
-        assert_eq!(Cell::Array(0).type_name(), "Array");
+        assert_eq!(Cell::Array(ArrayRef::new(vec![])).type_name(), "Array");
         assert_eq!(Cell::string("hello").type_name(), "Str");
     }
 
@@ -616,7 +614,7 @@ mod tests {
     #[test]
     fn tuple_element_type_rejection() {
         // Cell::Array is a forbidden element type
-        let result = Cell::new_tuple(vec![Cell::Array(0)]);
+        let result = Cell::new_tuple(vec![Cell::Array(ArrayRef::new(vec![]))]);
         assert!(result.is_err());
         // Cell::Tuple (nested) is forbidden
         let inner = Cell::new_tuple(vec![Cell::Int(1)]).unwrap();
@@ -640,7 +638,7 @@ mod tests {
         assert!(!Cell::Float(0.0).is_truthy());
         // non-Int/Bool/Float variants are falsy
         assert!(!Cell::None.is_truthy());
-        assert!(!Cell::Array(0).is_truthy());
+        assert!(!Cell::Array(ArrayRef::new(vec![])).is_truthy());
         assert!(!Cell::DictAddr(1).is_truthy());
         assert!(!Cell::StackAddr(1).is_truthy());
     }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -904,15 +904,16 @@ pub fn dim_prim(vm: &mut VM) -> Result<(), TbxError> {
         let storage_idx = vm.dp;
         vm.dict_write(Cell::None)?;
 
-        // Create the array in the array pool.
+        // Create the array and register it in the compatibility pool.
         let pool_idx = vm.arrays.len();
-        vm.arrays.push(ArrayRef::new(vec![Cell::None; size]));
+        let ar = ArrayRef::new(vec![Cell::None; size]);
+        vm.arrays.push(ar.clone());
 
         // Promote to the global array region so it persists across word calls.
         vm.global_array_pool_len = vm.global_array_pool_len.max(pool_idx + 1);
 
         // Store the array handle in the variable slot.
-        vm.dict_write_at(storage_idx, Cell::Array(pool_idx))?;
+        vm.dict_write_at(storage_idx, Cell::Array(ar))?;
 
         // Register the variable in the dictionary.
         let entry = crate::dict::WordEntry::new_variable(&name, storage_idx);
@@ -3507,8 +3508,9 @@ mod tests {
     #[test]
     fn test_putval_array_error() {
         let mut vm = VM::new();
-        vm.arrays.push(ArrayRef::new(vec![Cell::None; 3]));
-        vm.push(Cell::Array(0)).unwrap();
+        let ar = ArrayRef::new(vec![Cell::None; 3]);
+        vm.arrays.push(ar.clone());
+        vm.push(Cell::Array(ar)).unwrap();
         assert!(matches!(
             putval_prim(&mut vm),
             Err(TbxError::TypeError { .. })
@@ -5949,12 +5951,9 @@ mod tests {
     fn test_array_get_prim_reads_element() {
         // User index 1 maps to internal index 0.
         let mut vm = VM::new();
-        vm.arrays.push(ArrayRef::new(vec![
-            Cell::Int(10),
-            Cell::Int(20),
-            Cell::Int(30),
-        ]));
-        vm.push(Cell::Array(0)).unwrap();
+        let ar = ArrayRef::new(vec![Cell::Int(10), Cell::Int(20), Cell::Int(30)]);
+        vm.arrays.push(ar.clone());
+        vm.push(Cell::Array(ar)).unwrap();
         vm.push(Cell::Int(1)).unwrap();
         array_get_prim(&mut vm).unwrap();
         assert_eq!(vm.pop(), Ok(Cell::Int(10)));
@@ -5964,12 +5963,9 @@ mod tests {
     fn test_array_get_prim_reads_second_element() {
         // User index 2 maps to internal index 1.
         let mut vm = VM::new();
-        vm.arrays.push(ArrayRef::new(vec![
-            Cell::Int(10),
-            Cell::Int(20),
-            Cell::Int(30),
-        ]));
-        vm.push(Cell::Array(0)).unwrap();
+        let ar = ArrayRef::new(vec![Cell::Int(10), Cell::Int(20), Cell::Int(30)]);
+        vm.arrays.push(ar.clone());
+        vm.push(Cell::Array(ar)).unwrap();
         vm.push(Cell::Int(2)).unwrap();
         array_get_prim(&mut vm).unwrap();
         assert_eq!(vm.pop(), Ok(Cell::Int(20)));
@@ -5978,8 +5974,9 @@ mod tests {
     #[test]
     fn test_array_get_prim_out_of_bounds() {
         let mut vm = VM::new();
-        vm.arrays.push(ArrayRef::new(vec![Cell::Int(1)]));
-        vm.push(Cell::Array(0)).unwrap();
+        let ar = ArrayRef::new(vec![Cell::Int(1)]);
+        vm.arrays.push(ar.clone());
+        vm.push(Cell::Array(ar)).unwrap();
         vm.push(Cell::Int(5)).unwrap();
         assert!(matches!(
             array_get_prim(&mut vm),
@@ -5991,8 +5988,9 @@ mod tests {
     fn test_array_get_prim_zero_index_is_out_of_bounds() {
         // Index 0 is invalid in 1-based indexing.
         let mut vm = VM::new();
-        vm.arrays.push(ArrayRef::new(vec![Cell::Int(1)]));
-        vm.push(Cell::Array(0)).unwrap();
+        let ar = ArrayRef::new(vec![Cell::Int(1)]);
+        vm.arrays.push(ar.clone());
+        vm.push(Cell::Array(ar)).unwrap();
         vm.push(Cell::Int(0)).unwrap();
         assert!(matches!(
             array_get_prim(&mut vm),
@@ -6003,8 +6001,9 @@ mod tests {
     #[test]
     fn test_array_get_prim_negative_index() {
         let mut vm = VM::new();
-        vm.arrays.push(ArrayRef::new(vec![Cell::Int(1)]));
-        vm.push(Cell::Array(0)).unwrap();
+        let ar = ArrayRef::new(vec![Cell::Int(1)]);
+        vm.arrays.push(ar.clone());
+        vm.push(Cell::Array(ar)).unwrap();
         vm.push(Cell::Int(-1)).unwrap();
         assert!(matches!(
             array_get_prim(&mut vm),
@@ -6018,9 +6017,9 @@ mod tests {
     fn test_array_addr_prim_pushes_array_addr() {
         // User index 1 maps to internal elem_idx 0.
         let mut vm = VM::new();
-        vm.arrays
-            .push(ArrayRef::new(vec![Cell::Int(0), Cell::Int(0)]));
-        vm.push(Cell::Array(0)).unwrap();
+        let ar = ArrayRef::new(vec![Cell::Int(0), Cell::Int(0)]);
+        vm.arrays.push(ar.clone());
+        vm.push(Cell::Array(ar)).unwrap();
         vm.push(Cell::Int(1)).unwrap();
         array_addr_prim(&mut vm).unwrap();
         assert_eq!(
@@ -6036,9 +6035,9 @@ mod tests {
     fn test_array_addr_prim_zero_index_is_out_of_bounds() {
         // Index 0 is invalid in 1-based indexing.
         let mut vm = VM::new();
-        vm.arrays
-            .push(ArrayRef::new(vec![Cell::Int(0), Cell::Int(0)]));
-        vm.push(Cell::Array(0)).unwrap();
+        let ar = ArrayRef::new(vec![Cell::Int(0), Cell::Int(0)]);
+        vm.arrays.push(ar.clone());
+        vm.push(Cell::Array(ar)).unwrap();
         vm.push(Cell::Int(0)).unwrap();
         assert!(matches!(
             array_addr_prim(&mut vm),
@@ -6053,7 +6052,7 @@ mod tests {
         // STORE must reject Cell::Array written to a DictAddr (scalar variable) slot.
         let mut vm = VM::new();
         vm.dictionary.push(Cell::None); // dict[0] = placeholder
-        vm.push(Cell::Array(0)).unwrap(); // value
+        vm.push(Cell::Array(ArrayRef::new(vec![]))).unwrap(); // value
         vm.push(Cell::DictAddr(0)).unwrap(); // address
         assert!(
             matches!(
@@ -6071,7 +6070,7 @@ mod tests {
         vm.dictionary.push(Cell::None); // dict[0] = placeholder
                                         // set_prim: stack is [..., addr, value]
         vm.push(Cell::DictAddr(0)).unwrap(); // address
-        vm.push(Cell::Array(0)).unwrap(); // value
+        vm.push(Cell::Array(ArrayRef::new(vec![]))).unwrap(); // value
         assert!(
             matches!(
                 set_prim(&mut vm),
@@ -6188,14 +6187,15 @@ mod tests {
         // Cell::Array must always be rejected as an array element.
         let mut vm = VM::new();
         vm.arrays.push(ArrayRef::new(vec![Cell::None])); // pool_idx = 0: target array
-        vm.arrays.push(ArrayRef::new(vec![Cell::None])); // pool_idx = 1: value to store
+        let inner_ar = ArrayRef::new(vec![Cell::None]); // value to store
+        vm.arrays.push(inner_ar.clone()); // pool_idx = 1
         vm.global_array_pool_len = 2; // both are global
         vm.push(Cell::ArrayAddr {
             pool_idx: 0,
             elem_idx: 0,
         })
         .unwrap();
-        vm.push(Cell::Array(1)).unwrap();
+        vm.push(Cell::Array(inner_ar)).unwrap();
         assert_eq!(
             set_prim(&mut vm),
             Err(TbxError::InvalidArrayElement { got: "Array" })
@@ -6287,8 +6287,9 @@ mod tests {
     fn test_to_tuple_prim_rejects_array() {
         // Cell::Array is a forbidden tuple element type.
         let mut vm = VM::new();
-        vm.arrays.push(ArrayRef::new(vec![Cell::Int(1)]));
-        vm.push(Cell::Array(0)).unwrap();
+        let ar = ArrayRef::new(vec![Cell::Int(1)]);
+        vm.arrays.push(ar.clone());
+        vm.push(Cell::Array(ar)).unwrap();
         vm.push(Cell::Int(1)).unwrap(); // arity
         assert!(matches!(
             to_tuple_prim(&mut vm),
@@ -6373,8 +6374,9 @@ mod tests {
     fn test_array_len_prim_basic() {
         // ARRAY_LEN on a 5-element array must return 5.
         let mut vm = VM::new();
-        vm.arrays.push(ArrayRef::new(vec![Cell::None; 5]));
-        vm.push(Cell::Array(0)).unwrap();
+        let ar = ArrayRef::new(vec![Cell::None; 5]);
+        vm.arrays.push(ar.clone());
+        vm.push(Cell::Array(ar)).unwrap();
         array_len_prim(&mut vm).unwrap();
         assert_eq!(vm.pop(), Ok(Cell::Int(5)));
     }
@@ -6383,8 +6385,9 @@ mod tests {
     fn test_array_len_prim_one_element() {
         // ARRAY_LEN on a 1-element array must return 1.
         let mut vm = VM::new();
-        vm.arrays.push(ArrayRef::new(vec![Cell::None]));
-        vm.push(Cell::Array(0)).unwrap();
+        let ar = ArrayRef::new(vec![Cell::None]);
+        vm.arrays.push(ar.clone());
+        vm.push(Cell::Array(ar)).unwrap();
         array_len_prim(&mut vm).unwrap();
         assert_eq!(vm.pop(), Ok(Cell::Int(1)));
     }

--- a/src/primitives/arrays.rs
+++ b/src/primitives/arrays.rs
@@ -32,10 +32,10 @@ pub(super) fn array_prim(vm: &mut VM) -> Result<(), TbxError> {
         });
     }
     let size = n as usize;
-    let idx = vm.arrays.len();
     let ar = ArrayRef::new(vec![Cell::None; size]);
-    vm.arrays.push(ar);
-    vm.push(Cell::Array(idx))?;
+    // Register the ArrayRef in the compatibility pool for lifetime tracking.
+    vm.arrays.push(ar.clone());
+    vm.push(Cell::Array(ar))?;
     Ok(())
 }
 
@@ -56,8 +56,8 @@ pub(super) fn array_store_local_prim(vm: &mut VM) -> Result<(), TbxError> {
     let addr = vm.pop()?;
 
     // Invariant: value must be a Cell::Array (compiler-generated call only).
-    let pool_idx = match value {
-        Cell::Array(idx) => idx,
+    let ar = match value {
+        Cell::Array(ar) => ar,
         other => {
             return Err(TbxError::TypeError {
                 expected: "Array (internal: ARRAY_STORE_LOCAL invariant violated)",
@@ -77,7 +77,7 @@ pub(super) fn array_store_local_prim(vm: &mut VM) -> Result<(), TbxError> {
         }
     };
 
-    vm.local_write(local_idx, Cell::Array(pool_idx))?;
+    vm.local_write(local_idx, Cell::Array(ar))?;
     Ok(())
 }
 
@@ -121,8 +121,8 @@ pub fn to_tuple_prim(vm: &mut VM) -> Result<(), TbxError> {
 /// The index is translated to 0-based internally before accessing the Vec.
 pub fn array_get_prim(vm: &mut VM) -> Result<(), TbxError> {
     let elem_idx_raw = vm.pop_int()?;
-    let pool_idx = match vm.pop()? {
-        Cell::Array(idx) => idx,
+    let ar = match vm.pop()? {
+        Cell::Array(ar) => ar,
         other => {
             return Err(TbxError::TypeError {
                 expected: "Array",
@@ -130,10 +130,6 @@ pub fn array_get_prim(vm: &mut VM) -> Result<(), TbxError> {
             })
         }
     };
-    let ar = vm.arrays.get(pool_idx).ok_or(TbxError::IndexOutOfBounds {
-        index: pool_idx,
-        size: vm.arrays.len(),
-    })?;
     let size = ar.len();
     // Translate 1-based user index to 0-based internal index.
     // Index 0 or negative is out of bounds.
@@ -173,8 +169,8 @@ pub fn array_get_prim(vm: &mut VM) -> Result<(), TbxError> {
 /// The index is translated to 0-based internally before storing in `Cell::ArrayAddr`.
 pub fn array_addr_prim(vm: &mut VM) -> Result<(), TbxError> {
     let elem_idx_raw = vm.pop_int()?;
-    let pool_idx = match vm.pop()? {
-        Cell::Array(idx) => idx,
+    let ar = match vm.pop()? {
+        Cell::Array(ar) => ar,
         other => {
             return Err(TbxError::TypeError {
                 expected: "Array",
@@ -182,11 +178,6 @@ pub fn array_addr_prim(vm: &mut VM) -> Result<(), TbxError> {
             })
         }
     };
-    // Validate bounds at address-computation time.
-    let ar = vm.arrays.get(pool_idx).ok_or(TbxError::IndexOutOfBounds {
-        index: pool_idx,
-        size: vm.arrays.len(),
-    })?;
     let size = ar.len();
     // Translate 1-based user index to 0-based internal index.
     // Index 0 or negative is out of bounds.
@@ -203,6 +194,15 @@ pub fn array_addr_prim(vm: &mut VM) -> Result<(), TbxError> {
             size,
         });
     }
+    // Resolve pool_idx by pointer-identity search in vm.arrays.
+    // Cell::ArrayAddr still carries pool_idx for compatibility with FETCH/STORE.
+    let pool_idx =
+        vm.arrays
+            .iter()
+            .position(|entry| entry.ptr_eq(&ar))
+            .ok_or(TbxError::InvalidArgument {
+                message: "ARRAY_ADDR: array handle not found in pool".to_string(),
+            })?;
     vm.push(Cell::ArrayAddr { pool_idx, elem_idx })?;
     Ok(())
 }
@@ -287,8 +287,8 @@ pub fn tuple_len_prim(vm: &mut VM) -> Result<(), TbxError> {
 /// `ARRAY_LEN(A)` is unsupported and rejected by the expression compiler / lookup
 /// path before it should reach this primitive.
 pub fn array_len_prim(vm: &mut VM) -> Result<(), TbxError> {
-    let pool_idx = match vm.pop()? {
-        Cell::Array(idx) => idx,
+    let ar = match vm.pop()? {
+        Cell::Array(ar) => ar,
         other => {
             return Err(TbxError::TypeError {
                 expected: "Array",
@@ -296,10 +296,6 @@ pub fn array_len_prim(vm: &mut VM) -> Result<(), TbxError> {
             })
         }
     };
-    let ar = vm.arrays.get(pool_idx).ok_or(TbxError::IndexOutOfBounds {
-        index: pool_idx,
-        size: vm.arrays.len(),
-    })?;
     let len = ar.len() as i64;
     vm.push(Cell::Int(len))?;
     Ok(())

--- a/src/primitives/memory.rs
+++ b/src/primitives/memory.rs
@@ -164,7 +164,7 @@ mod tests {
             .push(crate::array_ref::ArrayRef::new(vec![Cell::None]));
 
         // Push array handle and 1-based index, then call ARRAY_ADDR.
-        vm.push(Cell::Array(pool_idx)).unwrap();
+        vm.push(Cell::Array(vm.arrays[pool_idx].clone())).unwrap();
         vm.push(Cell::Int(1)).unwrap();
         array_addr_prim(&mut vm).unwrap();
 
@@ -206,12 +206,11 @@ mod tests {
             .push(crate::array_ref::ArrayRef::new(vec![Cell::None]));
 
         // Inner array — the value to be (illegally) stored.
-        let inner_idx = vm.arrays.len();
-        vm.arrays
-            .push(crate::array_ref::ArrayRef::new(vec![Cell::Int(1)]));
+        let inner_ar = crate::array_ref::ArrayRef::new(vec![Cell::Int(1)]);
+        vm.arrays.push(inner_ar.clone());
 
         // STORE convention: push value then addr.
-        vm.push(Cell::Array(inner_idx)).unwrap();
+        vm.push(Cell::Array(inner_ar)).unwrap();
         vm.push(Cell::ArrayAddr {
             pool_idx: outer_idx,
             elem_idx: 0,
@@ -237,9 +236,8 @@ mod tests {
             .push(crate::array_ref::ArrayRef::new(vec![Cell::None]));
 
         // Value array (nested).
-        let inner_idx = vm.arrays.len();
-        vm.arrays
-            .push(crate::array_ref::ArrayRef::new(vec![Cell::Int(1)]));
+        let inner_ar = crate::array_ref::ArrayRef::new(vec![Cell::Int(1)]);
+        vm.arrays.push(inner_ar.clone());
 
         // SET convention: push addr then value.
         vm.push(Cell::ArrayAddr {
@@ -247,7 +245,7 @@ mod tests {
             elem_idx: 0,
         })
         .unwrap();
-        vm.push(Cell::Array(inner_idx)).unwrap();
+        vm.push(Cell::Array(inner_ar)).unwrap();
 
         let result = set_prim(&mut vm);
         assert!(
@@ -267,12 +265,11 @@ mod tests {
         vm.dictionary.push(Cell::None);
         vm.dp = 1;
 
-        let pool_idx = vm.arrays.len();
-        vm.arrays
-            .push(crate::array_ref::ArrayRef::new(vec![Cell::Int(7)]));
+        let ar = crate::array_ref::ArrayRef::new(vec![Cell::Int(7)]);
+        vm.arrays.push(ar.clone());
 
         // STORE convention: push value then addr.
-        vm.push(Cell::Array(pool_idx)).unwrap();
+        vm.push(Cell::Array(ar)).unwrap();
         vm.push(Cell::DictAddr(0)).unwrap();
 
         let result = store_prim(&mut vm);
@@ -294,12 +291,11 @@ mod tests {
         vm.data_stack.push(Cell::None);
         vm.bp = 0;
 
-        let pool_idx = vm.arrays.len();
-        vm.arrays
-            .push(crate::array_ref::ArrayRef::new(vec![Cell::Int(3)]));
+        let ar = crate::array_ref::ArrayRef::new(vec![Cell::Int(3)]);
+        vm.arrays.push(ar.clone());
 
         // STORE convention: push value then addr.
-        vm.push(Cell::Array(pool_idx)).unwrap();
+        vm.push(Cell::Array(ar)).unwrap();
         vm.push(Cell::StackAddr(0)).unwrap();
 
         let result = store_prim(&mut vm);
@@ -318,13 +314,12 @@ mod tests {
         vm.dictionary.push(Cell::None);
         vm.dp = 1;
 
-        let pool_idx = vm.arrays.len();
-        vm.arrays
-            .push(crate::array_ref::ArrayRef::new(vec![Cell::Int(5)]));
+        let ar = crate::array_ref::ArrayRef::new(vec![Cell::Int(5)]);
+        vm.arrays.push(ar.clone());
 
         // SET convention: push addr then value.
         vm.push(Cell::DictAddr(0)).unwrap();
-        vm.push(Cell::Array(pool_idx)).unwrap();
+        vm.push(Cell::Array(ar)).unwrap();
 
         let result = set_prim(&mut vm);
         assert!(
@@ -342,13 +337,12 @@ mod tests {
         vm.data_stack.push(Cell::None);
         vm.bp = 0;
 
-        let pool_idx = vm.arrays.len();
-        vm.arrays
-            .push(crate::array_ref::ArrayRef::new(vec![Cell::Int(2)]));
+        let ar = crate::array_ref::ArrayRef::new(vec![Cell::Int(2)]);
+        vm.arrays.push(ar.clone());
 
         // SET convention: push addr then value.
         vm.push(Cell::StackAddr(0)).unwrap();
-        vm.push(Cell::Array(pool_idx)).unwrap();
+        vm.push(Cell::Array(ar)).unwrap();
 
         let result = set_prim(&mut vm);
         assert!(

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -167,19 +167,18 @@ pub struct VM {
     /// Drained by `exec_immediate_word` in the interpreter, which calls
     /// `exec_source` on the file content.
     pub(crate) pending_use_path: Option<String>,
-    /// Array pool: indexed by `Cell::Array(usize)` values.
+    /// Array pool: compatibility registry for `ArrayRef` lifetime management.
     ///
     /// Each entry is an `ArrayRef` handle created by the `ARRAY(N)` primitive.
     /// On every word EXIT or RETURN_VAL, the pool is truncated back to the
-    /// length saved in `ReturnFrame::Call::saved_array_pool_len`, freeing all
-    /// arrays allocated within that call.
+    /// length saved in `ReturnFrame::Call::saved_array_pool_len`, bounding the
+    /// set of `Rc` clones that can be reached from live `Cell::Array` handles.
     ///
-    /// # Ownership note
-    ///
-    /// `VM::arrays` is the **compatibility registry** for pool-index-to-`ArrayRef`
-    /// mapping.  It is not the final owner of array data in the long term: once
-    /// `Cell::Array` is evolved to hold an `ArrayRef` directly, this registry will
-    /// become redundant and may be removed.
+    /// `Cell::Array` now holds an `ArrayRef` directly, so `VM::arrays` no longer
+    /// acts as the primary lookup table.  It is retained for:
+    ///   - pool-length lifetime tracking (truncate on EXIT / RETURN_VAL)
+    ///   - pool_idx resolution needed by `Cell::ArrayAddr` (via ptr_eq search)
+    ///   - global-array promotion tracking (`global_array_pool_len`)
     pub arrays: Vec<ArrayRef>,
     /// Length of the "global" (persistent) region of `arrays`.
     ///
@@ -956,27 +955,21 @@ impl VM {
                         });
                     }
                     // Ownership transfer for frame-local Cell::Array:
-                    // If the returned array was created in this frame
-                    // (pool_idx >= array_frame_boundary), swap it to the
-                    // boundary slot and mark it for preservation.
-                    // Array elements are guaranteed to be Int/Float/Bool/None
-                    // (no nested references), so no recursive check is needed.
+                    // `Cell::Array` is rejected above by the surface ban, so this
+                    // branch is unreachable in practice.  The `array_transferred`
+                    // flag is kept for symmetry with pool lifetime logic; it will
+                    // always be `false` here because `retval` is never `Cell::Array`.
                     // `Cell::Str` is `Rc<str>`-backed and needs no swap.
-                    let array_transferred = if let Cell::Array(pool_idx) = &retval {
-                        if *pool_idx >= array_frame_boundary {
-                            // Bounds check before swap: both indices must be valid.
-                            // pool_idx >= array_frame_boundary is already confirmed;
-                            // checking pool_idx < arrays.len() implies array_frame_boundary
-                            // is also in range.
-                            if *pool_idx >= self.arrays.len() {
-                                return Err(TbxError::IndexOutOfBounds {
-                                    index: *pool_idx,
-                                    size: self.arrays.len(),
-                                });
+                    let array_transferred = if let Cell::Array(ar) = &retval {
+                        // Locate the array's pool slot by pointer identity.
+                        if let Some(pool_idx) = self.arrays.iter().position(|e| e.ptr_eq(ar)) {
+                            if pool_idx >= array_frame_boundary {
+                                self.arrays.swap(pool_idx, array_frame_boundary);
+                                retval = Cell::Array(self.arrays[array_frame_boundary].clone());
+                                true
+                            } else {
+                                false
                             }
-                            self.arrays.swap(*pool_idx, array_frame_boundary);
-                            retval = Cell::Array(array_frame_boundary);
-                            true
                         } else {
                             false
                         }
@@ -3022,7 +3015,7 @@ mod tests {
         let slot = vm.dp;
         vm.dict_write(Cell::None).unwrap();
 
-        let arr = Cell::Array(0);
+        let arr = Cell::Array(crate::array_ref::ArrayRef::new(vec![Cell::Int(0); 5]));
         // store_prim pops addr first, then value; so push value then addr.
         vm.push(arr).unwrap();
         vm.push(Cell::DictAddr(slot)).unwrap();
@@ -3037,8 +3030,8 @@ mod tests {
     fn test_global_array_stored_via_set_prim() {
         // set_prim must also reject Cell::Array written to a DictAddr slot.
         let mut vm = VM::new();
-        vm.arrays
-            .push(crate::array_ref::ArrayRef::new(vec![Cell::Int(0); 3]));
+        let ar = crate::array_ref::ArrayRef::new(vec![Cell::Int(0); 3]);
+        vm.arrays.push(ar.clone());
         vm.global_array_pool_len = 1;
 
         let slot = vm.dp;
@@ -3046,7 +3039,7 @@ mod tests {
 
         // set_prim pops value first, then addr (stack: [..., addr, value]).
         vm.push(Cell::DictAddr(slot)).unwrap();
-        vm.push(Cell::Array(0)).unwrap();
+        vm.push(Cell::Array(ar)).unwrap();
         let result = crate::primitives::set_prim(&mut vm);
         assert!(
             matches!(result, Err(TbxError::TypeError { got: "Array", .. })),
@@ -3084,7 +3077,8 @@ mod tests {
         vm.dict_write(Cell::None).unwrap();
 
         // store_prim pops addr first, then value; so push value then addr.
-        vm.push(Cell::Array(0)).unwrap();
+        let ar = crate::array_ref::ArrayRef::new(vec![Cell::Int(0); 5]);
+        vm.push(Cell::Array(ar)).unwrap();
         vm.push(Cell::DictAddr(slot)).unwrap();
         let result = crate::primitives::store_prim(&mut vm);
         assert!(
@@ -3095,17 +3089,17 @@ mod tests {
 
     #[test]
     fn test_global_array_returnable_from_word() {
-        // A global array (pool_idx < saved_array_pool_len of the CALL frame) can
-        // be returned from a word without triggering ArrayFrameEscape.
+        // A global array (registered in pool before the CALL frame) can be
+        // returned from a word without triggering ArrayFrameEscape.
         //
-        // The ReturnVal check uses `frame_boundary = saved_array_pool_len` of the
-        // current CALL frame.  A global array created before the call has
+        // The ReturnVal check resolves pool_idx via ptr_eq and verifies that
+        // pool_idx < frame_boundary.  A global array created before the call has
         // pool_idx < saved_array_pool_len, so it is safe to return.
         let mut vm = VM::new();
 
         // Insert a "global" array at pool slot 0.
-        vm.arrays
-            .push(crate::array_ref::ArrayRef::new(vec![Cell::Int(99); 3]));
+        let global_ar = crate::array_ref::ArrayRef::new(vec![Cell::Int(99); 3]);
+        vm.arrays.push(global_ar.clone());
         // Simulate that TopLevel exit has already promoted it.
         vm.global_array_pool_len = 1;
 
@@ -3121,9 +3115,10 @@ mod tests {
         });
 
         // Push the global array as the return value.
-        vm.push(Cell::Array(0)).unwrap();
+        vm.push(Cell::Array(global_ar.clone())).unwrap();
 
-        // Mimic the ReturnVal boundary check: frame_boundary = 1, pool_idx = 0 < 1 → OK.
+        // Mimic the ReturnVal boundary check: locate pool_idx by ptr_eq,
+        // then verify pool_idx < frame_boundary (0 < 1 → OK).
         let frame_boundary = match vm.return_stack.last().unwrap() {
             ReturnFrame::Call {
                 saved_array_pool_len,
@@ -3132,9 +3127,14 @@ mod tests {
             _ => panic!("unexpected frame"),
         };
         let retval = vm.pop().unwrap();
-        if let Cell::Array(pool_idx) = &retval {
+        if let Cell::Array(ar) = &retval {
+            let pool_idx = vm
+                .arrays
+                .iter()
+                .position(|e| e.ptr_eq(ar))
+                .expect("array must be in pool");
             assert!(
-                *pool_idx < frame_boundary,
+                pool_idx < frame_boundary,
                 "global array should pass ReturnVal check"
             );
         }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -932,20 +932,7 @@ impl VM {
                     }
                 }
                 EntryKind::ReturnVal => {
-                    // Determine the array frame boundary before popping the return
-                    // value, so we can detect whether the array belongs to the
-                    // current frame.
-                    let array_frame_boundary = match self.return_stack.last() {
-                        Some(ReturnFrame::Call {
-                            saved_array_pool_len,
-                            ..
-                        }) => *saved_array_pool_len,
-                        Some(ReturnFrame::TopLevel) => {
-                            return Err(TbxError::InvalidReturn);
-                        }
-                        None => return Err(TbxError::StackUnderflow),
-                    };
-                    let mut retval = self.pop()?;
+                    let retval = self.pop()?;
                     // Reject whole-array handle as a return value.
                     // Only scalar types are permitted to flow out of a word via RETURN.
                     if matches!(retval, Cell::Array(_)) {
@@ -954,28 +941,8 @@ impl VM {
                             got: "Array",
                         });
                     }
-                    // Ownership transfer for frame-local Cell::Array:
-                    // `Cell::Array` is rejected above by the surface ban, so this
-                    // branch is unreachable in practice.  The `array_transferred`
-                    // flag is kept for symmetry with pool lifetime logic; it will
-                    // always be `false` here because `retval` is never `Cell::Array`.
-                    // `Cell::Str` is `Rc<str>`-backed and needs no swap.
-                    let array_transferred = if let Cell::Array(ar) = &retval {
-                        // Locate the array's pool slot by pointer identity.
-                        if let Some(pool_idx) = self.arrays.iter().position(|e| e.ptr_eq(ar)) {
-                            if pool_idx >= array_frame_boundary {
-                                self.arrays.swap(pool_idx, array_frame_boundary);
-                                retval = Cell::Array(self.arrays[array_frame_boundary].clone());
-                                true
-                            } else {
-                                false
-                            }
-                        } else {
-                            false
-                        }
-                    } else {
-                        false
-                    };
+                    // `Cell::Str` is `Rc<str>`-backed and needs no ownership transfer.
+                    // `Cell::Array` is already rejected above; the pool simply truncates.
                     match self.return_stack.pop().ok_or(TbxError::StackUnderflow)? {
                         ReturnFrame::Call {
                             callee_xt: _,
@@ -986,11 +953,7 @@ impl VM {
                         } => {
                             self.data_stack.truncate(self.bp);
                             // Truncate the array pool back to the saved boundary.
-                            // If ownership was transferred, the returned value now sits
-                            // at `saved_array_pool_len` (the boundary slot), so we keep
-                            // exactly one extra entry beyond the boundary.
-                            let array_keep = saved_array_pool_len + usize::from(array_transferred);
-                            self.arrays.truncate(array_keep);
+                            self.arrays.truncate(saved_array_pool_len);
                             self.push(retval)?;
                             self.pc = return_pc;
                             self.bp = saved_bp;
@@ -3088,59 +3051,6 @@ mod tests {
     }
 
     #[test]
-    fn test_global_array_returnable_from_word() {
-        // A global array (registered in pool before the CALL frame) can be
-        // returned from a word without triggering ArrayFrameEscape.
-        //
-        // The ReturnVal check resolves pool_idx via ptr_eq and verifies that
-        // pool_idx < frame_boundary.  A global array created before the call has
-        // pool_idx < saved_array_pool_len, so it is safe to return.
-        let mut vm = VM::new();
-
-        // Insert a "global" array at pool slot 0.
-        let global_ar = crate::array_ref::ArrayRef::new(vec![Cell::Int(99); 3]);
-        vm.arrays.push(global_ar.clone());
-        // Simulate that TopLevel exit has already promoted it.
-        vm.global_array_pool_len = 1;
-
-        // Simulate a CALL frame where saved_array_pool_len = 1 (the array already
-        // existed when the word was called).
-        vm.return_stack.push(ReturnFrame::TopLevel);
-        vm.return_stack.push(ReturnFrame::Call {
-            callee_xt: Xt(0),
-            return_pc: 0,
-            saved_bp: 0,
-            saved_array_pool_len: 1,
-            actual_arity: 0,
-        });
-
-        // Push the global array as the return value.
-        vm.push(Cell::Array(global_ar.clone())).unwrap();
-
-        // Mimic the ReturnVal boundary check: locate pool_idx by ptr_eq,
-        // then verify pool_idx < frame_boundary (0 < 1 → OK).
-        let frame_boundary = match vm.return_stack.last().unwrap() {
-            ReturnFrame::Call {
-                saved_array_pool_len,
-                ..
-            } => *saved_array_pool_len,
-            _ => panic!("unexpected frame"),
-        };
-        let retval = vm.pop().unwrap();
-        if let Cell::Array(ar) = &retval {
-            let pool_idx = vm
-                .arrays
-                .iter()
-                .position(|e| e.ptr_eq(ar))
-                .expect("array must be in pool");
-            assert!(
-                pool_idx < frame_boundary,
-                "global array should pass ReturnVal check"
-            );
-        }
-    }
-
-    #[test]
     fn test_stack_trace_frames_innermost_first() {
         let mut vm = VM::new();
 
@@ -3350,6 +3260,22 @@ mod tests {
         assert!(
             matches!(result, Err(crate::error::TbxError::TypeError { .. })),
             "expected TypeError when returning array handle, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_global_array_return_errors() {
+        // `RETURN A` where A is a *global* array (DIM at top-level) must also
+        // produce TypeError — global arrays are not exempt from the whole-array
+        // return ban introduced in #718.
+        let result = run_source(
+            "DIM @A[2]\n\
+             DEF BAD()\n  RETURN A\nEND\n\
+             BAD",
+        );
+        assert!(
+            matches!(result, Err(crate::error::TbxError::TypeError { .. })),
+            "expected TypeError when returning global array handle, got: {result:?}"
         );
     }
 


### PR DESCRIPTION
## 概要

`Cell::Array` の内部表現を `usize`（pool インデックス）から `ArrayRef`（Rc-backed ハンドル）に変更する。
`Cell::Array(ArrayRef)` は internal representation であり、surface first-class array value ではない。

## 変更内容

- `cell.rs`: `ArrayRef` を import し、`Cell::Array(usize)` を `Cell::Array(ArrayRef)` に変更する
- `cell.rs`: `as_array_index()` を `as_array_ref()` に置き換える
- `cell.rs`: `Display` を diagnostic 用の `<array>` に更新する
- `cell.rs`: `PartialEq` を `ArrayRef::ptr_eq` を使ったポインタ同一性比較に更新し、surface equality semantics ではないことをコメントに明記する
- `primitives/arrays.rs`: `array_prim` が `ArrayRef` を作成して pool に登録し `Cell::Array(ar)` を push するよう更新する
- `primitives/arrays.rs`: `array_store_local_prim` が `Cell::Array(ArrayRef)` を受け取るよう更新する
- `primitives/arrays.rs`: `array_get_prim` / `array_len_prim` が `Cell::Array(ar)` から `ArrayRef` を直接使うよう更新する
- `primitives/arrays.rs`: `array_addr_prim` が `ptr_eq` で pool_idx を解決するよう更新する（`Cell::ArrayAddr` は引き続き `pool_idx: usize` を保持）
- `primitives.rs`: `dim_prim` のグローバル DIM パスを `Cell::Array(ArrayRef)` を生成するよう更新する
- `vm.rs`: RETURN_VAL の whole-array return ban を維持し、Cell::Array(ArrayRef) 移行後も array return compatibility は追加しない
- 各ファイルのユニットテストを `Cell::Array(ArrayRef)` を使うよう更新する

Closes #727