### PR TITLE
DIM @A[w, h] の allocation に overflow と過大サイズの検証を追加する

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -10,11 +10,11 @@ pub const MAX_DATA_STACK_DEPTH: usize = 65_536;
 /// Exceeding this limit raises `TbxError::ReturnStackOverflow`.
 pub const MAX_RETURN_STACK_DEPTH: usize = 4_096;
 
-/// Maximum number of elements a single array may hold.
+/// Maximum number of elements a 2D array allocation may hold.
 ///
-/// Applies to both 1D and 2D allocations.  For 2D arrays, `width * height`
-/// must not exceed this value.  The limit guards against accidental allocation
-/// of multi-gigabyte arrays due to programmer error.
+/// For `DIM @A[width, height]`, `width * height` must not exceed this value.
+/// 1D array allocation currently preserves the existing behavior and does not
+/// apply this limit.
 pub const MAX_ARRAY_ELEMENTS: usize = 16_777_216;
 
 /// Base index offset for VAR-declared local variables in variadic words.

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -10,6 +10,13 @@ pub const MAX_DATA_STACK_DEPTH: usize = 65_536;
 /// Exceeding this limit raises `TbxError::ReturnStackOverflow`.
 pub const MAX_RETURN_STACK_DEPTH: usize = 4_096;
 
+/// Maximum number of elements a single array may hold.
+///
+/// Applies to both 1D and 2D allocations.  For 2D arrays, `width * height`
+/// must not exceed this value.  The limit guards against accidental allocation
+/// of multi-gigabyte arrays due to programmer error.
+pub const MAX_ARRAY_ELEMENTS: usize = 16_777_216;
+
 /// Base index offset for VAR-declared local variables in variadic words.
 ///
 /// In variadic words, the number of actual arguments is not known at compile time,

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1,6 +1,6 @@
 use crate::array_ref::ArrayRef;
 use crate::cell::{Cell, CompileEntry};
-use crate::constants::MAX_DICTIONARY_CELLS;
+use crate::constants::{MAX_ARRAY_ELEMENTS, MAX_DICTIONARY_CELLS};
 use crate::dict::{EntryKind, WordEntry, FLAG_HIDDEN, FLAG_IMMEDIATE, FLAG_SYSTEM};
 use crate::error::TbxError;
 use crate::expr::ExprCompiler;
@@ -1019,7 +1019,19 @@ pub fn dim_prim(vm: &mut VM) -> Result<(), TbxError> {
             DimKind::TwoD(d0_tokens, d1_tokens) => {
                 let width = eval_dim_expr(vm, &d0_tokens)?;
                 let height = eval_dim_expr(vm, &d1_tokens)?;
-                ArrayRef::new_2d(vec![Cell::None; width * height], width, height)
+                let total = width
+                    .checked_mul(height)
+                    .ok_or_else(|| TbxError::InvalidArgument {
+                        message: format!("DIM: {width} * {height} overflows"),
+                    })?;
+                if total > MAX_ARRAY_ELEMENTS {
+                    return Err(TbxError::InvalidArgument {
+                        message: format!(
+                            "DIM: total size {total} exceeds maximum {MAX_ARRAY_ELEMENTS}"
+                        ),
+                    });
+                }
+                ArrayRef::new_2d(vec![Cell::None; total], width, height)
             }
         };
 

--- a/src/primitives/arrays.rs
+++ b/src/primitives/arrays.rs
@@ -1,5 +1,6 @@
 use crate::array_ref::ArrayRef;
 use crate::cell::Cell;
+use crate::constants::MAX_ARRAY_ELEMENTS;
 use crate::error::TbxError;
 use crate::vm::VM;
 
@@ -59,7 +60,17 @@ pub(super) fn array_2d_prim(vm: &mut VM) -> Result<(), TbxError> {
     }
     let width = width_val as usize;
     let height = height_val as usize;
-    let ar = ArrayRef::new_2d(vec![Cell::None; width * height], width, height);
+    let total = width
+        .checked_mul(height)
+        .ok_or_else(|| TbxError::InvalidArgument {
+            message: format!("ARRAY_2D: {width} * {height} overflows"),
+        })?;
+    if total > MAX_ARRAY_ELEMENTS {
+        return Err(TbxError::InvalidArgument {
+            message: format!("ARRAY_2D: total size {total} exceeds maximum {MAX_ARRAY_ELEMENTS}"),
+        });
+    }
+    let ar = ArrayRef::new_2d(vec![Cell::None; total], width, height);
     vm.push(Cell::Array(ar))?;
     Ok(())
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -3387,4 +3387,164 @@ mod tests {
         assert!(result.is_ok(), "expected success, got: {result:?}");
         assert_eq!(result.unwrap().trim(), "12");
     }
+
+    // --- 2D array allocation validation (issue #746) ---
+
+    #[test]
+    fn test_dim_2d_3x2_allocates_6_elements() {
+        // `DIM @A[3, 2]` must allocate exactly 6 elements.
+        let result = run_source(
+            "DIM @A[3, 2]\n\
+             PUTDEC ARRAY_LEN(@A)",
+        );
+        assert!(result.is_ok(), "expected success, got: {result:?}");
+        assert_eq!(result.unwrap().trim(), "6");
+    }
+
+    #[test]
+    fn test_dim_2d_1x1_allocates_1_element() {
+        // `DIM @A[1, 1]` must allocate exactly 1 element.
+        let result = run_source(
+            "DIM @A[1, 1]\n\
+             PUTDEC ARRAY_LEN(@A)",
+        );
+        assert!(result.is_ok(), "expected success, got: {result:?}");
+        assert_eq!(result.unwrap().trim(), "1");
+    }
+
+    #[test]
+    fn test_dim_2d_zero_width_is_error() {
+        // width = 0 must be rejected.
+        let result = run_source("DIM @A[0, 5]");
+        assert!(
+            result.is_err(),
+            "expected error for DIM @A[0, 5], got success"
+        );
+    }
+
+    #[test]
+    fn test_dim_2d_zero_height_is_error() {
+        // height = 0 must be rejected.
+        let result = run_source("DIM @A[5, 0]");
+        assert!(
+            result.is_err(),
+            "expected error for DIM @A[5, 0], got success"
+        );
+    }
+
+    #[test]
+    fn test_dim_2d_negative_width_is_error() {
+        // Negative width must be rejected.
+        let result = run_source("DIM @A[0 - 1, 5]");
+        assert!(
+            result.is_err(),
+            "expected error for negative width, got success"
+        );
+    }
+
+    #[test]
+    fn test_dim_2d_negative_height_is_error() {
+        // Negative height must be rejected.
+        let result = run_source("DIM @A[5, 0 - 1]");
+        assert!(
+            result.is_err(),
+            "expected error for negative height, got success"
+        );
+    }
+
+    #[test]
+    fn test_dim_2d_overflow_is_error() {
+        // width * height that overflows usize must be rejected.
+        // 100_000_000_000_000 * 100_000_000_000_000 = 10^28 > usize::MAX.
+        let result = run_source("DIM @A[100000000000000, 100000000000000]");
+        assert!(
+            result.is_err(),
+            "expected error for overflowing 2D size, got success"
+        );
+    }
+
+    #[test]
+    fn test_dim_2d_over_large_is_error() {
+        // width * height that exceeds MAX_ARRAY_ELEMENTS must be rejected.
+        // 5000 * 5000 = 25_000_000 > MAX_ARRAY_ELEMENTS (16_777_216).
+        let result = run_source("DIM @A[5000, 5000]");
+        assert!(
+            result.is_err(),
+            "expected error for over-large 2D size, got success"
+        );
+    }
+
+    #[test]
+    fn test_dim_2d_compile_mode_3x2_allocates_6_elements() {
+        // Inside a DEF, `DIM @A[3, 2]` must allocate 3 * 2 = 6 elements.
+        let result = run_source(
+            "DEF F()\n\
+               DIM @A[3, 2]\n\
+               RETURN ARRAY_LEN(@A)\n\
+             END\n\
+             PUTDEC F()",
+        );
+        assert!(result.is_ok(), "expected success, got: {result:?}");
+        assert_eq!(result.unwrap().trim(), "6");
+    }
+
+    #[test]
+    fn test_dim_2d_compile_mode_1x1_allocates_1_element() {
+        // Inside a DEF, `DIM @A[1, 1]` must allocate exactly 1 element.
+        let result = run_source(
+            "DEF F()\n\
+               DIM @A[1, 1]\n\
+               RETURN ARRAY_LEN(@A)\n\
+             END\n\
+             PUTDEC F()",
+        );
+        assert!(result.is_ok(), "expected success, got: {result:?}");
+        assert_eq!(result.unwrap().trim(), "1");
+    }
+
+    #[test]
+    fn test_dim_2d_compile_mode_zero_width_is_error() {
+        // In compile mode, width = 0 must be rejected at runtime.
+        let result = run_source(
+            "DEF MAKE(W, H)\n\
+               DIM @A[W, H]\n\
+               RETURN ARRAY_LEN(@A)\n\
+             END\n\
+             PUTDEC MAKE(0, 5)",
+        );
+        assert!(
+            result.is_err(),
+            "expected error for zero width in compile mode, got success"
+        );
+    }
+
+    #[test]
+    fn test_dim_2d_compile_mode_overflow_is_error() {
+        // In compile mode, overflow of width * height must be rejected at runtime.
+        let result = run_source(
+            "DEF MAKE(W, H)\n\
+               DIM @A[W, H]\n\
+               RETURN ARRAY_LEN(@A)\n\
+             END\n\
+             PUTDEC MAKE(100000000000000, 100000000000000)",
+        );
+        assert!(
+            result.is_err(),
+            "expected error for overflowing 2D size in compile mode, got success"
+        );
+    }
+
+    #[test]
+    fn test_dim_1d_unaffected_by_2d_limits() {
+        // 1D `DIM @A[n]` must continue to work; its validation is independent of 2D limits.
+        let result = run_source(
+            "DEF F()\n\
+               DIM @A[10]\n\
+               RETURN ARRAY_LEN(@A)\n\
+             END\n\
+             PUTDEC F()",
+        );
+        assert!(result.is_ok(), "expected success, got: {result:?}");
+        assert_eq!(result.unwrap().trim(), "10");
+    }
 }


### PR DESCRIPTION
## 概要

#744/#745 で `DIM @A[w, h]` のパースと `ArrayShape::TwoD` メタデータは実装済み。
本 PR では runtime allocation の検証ロジックを追加し、issue #746 の受け入れ条件をすべて満たす。

## 変更内容

- `src/constants.rs`: `MAX_ARRAY_ELEMENTS = 16_777_216` を追加する
- `src/primitives/arrays.rs` (`array_2d_prim`): `checked_mul` による overflow 検証と `MAX_ARRAY_ELEMENTS` による上限検証を追加する（コンパイルモードパス）
- `src/primitives.rs` (execute mode `DimKind::TwoD`): 同じ検証を追加する（実行モードパス）
- `src/vm.rs`: 受け入れ条件を網羅する13件のテストを追加する

### 受け入れ条件の対応

| 受け入れ条件 | テスト |
|---|---|
| `DIM @A[3, 2]` が6要素を確保する | `test_dim_2d_3x2_allocates_6_elements` (execute/compile mode) |
| `DIM @A[1, 1]` が1要素を確保する | `test_dim_2d_1x1_allocates_1_element` (execute/compile mode) |
| width / height が 0 の場合に拒否される | `test_dim_2d_zero_width_is_error`, `test_dim_2d_zero_height_is_error` |
| width / height が負の場合に拒否される | `test_dim_2d_negative_width_is_error`, `test_dim_2d_negative_height_is_error` |
| overflow が拒否される | `test_dim_2d_overflow_is_error`, `test_dim_2d_compile_mode_overflow_is_error` |
| 過大な total size が拒否される | `test_dim_2d_over_large_is_error` (5000×5000=25M > 16M) |
| 1D `DIM @A[n]` の挙動が変わらない | `test_dim_1d_unaffected_by_2d_limits` |
| 内部ストレージは linear のまま | `ArrayRef::new_2d` を使用、変更なし |

### 設計上の判断

- `ARRAY_LEN(@A)` は `width * height`（総要素数）を返す。既存の `array_len_prim` が `ar.len()` を返すため、追加変更なし。
- `MAX_ARRAY_ELEMENTS` は 2D のみに適用し、1D の既存挙動を変えない。

Closes #746
