### PR TITLE
Cell::ArrayAddr を pool_idx ベースから ArrayRef + elem_idx ベースへ移行する

### DIFF
--- a/src/cell.rs
+++ b/src/cell.rs
@@ -129,9 +129,13 @@ pub enum Cell {
     ///
     /// Produced by the `&@A[i]` construct where `A` holds a `Cell::Array`.
     /// Used by `FETCH`, `STORE`, and `SET` to read/write individual elements.
+    ///
+    /// Holds the `ArrayRef` directly (Rc-backed shared handle) so that
+    /// `FETCH` / `SET` / `STORE` can access the element without going through
+    /// `VM::arrays`.  `VM::arrays` is no longer needed for `ArrayAddr` resolution.
     ArrayAddr {
-        /// Index into `VM::arrays` (the array pool).
-        pool_idx: usize,
+        /// Rc-backed handle to the array storage.
+        array: ArrayRef,
         /// Zero-based element index within the array.
         elem_idx: usize,
     },
@@ -175,8 +179,8 @@ impl std::fmt::Display for Cell {
             Cell::Bool(b) => write!(f, "{}", b),
             Cell::Array(_) => write!(f, "<array>"),
             Cell::Str(s) => write!(f, "{}", s),
-            Cell::ArrayAddr { pool_idx, elem_idx } => {
-                write!(f, "<arrayaddr:{}[{}]>", pool_idx, elem_idx)
+            Cell::ArrayAddr { array: _, elem_idx } => {
+                write!(f, "<arrayaddr:[{}]>", elem_idx)
             }
             Cell::None => write!(f, "<none>"),
             Cell::Marker => write!(f, "<marker>"),
@@ -362,14 +366,14 @@ impl PartialEq for Cell {
             (Cell::Str(a), Cell::Str(b)) => a == b,
             (
                 Cell::ArrayAddr {
-                    pool_idx: pa,
+                    array: aa,
                     elem_idx: ea,
                 },
                 Cell::ArrayAddr {
-                    pool_idx: pb,
+                    array: ab,
                     elem_idx: eb,
                 },
-            ) => pa == pb && ea == eb,
+            ) => aa.ptr_eq(ab) && ea == eb,
             (Cell::Tuple(a), Cell::Tuple(b)) => a == b,
             _ => false,
         }
@@ -452,14 +456,14 @@ mod tests {
     #[test]
     fn test_display_array() {
         let ar = ArrayRef::new(vec![]);
-        assert_eq!(Cell::Array(ar).to_string(), "<array>");
+        assert_eq!(Cell::Array(ar.clone()).to_string(), "<array>");
         assert_eq!(
             Cell::ArrayAddr {
-                pool_idx: 3,
-                elem_idx: 7
+                array: ar,
+                elem_idx: 7,
             }
             .to_string(),
-            "<arrayaddr:3[7]>"
+            "<arrayaddr:[7]>"
         );
     }
 

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -180,7 +180,7 @@ impl std::fmt::Display for Cell {
             Cell::Array(_) => write!(f, "<array>"),
             Cell::Str(s) => write!(f, "{}", s),
             Cell::ArrayAddr { array: _, elem_idx } => {
-                write!(f, "<arrayaddr:[{}]>", elem_idx)
+                write!(f, "<arrayaddr[{}]>", elem_idx)
             }
             Cell::None => write!(f, "<none>"),
             Cell::Marker => write!(f, "<marker>"),
@@ -463,7 +463,7 @@ mod tests {
                 elem_idx: 7,
             }
             .to_string(),
-            "<arrayaddr:[7]>"
+            "<arrayaddr[7]>"
         );
     }
 

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -6016,19 +6016,23 @@ mod tests {
     #[test]
     fn test_array_addr_prim_pushes_array_addr() {
         // User index 1 maps to internal elem_idx 0.
+        // Cell::ArrayAddr now holds the ArrayRef directly (no pool_idx search).
         let mut vm = VM::new();
         let ar = ArrayRef::new(vec![Cell::Int(0), Cell::Int(0)]);
-        vm.arrays.push(ar.clone());
-        vm.push(Cell::Array(ar)).unwrap();
+        vm.push(Cell::Array(ar.clone())).unwrap();
         vm.push(Cell::Int(1)).unwrap();
         array_addr_prim(&mut vm).unwrap();
-        assert_eq!(
-            vm.pop(),
-            Ok(Cell::ArrayAddr {
-                pool_idx: 0,
-                elem_idx: 0
-            })
-        );
+        // Verify that the result is an ArrayAddr pointing to the same array.
+        match vm.pop().unwrap() {
+            Cell::ArrayAddr { array, elem_idx } => {
+                assert!(
+                    array.ptr_eq(&ar),
+                    "ArrayAddr must reference the same ArrayRef"
+                );
+                assert_eq!(elem_idx, 0);
+            }
+            other => panic!("expected ArrayAddr, got {:?}", other),
+        }
     }
 
     #[test]
@@ -6084,30 +6088,32 @@ mod tests {
 
     #[test]
     fn test_store_to_array_addr() {
+        // Cell::ArrayAddr now holds the ArrayRef directly; VM::arrays is not consulted.
         let mut vm = VM::new();
-        vm.arrays.push(ArrayRef::new(vec![Cell::None, Cell::None]));
+        let ar = ArrayRef::new(vec![Cell::None, Cell::None]);
         vm.push(Cell::Int(99)).unwrap();
         vm.push(Cell::ArrayAddr {
-            pool_idx: 0,
+            array: ar.clone(),
             elem_idx: 1,
         })
         .unwrap();
         store_prim(&mut vm).unwrap();
-        assert_eq!(vm.arrays[0].get_cloned(1), Some(Cell::Int(99)));
+        assert_eq!(ar.get_cloned(1), Some(Cell::Int(99)));
     }
 
     #[test]
     fn test_set_to_array_addr() {
+        // Cell::ArrayAddr now holds the ArrayRef directly; VM::arrays is not consulted.
         let mut vm = VM::new();
-        vm.arrays.push(ArrayRef::new(vec![Cell::None, Cell::None]));
+        let ar = ArrayRef::new(vec![Cell::None, Cell::None]);
         vm.push(Cell::ArrayAddr {
-            pool_idx: 0,
+            array: ar.clone(),
             elem_idx: 0,
         })
         .unwrap();
         vm.push(Cell::Int(42)).unwrap();
         set_prim(&mut vm).unwrap();
-        assert_eq!(vm.arrays[0].get_cloned(0), Some(Cell::Int(42)));
+        assert_eq!(ar.get_cloned(0), Some(Cell::Int(42)));
     }
 
     // --- array element write: Cell::Str (D-4: Rc<str> liberation, #591) ---
@@ -6120,78 +6126,79 @@ mod tests {
     #[test]
     fn test_set_str_to_array_element_is_allowed() {
         // Cell::Str(Rc<str>) written through SET must succeed (#591).
+        // Cell::ArrayAddr now holds the ArrayRef directly; VM::arrays is not consulted.
         let mut vm = VM::new();
-        vm.arrays.push(ArrayRef::new(vec![Cell::None]));
+        let ar = ArrayRef::new(vec![Cell::None]);
         vm.push(Cell::ArrayAddr {
-            pool_idx: 0,
+            array: ar.clone(),
             elem_idx: 0,
         })
         .unwrap();
         vm.push(Cell::string("hello")).unwrap();
         set_prim(&mut vm).unwrap();
-        assert_eq!(vm.arrays[0].get_cloned(0), Some(Cell::string("hello")));
+        assert_eq!(ar.get_cloned(0), Some(Cell::string("hello")));
     }
 
     #[test]
     fn test_store_str_to_array_element_is_allowed() {
         // Same as the SET path above, exercised through STORE (#591).
+        // Cell::ArrayAddr now holds the ArrayRef directly; VM::arrays is not consulted.
         let mut vm = VM::new();
-        vm.arrays.push(ArrayRef::new(vec![Cell::None]));
+        let ar = ArrayRef::new(vec![Cell::None]);
         vm.push(Cell::string("world")).unwrap();
         vm.push(Cell::ArrayAddr {
-            pool_idx: 0,
+            array: ar.clone(),
             elem_idx: 0,
         })
         .unwrap();
         store_prim(&mut vm).unwrap();
-        assert_eq!(vm.arrays[0].get_cloned(0), Some(Cell::string("world")));
+        assert_eq!(ar.get_cloned(0), Some(Cell::string("world")));
     }
 
     #[test]
     fn test_set_str_to_global_array_element_is_allowed() {
-        // Storing a Str into a global array (global_array_pool_len covers it) must succeed.
+        // Storing a Str into a global array element must succeed.
+        // (global_array_pool_len is irrelevant for ArrayAddr resolution now.)
         let mut vm = VM::new();
-        vm.arrays.push(ArrayRef::new(vec![Cell::None]));
-        vm.global_array_pool_len = 1; // mark as global
+        let ar = ArrayRef::new(vec![Cell::None]);
+        vm.arrays.push(ar.clone());
+        vm.global_array_pool_len = 1; // mark as global (pool tracking only)
         vm.push(Cell::ArrayAddr {
-            pool_idx: 0,
+            array: ar.clone(),
             elem_idx: 0,
         })
         .unwrap();
         vm.push(Cell::string("global")).unwrap();
         set_prim(&mut vm).unwrap();
-        assert_eq!(vm.arrays[0].get_cloned(0), Some(Cell::string("global")));
+        assert_eq!(ar.get_cloned(0), Some(Cell::string("global")));
     }
 
     #[test]
     fn test_set_str_to_frame_local_array_element_is_allowed() {
         // Storing a Str into a frame-local array must succeed (#591).
+        // Cell::ArrayAddr now holds the ArrayRef directly; VM::arrays is not consulted.
         let mut vm = VM::new();
-        vm.arrays.push(ArrayRef::new(vec![Cell::None]));
+        let ar = ArrayRef::new(vec![Cell::None]);
         // global_array_pool_len = 0 (default) → array is frame-local
         vm.push(Cell::ArrayAddr {
-            pool_idx: 0,
+            array: ar.clone(),
             elem_idx: 0,
         })
         .unwrap();
         vm.push(Cell::string("frame-local")).unwrap();
         set_prim(&mut vm).unwrap();
-        assert_eq!(
-            vm.arrays[0].get_cloned(0),
-            Some(Cell::string("frame-local"))
-        );
+        assert_eq!(ar.get_cloned(0), Some(Cell::string("frame-local")));
     }
 
     #[test]
     fn test_set_nested_array_to_array_element_is_invalid_array_element() {
         // Cell::Array must always be rejected as an array element.
+        // Cell::ArrayAddr now holds the ArrayRef directly; VM::arrays is not consulted.
         let mut vm = VM::new();
-        vm.arrays.push(ArrayRef::new(vec![Cell::None])); // pool_idx = 0: target array
-        let inner_ar = ArrayRef::new(vec![Cell::None]); // value to store
-        vm.arrays.push(inner_ar.clone()); // pool_idx = 1
-        vm.global_array_pool_len = 2; // both are global
+        let outer_ar = ArrayRef::new(vec![Cell::None]); // target array
+        let inner_ar = ArrayRef::new(vec![Cell::None]); // value to store (nested, forbidden)
         vm.push(Cell::ArrayAddr {
-            pool_idx: 0,
+            array: outer_ar,
             elem_idx: 0,
         })
         .unwrap();
@@ -6206,10 +6213,11 @@ mod tests {
 
     #[test]
     fn test_fetch_array_addr() {
+        // Cell::ArrayAddr now holds the ArrayRef directly; VM::arrays is not consulted.
         let mut vm = VM::new();
-        vm.arrays.push(ArrayRef::new(vec![Cell::Int(77)]));
+        let ar = ArrayRef::new(vec![Cell::Int(77)]);
         vm.push(Cell::ArrayAddr {
-            pool_idx: 0,
+            array: ar,
             elem_idx: 0,
         })
         .unwrap();

--- a/src/primitives/arrays.rs
+++ b/src/primitives/arrays.rs
@@ -158,7 +158,7 @@ pub fn array_get_prim(vm: &mut VM) -> Result<(), TbxError> {
 
 /// ARRAY_ADDR — compute the address of an array element.
 ///
-/// Stack: `[..., Cell::Array(pool_idx), Cell::Int(elem_idx)]` → `Cell::ArrayAddr { pool_idx, elem_idx }`
+/// Stack: `[..., Cell::Array(ar), Cell::Int(elem_idx)]` → `Cell::ArrayAddr { array: ar, elem_idx }`
 ///
 /// This is the VM-level primitive that `&@A[i]` compiles to.  The expression
 /// compiler lowers `&@A[i]` to: `<array handle read>  <index expr>  ARRAY_ADDR`.
@@ -167,6 +167,9 @@ pub fn array_get_prim(vm: &mut VM) -> Result<(), TbxError> {
 ///
 /// Array indices are 1-based from the user's perspective: valid range is `1..=N`.
 /// The index is translated to 0-based internally before storing in `Cell::ArrayAddr`.
+///
+/// `VM::arrays` is NOT consulted here; the `ArrayRef` from the popped `Cell::Array`
+/// is stored directly in `Cell::ArrayAddr`.
 pub fn array_addr_prim(vm: &mut VM) -> Result<(), TbxError> {
     let elem_idx_raw = vm.pop_int()?;
     let ar = match vm.pop()? {
@@ -194,16 +197,11 @@ pub fn array_addr_prim(vm: &mut VM) -> Result<(), TbxError> {
             size,
         });
     }
-    // Resolve pool_idx by pointer-identity search in vm.arrays.
-    // Cell::ArrayAddr still carries pool_idx for compatibility with FETCH/STORE.
-    let pool_idx =
-        vm.arrays
-            .iter()
-            .position(|entry| entry.ptr_eq(&ar))
-            .ok_or(TbxError::InvalidArgument {
-                message: "ARRAY_ADDR: array handle not found in pool".to_string(),
-            })?;
-    vm.push(Cell::ArrayAddr { pool_idx, elem_idx })?;
+    // Store the ArrayRef directly — no ptr_eq search in VM::arrays needed.
+    vm.push(Cell::ArrayAddr {
+        array: ar,
+        elem_idx,
+    })?;
     Ok(())
 }
 

--- a/src/primitives/memory.rs
+++ b/src/primitives/memory.rs
@@ -17,24 +17,17 @@ fn reject_array_value(value: &Cell) -> Result<(), TbxError> {
     Ok(())
 }
 
-/// Write `value` to element `elem_idx` of the array at `pool_idx`.
+/// Write `value` to element `elem_idx` of the array referenced by `ar`.
+///
+/// `VM::arrays` is NOT consulted; `ar` is the direct `ArrayRef` handle held
+/// inside a `Cell::ArrayAddr`.
 fn write_array_element(
-    vm: &mut VM,
-    pool_idx: usize,
+    ar: &crate::array_ref::ArrayRef,
     elem_idx: usize,
     value: Cell,
 ) -> Result<(), TbxError> {
     // Validate element type before touching the array.
     super::arrays::check_array_element_value(&value)?;
-    let pool_size = vm.arrays.len();
-    let ar = vm
-        .arrays
-        .get(pool_idx)
-        .ok_or(TbxError::IndexOutOfBounds {
-            index: pool_idx,
-            size: pool_size,
-        })?
-        .clone();
     ar.set(elem_idx, value)
 }
 
@@ -52,17 +45,9 @@ pub fn fetch_prim(vm: &mut VM) -> Result<(), TbxError> {
             vm.push(value)?;
             Ok(())
         }
-        Cell::ArrayAddr { pool_idx, elem_idx } => {
-            let ar = vm
-                .arrays
-                .get(pool_idx)
-                .ok_or(TbxError::IndexOutOfBounds {
-                    index: pool_idx,
-                    size: vm.arrays.len(),
-                })?
-                .clone();
-            let size = ar.len();
-            let value = ar
+        Cell::ArrayAddr { array, elem_idx } => {
+            let size = array.len();
+            let value = array
                 .get_cloned(elem_idx)
                 .ok_or(TbxError::ArrayIndexOutOfBounds {
                     index: elem_idx as i64,
@@ -98,9 +83,7 @@ pub fn store_prim(vm: &mut VM) -> Result<(), TbxError> {
             vm.local_write(a, value)?;
             Ok(())
         }
-        Cell::ArrayAddr { pool_idx, elem_idx } => {
-            write_array_element(vm, pool_idx, elem_idx, value)
-        }
+        Cell::ArrayAddr { array, elem_idx } => write_array_element(&array, elem_idx, value),
         _ => Err(TbxError::TypeError {
             expected: "address",
             got: "non-address",
@@ -130,9 +113,7 @@ pub fn set_prim(vm: &mut VM) -> Result<(), TbxError> {
             vm.local_write(a, value)?;
             Ok(())
         }
-        Cell::ArrayAddr { pool_idx, elem_idx } => {
-            write_array_element(vm, pool_idx, elem_idx, value)
-        }
+        Cell::ArrayAddr { array, elem_idx } => write_array_element(&array, elem_idx, value),
         _ => Err(TbxError::TypeError {
             expected: "address",
             got: "non-address",
@@ -152,19 +133,20 @@ mod tests {
     /// ARRAY_ADDR computes a Cell::ArrayAddr; STORE writes through it; FETCH reads
     /// the value back.  After the roundtrip the stored value must equal what was
     /// pushed before STORE.
+    ///
+    /// Cell::ArrayAddr now holds an ArrayRef directly; VM::arrays is not consulted.
     #[test]
     fn test_array_addr_store_fetch_roundtrip() {
+        use crate::array_ref::ArrayRef;
         use crate::primitives::arrays::array_addr_prim;
 
         let mut vm = VM::new();
 
         // Create a one-element array with initial value Cell::None.
-        let pool_idx = vm.arrays.len();
-        vm.arrays
-            .push(crate::array_ref::ArrayRef::new(vec![Cell::None]));
+        let ar = ArrayRef::new(vec![Cell::None]);
 
         // Push array handle and 1-based index, then call ARRAY_ADDR.
-        vm.push(Cell::Array(vm.arrays[pool_idx].clone())).unwrap();
+        vm.push(Cell::Array(ar.clone())).unwrap();
         vm.push(Cell::Int(1)).unwrap();
         array_addr_prim(&mut vm).unwrap();
 
@@ -180,12 +162,12 @@ mod tests {
 
         store_prim(&mut vm).unwrap();
 
-        // Verify the array element was updated.
-        assert_eq!(vm.arrays[pool_idx].get_cloned(0), Some(new_value.clone()));
+        // Verify the array element was updated via the shared ArrayRef.
+        assert_eq!(ar.get_cloned(0), Some(new_value.clone()));
 
-        // Now FETCH: push the ArrayAddr again and call fetch_prim.
+        // Now FETCH: push a new Cell::ArrayAddr with the same ArrayRef and call fetch_prim.
         vm.push(Cell::ArrayAddr {
-            pool_idx,
+            array: ar,
             elem_idx: 0,
         })
         .unwrap();
@@ -196,23 +178,24 @@ mod tests {
 
     /// Verify that STORE rejects a nested Cell::Array written to an array element
     /// (i.e., when the destination address is a Cell::ArrayAddr).
+    ///
+    /// Cell::ArrayAddr now holds an ArrayRef directly; VM::arrays is not consulted.
     #[test]
     fn test_store_array_element_rejects_nested_array() {
+        use crate::array_ref::ArrayRef;
+
         let mut vm = VM::new();
 
         // Outer array — the target element.
-        let outer_idx = vm.arrays.len();
-        vm.arrays
-            .push(crate::array_ref::ArrayRef::new(vec![Cell::None]));
+        let outer_ar = ArrayRef::new(vec![Cell::None]);
 
         // Inner array — the value to be (illegally) stored.
-        let inner_ar = crate::array_ref::ArrayRef::new(vec![Cell::Int(1)]);
-        vm.arrays.push(inner_ar.clone());
+        let inner_ar = ArrayRef::new(vec![Cell::Int(1)]);
 
         // STORE convention: push value then addr.
         vm.push(Cell::Array(inner_ar)).unwrap();
         vm.push(Cell::ArrayAddr {
-            pool_idx: outer_idx,
+            array: outer_ar,
             elem_idx: 0,
         })
         .unwrap();
@@ -226,22 +209,23 @@ mod tests {
     }
 
     /// Verify that SET rejects a nested Cell::Array written to an array element.
+    ///
+    /// Cell::ArrayAddr now holds an ArrayRef directly; VM::arrays is not consulted.
     #[test]
     fn test_set_array_element_rejects_nested_array() {
+        use crate::array_ref::ArrayRef;
+
         let mut vm = VM::new();
 
-        // Target array.
-        let outer_idx = vm.arrays.len();
-        vm.arrays
-            .push(crate::array_ref::ArrayRef::new(vec![Cell::None]));
+        // Outer array — the target element.
+        let outer_ar = ArrayRef::new(vec![Cell::None]);
 
         // Value array (nested).
-        let inner_ar = crate::array_ref::ArrayRef::new(vec![Cell::Int(1)]);
-        vm.arrays.push(inner_ar.clone());
+        let inner_ar = ArrayRef::new(vec![Cell::Int(1)]);
 
         // SET convention: push addr then value.
         vm.push(Cell::ArrayAddr {
-            pool_idx: outer_idx,
+            array: outer_ar,
             elem_idx: 0,
         })
         .unwrap();
@@ -260,13 +244,14 @@ mod tests {
     /// Surface-level STORE must never accept a whole-array handle for a scalar slot.
     #[test]
     fn test_store_array_to_dict_addr_is_type_error() {
+        use crate::array_ref::ArrayRef;
+
         let mut vm = VM::new();
 
         vm.dictionary.push(Cell::None);
         vm.dp = 1;
 
-        let ar = crate::array_ref::ArrayRef::new(vec![Cell::Int(7)]);
-        vm.arrays.push(ar.clone());
+        let ar = ArrayRef::new(vec![Cell::Int(7)]);
 
         // STORE convention: push value then addr.
         vm.push(Cell::Array(ar)).unwrap();
@@ -285,14 +270,15 @@ mod tests {
     /// Surface-level STORE must never accept a whole-array handle for a local slot.
     #[test]
     fn test_store_array_to_stack_addr_is_type_error() {
+        use crate::array_ref::ArrayRef;
+
         let mut vm = VM::new();
 
         // Allocate a local slot via the data stack.
         vm.data_stack.push(Cell::None);
         vm.bp = 0;
 
-        let ar = crate::array_ref::ArrayRef::new(vec![Cell::Int(3)]);
-        vm.arrays.push(ar.clone());
+        let ar = ArrayRef::new(vec![Cell::Int(3)]);
 
         // STORE convention: push value then addr.
         vm.push(Cell::Array(ar)).unwrap();
@@ -309,13 +295,14 @@ mod tests {
     /// Verify that SET rejects a Cell::Array written to a DictAddr slot.
     #[test]
     fn test_set_array_to_dict_addr_is_type_error() {
+        use crate::array_ref::ArrayRef;
+
         let mut vm = VM::new();
 
         vm.dictionary.push(Cell::None);
         vm.dp = 1;
 
-        let ar = crate::array_ref::ArrayRef::new(vec![Cell::Int(5)]);
-        vm.arrays.push(ar.clone());
+        let ar = ArrayRef::new(vec![Cell::Int(5)]);
 
         // SET convention: push addr then value.
         vm.push(Cell::DictAddr(0)).unwrap();
@@ -332,13 +319,14 @@ mod tests {
     /// Verify that SET rejects a Cell::Array written to a StackAddr slot.
     #[test]
     fn test_set_array_to_stack_addr_is_type_error() {
+        use crate::array_ref::ArrayRef;
+
         let mut vm = VM::new();
 
         vm.data_stack.push(Cell::None);
         vm.bp = 0;
 
-        let ar = crate::array_ref::ArrayRef::new(vec![Cell::Int(2)]);
-        vm.arrays.push(ar.clone());
+        let ar = ArrayRef::new(vec![Cell::Int(2)]);
 
         // SET convention: push addr then value.
         vm.push(Cell::StackAddr(0)).unwrap();

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -175,9 +175,10 @@ pub struct VM {
     /// set of `Rc` clones that can be reached from live `Cell::Array` handles.
     ///
     /// `Cell::Array` now holds an `ArrayRef` directly, so `VM::arrays` no longer
-    /// acts as the primary lookup table.  It is retained for:
+    /// acts as the primary lookup table.  `Cell::ArrayAddr` also holds an
+    /// `ArrayRef` directly (since issue #733), so `VM::arrays` is no longer
+    /// consulted for `ArrayAddr` resolution either.  It is retained for:
     ///   - pool-length lifetime tracking (truncate on EXIT / RETURN_VAL)
-    ///   - pool_idx resolution needed by `Cell::ArrayAddr` (via ptr_eq search)
     ///   - global-array promotion tracking (`global_array_pool_len`)
     pub arrays: Vec<ArrayRef>,
     /// Length of the "global" (persistent) region of `arrays`.


### PR DESCRIPTION
## 概要

`Cell::ArrayAddr` が保持するフィールドを `pool_idx: usize` から `array: ArrayRef` に変更し、`FETCH` / `SET` / `STORE` の `ArrayAddr` パスが `VM::arrays` を参照しないようにする。
これにより `array_addr_prim` から `VM::arrays` への `ptr_eq` 検索が不要になった。

## 変更内容

- `Cell::ArrayAddr` の `pool_idx: usize` を `array: ArrayRef` に変更する（`src/cell.rs`）
- `Cell::ArrayAddr` の `Display` を `<arrayaddr:pool_idx[elem_idx]>` から `<arrayaddr:[elem_idx]>` に変更する
- `Cell::ArrayAddr` の `PartialEq` を `pool_idx` 比較から `ArrayRef::ptr_eq` 比較に変更する
- `array_addr_prim` から `VM::arrays` の `ptr_eq` 検索を削除し、ポップした `ArrayRef` を直接 `Cell::ArrayAddr` に格納する（`src/primitives/arrays.rs`）
- `FETCH` の `ArrayAddr` パスを `array.get_cloned(elem_idx)` で直接アクセスするよう変更する（`src/primitives/memory.rs`）
- `SET` / `STORE` の `ArrayAddr` パスを `array.set(elem_idx, value)` で直接アクセスするよう変更する
- `write_array_element` ヘルパーの引数を `VM + pool_idx` から `&ArrayRef` に変更する（VM::arrays 参照を削除）
- `cell.rs` / `primitives.rs` / `primitives/memory.rs` のテストを `pool_idx` 前提から `ArrayRef` 前提に更新する
- `VM::arrays` のコメントを更新し、`ArrayAddr` の解決にも不要になったことを明記する（`src/vm.rs`）

## VM::arrays について

`VM::arrays` は `Cell::ArrayAddr` の `pool_idx` 解決のために使われていたが、本 PR により `Cell::ArrayAddr` が `ArrayRef` を直接保持するようになったため、`ArrayAddr` の解決に `VM::arrays` を参照する必要がなくなった。

`VM::arrays` は引き続き以下の目的で保持される（本 PR では削除しない）：
- EXIT / RETURN_VAL 時の pool 長トランケーション（フレームローカル配列の解放）
- グローバル配列プール追跡（`global_array_pool_len`）

Closes #733
