### PR TITLE
2D 配列バインディングに対する @A[x, y] の read access を実装する

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -696,13 +696,37 @@ impl<'a> ExprCompiler<'a> {
                                 }
                             }
 
-                            // Emit: compile the index expression.
-                            let index_cells = self.compile_expr(index_toks)?;
-                            output.extend(index_cells);
-
-                            // Emit: ARRAY_GET (hidden system helper) — pops (Array, index) and pushes element.
-                            let array_get_xt = require_hidden_system_xt(self.vm, "ARRAY_GET")?;
-                            output.push(Cell::Xt(array_get_xt));
+                            // Dispatch on 1D vs 2D based on whether the bracket content
+                            // contains a top-level comma.
+                            if let Some((x_toks, y_toks)) = split_at_top_level_comma(index_toks) {
+                                // 2D access: @A[x, y]
+                                // Compile x and y expressions separately.
+                                if x_toks.is_empty() {
+                                    return Err(TbxError::InvalidExpression {
+                                        reason: "missing x expression in @A[x, y]",
+                                    });
+                                }
+                                if y_toks.is_empty() {
+                                    return Err(TbxError::InvalidExpression {
+                                        reason: "missing y expression in @A[x, y]",
+                                    });
+                                }
+                                let x_cells = self.compile_expr(x_toks)?;
+                                output.extend(x_cells);
+                                let y_cells = self.compile_expr(y_toks)?;
+                                output.extend(y_cells);
+                                // Emit: ARRAY_GET_2D (hidden system helper).
+                                let array_get_2d_xt =
+                                    require_hidden_system_xt(self.vm, "ARRAY_GET_2D")?;
+                                output.push(Cell::Xt(array_get_2d_xt));
+                            } else {
+                                // 1D access: @A[i]
+                                let index_cells = self.compile_expr(index_toks)?;
+                                output.extend(index_cells);
+                                // Emit: ARRAY_GET (hidden system helper).
+                                let array_get_xt = require_hidden_system_xt(self.vm, "ARRAY_GET")?;
+                                output.push(Cell::Xt(array_get_xt));
+                            }
 
                             // Advance past `@`, Ident, `[`, <index_toks>, `]`.
                             i = close_pos;
@@ -811,6 +835,29 @@ fn parse_at_index_tokens(
         });
     }
     Ok((index_toks, close_pos))
+}
+
+/// Split a bracket-content token slice at the first top-level comma.
+///
+/// Returns `Some((x_toks, y_toks))` if a top-level comma is found; `None`
+/// for a 1D index expression with no top-level comma.
+///
+/// "Top-level" means the comma is not nested inside `(...)` or `[...]`.
+fn split_at_top_level_comma(toks: &[SpannedToken]) -> Option<(&[SpannedToken], &[SpannedToken])> {
+    let mut depth = 0usize;
+    for (i, st) in toks.iter().enumerate() {
+        match &st.token {
+            Token::LParen | Token::LBracket => depth += 1,
+            Token::RParen | Token::RBracket => {
+                depth = depth.saturating_sub(1);
+            }
+            Token::Comma if depth == 0 => {
+                return Some((&toks[..i], &toks[i + 1..]));
+            }
+            _ => {}
+        }
+    }
+    None
 }
 
 /// Emit `Xt(LIT)` followed by `value` onto `output`.
@@ -2004,6 +2051,153 @@ mod tests {
         assert!(
             matches!(err, TbxError::InvalidExpression { .. }),
             "expected InvalidExpression for bare @, got: {err:?}"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Token::At 2D — @A[x, y] element read for 2D arrays (issue #747)
+    // ------------------------------------------------------------------
+
+    /// `@A[1, 2]` against a global variable A must compile to:
+    /// LIT DictAddr(0) FETCH LIT 1 LIT 2 ARRAY_GET_2D.
+    #[test]
+    fn test_at_global_2d_array_element_read() {
+        let mut vm = make_vm();
+        vm.dict_write(Cell::Int(0)).unwrap();
+        vm.register(crate::dict::WordEntry::new_variable("A", 0));
+
+        let tokens = lex("@A[1, 2]");
+        let result = ExprCompiler::new(&mut vm).compile_expr(&tokens).unwrap();
+
+        let lit_xt = vm.lookup("LIT").unwrap();
+        let fetch_xt = vm.lookup("FETCH").unwrap();
+        let array_get_2d_xt = vm.lookup_hidden_system("ARRAY_GET_2D").unwrap();
+
+        assert_eq!(
+            result,
+            vec![
+                Cell::Xt(lit_xt),
+                Cell::DictAddr(0),
+                Cell::Xt(fetch_xt),
+                Cell::Xt(lit_xt),
+                Cell::Int(1),
+                Cell::Xt(lit_xt),
+                Cell::Int(2),
+                Cell::Xt(array_get_2d_xt),
+            ]
+        );
+    }
+
+    /// `@A[x, y]` against a local variable A at slot 0 must compile to:
+    /// LIT StackAddr(0) FETCH <x> <y> ARRAY_GET_2D.
+    #[test]
+    fn test_at_local_2d_array_element_read() {
+        let mut vm = make_vm();
+
+        let mut local_table = HashMap::new();
+        local_table.insert("A".to_string(), 0usize);
+
+        let tokens = lex("@A[3, 1]");
+        let result = ExprCompiler::with_context(&mut vm, Some(&local_table), None, None)
+            .compile_expr(&tokens)
+            .unwrap();
+
+        let lit_xt = vm.lookup("LIT").unwrap();
+        let fetch_xt = vm.lookup("FETCH").unwrap();
+        let array_get_2d_xt = vm.lookup_hidden_system("ARRAY_GET_2D").unwrap();
+
+        assert_eq!(
+            result,
+            vec![
+                Cell::Xt(lit_xt),
+                Cell::StackAddr(0),
+                Cell::Xt(fetch_xt),
+                Cell::Xt(lit_xt),
+                Cell::Int(3),
+                Cell::Xt(lit_xt),
+                Cell::Int(1),
+                Cell::Xt(array_get_2d_xt),
+            ]
+        );
+    }
+
+    /// `@A[x, y]` must emit ARRAY_GET_2D, not ARRAY_GET.
+    #[test]
+    fn test_at_2d_emits_array_get_2d_not_array_get() {
+        let mut vm = make_vm();
+        vm.dict_write(Cell::Int(0)).unwrap();
+        vm.register(crate::dict::WordEntry::new_variable("A", 0));
+
+        let array_get_xt = vm.lookup_hidden_system("ARRAY_GET").unwrap();
+        let array_get_2d_xt = vm.lookup_hidden_system("ARRAY_GET_2D").unwrap();
+
+        let tokens = lex("@A[2, 1]");
+        let result = ExprCompiler::new(&mut vm).compile_expr(&tokens).unwrap();
+
+        assert!(
+            result.contains(&Cell::Xt(array_get_2d_xt)),
+            "@A[x, y] must emit ARRAY_GET_2D"
+        );
+        assert!(
+            !result.contains(&Cell::Xt(array_get_xt)),
+            "@A[x, y] must not emit 1D ARRAY_GET"
+        );
+    }
+
+    /// `@A[i]` (1D syntax) must still emit ARRAY_GET, not ARRAY_GET_2D.
+    #[test]
+    fn test_at_1d_still_emits_array_get() {
+        let mut vm = make_vm();
+        vm.dict_write(Cell::Int(0)).unwrap();
+        vm.register(crate::dict::WordEntry::new_variable("A", 0));
+
+        let array_get_xt = vm.lookup_hidden_system("ARRAY_GET").unwrap();
+        let array_get_2d_xt = vm.lookup_hidden_system("ARRAY_GET_2D").unwrap();
+
+        let tokens = lex("@A[2]");
+        let result = ExprCompiler::new(&mut vm).compile_expr(&tokens).unwrap();
+
+        assert!(
+            result.contains(&Cell::Xt(array_get_xt)),
+            "@A[i] must emit ARRAY_GET"
+        );
+        assert!(
+            !result.contains(&Cell::Xt(array_get_2d_xt)),
+            "@A[i] must not emit ARRAY_GET_2D"
+        );
+    }
+
+    /// `@A[, 1]` (missing x) must produce a syntax error.
+    #[test]
+    fn test_at_2d_missing_x_is_error() {
+        let mut vm = make_vm();
+        vm.dict_write(Cell::Int(0)).unwrap();
+        vm.register(crate::dict::WordEntry::new_variable("A", 0));
+
+        let tokens = lex("@A[, 1]");
+        let err = ExprCompiler::new(&mut vm)
+            .compile_expr(&tokens)
+            .unwrap_err();
+        assert!(
+            matches!(err, TbxError::InvalidExpression { .. }),
+            "expected InvalidExpression for @A[, 1], got: {err:?}"
+        );
+    }
+
+    /// `@A[1,]` (missing y) must produce a syntax error.
+    #[test]
+    fn test_at_2d_missing_y_is_error() {
+        let mut vm = make_vm();
+        vm.dict_write(Cell::Int(0)).unwrap();
+        vm.register(crate::dict::WordEntry::new_variable("A", 0));
+
+        let tokens = lex("@A[1,]");
+        let err = ExprCompiler::new(&mut vm)
+            .compile_expr(&tokens)
+            .unwrap_err();
+        assert!(
+            matches!(err, TbxError::InvalidExpression { .. }),
+            "expected InvalidExpression for @A[1,], got: {err:?}"
         );
     }
 

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -698,7 +698,7 @@ impl<'a> ExprCompiler<'a> {
 
                             // Dispatch on 1D vs 2D based on whether the bracket content
                             // contains a top-level comma.
-                            if let Some((x_toks, y_toks)) = split_at_top_level_comma(index_toks) {
+                            if let Some((x_toks, y_toks)) = split_at_top_level_comma(index_toks)? {
                                 // 2D access: @A[x, y]
                                 // Compile x and y expressions separately.
                                 if x_toks.is_empty() {
@@ -837,14 +837,18 @@ fn parse_at_index_tokens(
     Ok((index_toks, close_pos))
 }
 
-/// Split a bracket-content token slice at the first top-level comma.
+/// Split a bracket-content token slice at top-level commas for `@A[x, y]`.
 ///
-/// Returns `Some((x_toks, y_toks))` if a top-level comma is found; `None`
-/// for a 1D index expression with no top-level comma.
+/// - Returns `None` if there are no top-level commas (1D access: `@A[i]`).
+/// - Returns `Some((x_toks, y_toks))` if there is exactly one top-level comma (2D access).
+/// - Returns `Err(InvalidExpression)` if there are two or more top-level commas (arity ≥ 3).
 ///
 /// "Top-level" means the comma is not nested inside `(...)` or `[...]`.
-fn split_at_top_level_comma(toks: &[SpannedToken]) -> Option<(&[SpannedToken], &[SpannedToken])> {
+fn split_at_top_level_comma(
+    toks: &[SpannedToken],
+) -> Result<Option<(&[SpannedToken], &[SpannedToken])>, TbxError> {
     let mut depth = 0usize;
+    let mut first_comma: Option<usize> = None;
     for (i, st) in toks.iter().enumerate() {
         match &st.token {
             Token::LParen | Token::LBracket => depth += 1,
@@ -852,12 +856,17 @@ fn split_at_top_level_comma(toks: &[SpannedToken]) -> Option<(&[SpannedToken], &
                 depth = depth.saturating_sub(1);
             }
             Token::Comma if depth == 0 => {
-                return Some((&toks[..i], &toks[i + 1..]));
+                if first_comma.is_some() {
+                    return Err(TbxError::InvalidExpression {
+                        reason: "@A[...] accepts at most 2 indices: use @A[i] or @A[x, y]",
+                    });
+                }
+                first_comma = Some(i);
             }
             _ => {}
         }
     }
-    None
+    Ok(first_comma.map(|i| (&toks[..i], &toks[i + 1..])))
 }
 
 /// Emit `Xt(LIT)` followed by `value` onto `output`.
@@ -2198,6 +2207,27 @@ mod tests {
         assert!(
             matches!(err, TbxError::InvalidExpression { .. }),
             "expected InvalidExpression for @A[1,], got: {err:?}"
+        );
+    }
+
+    /// `@A[1, 2, 3]` (arity 3) must be rejected at compile time.
+    #[test]
+    fn test_at_arity_3_is_error() {
+        let mut vm = make_vm();
+        vm.dict_write(Cell::Int(0)).unwrap();
+        vm.register(crate::dict::WordEntry::new_variable("A", 0));
+
+        let tokens = lex("@A[1, 2, 3]");
+        let err = ExprCompiler::new(&mut vm)
+            .compile_expr(&tokens)
+            .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                TbxError::InvalidExpression { reason }
+                    if reason.contains("at most 2 indices")
+            ),
+            "expected InvalidExpression for @A[1, 2, 3], got: {err:?}"
         );
     }
 

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -2378,6 +2378,14 @@ pub fn register_all(vm: &mut VM) {
     let mut array_get_entry = WordEntry::new_primitive("ARRAY_GET", array_get_prim);
     array_get_entry.flags = FLAG_SYSTEM | FLAG_HIDDEN;
     vm.register(array_get_entry);
+    // ARRAY_GET_2D reads an element from a 2D array (`@A[x, y]` compiles to
+    // `<array handle read> <x expr> <y expr> ARRAY_GET_2D`).
+    // It validates that the array was declared with DIM @A[w, h] and computes
+    // the flat index as (y-1)*width + (x-1).
+    let mut array_get_2d_entry =
+        WordEntry::new_primitive("ARRAY_GET_2D", arrays::array_get_2d_prim);
+    array_get_2d_entry.flags = FLAG_SYSTEM | FLAG_HIDDEN;
+    vm.register(array_get_2d_entry);
     let mut array_addr_entry = WordEntry::new_primitive("ARRAY_ADDR", array_addr_prim);
     array_addr_entry.flags = FLAG_SYSTEM | FLAG_HIDDEN;
     vm.register(array_addr_entry);
@@ -6532,6 +6540,120 @@ mod tests {
                 ..
             })
         ));
+    }
+
+    // --- 2D array element read: DIM @A[w, h] + @A[x, y] integration ---
+
+    fn run_src_2d(src: &str) -> Result<String, crate::error::TbxError> {
+        let mut interp = crate::interpreter::Interpreter::new();
+        interp.exec_source(src).map_err(|e| e.kind)?;
+        Ok(interp.take_output())
+    }
+
+    #[test]
+    fn test_2d_array_read_top_left() {
+        // @A[1, 1] reads flat index 0.
+        let src = concat!(
+            "DEF TEST()\n",
+            "  DIM @A[3, 2]\n",
+            "  LET @A[1] = 10\n",
+            "  PUTDEC @A[1, 1]\n",
+            "END\n",
+            "TEST",
+        );
+        assert_eq!(run_src_2d(src).unwrap(), "10");
+    }
+
+    #[test]
+    fn test_2d_array_read_index_formula() {
+        // @A[x, y] maps to flat index (y-1)*width + (x-1).
+        // 3x2 array, elements 1..6 in row-major order via 1D LET.
+        let src = concat!(
+            "DEF TEST()\n",
+            "  DIM @A[3, 2]\n",
+            "  LET @A[1] = 1\n",
+            "  LET @A[2] = 2\n",
+            "  LET @A[3] = 3\n",
+            "  LET @A[4] = 4\n",
+            "  LET @A[5] = 5\n",
+            "  LET @A[6] = 6\n",
+            "  PUTDEC @A[1, 1]\n", // flat 0 → 1
+            "  PUTDEC @A[3, 1]\n", // flat 2 → 3
+            "  PUTDEC @A[1, 2]\n", // flat 3 → 4
+            "  PUTDEC @A[3, 2]\n", // flat 5 → 6
+            "END\n",
+            "TEST",
+        );
+        assert_eq!(run_src_2d(src).unwrap(), "1346");
+    }
+
+    #[test]
+    fn test_2d_array_read_out_of_bounds_x() {
+        let src = concat!(
+            "DEF TEST()\n",
+            "  DIM @A[3, 2]\n",
+            "  PUTDEC @A[4, 1]\n",
+            "END\n",
+            "TEST",
+        );
+        let err = run_src_2d(src).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                crate::error::TbxError::ArrayIndexOutOfBounds { index: 4, .. }
+            ),
+            "expected out-of-bounds for x=4, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_2d_array_read_out_of_bounds_y() {
+        let src = concat!(
+            "DEF TEST()\n",
+            "  DIM @A[3, 2]\n",
+            "  PUTDEC @A[1, 3]\n",
+            "END\n",
+            "TEST",
+        );
+        let err = run_src_2d(src).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                crate::error::TbxError::ArrayIndexOutOfBounds { index: 3, .. }
+            ),
+            "expected out-of-bounds for y=3, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_2d_array_read_on_1d_array_is_type_error() {
+        // @A[x, y] on a 1D array must produce a TypeError at runtime.
+        let src = concat!(
+            "DEF TEST()\n",
+            "  DIM @A[6]\n",
+            "  PUTDEC @A[1, 1]\n",
+            "END\n",
+            "TEST",
+        );
+        let err = run_src_2d(src).unwrap_err();
+        assert!(
+            matches!(err, crate::error::TbxError::TypeError { .. }),
+            "expected TypeError for 2D access on 1D array, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_1d_array_read_still_works_after_2d_changes() {
+        // Regression: existing @A[i] 1D syntax must still work.
+        let src = concat!(
+            "DEF TEST()\n",
+            "  DIM @A[4]\n",
+            "  LET @A[2] = 99\n",
+            "  PUTDEC @A[2]\n",
+            "END\n",
+            "TEST",
+        );
+        assert_eq!(run_src_2d(src).unwrap(), "99");
     }
 
     // --- rnd_prim ---

--- a/src/primitives/arrays.rs
+++ b/src/primitives/arrays.rs
@@ -1,4 +1,4 @@
-use crate::array_ref::ArrayRef;
+use crate::array_ref::{ArrayRef, ArrayShape};
 use crate::cell::Cell;
 use crate::constants::MAX_ARRAY_ELEMENTS;
 use crate::error::TbxError;
@@ -114,6 +114,62 @@ pub(super) fn array_store_local_prim(vm: &mut VM) -> Result<(), TbxError> {
     };
 
     vm.local_write(local_idx, Cell::Array(ar))?;
+    Ok(())
+}
+
+/// ARRAY_GET_2D — read an element from a 2D array using (x, y) coordinates.
+///
+/// Stack: `[..., Cell::Array(ar), Cell::Int(x), Cell::Int(y)]` → `value`
+///
+/// This is the VM-level primitive that `@A[x, y]` compiles to.  The expression
+/// compiler lowers `@A[x, y]` to:
+///   `<array handle read>  <x expr>  <y expr>  ARRAY_GET_2D`.
+///
+/// Coordinates are 1-based: x is the column (1 = leftmost), y is the row (1 = top).
+/// The flat index is computed as `(y - 1) * width + (x - 1)` (0-based).
+///
+/// The array must have `ArrayShape::TwoD` shape; a 1D array is rejected.
+pub(super) fn array_get_2d_prim(vm: &mut VM) -> Result<(), TbxError> {
+    let y_raw = vm.pop_int()?;
+    let x_raw = vm.pop_int()?;
+    let ar = match vm.pop()? {
+        Cell::Array(ar) => ar,
+        other => {
+            return Err(TbxError::TypeError {
+                expected: "Array",
+                got: other.type_name(),
+            })
+        }
+    };
+    let (width, height) = match ar.shape() {
+        ArrayShape::TwoD { width, height } => (*width, *height),
+        ArrayShape::OneD => {
+            return Err(TbxError::TypeError {
+                expected: "2D Array (declared with DIM @A[w, h])",
+                got: "1D Array",
+            })
+        }
+    };
+    if x_raw < 1 || x_raw > width as i64 {
+        return Err(TbxError::ArrayIndexOutOfBounds {
+            index: x_raw,
+            size: width,
+        });
+    }
+    if y_raw < 1 || y_raw > height as i64 {
+        return Err(TbxError::ArrayIndexOutOfBounds {
+            index: y_raw,
+            size: height,
+        });
+    }
+    let flat_idx = (y_raw as usize - 1) * width + (x_raw as usize - 1);
+    let value = ar
+        .get_cloned(flat_idx)
+        .ok_or(TbxError::ArrayIndexOutOfBounds {
+            index: flat_idx as i64 + 1,
+            size: ar.len(),
+        })?;
+    vm.push(value)?;
     Ok(())
 }
 
@@ -449,6 +505,137 @@ mod tests {
             tuple_get_prim(&mut vm),
             Err(TbxError::TypeError {
                 expected: "Tuple",
+                ..
+            })
+        ));
+    }
+
+    // --- array_get_2d_prim ---
+
+    fn make_3x2_array() -> ArrayRef {
+        // 3 columns × 2 rows; elements 1..=6 in row-major order.
+        // [1,2,3] row 0 (y=1)
+        // [4,5,6] row 1 (y=2)
+        ArrayRef::new_2d(
+            vec![
+                Cell::Int(1),
+                Cell::Int(2),
+                Cell::Int(3),
+                Cell::Int(4),
+                Cell::Int(5),
+                Cell::Int(6),
+            ],
+            3,
+            2,
+        )
+    }
+
+    #[test]
+    fn test_array_get_2d_top_left() {
+        // @A[1, 1] → flat index 0 → value 1.
+        let mut vm = VM::new();
+        vm.push(Cell::Array(make_3x2_array())).unwrap();
+        vm.push(Cell::Int(1)).unwrap(); // x
+        vm.push(Cell::Int(1)).unwrap(); // y
+        array_get_2d_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Int(1)));
+    }
+
+    #[test]
+    fn test_array_get_2d_top_right() {
+        // @A[3, 1] → flat index 2 → value 3.
+        let mut vm = VM::new();
+        vm.push(Cell::Array(make_3x2_array())).unwrap();
+        vm.push(Cell::Int(3)).unwrap(); // x
+        vm.push(Cell::Int(1)).unwrap(); // y
+        array_get_2d_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Int(3)));
+    }
+
+    #[test]
+    fn test_array_get_2d_second_row_first_col() {
+        // @A[1, 2] → flat index 3 → value 4.
+        let mut vm = VM::new();
+        vm.push(Cell::Array(make_3x2_array())).unwrap();
+        vm.push(Cell::Int(1)).unwrap(); // x
+        vm.push(Cell::Int(2)).unwrap(); // y
+        array_get_2d_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Int(4)));
+    }
+
+    #[test]
+    fn test_array_get_2d_bottom_right() {
+        // @A[3, 2] → flat index 5 → value 6.
+        let mut vm = VM::new();
+        vm.push(Cell::Array(make_3x2_array())).unwrap();
+        vm.push(Cell::Int(3)).unwrap(); // x
+        vm.push(Cell::Int(2)).unwrap(); // y
+        array_get_2d_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Int(6)));
+    }
+
+    #[test]
+    fn test_array_get_2d_x_out_of_bounds() {
+        let mut vm = VM::new();
+        vm.push(Cell::Array(make_3x2_array())).unwrap();
+        vm.push(Cell::Int(4)).unwrap(); // x > width
+        vm.push(Cell::Int(1)).unwrap();
+        assert!(matches!(
+            array_get_2d_prim(&mut vm),
+            Err(TbxError::ArrayIndexOutOfBounds { index: 4, .. })
+        ));
+    }
+
+    #[test]
+    fn test_array_get_2d_y_out_of_bounds() {
+        let mut vm = VM::new();
+        vm.push(Cell::Array(make_3x2_array())).unwrap();
+        vm.push(Cell::Int(1)).unwrap();
+        vm.push(Cell::Int(3)).unwrap(); // y > height
+        assert!(matches!(
+            array_get_2d_prim(&mut vm),
+            Err(TbxError::ArrayIndexOutOfBounds { index: 3, .. })
+        ));
+    }
+
+    #[test]
+    fn test_array_get_2d_x_zero_is_out_of_bounds() {
+        let mut vm = VM::new();
+        vm.push(Cell::Array(make_3x2_array())).unwrap();
+        vm.push(Cell::Int(0)).unwrap(); // x = 0 invalid (1-based)
+        vm.push(Cell::Int(1)).unwrap();
+        assert!(matches!(
+            array_get_2d_prim(&mut vm),
+            Err(TbxError::ArrayIndexOutOfBounds { index: 0, .. })
+        ));
+    }
+
+    #[test]
+    fn test_array_get_2d_on_1d_array_returns_type_error() {
+        let mut vm = VM::new();
+        let ar = ArrayRef::new(vec![Cell::Int(1), Cell::Int(2), Cell::Int(3)]);
+        vm.push(Cell::Array(ar)).unwrap();
+        vm.push(Cell::Int(1)).unwrap();
+        vm.push(Cell::Int(1)).unwrap();
+        assert!(matches!(
+            array_get_2d_prim(&mut vm),
+            Err(TbxError::TypeError {
+                expected: "2D Array (declared with DIM @A[w, h])",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn test_array_get_2d_non_array_returns_type_error() {
+        let mut vm = VM::new();
+        vm.push(Cell::Int(42)).unwrap(); // not an array
+        vm.push(Cell::Int(1)).unwrap();
+        vm.push(Cell::Int(1)).unwrap();
+        assert!(matches!(
+            array_get_2d_prim(&mut vm),
+            Err(TbxError::TypeError {
+                expected: "Array",
                 ..
             })
         ));


### PR DESCRIPTION
## 概要

#742 / #747 の一部。`DIM @A[w, h]` で確保した 2D 配列バインディングに対して `@A[x, y]` による要素読み取りを実装する。座標は 1-origin で、flat index 計算 `(y-1)*width + (x-1)` は処理系 built-in として行う。

## 変更内容

- **`src/primitives/arrays.rs`**: `ARRAY_GET_2D` プリミティブを追加。スタック `(Array, x, y)` → 要素値。`ArrayShape::TwoD` のみ受け付け、1D 配列を `TypeError` で拒否する。x/y の境界チェック（1-origin）も行う。
- **`src/primitives.rs`**: `ARRAY_GET_2D` を `FLAG_SYSTEM | FLAG_HIDDEN` の隠しシステムエントリとして登録する。エンドツーエンド統合テスト（index formula 検証、境界外、1D 配列への 2D アクセス、1D リグレッション）を追加する。
- **`src/expr.rs`**: `Token::At` ハンドラで括弧内にトップレベルコンマがあれば 2D パスに分岐。`split_at_top_level_comma` ヘルパーを追加。x/y を個別にコンパイルして `ARRAY_GET_2D` を emit する。`@A[i]` の 1D パスは従来通り `ARRAY_GET` を emit する。コンパイラユニットテストを追加する。

## 非目標（defer）

- `@A[i]`（1D 構文）で 2D 配列にアクセスする場合の arity mismatch 検出は defer。現状は `ARRAY_GET` が flat linear アクセスとして動作する。follow-up issue で tighten する予定。
- `&@A[x, y]`、`LET @A[x, y] = expr`、shape query、nested array は本 issue のスコープ外。

Closes #747
