### PR TITLE
LET @A[x, y] = expr の 2D 配列要素代入 sugar を実装する

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -871,7 +871,7 @@ fn parse_at_index_tokens(
 ///
 /// "Top-level" means the comma is not nested inside `(...)` or `[...]`.
 #[allow(clippy::type_complexity)]
-fn split_at_top_level_comma(
+pub(crate) fn split_at_top_level_comma(
     toks: &[SpannedToken],
 ) -> Result<Option<(&[SpannedToken], &[SpannedToken])>, TbxError> {
     let mut depth = 0usize;

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -1823,27 +1823,70 @@ fn compile_at_array_lvalue(vm: &mut VM) -> Result<(), TbxError> {
         vm.dict_write(Cell::Xt(fetch_xt))?;
     }
 
-    // Compile the index expression and emit ARRAY_ADDR.
-    let (index_cells, index_patch_offsets) = compile_expr_taking_local_table(vm, &index_tokens)?;
-
-    let array_addr_xt = vm
-        .lookup_hidden_system("ARRAY_ADDR")
-        .ok_or(TbxError::UndefinedSymbol {
-            name: "ARRAY_ADDR".to_string(),
-        })?;
-
-    // Emit the compiled index expression.
-    let base_dp = vm.dp;
-    for cell in index_cells {
-        vm.dict_write(cell)?;
-    }
-    if let Some(state) = vm.compile_state.as_mut() {
-        for offset in index_patch_offsets {
-            state.call_patch_list.push(base_dp + offset);
+    // Dispatch on 1D vs 2D based on whether the index contains a top-level comma.
+    if let Some((x_toks, y_toks)) = crate::expr::split_at_top_level_comma(&index_tokens)? {
+        // 2D path: LET @A[x, y] = expr
+        if x_toks.is_empty() {
+            return Err(TbxError::InvalidExpression {
+                reason: "LET @A[x, y]: missing x expression",
+            });
         }
+        if y_toks.is_empty() {
+            return Err(TbxError::InvalidExpression {
+                reason: "LET @A[x, y]: missing y expression",
+            });
+        }
+
+        let (x_cells, x_patch_offsets) = compile_expr_taking_local_table(vm, x_toks)?;
+        let (y_cells, y_patch_offsets) = compile_expr_taking_local_table(vm, y_toks)?;
+
+        let array_addr_2d_xt =
+            vm.lookup_hidden_system("ARRAY_ADDR_2D")
+                .ok_or(TbxError::UndefinedSymbol {
+                    name: "ARRAY_ADDR_2D".to_string(),
+                })?;
+
+        let base_dp = vm.dp;
+        for cell in x_cells {
+            vm.dict_write(cell)?;
+        }
+        if let Some(state) = vm.compile_state.as_mut() {
+            for offset in x_patch_offsets {
+                state.call_patch_list.push(base_dp + offset);
+            }
+        }
+        let base_dp = vm.dp;
+        for cell in y_cells {
+            vm.dict_write(cell)?;
+        }
+        if let Some(state) = vm.compile_state.as_mut() {
+            for offset in y_patch_offsets {
+                state.call_patch_list.push(base_dp + offset);
+            }
+        }
+        vm.dict_write(Cell::Xt(array_addr_2d_xt))?;
+    } else {
+        // 1D path: LET @A[i] = expr
+        let (index_cells, index_patch_offsets) =
+            compile_expr_taking_local_table(vm, &index_tokens)?;
+
+        let array_addr_xt =
+            vm.lookup_hidden_system("ARRAY_ADDR")
+                .ok_or(TbxError::UndefinedSymbol {
+                    name: "ARRAY_ADDR".to_string(),
+                })?;
+
+        let base_dp = vm.dp;
+        for cell in index_cells {
+            vm.dict_write(cell)?;
+        }
+        if let Some(state) = vm.compile_state.as_mut() {
+            for offset in index_patch_offsets {
+                state.call_patch_list.push(base_dp + offset);
+            }
+        }
+        vm.dict_write(Cell::Xt(array_addr_xt))?;
     }
-    // Emit ARRAY_ADDR — pops (Array, index) and pushes the element address.
-    vm.dict_write(Cell::Xt(array_addr_xt))?;
 
     Ok(())
 }

--- a/tests/tbx_lib_tests.rs
+++ b/tests/tbx_lib_tests.rs
@@ -1359,17 +1359,20 @@ fn test_set_at_array_2d_local_element_address() {
 /// and `@A[x, y]` must read it back.
 ///
 /// TBX code under test:
-///   DIM @A[3, 2]
-///   LET @A[2, 1] = 99
-///   PUTDEC @A[2, 1]
+///   DIM @A[3, 2]          ← global (top-level)
+///   DEF F()
+///     LET @A[2, 1] = 99   ← LET inside DEF, writing to global array
+///     PUTDEC @A[2, 1]
+///   END
+///   F
 ///
 /// Expected output: `99`
 #[test]
 fn test_let_at_array_2d_global_element_assignment() {
     let mut interp = Interpreter::new();
     let src = concat!(
+        "DIM @A[3, 2]\n",
         "DEF F()\n",
-        "  DIM @A[3, 2]\n",
         "  LET @A[2, 1] = 99\n",
         "  PUTDEC @A[2, 1]\n",
         "END\n",
@@ -1377,7 +1380,7 @@ fn test_let_at_array_2d_global_element_assignment() {
     );
     interp
         .exec_source(src)
-        .expect("LET @A[2, 1] = 99 should write 99 to 2D element (2, 1)");
+        .expect("LET @A[2, 1] = 99 should write 99 to 2D element (2, 1) of global array");
     assert_eq!(interp.take_output(), "99");
 }
 

--- a/tests/tbx_lib_tests.rs
+++ b/tests/tbx_lib_tests.rs
@@ -1351,3 +1351,135 @@ fn test_set_at_array_2d_local_element_address() {
         .expect("SET &@A[2, 1], 99 should write 99 to 2D element (2, 1) of local array");
     assert_eq!(interp.take_output(), "99");
 }
+
+// LET @A[x, y] = expr — 2D array element assignment sugar (issue #749)
+// ---------------------------------------------------------------------------
+
+/// `LET @A[x, y] = expr` on a global 2D array binding must write the value
+/// and `@A[x, y]` must read it back.
+///
+/// TBX code under test:
+///   DIM @A[3, 2]
+///   LET @A[2, 1] = 99
+///   PUTDEC @A[2, 1]
+///
+/// Expected output: `99`
+#[test]
+fn test_let_at_array_2d_global_element_assignment() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF F()\n",
+        "  DIM @A[3, 2]\n",
+        "  LET @A[2, 1] = 99\n",
+        "  PUTDEC @A[2, 1]\n",
+        "END\n",
+        "F\n",
+    );
+    interp
+        .exec_source(src)
+        .expect("LET @A[2, 1] = 99 should write 99 to 2D element (2, 1)");
+    assert_eq!(interp.take_output(), "99");
+}
+
+/// `LET @A[x, y] = expr` on a local 2D array binding inside a DEF must write
+/// the value and `@A[x, y]` must read it back.
+#[test]
+fn test_let_at_array_2d_local_element_assignment() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF F()\n",
+        "  DIM @A[3, 2]\n",
+        "  LET @A[2, 1] = 99\n",
+        "  RETURN @A[2, 1]\n",
+        "END\n",
+        "PUTDEC F()\n",
+    );
+    interp
+        .exec_source(src)
+        .expect("LET @A[2, 1] = 99 should write 99 to local 2D element (2, 1)");
+    assert_eq!(interp.take_output(), "99");
+}
+
+/// `LET @A[x, y] = expr` must map to the same flat index as `SET &@A[x, y], expr`.
+///
+/// 3×2 array, fill all 6 elements via `LET @A[x, y]`, then read back with
+/// `@A[x, y]` to verify the index formula `(y-1)*width + (x-1)`.
+#[test]
+fn test_let_at_array_2d_index_formula() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF F()\n",
+        "  DIM @A[3, 2]\n",
+        "  LET @A[1, 1] = 11\n",
+        "  LET @A[2, 1] = 21\n",
+        "  LET @A[3, 1] = 31\n",
+        "  LET @A[1, 2] = 12\n",
+        "  LET @A[2, 2] = 22\n",
+        "  LET @A[3, 2] = 32\n",
+        "  PUTDEC @A[1, 1]\n",
+        "  PUTDEC @A[3, 1]\n",
+        "  PUTDEC @A[1, 2]\n",
+        "  PUTDEC @A[3, 2]\n",
+        "END\n",
+        "F\n",
+    );
+    interp
+        .exec_source(src)
+        .expect("LET @A[x, y] should write to the correct flat index");
+    // (1,1)→11, (3,1)→31, (1,2)→12, (3,2)→32
+    assert_eq!(interp.take_output(), "11311232");
+}
+
+/// `LET @A[x, y] = expr` must produce the same element as `SET &@A[x, y], expr`.
+#[test]
+fn test_let_at_array_2d_equivalent_to_set_address() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF F()\n",
+        "  DIM @A[3, 2]\n",
+        "  SET &@A[2, 1], 42\n",
+        "  LET @A[2, 1] = 99\n",
+        "  RETURN @A[2, 1]\n",
+        "END\n",
+        "PUTDEC F()\n",
+    );
+    interp
+        .exec_source(src)
+        .expect("LET @A[x, y] should overwrite the same element as SET &@A[x, y]");
+    assert_eq!(interp.take_output(), "99");
+}
+
+/// `LET @A[i] = expr` (1D syntax) must still work after introducing 2D support.
+#[test]
+fn test_let_at_array_1d_regression_after_2d() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF F()\n",
+        "  DIM @A[4]\n",
+        "  LET @A[3] = 77\n",
+        "  RETURN @A[3]\n",
+        "END\n",
+        "PUTDEC F()\n",
+    );
+    interp
+        .exec_source(src)
+        .expect("LET @A[i] 1D assignment must still work after 2D changes");
+    assert_eq!(interp.take_output(), "77");
+}
+
+/// `LET @A[x, y, z] = expr` (arity ≥ 3) must be rejected at compile time.
+#[test]
+fn test_let_at_array_2d_arity_3_is_compile_error() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF F()\n",
+        "  DIM @A[3, 2]\n",
+        "  LET @A[1, 1, 1] = 0\n",
+        "END\n",
+        "F\n",
+    );
+    assert!(
+        interp.exec_source(src).is_err(),
+        "LET @A[x, y, z] with arity >= 3 must be a compile error"
+    );
+}


### PR DESCRIPTION
## 概要

issue #749 の対応として、2D 配列要素への代入 sugar `LET @A[x, y] = expr` を実装する。
これは `SET &@A[x, y], expr` と同じ要素に書き込む構文糖衣であり、#748 で実装済みの `ARRAY_ADDR_2D` を再利用する。

## 変更内容

- `src/expr.rs`: `split_at_top_level_comma` を `pub(crate)` に変更して `primitives.rs` から呼べるようにする
- `src/primitives.rs`: `compile_at_array_lvalue` を拡張し、index に top-level カンマがある場合は `ARRAY_ADDR_2D` を emit する 2D パスに分岐する（1D パスは既存の `ARRAY_ADDR` を維持）。arity 3 以上は `split_at_top_level_comma` が compile error を返す
- `tests/tbx_lib_tests.rs`: `LET @A[x, y]` のグローバル・ローカル・index formula・SET equivalence・1D regression・arity 3 error の end-to-end テストを追加

Closes #749
