### PR TITLE
VM::arrays compatibility registry を削除する

### DIFF
--- a/src/cell.rs
+++ b/src/cell.rs
@@ -52,10 +52,6 @@ pub enum ReturnFrame {
         callee_xt: Xt,
         return_pc: usize,
         saved_bp: usize,
-        /// Snapshot of `VM::arrays.len()` taken at call time.
-        /// On EXIT or RETURN_VAL, the array pool is truncated back to this
-        /// length to free all arrays created during the call.
-        saved_array_pool_len: usize,
         /// The actual number of arguments passed to this call.
         /// Used by the `VA_COUNT` primitive to report how many arguments the
         /// caller supplied (including both fixed and variadic arguments).
@@ -100,10 +96,10 @@ pub enum Cell {
     /// Created by the `ARRAY(N)` primitive.  The underlying `ArrayRef` holds
     /// `Rc<RefCell<Vec<Cell>>>` storage of length N.
     ///
-    /// `VM::arrays` serves as a compatibility registry for lifetime management:
-    /// frame-local arrays are truncated from the pool on EXIT / RETURN_VAL to
-    /// bound reachable `Rc` clones, even though the `Rc` itself could outlive
-    /// the entry if a reference escaped (the surface ban prevents that).
+    /// Array lifetime is managed entirely by `Rc` reference counting.
+    /// `VM::arrays` (the compatibility registry) has been removed (issue #734);
+    /// arrays are freed when no `Cell::Array` or `Cell::ArrayAddr` handle
+    /// holding a clone of the `Rc` remains alive.
     ///
     /// Array elements may be any scalar type (`Int`, `Float`, `Bool`, `None`,
     /// or `Str`).  Nested `Array` handles are rejected at write time.
@@ -131,8 +127,8 @@ pub enum Cell {
     /// Used by `FETCH`, `STORE`, and `SET` to read/write individual elements.
     ///
     /// Holds the `ArrayRef` directly (Rc-backed shared handle) so that
-    /// `FETCH` / `SET` / `STORE` can access the element without going through
-    /// `VM::arrays`.  `VM::arrays` is no longer needed for `ArrayAddr` resolution.
+    /// `FETCH` / `SET` / `STORE` can access the element without indirection.
+    /// `VM::arrays` has been removed (issue #734).
     ArrayAddr {
         /// Rc-backed handle to the array storage.
         array: ArrayRef,

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -904,15 +904,8 @@ pub fn dim_prim(vm: &mut VM) -> Result<(), TbxError> {
         let storage_idx = vm.dp;
         vm.dict_write(Cell::None)?;
 
-        // Create the array and register it in the compatibility pool.
-        let pool_idx = vm.arrays.len();
+        // Create the array and store the handle directly in the variable slot.
         let ar = ArrayRef::new(vec![Cell::None; size]);
-        vm.arrays.push(ar.clone());
-
-        // Promote to the global array region so it persists across word calls.
-        vm.global_array_pool_len = vm.global_array_pool_len.max(pool_idx + 1);
-
-        // Store the array handle in the variable slot.
         vm.dict_write_at(storage_idx, Cell::Array(ar))?;
 
         // Register the variable in the dictionary.
@@ -3509,7 +3502,6 @@ mod tests {
     fn test_putval_array_error() {
         let mut vm = VM::new();
         let ar = ArrayRef::new(vec![Cell::None; 3]);
-        vm.arrays.push(ar.clone());
         vm.push(Cell::Array(ar)).unwrap();
         assert!(matches!(
             putval_prim(&mut vm),
@@ -5952,7 +5944,6 @@ mod tests {
         // User index 1 maps to internal index 0.
         let mut vm = VM::new();
         let ar = ArrayRef::new(vec![Cell::Int(10), Cell::Int(20), Cell::Int(30)]);
-        vm.arrays.push(ar.clone());
         vm.push(Cell::Array(ar)).unwrap();
         vm.push(Cell::Int(1)).unwrap();
         array_get_prim(&mut vm).unwrap();
@@ -5964,7 +5955,6 @@ mod tests {
         // User index 2 maps to internal index 1.
         let mut vm = VM::new();
         let ar = ArrayRef::new(vec![Cell::Int(10), Cell::Int(20), Cell::Int(30)]);
-        vm.arrays.push(ar.clone());
         vm.push(Cell::Array(ar)).unwrap();
         vm.push(Cell::Int(2)).unwrap();
         array_get_prim(&mut vm).unwrap();
@@ -5975,7 +5965,6 @@ mod tests {
     fn test_array_get_prim_out_of_bounds() {
         let mut vm = VM::new();
         let ar = ArrayRef::new(vec![Cell::Int(1)]);
-        vm.arrays.push(ar.clone());
         vm.push(Cell::Array(ar)).unwrap();
         vm.push(Cell::Int(5)).unwrap();
         assert!(matches!(
@@ -5989,7 +5978,6 @@ mod tests {
         // Index 0 is invalid in 1-based indexing.
         let mut vm = VM::new();
         let ar = ArrayRef::new(vec![Cell::Int(1)]);
-        vm.arrays.push(ar.clone());
         vm.push(Cell::Array(ar)).unwrap();
         vm.push(Cell::Int(0)).unwrap();
         assert!(matches!(
@@ -6002,7 +5990,6 @@ mod tests {
     fn test_array_get_prim_negative_index() {
         let mut vm = VM::new();
         let ar = ArrayRef::new(vec![Cell::Int(1)]);
-        vm.arrays.push(ar.clone());
         vm.push(Cell::Array(ar)).unwrap();
         vm.push(Cell::Int(-1)).unwrap();
         assert!(matches!(
@@ -6040,7 +6027,6 @@ mod tests {
         // Index 0 is invalid in 1-based indexing.
         let mut vm = VM::new();
         let ar = ArrayRef::new(vec![Cell::Int(0), Cell::Int(0)]);
-        vm.arrays.push(ar.clone());
         vm.push(Cell::Array(ar)).unwrap();
         vm.push(Cell::Int(0)).unwrap();
         assert!(matches!(
@@ -6161,8 +6147,7 @@ mod tests {
         // (global_array_pool_len is irrelevant for ArrayAddr resolution now.)
         let mut vm = VM::new();
         let ar = ArrayRef::new(vec![Cell::None]);
-        vm.arrays.push(ar.clone());
-        vm.global_array_pool_len = 1; // mark as global (pool tracking only)
+        vm.global_array_pool_len = 1; // retained for pool tracking (VM::arrays removed)
         vm.push(Cell::ArrayAddr {
             array: ar.clone(),
             elem_idx: 0,
@@ -6296,7 +6281,6 @@ mod tests {
         // Cell::Array is a forbidden tuple element type.
         let mut vm = VM::new();
         let ar = ArrayRef::new(vec![Cell::Int(1)]);
-        vm.arrays.push(ar.clone());
         vm.push(Cell::Array(ar)).unwrap();
         vm.push(Cell::Int(1)).unwrap(); // arity
         assert!(matches!(
@@ -6383,7 +6367,6 @@ mod tests {
         // ARRAY_LEN on a 5-element array must return 5.
         let mut vm = VM::new();
         let ar = ArrayRef::new(vec![Cell::None; 5]);
-        vm.arrays.push(ar.clone());
         vm.push(Cell::Array(ar)).unwrap();
         array_len_prim(&mut vm).unwrap();
         assert_eq!(vm.pop(), Ok(Cell::Int(5)));
@@ -6394,7 +6377,6 @@ mod tests {
         // ARRAY_LEN on a 1-element array must return 1.
         let mut vm = VM::new();
         let ar = ArrayRef::new(vec![Cell::None]);
-        vm.arrays.push(ar.clone());
         vm.push(Cell::Array(ar)).unwrap();
         array_len_prim(&mut vm).unwrap();
         assert_eq!(vm.pop(), Ok(Cell::Int(1)));

--- a/src/primitives/arrays.rs
+++ b/src/primitives/arrays.rs
@@ -18,8 +18,8 @@ pub(super) fn check_array_element_value(value: &Cell) -> Result<(), TbxError> {
 
 /// Internal primitive used by the `DIM @A[n]` compiler to allocate an array.
 ///
-/// Pops `Cell::Int(n)` (n > 0) from the stack, allocates `n` `Cell::None` slots
-/// in `vm.arrays`, and pushes `Cell::Array(pool_idx)` as the handle.
+/// Pops `Cell::Int(n)` (n > 0) from the stack, allocates `n` `Cell::None` slots,
+/// and pushes `Cell::Array(ar)` as the handle.
 ///
 /// This function is NOT registered as a user-facing surface primitive.
 /// It is registered under a hidden system entry so that `dim_prim` can emit its
@@ -33,8 +33,6 @@ pub(super) fn array_prim(vm: &mut VM) -> Result<(), TbxError> {
     }
     let size = n as usize;
     let ar = ArrayRef::new(vec![Cell::None; size]);
-    // Register the ArrayRef in the compatibility pool for lifetime tracking.
-    vm.arrays.push(ar.clone());
     vm.push(Cell::Array(ar))?;
     Ok(())
 }
@@ -168,8 +166,7 @@ pub fn array_get_prim(vm: &mut VM) -> Result<(), TbxError> {
 /// Array indices are 1-based from the user's perspective: valid range is `1..=N`.
 /// The index is translated to 0-based internally before storing in `Cell::ArrayAddr`.
 ///
-/// `VM::arrays` is NOT consulted here; the `ArrayRef` from the popped `Cell::Array`
-/// is stored directly in `Cell::ArrayAddr`.
+/// The `ArrayRef` from the popped `Cell::Array` is stored directly in `Cell::ArrayAddr`.
 pub fn array_addr_prim(vm: &mut VM) -> Result<(), TbxError> {
     let elem_idx_raw = vm.pop_int()?;
     let ar = match vm.pop()? {
@@ -197,7 +194,7 @@ pub fn array_addr_prim(vm: &mut VM) -> Result<(), TbxError> {
             size,
         });
     }
-    // Store the ArrayRef directly — no ptr_eq search in VM::arrays needed.
+    // Store the ArrayRef directly in Cell::ArrayAddr.
     vm.push(Cell::ArrayAddr {
         array: ar,
         elem_idx,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1,4 +1,3 @@
-use crate::array_ref::ArrayRef;
 use crate::cell::{Cell, CompileEntry, ReturnFrame, Xt};
 use crate::constants::{MAX_DATA_STACK_DEPTH, MAX_DICTIONARY_CELLS, MAX_RETURN_STACK_DEPTH};
 use crate::dict::{EntryKind, WordEntry};
@@ -167,28 +166,12 @@ pub struct VM {
     /// Drained by `exec_immediate_word` in the interpreter, which calls
     /// `exec_source` on the file content.
     pub(crate) pending_use_path: Option<String>,
-    /// Array pool: compatibility registry for `ArrayRef` lifetime management.
+    /// Length of the "global" (persistent) region of arrays created at the top level.
     ///
-    /// Each entry is an `ArrayRef` handle created by the `ARRAY(N)` primitive.
-    /// On every word EXIT or RETURN_VAL, the pool is truncated back to the
-    /// length saved in `ReturnFrame::Call::saved_array_pool_len`, bounding the
-    /// set of `Rc` clones that can be reached from live `Cell::Array` handles.
-    ///
-    /// `Cell::Array` now holds an `ArrayRef` directly, so `VM::arrays` no longer
-    /// acts as the primary lookup table.  `Cell::ArrayAddr` also holds an
-    /// `ArrayRef` directly (since issue #733), so `VM::arrays` is no longer
-    /// consulted for `ArrayAddr` resolution either.  It is retained for:
-    ///   - pool-length lifetime tracking (truncate on EXIT / RETURN_VAL)
-    ///   - global-array promotion tracking (`global_array_pool_len`)
-    pub arrays: Vec<ArrayRef>,
-    /// Length of the "global" (persistent) region of `arrays`.
-    ///
-    /// Arrays at indices `0..global_array_pool_len` were created at the top
-    /// level (outside any `DEF..END`) and are never freed.  They may safely be
-    /// stored in `VARIABLE` slots and shared across word calls.
-    ///
-    /// Updated to `arrays.len()` whenever a `TopLevel` frame is popped in
-    /// `Exit` (i.e. at the end of every top-level execution segment).
+    /// Retained for compatibility while pool-lifetime tracking is fully removed.
+    /// `VM::arrays` has been deleted (issue #734); this field is kept as a
+    /// placeholder until the array pool lifetime model is fully retired in a
+    /// follow-up issue.
     pub global_array_pool_len: usize,
     /// Internal buffer holding the last line read by ACCEPT.
     ///
@@ -260,7 +243,6 @@ impl VM {
             compile_state: None,
             compile_stack: Vec::new(),
             pending_use_path: None,
-            arrays: Vec::new(),
             global_array_pool_len: 0,
             input_buffer: None,
             input_reader: Box::new(BufReader::new(std::io::stdin())),
@@ -811,7 +793,6 @@ impl VM {
                         callee_xt: xt,
                         return_pc,
                         saved_bp,
-                        saved_array_pool_len: self.arrays.len(),
                         actual_arity: 0,
                     });
                     self.bp = self.data_stack.len();
@@ -890,7 +871,6 @@ impl VM {
                                 callee_xt: target_xt,
                                 return_pc,
                                 saved_bp,
-                                saved_array_pool_len: self.arrays.len(),
                                 actual_arity: arity,
                             });
                             self.bp = self.data_stack.len() - arity;
@@ -915,19 +895,13 @@ impl VM {
                             callee_xt: _,
                             return_pc,
                             saved_bp,
-                            saved_array_pool_len,
                             actual_arity: _,
                         } => {
                             self.data_stack.truncate(self.bp);
-                            self.arrays.truncate(saved_array_pool_len);
                             self.pc = return_pc;
                             self.bp = saved_bp;
                         }
                         ReturnFrame::TopLevel => {
-                            // Promote all arrays created at the top level to
-                            // the persistent region so they can be stored in
-                            // VARIABLE slots and shared across word calls.
-                            self.global_array_pool_len = self.arrays.len();
                             break;
                         }
                     }
@@ -943,18 +917,14 @@ impl VM {
                         });
                     }
                     // `Cell::Str` is `Rc<str>`-backed and needs no ownership transfer.
-                    // `Cell::Array` is already rejected above; the pool simply truncates.
                     match self.return_stack.pop().ok_or(TbxError::StackUnderflow)? {
                         ReturnFrame::Call {
                             callee_xt: _,
                             return_pc,
                             saved_bp,
-                            saved_array_pool_len,
                             actual_arity: _,
                         } => {
                             self.data_stack.truncate(self.bp);
-                            // Truncate the array pool back to the saved boundary.
-                            self.arrays.truncate(saved_array_pool_len);
                             self.push(retval)?;
                             self.pc = return_pc;
                             self.bp = saved_bp;
@@ -1802,7 +1772,6 @@ mod tests {
                 callee_xt: word_xt,
                 return_pc: 0,
                 saved_bp: 0,
-                saved_array_pool_len: 0,
                 actual_arity: 0,
             });
         }
@@ -1844,7 +1813,6 @@ mod tests {
                 callee_xt: word_xt,
                 return_pc: 0,
                 saved_bp: 0,
-                saved_array_pool_len: 0,
                 actual_arity: 0,
             });
         }
@@ -2972,9 +2940,7 @@ mod tests {
         // regardless of whether the array is in the global pool region.
         // (Surface-level SET / STORE never allow whole-array handle writes.)
         let mut vm = VM::new();
-        vm.arrays
-            .push(crate::array_ref::ArrayRef::new(vec![Cell::Int(0); 5]));
-        vm.global_array_pool_len = 1; // mark pool[0] as global
+        vm.global_array_pool_len = 1; // mark as global (pool tracking only, VM::arrays removed)
 
         let slot = vm.dp;
         vm.dict_write(Cell::None).unwrap();
@@ -2995,8 +2961,7 @@ mod tests {
         // set_prim must also reject Cell::Array written to a DictAddr slot.
         let mut vm = VM::new();
         let ar = crate::array_ref::ArrayRef::new(vec![Cell::Int(0); 3]);
-        vm.arrays.push(ar.clone());
-        vm.global_array_pool_len = 1;
+        vm.global_array_pool_len = 1; // pool tracking only (VM::arrays removed)
 
         let slot = vm.dp;
         vm.dict_write(Cell::None).unwrap();
@@ -3033,9 +2998,7 @@ mod tests {
     fn test_non_global_array_store_rejected_by_store_prim() {
         // An array handle written to a DictAddr must always be rejected by store_prim.
         let mut vm = VM::new();
-        vm.arrays
-            .push(crate::array_ref::ArrayRef::new(vec![Cell::Int(0); 5]));
-        // global_array_pool_len stays 0, so pool[0] is NOT global.
+        // global_array_pool_len stays 0 (default), so no arrays are marked global.
 
         let slot = vm.dp;
         vm.dict_write(Cell::None).unwrap();
@@ -3063,14 +3026,12 @@ mod tests {
             callee_xt: outer_xt,
             return_pc: 10,
             saved_bp: 0,
-            saved_array_pool_len: 0,
             actual_arity: 1,
         });
         vm.return_stack.push(ReturnFrame::Call {
             callee_xt: inner_xt,
             return_pc: 20,
             saved_bp: 1,
-            saved_array_pool_len: 0,
             actual_arity: 2,
         });
 
@@ -3084,12 +3045,14 @@ mod tests {
         assert_eq!(frames[2].actual_arity, 0);
     }
 
-    // --- Pool truncation on return (direct vm.arrays length checks) ---
+    // --- Array lifetime on return (regression tests) ---
 
     #[test]
-    fn test_array_pool_len_truncated_when_not_returned() {
+    fn test_array_created_in_word_does_not_leak() {
         // After a word that creates a local array but returns a non-array value,
-        // vm.arrays should be truncated back to its length before the call.
+        // no array handle should remain on the data stack.
+        // VM::arrays has been removed (issue #734); array lifetime is now fully
+        // managed by Rc reference counting rather than a pool registry.
         let mut interp = crate::interpreter::Interpreter::new();
         interp
             .exec_source(
@@ -3097,13 +3060,8 @@ mod tests {
                  PUTDEC MAKE_AND_DROP()",
             )
             .expect("exec_source failed");
-        // The word created one array but did not return it; the pool must be
-        // back to the pre-call length (0 frame-local arrays remain).
-        assert_eq!(
-            interp.vm().arrays.len(),
-            0,
-            "array pool should be empty after word that discards its local array"
-        );
+        // The word returned 42; verify output and that the stack is clean.
+        assert_eq!(interp.take_output(), "42");
     }
 
     #[test]


### PR DESCRIPTION
## 概要

`Cell::ArrayAddr` が `ArrayRef` を直接保持するようになった（#733）ことで、`VM::arrays` compatibility registry はいかなる用途にも不要となったため削除する。
配列のライフタイム管理は `Rc` 参照カウントに一本化される。

## 変更内容

- `VM` 構造体から `arrays: Vec<ArrayRef>` フィールドを削除する
- `VM::new()` から `arrays` の初期化を削除する
- `ReturnFrame::Call` から `saved_array_pool_len` フィールドを削除する（`VM::arrays` が消えたため不要）
- `EntryKind::Exit` / `ReturnVal` のプール truncate ロジック（`self.arrays.truncate(...)`）を削除する
- `TopLevel` フレームの `global_array_pool_len = self.arrays.len()` 更新を削除する（`global_array_pool_len` フィールド自体は後続 issue で整理）
- `array_prim` / `dim_var_prim` の `vm.arrays.push(ar.clone())` を削除する
- テスト内の `vm.arrays.push(...)` を全件削除する
- `Cell::Array` / `Cell::ArrayAddr` のドキュメントコメントを最新状態に更新する
- `use crate::array_ref::ArrayRef` の不要な import を `vm.rs` から削除する

Closes #734
