### PR TITLE
2D 配列バインディングに対する &@A[x, y] の address access を実装する

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -436,14 +436,40 @@ impl<'a> ExprCompiler<'a> {
                                             }
                                         }
 
-                                        // Compile the index expression.
-                                        let index_cells = self.compile_expr(index_toks)?;
-                                        output.extend(index_cells);
-
-                                        // Emit ARRAY_ADDR (hidden system helper).
-                                        let array_addr_xt =
-                                            require_hidden_system_xt(self.vm, "ARRAY_ADDR")?;
-                                        output.push(Cell::Xt(array_addr_xt));
+                                        // Dispatch on 1D vs 2D based on whether
+                                        // the bracket content contains a top-level comma.
+                                        if let Some((x_toks, y_toks)) =
+                                            split_at_top_level_comma(index_toks)?
+                                        {
+                                            // 2D address access: &@A[x, y]
+                                            if x_toks.is_empty() {
+                                                return Err(TbxError::InvalidExpression {
+                                                    reason: "missing x expression in &@A[x, y]",
+                                                });
+                                            }
+                                            if y_toks.is_empty() {
+                                                return Err(TbxError::InvalidExpression {
+                                                    reason: "missing y expression in &@A[x, y]",
+                                                });
+                                            }
+                                            let x_cells = self.compile_expr(x_toks)?;
+                                            output.extend(x_cells);
+                                            let y_cells = self.compile_expr(y_toks)?;
+                                            output.extend(y_cells);
+                                            // Emit ARRAY_ADDR_2D (hidden system helper).
+                                            let array_addr_2d_xt =
+                                                require_hidden_system_xt(self.vm, "ARRAY_ADDR_2D")?;
+                                            output.push(Cell::Xt(array_addr_2d_xt));
+                                        } else {
+                                            // 1D address access: &@A[i]
+                                            // Compile the index expression.
+                                            let index_cells = self.compile_expr(index_toks)?;
+                                            output.extend(index_cells);
+                                            // Emit ARRAY_ADDR (hidden system helper).
+                                            let array_addr_xt =
+                                                require_hidden_system_xt(self.vm, "ARRAY_ADDR")?;
+                                            output.push(Cell::Xt(array_addr_xt));
+                                        }
 
                                         i = close_pos;
                                     }
@@ -844,6 +870,7 @@ fn parse_at_index_tokens(
 /// - Returns `Err(InvalidExpression)` if there are two or more top-level commas (arity ≥ 3).
 ///
 /// "Top-level" means the comma is not nested inside `(...)` or `[...]`.
+#[allow(clippy::type_complexity)]
 fn split_at_top_level_comma(
     toks: &[SpannedToken],
 ) -> Result<Option<(&[SpannedToken], &[SpannedToken])>, TbxError> {
@@ -2585,6 +2612,174 @@ mod tests {
         assert!(
             matches!(err, TbxError::InvalidExpression { .. }),
             "expected InvalidExpression for ARRAY_LEN(1), got: {err:?}"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // &@A[x, y] — 2D array element address access (issue #748)
+    // ------------------------------------------------------------------
+
+    /// `&@A[1, 2]` against a global variable A must compile to:
+    /// LIT DictAddr(0) FETCH LIT 1 LIT 2 ARRAY_ADDR_2D.
+    #[test]
+    fn test_ampersand_at_global_2d_array_element_address() {
+        let mut vm = make_vm();
+        vm.dict_write(Cell::Int(0)).unwrap();
+        vm.register(crate::dict::WordEntry::new_variable("A", 0));
+
+        let tokens = lex("&@A[1, 2]");
+        let result = ExprCompiler::new(&mut vm).compile_expr(&tokens).unwrap();
+
+        let lit_xt = vm.lookup("LIT").unwrap();
+        let fetch_xt = vm.lookup("FETCH").unwrap();
+        let array_addr_2d_xt = vm.lookup_hidden_system("ARRAY_ADDR_2D").unwrap();
+
+        assert_eq!(
+            result,
+            vec![
+                Cell::Xt(lit_xt),
+                Cell::DictAddr(0),
+                Cell::Xt(fetch_xt),
+                Cell::Xt(lit_xt),
+                Cell::Int(1),
+                Cell::Xt(lit_xt),
+                Cell::Int(2),
+                Cell::Xt(array_addr_2d_xt),
+            ]
+        );
+    }
+
+    /// `&@A[x, y]` against a local variable A at slot 0 must compile to:
+    /// LIT StackAddr(0) FETCH <x> <y> ARRAY_ADDR_2D.
+    #[test]
+    fn test_ampersand_at_local_2d_array_element_address() {
+        let mut vm = make_vm();
+
+        let mut local_table = HashMap::new();
+        local_table.insert("A".to_string(), 0usize);
+
+        let tokens = lex("&@A[3, 1]");
+        let result = ExprCompiler::with_context(&mut vm, Some(&local_table), None, None)
+            .compile_expr(&tokens)
+            .unwrap();
+
+        let lit_xt = vm.lookup("LIT").unwrap();
+        let fetch_xt = vm.lookup("FETCH").unwrap();
+        let array_addr_2d_xt = vm.lookup_hidden_system("ARRAY_ADDR_2D").unwrap();
+
+        assert_eq!(
+            result,
+            vec![
+                Cell::Xt(lit_xt),
+                Cell::StackAddr(0),
+                Cell::Xt(fetch_xt),
+                Cell::Xt(lit_xt),
+                Cell::Int(3),
+                Cell::Xt(lit_xt),
+                Cell::Int(1),
+                Cell::Xt(array_addr_2d_xt),
+            ]
+        );
+    }
+
+    /// `&@A[x, y]` must emit ARRAY_ADDR_2D, not ARRAY_ADDR.
+    #[test]
+    fn test_ampersand_at_2d_emits_array_addr_2d_not_array_addr() {
+        let mut vm = make_vm();
+        vm.dict_write(Cell::Int(0)).unwrap();
+        vm.register(crate::dict::WordEntry::new_variable("A", 0));
+
+        let array_addr_xt = vm.lookup_hidden_system("ARRAY_ADDR").unwrap();
+        let array_addr_2d_xt = vm.lookup_hidden_system("ARRAY_ADDR_2D").unwrap();
+
+        let tokens = lex("&@A[2, 1]");
+        let result = ExprCompiler::new(&mut vm).compile_expr(&tokens).unwrap();
+
+        assert!(
+            result.contains(&Cell::Xt(array_addr_2d_xt)),
+            "&@A[x, y] must emit ARRAY_ADDR_2D"
+        );
+        assert!(
+            !result.contains(&Cell::Xt(array_addr_xt)),
+            "&@A[x, y] must not emit 1D ARRAY_ADDR"
+        );
+    }
+
+    /// `&@A[i]` (1D syntax) must still emit ARRAY_ADDR, not ARRAY_ADDR_2D.
+    #[test]
+    fn test_ampersand_at_1d_still_emits_array_addr() {
+        let mut vm = make_vm();
+        vm.dict_write(Cell::Int(0)).unwrap();
+        vm.register(crate::dict::WordEntry::new_variable("A", 0));
+
+        let array_addr_xt = vm.lookup_hidden_system("ARRAY_ADDR").unwrap();
+        let array_addr_2d_xt = vm.lookup_hidden_system("ARRAY_ADDR_2D").unwrap();
+
+        let tokens = lex("&@A[2]");
+        let result = ExprCompiler::new(&mut vm).compile_expr(&tokens).unwrap();
+
+        assert!(
+            result.contains(&Cell::Xt(array_addr_xt)),
+            "&@A[i] must emit ARRAY_ADDR"
+        );
+        assert!(
+            !result.contains(&Cell::Xt(array_addr_2d_xt)),
+            "&@A[i] must not emit ARRAY_ADDR_2D"
+        );
+    }
+
+    /// `&@A[, 1]` (missing x) must produce a syntax error.
+    #[test]
+    fn test_ampersand_at_2d_missing_x_is_error() {
+        let mut vm = make_vm();
+        vm.dict_write(Cell::Int(0)).unwrap();
+        vm.register(crate::dict::WordEntry::new_variable("A", 0));
+
+        let tokens = lex("&@A[, 1]");
+        let err = ExprCompiler::new(&mut vm)
+            .compile_expr(&tokens)
+            .unwrap_err();
+        assert!(
+            matches!(err, TbxError::InvalidExpression { .. }),
+            "expected InvalidExpression for &@A[, 1], got: {err:?}"
+        );
+    }
+
+    /// `&@A[1,]` (missing y) must produce a syntax error.
+    #[test]
+    fn test_ampersand_at_2d_missing_y_is_error() {
+        let mut vm = make_vm();
+        vm.dict_write(Cell::Int(0)).unwrap();
+        vm.register(crate::dict::WordEntry::new_variable("A", 0));
+
+        let tokens = lex("&@A[1,]");
+        let err = ExprCompiler::new(&mut vm)
+            .compile_expr(&tokens)
+            .unwrap_err();
+        assert!(
+            matches!(err, TbxError::InvalidExpression { .. }),
+            "expected InvalidExpression for &@A[1,], got: {err:?}"
+        );
+    }
+
+    /// `&@A[1, 2, 3]` (arity 3) must be rejected at compile time.
+    #[test]
+    fn test_ampersand_at_arity_3_is_error() {
+        let mut vm = make_vm();
+        vm.dict_write(Cell::Int(0)).unwrap();
+        vm.register(crate::dict::WordEntry::new_variable("A", 0));
+
+        let tokens = lex("&@A[1, 2, 3]");
+        let err = ExprCompiler::new(&mut vm)
+            .compile_expr(&tokens)
+            .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                TbxError::InvalidExpression { reason }
+                    if reason.contains("at most 2 indices")
+            ),
+            "expected InvalidExpression for &@A[1, 2, 3], got: {err:?}"
         );
     }
 }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1783,8 +1783,44 @@ fn compile_at_array_lvalue(vm: &mut VM) -> Result<(), TbxError> {
         });
     }
 
-    // Compile the index expression using the current local table.
-    let (index_cells, index_patch_offsets) = compile_expr_taking_local_table(vm, &index_tokens)?;
+    // Determine whether this is a 1D or 2D access by looking for a top-level comma.
+    // This mirrors split_at_top_level_comma() in expr.rs but works on owned Vec.
+    enum IndexKind {
+        OneD,
+        TwoD { comma_pos: usize },
+    }
+
+    let index_kind = {
+        use crate::lexer::Token as Tok;
+        let mut depth = 0usize;
+        let mut first_comma: Option<usize> = None;
+        let mut second_comma = false;
+        for (j, st) in index_tokens.iter().enumerate() {
+            match &st.token {
+                Tok::LParen | Tok::LBracket => depth += 1,
+                Tok::RParen | Tok::RBracket => {
+                    depth = depth.saturating_sub(1);
+                }
+                Tok::Comma if depth == 0 => {
+                    if first_comma.is_some() {
+                        second_comma = true;
+                        break;
+                    }
+                    first_comma = Some(j);
+                }
+                _ => {}
+            }
+        }
+        if second_comma {
+            return Err(TbxError::InvalidExpression {
+                reason: "LET @A[...]: at most 2 indices allowed: use LET @A[i] or LET @A[x, y]",
+            });
+        }
+        match first_comma {
+            None => IndexKind::OneD,
+            Some(pos) => IndexKind::TwoD { comma_pos: pos },
+        }
+    };
 
     // Resolve the array handle: local binding takes priority over global.
     let local_idx: Option<usize> = vm
@@ -1800,11 +1836,6 @@ fn compile_at_array_lvalue(vm: &mut VM) -> Result<(), TbxError> {
     let fetch_xt = vm.lookup("FETCH").ok_or(TbxError::UndefinedSymbol {
         name: "FETCH".to_string(),
     })?;
-    let array_addr_xt = vm
-        .lookup_hidden_system("ARRAY_ADDR")
-        .ok_or(TbxError::UndefinedSymbol {
-            name: "ARRAY_ADDR".to_string(),
-        })?;
 
     if let Some(idx) = local_idx {
         // Emit: LIT StackAddr(idx)  FETCH  — load the local array handle.
@@ -1831,20 +1862,80 @@ fn compile_at_array_lvalue(vm: &mut VM) -> Result<(), TbxError> {
         vm.dict_write(Cell::Xt(fetch_xt))?;
     }
 
-    // Emit the compiled index expression.
-    let base_dp = vm.dp;
-    for cell in index_cells {
-        vm.dict_write(cell)?;
-    }
-    // Register any self-recursive call patch positions from the index expression.
-    if let Some(state) = vm.compile_state.as_mut() {
-        for offset in index_patch_offsets {
-            state.call_patch_list.push(base_dp + offset);
+    match index_kind {
+        IndexKind::OneD => {
+            // 1D path: compile single index expression, emit ARRAY_ADDR.
+            let (index_cells, index_patch_offsets) =
+                compile_expr_taking_local_table(vm, &index_tokens)?;
+
+            let array_addr_xt =
+                vm.lookup_hidden_system("ARRAY_ADDR")
+                    .ok_or(TbxError::UndefinedSymbol {
+                        name: "ARRAY_ADDR".to_string(),
+                    })?;
+
+            // Emit the compiled index expression.
+            let base_dp = vm.dp;
+            for cell in index_cells {
+                vm.dict_write(cell)?;
+            }
+            if let Some(state) = vm.compile_state.as_mut() {
+                for offset in index_patch_offsets {
+                    state.call_patch_list.push(base_dp + offset);
+                }
+            }
+            // Emit ARRAY_ADDR — pops (Array, index) and pushes the element address.
+            vm.dict_write(Cell::Xt(array_addr_xt))?;
+        }
+        IndexKind::TwoD { comma_pos } => {
+            // 2D path: split at comma, compile x and y separately, emit ARRAY_ADDR_2D.
+            let x_tokens = index_tokens[..comma_pos].to_vec();
+            let y_tokens = index_tokens[comma_pos + 1..].to_vec();
+
+            if x_tokens.is_empty() {
+                return Err(TbxError::InvalidExpression {
+                    reason: "missing x expression in LET @A[x, y]",
+                });
+            }
+            if y_tokens.is_empty() {
+                return Err(TbxError::InvalidExpression {
+                    reason: "missing y expression in LET @A[x, y]",
+                });
+            }
+
+            let (x_cells, x_patch_offsets) = compile_expr_taking_local_table(vm, &x_tokens)?;
+            let (y_cells, y_patch_offsets) = compile_expr_taking_local_table(vm, &y_tokens)?;
+
+            let array_addr_2d_xt =
+                vm.lookup_hidden_system("ARRAY_ADDR_2D")
+                    .ok_or(TbxError::UndefinedSymbol {
+                        name: "ARRAY_ADDR_2D".to_string(),
+                    })?;
+
+            // Emit x expression.
+            let base_dp_x = vm.dp;
+            for cell in x_cells {
+                vm.dict_write(cell)?;
+            }
+            if let Some(state) = vm.compile_state.as_mut() {
+                for offset in x_patch_offsets {
+                    state.call_patch_list.push(base_dp_x + offset);
+                }
+            }
+            // Emit y expression.
+            let base_dp_y = vm.dp;
+            for cell in y_cells {
+                vm.dict_write(cell)?;
+            }
+            if let Some(state) = vm.compile_state.as_mut() {
+                for offset in y_patch_offsets {
+                    state.call_patch_list.push(base_dp_y + offset);
+                }
+            }
+            // Emit ARRAY_ADDR_2D — pops (Array, x, y) and pushes the element address.
+            vm.dict_write(Cell::Xt(array_addr_2d_xt))?;
         }
     }
-
-    // Emit ARRAY_ADDR — pops (Array, index) and pushes the element address.
-    vm.dict_write(Cell::Xt(array_addr_xt))?;
 
     Ok(())
 }
@@ -2389,6 +2480,14 @@ pub fn register_all(vm: &mut VM) {
     let mut array_addr_entry = WordEntry::new_primitive("ARRAY_ADDR", array_addr_prim);
     array_addr_entry.flags = FLAG_SYSTEM | FLAG_HIDDEN;
     vm.register(array_addr_entry);
+    // ARRAY_ADDR_2D computes the address of a 2D array element (`&@A[x, y]` compiles to
+    // `<array handle read> <x expr> <y expr> ARRAY_ADDR_2D`).
+    // It validates that the array was declared with DIM @A[w, h] and computes
+    // the flat index as (y-1)*width + (x-1).
+    let mut array_addr_2d_entry =
+        WordEntry::new_primitive("ARRAY_ADDR_2D", arrays::array_addr_2d_prim);
+    array_addr_2d_entry.flags = FLAG_SYSTEM | FLAG_HIDDEN;
+    vm.register(array_addr_2d_entry);
     let mut tuple_get_entry = WordEntry::new_primitive("TUPLE_GET", tuple_get_prim);
     tuple_get_entry.flags = FLAG_SYSTEM;
     vm.register(tuple_get_entry);

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1783,45 +1783,6 @@ fn compile_at_array_lvalue(vm: &mut VM) -> Result<(), TbxError> {
         });
     }
 
-    // Determine whether this is a 1D or 2D access by looking for a top-level comma.
-    // This mirrors split_at_top_level_comma() in expr.rs but works on owned Vec.
-    enum IndexKind {
-        OneD,
-        TwoD { comma_pos: usize },
-    }
-
-    let index_kind = {
-        use crate::lexer::Token as Tok;
-        let mut depth = 0usize;
-        let mut first_comma: Option<usize> = None;
-        let mut second_comma = false;
-        for (j, st) in index_tokens.iter().enumerate() {
-            match &st.token {
-                Tok::LParen | Tok::LBracket => depth += 1,
-                Tok::RParen | Tok::RBracket => {
-                    depth = depth.saturating_sub(1);
-                }
-                Tok::Comma if depth == 0 => {
-                    if first_comma.is_some() {
-                        second_comma = true;
-                        break;
-                    }
-                    first_comma = Some(j);
-                }
-                _ => {}
-            }
-        }
-        if second_comma {
-            return Err(TbxError::InvalidExpression {
-                reason: "LET @A[...]: at most 2 indices allowed: use LET @A[i] or LET @A[x, y]",
-            });
-        }
-        match first_comma {
-            None => IndexKind::OneD,
-            Some(pos) => IndexKind::TwoD { comma_pos: pos },
-        }
-    };
-
     // Resolve the array handle: local binding takes priority over global.
     let local_idx: Option<usize> = vm
         .compile_state
@@ -1862,80 +1823,27 @@ fn compile_at_array_lvalue(vm: &mut VM) -> Result<(), TbxError> {
         vm.dict_write(Cell::Xt(fetch_xt))?;
     }
 
-    match index_kind {
-        IndexKind::OneD => {
-            // 1D path: compile single index expression, emit ARRAY_ADDR.
-            let (index_cells, index_patch_offsets) =
-                compile_expr_taking_local_table(vm, &index_tokens)?;
+    // Compile the index expression and emit ARRAY_ADDR.
+    let (index_cells, index_patch_offsets) = compile_expr_taking_local_table(vm, &index_tokens)?;
 
-            let array_addr_xt =
-                vm.lookup_hidden_system("ARRAY_ADDR")
-                    .ok_or(TbxError::UndefinedSymbol {
-                        name: "ARRAY_ADDR".to_string(),
-                    })?;
+    let array_addr_xt = vm
+        .lookup_hidden_system("ARRAY_ADDR")
+        .ok_or(TbxError::UndefinedSymbol {
+            name: "ARRAY_ADDR".to_string(),
+        })?;
 
-            // Emit the compiled index expression.
-            let base_dp = vm.dp;
-            for cell in index_cells {
-                vm.dict_write(cell)?;
-            }
-            if let Some(state) = vm.compile_state.as_mut() {
-                for offset in index_patch_offsets {
-                    state.call_patch_list.push(base_dp + offset);
-                }
-            }
-            // Emit ARRAY_ADDR — pops (Array, index) and pushes the element address.
-            vm.dict_write(Cell::Xt(array_addr_xt))?;
-        }
-        IndexKind::TwoD { comma_pos } => {
-            // 2D path: split at comma, compile x and y separately, emit ARRAY_ADDR_2D.
-            let x_tokens = index_tokens[..comma_pos].to_vec();
-            let y_tokens = index_tokens[comma_pos + 1..].to_vec();
-
-            if x_tokens.is_empty() {
-                return Err(TbxError::InvalidExpression {
-                    reason: "missing x expression in LET @A[x, y]",
-                });
-            }
-            if y_tokens.is_empty() {
-                return Err(TbxError::InvalidExpression {
-                    reason: "missing y expression in LET @A[x, y]",
-                });
-            }
-
-            let (x_cells, x_patch_offsets) = compile_expr_taking_local_table(vm, &x_tokens)?;
-            let (y_cells, y_patch_offsets) = compile_expr_taking_local_table(vm, &y_tokens)?;
-
-            let array_addr_2d_xt =
-                vm.lookup_hidden_system("ARRAY_ADDR_2D")
-                    .ok_or(TbxError::UndefinedSymbol {
-                        name: "ARRAY_ADDR_2D".to_string(),
-                    })?;
-
-            // Emit x expression.
-            let base_dp_x = vm.dp;
-            for cell in x_cells {
-                vm.dict_write(cell)?;
-            }
-            if let Some(state) = vm.compile_state.as_mut() {
-                for offset in x_patch_offsets {
-                    state.call_patch_list.push(base_dp_x + offset);
-                }
-            }
-            // Emit y expression.
-            let base_dp_y = vm.dp;
-            for cell in y_cells {
-                vm.dict_write(cell)?;
-            }
-            if let Some(state) = vm.compile_state.as_mut() {
-                for offset in y_patch_offsets {
-                    state.call_patch_list.push(base_dp_y + offset);
-                }
-            }
-            // Emit ARRAY_ADDR_2D — pops (Array, x, y) and pushes the element address.
-            vm.dict_write(Cell::Xt(array_addr_2d_xt))?;
+    // Emit the compiled index expression.
+    let base_dp = vm.dp;
+    for cell in index_cells {
+        vm.dict_write(cell)?;
+    }
+    if let Some(state) = vm.compile_state.as_mut() {
+        for offset in index_patch_offsets {
+            state.call_patch_list.push(base_dp + offset);
         }
     }
+    // Emit ARRAY_ADDR — pops (Array, index) and pushes the element address.
+    vm.dict_write(Cell::Xt(array_addr_xt))?;
 
     Ok(())
 }

--- a/src/primitives/arrays.rs
+++ b/src/primitives/arrays.rs
@@ -173,6 +173,59 @@ pub(super) fn array_get_2d_prim(vm: &mut VM) -> Result<(), TbxError> {
     Ok(())
 }
 
+/// ARRAY_ADDR_2D — compute the address of a 2D array element using (x, y) coordinates.
+///
+/// Stack: `[..., Cell::Array(ar), Cell::Int(x), Cell::Int(y)]` → `Cell::ArrayAddr { array: ar, elem_idx }`
+///
+/// This is the VM-level primitive that `&@A[x, y]` compiles to.  The expression
+/// compiler lowers `&@A[x, y]` to:
+///   `<array handle read>  <x expr>  <y expr>  ARRAY_ADDR_2D`.
+///
+/// Coordinates are 1-based: x is the column (1 = leftmost), y is the row (1 = top).
+/// The flat index is computed as `(y - 1) * width + (x - 1)` (0-based).
+///
+/// The array must have `ArrayShape::TwoD` shape; a 1D array is rejected.
+pub(super) fn array_addr_2d_prim(vm: &mut VM) -> Result<(), TbxError> {
+    let y_raw = vm.pop_int()?;
+    let x_raw = vm.pop_int()?;
+    let ar = match vm.pop()? {
+        Cell::Array(ar) => ar,
+        other => {
+            return Err(TbxError::TypeError {
+                expected: "Array",
+                got: other.type_name(),
+            })
+        }
+    };
+    let (width, height) = match ar.shape() {
+        ArrayShape::TwoD { width, height } => (*width, *height),
+        ArrayShape::OneD => {
+            return Err(TbxError::TypeError {
+                expected: "2D Array (declared with DIM @A[w, h])",
+                got: "1D Array",
+            })
+        }
+    };
+    if x_raw < 1 || x_raw > width as i64 {
+        return Err(TbxError::ArrayIndexOutOfBounds {
+            index: x_raw,
+            size: width,
+        });
+    }
+    if y_raw < 1 || y_raw > height as i64 {
+        return Err(TbxError::ArrayIndexOutOfBounds {
+            index: y_raw,
+            size: height,
+        });
+    }
+    let flat_idx = (y_raw as usize - 1) * width + (x_raw as usize - 1);
+    vm.push(Cell::ArrayAddr {
+        array: ar,
+        elem_idx: flat_idx,
+    })?;
+    Ok(())
+}
+
 /// TUPLE — collect N values from the stack into a new immutable tuple.
 ///
 /// Pops the arity `n` from the stack, then pops `n` values and assembles them
@@ -639,5 +692,109 @@ mod tests {
                 ..
             })
         ));
+    }
+
+    // --- array_addr_2d_prim ---
+
+    #[test]
+    fn test_array_addr_2d_top_left() {
+        // &@A[1, 1] → flat index 0 → ArrayAddr { elem_idx: 0 }
+        let mut vm = VM::new();
+        vm.push(Cell::Array(make_3x2_array())).unwrap();
+        vm.push(Cell::Int(1)).unwrap(); // x
+        vm.push(Cell::Int(1)).unwrap(); // y
+        array_addr_2d_prim(&mut vm).unwrap();
+        let result = vm.pop().unwrap();
+        assert!(matches!(result, Cell::ArrayAddr { elem_idx: 0, .. }));
+    }
+
+    #[test]
+    fn test_array_addr_2d_second_row_first_col() {
+        // &@A[1, 2] → flat index 3 → ArrayAddr { elem_idx: 3 }
+        let mut vm = VM::new();
+        vm.push(Cell::Array(make_3x2_array())).unwrap();
+        vm.push(Cell::Int(1)).unwrap(); // x
+        vm.push(Cell::Int(2)).unwrap(); // y
+        array_addr_2d_prim(&mut vm).unwrap();
+        let result = vm.pop().unwrap();
+        assert!(matches!(result, Cell::ArrayAddr { elem_idx: 3, .. }));
+    }
+
+    #[test]
+    fn test_array_addr_2d_bottom_right() {
+        // &@A[3, 2] → flat index 5 → ArrayAddr { elem_idx: 5 }
+        let mut vm = VM::new();
+        vm.push(Cell::Array(make_3x2_array())).unwrap();
+        vm.push(Cell::Int(3)).unwrap(); // x
+        vm.push(Cell::Int(2)).unwrap(); // y
+        array_addr_2d_prim(&mut vm).unwrap();
+        let result = vm.pop().unwrap();
+        assert!(matches!(result, Cell::ArrayAddr { elem_idx: 5, .. }));
+    }
+
+    #[test]
+    fn test_array_addr_2d_x_out_of_bounds() {
+        let mut vm = VM::new();
+        vm.push(Cell::Array(make_3x2_array())).unwrap();
+        vm.push(Cell::Int(4)).unwrap(); // x > width
+        vm.push(Cell::Int(1)).unwrap();
+        assert!(matches!(
+            array_addr_2d_prim(&mut vm),
+            Err(TbxError::ArrayIndexOutOfBounds { index: 4, .. })
+        ));
+    }
+
+    #[test]
+    fn test_array_addr_2d_y_out_of_bounds() {
+        let mut vm = VM::new();
+        vm.push(Cell::Array(make_3x2_array())).unwrap();
+        vm.push(Cell::Int(1)).unwrap();
+        vm.push(Cell::Int(3)).unwrap(); // y > height
+        assert!(matches!(
+            array_addr_2d_prim(&mut vm),
+            Err(TbxError::ArrayIndexOutOfBounds { index: 3, .. })
+        ));
+    }
+
+    #[test]
+    fn test_array_addr_2d_on_1d_array_returns_type_error() {
+        let mut vm = VM::new();
+        let ar = ArrayRef::new(vec![Cell::Int(1), Cell::Int(2), Cell::Int(3)]);
+        vm.push(Cell::Array(ar)).unwrap();
+        vm.push(Cell::Int(1)).unwrap();
+        vm.push(Cell::Int(1)).unwrap();
+        assert!(matches!(
+            array_addr_2d_prim(&mut vm),
+            Err(TbxError::TypeError {
+                expected: "2D Array (declared with DIM @A[w, h])",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn test_array_addr_2d_write_and_read_back() {
+        // Write via ArrayAddr, read back via ARRAY_GET_2D to confirm roundtrip.
+        let mut vm = VM::new();
+        let ar = make_3x2_array();
+        // Get address of (2, 1) → flat index 1.
+        vm.push(Cell::Array(ar.clone())).unwrap();
+        vm.push(Cell::Int(2)).unwrap(); // x
+        vm.push(Cell::Int(1)).unwrap(); // y
+        array_addr_2d_prim(&mut vm).unwrap();
+        let addr = vm.pop().unwrap();
+        // Write 99 to that address.
+        match addr {
+            Cell::ArrayAddr { array, elem_idx } => {
+                array.set(elem_idx, Cell::Int(99)).unwrap();
+            }
+            other => panic!("expected ArrayAddr, got {other:?}"),
+        }
+        // Read it back via @A[2, 1].
+        vm.push(Cell::Array(ar)).unwrap();
+        vm.push(Cell::Int(2)).unwrap(); // x
+        vm.push(Cell::Int(1)).unwrap(); // y
+        array_get_2d_prim(&mut vm).unwrap();
+        assert_eq!(vm.pop(), Ok(Cell::Int(99)));
     }
 }

--- a/tests/tbx_lib_tests.rs
+++ b/tests/tbx_lib_tests.rs
@@ -1309,3 +1309,45 @@ fn test_dim_local_array_still_works_after_surface_ban() {
         .expect("DIM local array must still work after surface ban");
     assert_eq!(interp.take_output(), "20");
 }
+
+// ---------------------------------------------------------------------------
+// &@A[x, y] — 2D array element address access (issue #748)
+// ---------------------------------------------------------------------------
+
+/// `SET &@A[x, y], v` on a global 2D array binding must write the value and
+/// `@A[x, y]` must read it back via PUTDEC.
+///
+/// TBX code under test:
+///   DIM @A[3, 2]
+///   SET &@A[2, 1], 99
+///   PUTDEC @A[2, 1]
+///
+/// Expected output: `99`
+#[test]
+fn test_set_at_array_2d_global_element_address() {
+    let mut interp = Interpreter::new();
+    let src = concat!("DIM @A[3, 2]\n", "SET &@A[2, 1], 99\n", "PUTDEC @A[2, 1]\n",);
+    interp
+        .exec_source(src)
+        .expect("SET &@A[2, 1], 99 should write 99 to 2D element (2, 1) of global array");
+    assert_eq!(interp.take_output(), "99");
+}
+
+/// `SET &@A[x, y], v` on a local 2D array binding inside a DEF must write the
+/// value and `@A[x, y]` must read it back.
+#[test]
+fn test_set_at_array_2d_local_element_address() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF F()\n",
+        "  DIM @A[3, 2]\n",
+        "  SET &@A[2, 1], 99\n",
+        "  RETURN @A[2, 1]\n",
+        "END\n",
+        "PUTDEC F()\n",
+    );
+    interp
+        .exec_source(src)
+        .expect("SET &@A[2, 1], 99 should write 99 to 2D element (2, 1) of local array");
+    assert_eq!(interp.take_output(), "99");
+}


### PR DESCRIPTION
## 概要

2次元配列要素の address access `&@A[x, y]` を実装する。これにより `SET &@A[x, y], expr` で 2D 配列要素への書き込みが可能になる。内部ストレージは1次元のまま、linear index `(y - 1) * width + (x - 1)` で flat index を計算する。

## 変更内容

- `primitives/arrays.rs`: `array_addr_2d_prim` を追加（Stack: `[Array, x, y]` → `ArrayAddr { array, elem_idx }`）
  - `ArrayShape::TwoD` のバリデーション、1-based 座標の境界チェック、flat index 計算
- `primitives.rs`: `ARRAY_ADDR_2D` を hidden system helper (`FLAG_SYSTEM | FLAG_HIDDEN`) として登録
- `expr.rs`: `&@A[...]` のコンパイルパスに `split_at_top_level_comma` による 1D/2D 分岐を追加
  - 2D の場合は x・y を別々にコンパイルして `ARRAY_ADDR_2D` を emit
  - 1D の既存挙動（`ARRAY_ADDR` emit）は変わらない
- ユニットテストを `primitives/arrays.rs`、`expr.rs` に追加（arity 1/2/3 の全パターンを網羅）

Closes #748
