### PR TITLE
DIM @A[w, h] のコンマ区切り次元リストのパースを実装する

### DIFF
--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -744,8 +744,8 @@ pub fn dim_prim(vm: &mut VM) -> Result<(), TbxError> {
     };
 
     // Split collected tokens into dimension expressions by top-level commas.
-    // Depth tracks parentheses only (brackets cannot appear here; `[` was already
-    // consumed as the dimension-list opener).
+    // Track both parenthesis and nested bracket depth so only top-level commas
+    // split the DIM dimension list.
     let dim_list: Vec<Vec<crate::lexer::SpannedToken>> = {
         let mut dims: Vec<Vec<crate::lexer::SpannedToken>> = Vec::new();
         let mut current: Vec<crate::lexer::SpannedToken> = Vec::new();

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -750,6 +750,7 @@ pub fn dim_prim(vm: &mut VM) -> Result<(), TbxError> {
         let mut dims: Vec<Vec<crate::lexer::SpannedToken>> = Vec::new();
         let mut current: Vec<crate::lexer::SpannedToken> = Vec::new();
         let mut depth: usize = 0;
+        let mut bracket_depth: usize = 0;
         for tok in size_tokens {
             match &tok.token {
                 Token::LParen => {
@@ -760,7 +761,15 @@ pub fn dim_prim(vm: &mut VM) -> Result<(), TbxError> {
                     depth = depth.saturating_sub(1);
                     current.push(tok);
                 }
-                Token::Comma if depth == 0 => {
+                Token::LBracket => {
+                    bracket_depth += 1;
+                    current.push(tok);
+                }
+                Token::RBracket => {
+                    bracket_depth = bracket_depth.saturating_sub(1);
+                    current.push(tok);
+                }
+                Token::Comma if depth == 0 && bracket_depth == 0 => {
                     dims.push(current);
                     current = Vec::new();
                 }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -743,12 +743,86 @@ pub fn dim_prim(vm: &mut VM) -> Result<(), TbxError> {
         collected
     };
 
-    // Reject empty size expression: `DIM @A[]`.
-    if size_tokens.is_empty() {
+    // Split collected tokens into dimension expressions by top-level commas.
+    // Depth tracks parentheses only (brackets cannot appear here; `[` was already
+    // consumed as the dimension-list opener).
+    let dim_list: Vec<Vec<crate::lexer::SpannedToken>> = {
+        let mut dims: Vec<Vec<crate::lexer::SpannedToken>> = Vec::new();
+        let mut current: Vec<crate::lexer::SpannedToken> = Vec::new();
+        let mut depth: usize = 0;
+        for tok in size_tokens {
+            match &tok.token {
+                Token::LParen => {
+                    depth += 1;
+                    current.push(tok);
+                }
+                Token::RParen => {
+                    depth = depth.saturating_sub(1);
+                    current.push(tok);
+                }
+                Token::Comma if depth == 0 => {
+                    dims.push(current);
+                    current = Vec::new();
+                }
+                _ => {
+                    current.push(tok);
+                }
+            }
+        }
+        dims.push(current);
+        dims
+    };
+
+    // Reject arity 0: `DIM @A[]`.
+    if dim_list.len() == 1 && dim_list[0].is_empty() {
         return Err(TbxError::InvalidExpression {
             reason: "DIM: array size expression must not be empty",
         });
     }
+
+    // Reject arity 3+: `DIM @A[1, 2, 3]`.
+    if dim_list.len() > 2 {
+        return Err(TbxError::InvalidExpression {
+            reason: "DIM: array dimension list must have 1 or 2 elements",
+        });
+    }
+
+    // For a 1D declaration, use the single dimension token list directly.
+    // For a 2D declaration, combine both dimensions: the flat storage size is
+    // width * height.  Element-level 2D access (`@A[x,y]`) is not yet
+    // implemented; this handles only the declaration / allocation step.
+    let size_tokens: Vec<crate::lexer::SpannedToken> = if dim_list.len() == 1 {
+        dim_list.into_iter().next().unwrap()
+    } else {
+        // Build a synthetic token sequence: `dim0 * dim1`.
+        let (d0, d1) = {
+            let mut it = dim_list.into_iter();
+            (it.next().unwrap(), it.next().unwrap())
+        };
+        if d0.is_empty() || d1.is_empty() {
+            return Err(TbxError::InvalidExpression {
+                reason: "DIM: 2D array dimension expression must not be empty",
+            });
+        }
+        // Synthesise a `*` token so the size expression becomes `(d0) * (d1)`.
+        use crate::lexer::{Position, SpannedToken};
+        let dummy_pos = Position { line: 0, col: 0 };
+        let mk = |token: Token| SpannedToken {
+            token,
+            pos: dummy_pos.clone(),
+            source_offset: 0,
+            source_len: 0,
+        };
+        let mut combined: Vec<SpannedToken> = Vec::new();
+        combined.push(mk(Token::LParen));
+        combined.extend(d0);
+        combined.push(mk(Token::RParen));
+        combined.push(mk(Token::Op("*".to_string())));
+        combined.push(mk(Token::LParen));
+        combined.extend(d1);
+        combined.push(mk(Token::RParen));
+        combined
+    };
 
     if vm.is_compiling {
         // --- Compile mode (inside DEF) ---

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -3279,4 +3279,85 @@ mod tests {
         assert!(result.is_ok(), "expected success, got: {result:?}");
         assert_eq!(result.unwrap().trim(), "5");
     }
+
+    // --- 2D DIM parsing (issue #744) ---
+
+    #[test]
+    fn test_dim_2d_integer_literals_succeeds() {
+        // `DIM @A[8, 8]` must parse without error.
+        // The provisional implementation allocates 8 * 8 = 64 elements as a flat
+        // 1D array; element-level 2D access is not yet implemented.
+        let result = run_source(
+            "DEF F()\n\
+               DIM @A[8, 8]\n\
+               RETURN ARRAY_LEN(@A)\n\
+             END\n\
+             PUTDEC F()",
+        );
+        assert!(result.is_ok(), "expected success, got: {result:?}");
+        assert_eq!(result.unwrap().trim(), "64");
+    }
+
+    #[test]
+    fn test_dim_2d_variable_dimensions_succeeds() {
+        // `DIM @A[W, H]` must parse and compile without error when W and H are
+        // in scope as local parameters.
+        let result = run_source(
+            "DEF MAKE(W, H)\n\
+               DIM @A[W, H]\n\
+               RETURN ARRAY_LEN(@A)\n\
+             END\n\
+             PUTDEC MAKE(4, 3)",
+        );
+        assert!(result.is_ok(), "expected success, got: {result:?}");
+        assert_eq!(result.unwrap().trim(), "12");
+    }
+
+    #[test]
+    fn test_dim_2d_expression_dimensions_succeeds() {
+        // `DIM @A[WIDTH + 1, HEIGHT + 1]` must parse and compile without error.
+        let result = run_source(
+            "DEF MAKE(WIDTH, HEIGHT)\n\
+               DIM @A[WIDTH + 1, HEIGHT + 1]\n\
+               RETURN ARRAY_LEN(@A)\n\
+             END\n\
+             PUTDEC MAKE(7, 7)",
+        );
+        assert!(result.is_ok(), "expected success, got: {result:?}");
+        assert_eq!(result.unwrap().trim(), "64");
+    }
+
+    #[test]
+    fn test_dim_1d_still_works_after_2d_change() {
+        // 1D `DIM @A[10]` must continue to work unchanged.
+        let result = run_source(
+            "DEF F()\n\
+               DIM @A[10]\n\
+               RETURN ARRAY_LEN(@A)\n\
+             END\n\
+             PUTDEC F()",
+        );
+        assert!(result.is_ok(), "expected success, got: {result:?}");
+        assert_eq!(result.unwrap().trim(), "10");
+    }
+
+    #[test]
+    fn test_dim_empty_brackets_is_error() {
+        // `DIM @A[]` must produce a compile error, not a crash.
+        let result = run_source("DIM @A[]");
+        assert!(
+            result.is_err(),
+            "expected compile error for DIM @A[], got success"
+        );
+    }
+
+    #[test]
+    fn test_dim_three_dimensions_is_error() {
+        // `DIM @A[1, 2, 3]` (arity 3) must produce a compile error, not a crash.
+        let result = run_source("DIM @A[1, 2, 3]");
+        assert!(
+            result.is_err(),
+            "expected compile error for DIM @A[1, 2, 3], got success"
+        );
+    }
 }


### PR DESCRIPTION
## 概要

`DIM @A[w, h]` のコンマ区切り2次元リストをパーサーが受け付けるよう拡張する。
ランタイムのアロケーションは暫定的に `w * h` 要素の1D配列として実装し、要素アクセス（`@A[x,y]`）は今後の課題とする。

## 変更内容

- `src/primitives.rs` (`dim_prim`): ブラケット内トークンをトップレベルコンマで分割して次元リストを構築
  - 次元数 0（`DIM @A[]`）→ コンパイルエラー（既存動作維持）
  - 次元数 3 以上（`DIM @A[1, 2, 3]`）→ コンパイルエラー（新規）
  - 次元数 2（`DIM @A[w, h]`）→ `(w) * (h)` の合成トークン列を生成し暫定1D配列として確保
  - 次元数 1（`DIM @A[n]`）→ 既存動作を変更しない
- `src/vm.rs`: issue #744 のテストケースを追加
  - `DIM @A[8, 8]` → 成功（64要素の配列）
  - `DIM @A[W, H]` → 成功（ローカル変数による次元指定）
  - `DIM @A[WIDTH + 1, HEIGHT + 1]` → 成功（式による次元指定）
  - `DIM @A[10]` → 引き続き成功（1D動作の確認）
  - `DIM @A[]` → コンパイルエラー
  - `DIM @A[1, 2, 3]` → コンパイルエラー

Closes #744
