### PR TITLE
VM::global_array_pool_len と TbxError::ArrayFrameEscape を削除する

### DIFF
--- a/src/cell.rs
+++ b/src/cell.rs
@@ -97,8 +97,7 @@ pub enum Cell {
     /// `Rc<RefCell<Vec<Cell>>>` storage of length N.
     ///
     /// Array lifetime is managed entirely by `Rc` reference counting.
-    /// `VM::arrays` (the compatibility registry) has been removed (issue #734);
-    /// arrays are freed when no `Cell::Array` or `Cell::ArrayAddr` handle
+    /// Arrays are freed when no `Cell::Array` or `Cell::ArrayAddr` handle
     /// holding a clone of the `Rc` remains alive.
     ///
     /// Array elements may be any scalar type (`Int`, `Float`, `Bool`, `None`,
@@ -128,7 +127,6 @@ pub enum Cell {
     ///
     /// Holds the `ArrayRef` directly (Rc-backed shared handle) so that
     /// `FETCH` / `SET` / `STORE` can access the element without indirection.
-    /// `VM::arrays` has been removed (issue #734).
     ArrayAddr {
         /// Rc-backed handle to the array storage.
         array: ArrayRef,

--- a/src/error.rs
+++ b/src/error.rs
@@ -159,19 +159,6 @@ pub enum TbxError {
         /// Human-readable description of the I/O error.
         reason: String,
     },
-    /// An array value escaped its owning stack frame via a global variable write.
-    ///
-    /// Arrays (created with `ARRAY(N)`) that are created inside a word are bound
-    /// to the stack frame in which they were created.  Attempting to store a
-    /// frame-local `Cell::Array` value into a global variable (via `STORE` or
-    /// `SET` targeting a `DictAddr`) is forbidden, because the array pool is
-    /// truncated on EXIT and the stored index would dangle.
-    ///
-    /// Note: returning a frame-local array via `RETURN` is allowed (ownership
-    /// transfer) — the array slot is moved to the caller's pool boundary instead
-    /// of being truncated.
-    ArrayFrameEscape,
-
     /// A variadic word was called with fewer arguments than its fixed parameter count.
     ///
     /// `name` is the word name, `expected_min` is the number of fixed parameters
@@ -316,9 +303,6 @@ impl std::fmt::Display for TbxError {
             }
             TbxError::OutputIoError { reason } => {
                 write!(f, "ACCEPT: I/O error flushing output: {reason}")
-            }
-            TbxError::ArrayFrameEscape => {
-                write!(f, "array cannot escape its owning stack frame")
             }
             TbxError::WrongNumberOfArguments {
                 name,

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -672,7 +672,7 @@ pub fn var_prim(vm: &mut VM) -> Result<(), TbxError> {
 ///
 /// In execute mode (top level):
 ///   - Creates a global variable entry (`EntryKind::Variable`) backed by a
-///     `Cell::Array` in the array pool.
+///     `Cell::Array`.
 ///   - The size expression is evaluated immediately via a temporary code buffer.
 ///
 /// Collision rules (bare name used as the key in both modes):
@@ -6074,7 +6074,7 @@ mod tests {
 
     #[test]
     fn test_store_to_array_addr() {
-        // Cell::ArrayAddr now holds the ArrayRef directly; VM::arrays is not consulted.
+        // Cell::ArrayAddr holds the ArrayRef directly.
         let mut vm = VM::new();
         let ar = ArrayRef::new(vec![Cell::None, Cell::None]);
         vm.push(Cell::Int(99)).unwrap();
@@ -6089,7 +6089,7 @@ mod tests {
 
     #[test]
     fn test_set_to_array_addr() {
-        // Cell::ArrayAddr now holds the ArrayRef directly; VM::arrays is not consulted.
+        // Cell::ArrayAddr holds the ArrayRef directly.
         let mut vm = VM::new();
         let ar = ArrayRef::new(vec![Cell::None, Cell::None]);
         vm.push(Cell::ArrayAddr {
@@ -6112,7 +6112,7 @@ mod tests {
     #[test]
     fn test_set_str_to_array_element_is_allowed() {
         // Cell::Str(Rc<str>) written through SET must succeed (#591).
-        // Cell::ArrayAddr now holds the ArrayRef directly; VM::arrays is not consulted.
+        // Cell::ArrayAddr holds the ArrayRef directly.
         let mut vm = VM::new();
         let ar = ArrayRef::new(vec![Cell::None]);
         vm.push(Cell::ArrayAddr {
@@ -6128,7 +6128,7 @@ mod tests {
     #[test]
     fn test_store_str_to_array_element_is_allowed() {
         // Same as the SET path above, exercised through STORE (#591).
-        // Cell::ArrayAddr now holds the ArrayRef directly; VM::arrays is not consulted.
+        // Cell::ArrayAddr holds the ArrayRef directly.
         let mut vm = VM::new();
         let ar = ArrayRef::new(vec![Cell::None]);
         vm.push(Cell::string("world")).unwrap();
@@ -6144,10 +6144,8 @@ mod tests {
     #[test]
     fn test_set_str_to_global_array_element_is_allowed() {
         // Storing a Str into a global array element must succeed.
-        // (global_array_pool_len is irrelevant for ArrayAddr resolution now.)
         let mut vm = VM::new();
         let ar = ArrayRef::new(vec![Cell::None]);
-        vm.global_array_pool_len = 1; // retained for pool tracking (VM::arrays removed)
         vm.push(Cell::ArrayAddr {
             array: ar.clone(),
             elem_idx: 0,
@@ -6161,10 +6159,9 @@ mod tests {
     #[test]
     fn test_set_str_to_frame_local_array_element_is_allowed() {
         // Storing a Str into a frame-local array must succeed (#591).
-        // Cell::ArrayAddr now holds the ArrayRef directly; VM::arrays is not consulted.
+        // Cell::ArrayAddr holds the ArrayRef directly.
         let mut vm = VM::new();
         let ar = ArrayRef::new(vec![Cell::None]);
-        // global_array_pool_len = 0 (default) → array is frame-local
         vm.push(Cell::ArrayAddr {
             array: ar.clone(),
             elem_idx: 0,
@@ -6178,7 +6175,7 @@ mod tests {
     #[test]
     fn test_set_nested_array_to_array_element_is_invalid_array_element() {
         // Cell::Array must always be rejected as an array element.
-        // Cell::ArrayAddr now holds the ArrayRef directly; VM::arrays is not consulted.
+        // Cell::ArrayAddr holds the ArrayRef directly.
         let mut vm = VM::new();
         let outer_ar = ArrayRef::new(vec![Cell::None]); // target array
         let inner_ar = ArrayRef::new(vec![Cell::None]); // value to store (nested, forbidden)
@@ -6198,7 +6195,7 @@ mod tests {
 
     #[test]
     fn test_fetch_array_addr() {
-        // Cell::ArrayAddr now holds the ArrayRef directly; VM::arrays is not consulted.
+        // Cell::ArrayAddr holds the ArrayRef directly.
         let mut vm = VM::new();
         let ar = ArrayRef::new(vec![Cell::Int(77)]);
         vm.push(Cell::ArrayAddr {

--- a/src/primitives/memory.rs
+++ b/src/primitives/memory.rs
@@ -19,8 +19,7 @@ fn reject_array_value(value: &Cell) -> Result<(), TbxError> {
 
 /// Write `value` to element `elem_idx` of the array referenced by `ar`.
 ///
-/// `VM::arrays` is NOT consulted; `ar` is the direct `ArrayRef` handle held
-/// inside a `Cell::ArrayAddr`.
+/// `ar` is the direct `ArrayRef` handle held inside a `Cell::ArrayAddr`.
 fn write_array_element(
     ar: &crate::array_ref::ArrayRef,
     elem_idx: usize,
@@ -134,7 +133,7 @@ mod tests {
     /// the value back.  After the roundtrip the stored value must equal what was
     /// pushed before STORE.
     ///
-    /// Cell::ArrayAddr now holds an ArrayRef directly; VM::arrays is not consulted.
+    /// Cell::ArrayAddr holds an ArrayRef directly.
     #[test]
     fn test_array_addr_store_fetch_roundtrip() {
         use crate::array_ref::ArrayRef;
@@ -179,7 +178,7 @@ mod tests {
     /// Verify that STORE rejects a nested Cell::Array written to an array element
     /// (i.e., when the destination address is a Cell::ArrayAddr).
     ///
-    /// Cell::ArrayAddr now holds an ArrayRef directly; VM::arrays is not consulted.
+    /// Cell::ArrayAddr holds an ArrayRef directly.
     #[test]
     fn test_store_array_element_rejects_nested_array() {
         use crate::array_ref::ArrayRef;
@@ -210,7 +209,7 @@ mod tests {
 
     /// Verify that SET rejects a nested Cell::Array written to an array element.
     ///
-    /// Cell::ArrayAddr now holds an ArrayRef directly; VM::arrays is not consulted.
+    /// Cell::ArrayAddr holds an ArrayRef directly.
     #[test]
     fn test_set_array_element_rejects_nested_array() {
         use crate::array_ref::ArrayRef;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -166,13 +166,6 @@ pub struct VM {
     /// Drained by `exec_immediate_word` in the interpreter, which calls
     /// `exec_source` on the file content.
     pub(crate) pending_use_path: Option<String>,
-    /// Length of the "global" (persistent) region of arrays created at the top level.
-    ///
-    /// Retained for compatibility while pool-lifetime tracking is fully removed.
-    /// `VM::arrays` has been deleted (issue #734); this field is kept as a
-    /// placeholder until the array pool lifetime model is fully retired in a
-    /// follow-up issue.
-    pub global_array_pool_len: usize,
     /// Internal buffer holding the last line read by ACCEPT.
     ///
     /// ACCEPT reads one line from `input_reader` and stores it here (trimmed of
@@ -243,7 +236,6 @@ impl VM {
             compile_state: None,
             compile_stack: Vec::new(),
             pending_use_path: None,
-            global_array_pool_len: 0,
             input_buffer: None,
             input_reader: Box::new(BufReader::new(std::io::stdin())),
             output_writer: Box::new(std::io::stdout()),
@@ -2807,7 +2799,7 @@ mod tests {
     }
 
     // ------------------------------------------------------------------
-    // End-to-end integration tests: array pool management
+    // End-to-end integration tests: array lifetime management
     // ------------------------------------------------------------------
 
     /// Run a multi-line TBX source snippet through the full interpreter pipeline.
@@ -2818,13 +2810,13 @@ mod tests {
         Ok(interp.take_output())
     }
 
-    // --- Array pool management ---
+    // --- Array lifetime management ---
 
     #[test]
     fn test_arrays_pool_truncated_on_exit() {
-        // Verify that the array pool is empty after a word with an array returns.
+        // Verify that no array handle leaks after a word with an array returns.
         // run_source creates a fresh Interpreter (and therefore a fresh VM), so we
-        // check the absence of errors rather than the pool length directly.
+        // check the absence of errors rather than any internal length field.
         let result = run_source(
             "DEF HAS_ARRAY()\n  DIM @A[3]\n  RETURN 1\nEND\n\
              PUTDEC HAS_ARRAY()",
@@ -2863,7 +2855,6 @@ mod tests {
     #[test]
     fn test_array_frame_escape_via_store_to_dict_is_error() {
         // Verify that STORE of a Cell::Array into a global variable produces TypeError.
-        // (Previously ArrayFrameEscape; now uniformly TypeError for all array-handle writes.)
         let result = run_source(
             "VAR G\n\
              DEF BAD_STORE()\n  DIM @A[2]\n  SET &G, A\nEND\n\
@@ -2940,8 +2931,6 @@ mod tests {
         // regardless of whether the array is in the global pool region.
         // (Surface-level SET / STORE never allow whole-array handle writes.)
         let mut vm = VM::new();
-        vm.global_array_pool_len = 1; // mark as global (pool tracking only, VM::arrays removed)
-
         let slot = vm.dp;
         vm.dict_write(Cell::None).unwrap();
 
@@ -2961,8 +2950,6 @@ mod tests {
         // set_prim must also reject Cell::Array written to a DictAddr slot.
         let mut vm = VM::new();
         let ar = crate::array_ref::ArrayRef::new(vec![Cell::Int(0); 3]);
-        vm.global_array_pool_len = 1; // pool tracking only (VM::arrays removed)
-
         let slot = vm.dp;
         vm.dict_write(Cell::None).unwrap();
 
@@ -2979,7 +2966,6 @@ mod tests {
     #[test]
     fn test_word_array_store_to_global_var_is_still_error() {
         // Storing a local array handle into a global VAR must fail with TypeError.
-        // (Previously ArrayFrameEscape; now TypeError for all array-handle writes.)
         let result = run_source(
             "VAR gvar\n\
              DEF BAD()\n  DIM @a[3]\n  SET &gvar, a\nEND\n\
@@ -2998,8 +2984,6 @@ mod tests {
     fn test_non_global_array_store_rejected_by_store_prim() {
         // An array handle written to a DictAddr must always be rejected by store_prim.
         let mut vm = VM::new();
-        // global_array_pool_len stays 0 (default), so no arrays are marked global.
-
         let slot = vm.dp;
         vm.dict_write(Cell::None).unwrap();
 
@@ -3051,8 +3035,7 @@ mod tests {
     fn test_array_created_in_word_does_not_leak() {
         // After a word that creates a local array but returns a non-array value,
         // no array handle should remain on the data stack.
-        // VM::arrays has been removed (issue #734); array lifetime is now fully
-        // managed by Rc reference counting rather than a pool registry.
+        // Array lifetime is managed by Rc reference counting.
         let mut interp = crate::interpreter::Interpreter::new();
         interp
             .exec_source(
@@ -3187,8 +3170,8 @@ mod tests {
     // A Cell::Array (whole-array handle) must not appear at the user-visible
     // surface: it cannot be assigned to a variable, returned from a word,
     // compared with EQ/NEQ, used as a word argument, or stored into a dict
-    // slot from inside a called frame.  All such attempts must produce either
-    // a TypeError or an ArrayFrameEscape error at runtime.
+    // slot from inside a called frame.  All such attempts must produce a
+    // TypeError at runtime.
     //
     // Valid uses of arrays: DIM @A[n] (allocation), @A[i] (element read),
     // &@A[i] (element address for SET), LET @A[i] = expr (element write),
@@ -3196,7 +3179,7 @@ mod tests {
 
     #[test]
     fn test_whole_array_assignment_to_global_var_errors() {
-        // `SET &G, A` inside a DEF body must produce ArrayFrameEscape
+        // `SET &G, A` inside a DEF body must produce TypeError
         // (Cell::Array written into a DictAddr from a called frame).
         let result = run_source(
             "VAR G\n\


### PR DESCRIPTION
## 概要

issue #735 の実装残件として残っていた、旧配列プール寿命管理モデルの語彙・フィールドを一掃する。
`VM::arrays` 削除（issue #734）後に互換性のため残存していたプレースホルダーとエラー variant を完全に除去する。

## 変更内容

- `VM::global_array_pool_len` フィールドと `VM::new()` での初期化を削除する
- `TbxError::ArrayFrameEscape` variant および `Display` impl の対応 arm を削除する
- テストコードの `vm.global_array_pool_len = 1;` 直接設定行を削除する
- production code・コメントから旧語彙（`VM::arrays`、`array pool`、`ArrayFrameEscape`、`global_array_pool_len`）を除去する

Closes #735
