### PR TITLE
2D 配列の bounds check / rank mismatch エラーを補強する

### DIFF
--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -6606,7 +6606,7 @@ mod tests {
         let src = concat!(
             "DEF TEST()\n",
             "  DIM @A[3, 2]\n",
-            "  LET @A[1] = 10\n",
+            "  LET @A[1, 1] = 10\n",
             "  PUTDEC @A[1, 1]\n",
             "END\n",
             "TEST",
@@ -6617,16 +6617,16 @@ mod tests {
     #[test]
     fn test_2d_array_read_index_formula() {
         // @A[x, y] maps to flat index (y-1)*width + (x-1).
-        // 3x2 array, elements 1..6 in row-major order via 1D LET.
+        // 3x2 array, elements 1..6 in row-major order via 2D LET.
         let src = concat!(
             "DEF TEST()\n",
             "  DIM @A[3, 2]\n",
-            "  LET @A[1] = 1\n",
-            "  LET @A[2] = 2\n",
-            "  LET @A[3] = 3\n",
-            "  LET @A[4] = 4\n",
-            "  LET @A[5] = 5\n",
-            "  LET @A[6] = 6\n",
+            "  LET @A[1, 1] = 1\n",
+            "  LET @A[2, 1] = 2\n",
+            "  LET @A[3, 1] = 3\n",
+            "  LET @A[1, 2] = 4\n",
+            "  LET @A[2, 2] = 5\n",
+            "  LET @A[3, 2] = 6\n",
             "  PUTDEC @A[1, 1]\n", // flat 0 → 1
             "  PUTDEC @A[3, 1]\n", // flat 2 → 3
             "  PUTDEC @A[1, 2]\n", // flat 3 → 4

--- a/src/primitives/arrays.rs
+++ b/src/primitives/arrays.rs
@@ -255,7 +255,7 @@ pub fn to_tuple_prim(vm: &mut VM) -> Result<(), TbxError> {
     Ok(())
 }
 
-/// ARRAY_GET — read an element from an array.
+/// ARRAY_GET — read an element from a 1D array.
 ///
 /// Stack: `[..., Cell::Array(pool_idx), Cell::Int(elem_idx)]` → `value`
 ///
@@ -264,6 +264,9 @@ pub fn to_tuple_prim(vm: &mut VM) -> Result<(), TbxError> {
 ///
 /// Array indices are 1-based from the user's perspective: valid range is `1..=N`.
 /// The index is translated to 0-based internally before accessing the Vec.
+///
+/// A 2D array (declared with `DIM @A[w, h]`) is rejected with a rank mismatch
+/// error; use `@A[x, y]` (ARRAY_GET_2D) for 2D arrays.
 pub fn array_get_prim(vm: &mut VM) -> Result<(), TbxError> {
     let elem_idx_raw = vm.pop_int()?;
     let ar = match vm.pop()? {
@@ -275,6 +278,13 @@ pub fn array_get_prim(vm: &mut VM) -> Result<(), TbxError> {
             })
         }
     };
+    // Reject 2D arrays: use @A[x, y] instead.
+    if matches!(ar.shape(), ArrayShape::TwoD { .. }) {
+        return Err(TbxError::TypeError {
+            expected: "1D Array (declared with DIM @A[n]); use @A[x, y] for 2D arrays",
+            got: "2D Array",
+        });
+    }
     let size = ar.len();
     // Translate 1-based user index to 0-based internal index.
     // Index 0 or negative is out of bounds.
@@ -301,7 +311,7 @@ pub fn array_get_prim(vm: &mut VM) -> Result<(), TbxError> {
     Ok(())
 }
 
-/// ARRAY_ADDR — compute the address of an array element.
+/// ARRAY_ADDR — compute the address of a 1D array element.
 ///
 /// Stack: `[..., Cell::Array(ar), Cell::Int(elem_idx)]` → `Cell::ArrayAddr { array: ar, elem_idx }`
 ///
@@ -314,6 +324,9 @@ pub fn array_get_prim(vm: &mut VM) -> Result<(), TbxError> {
 /// The index is translated to 0-based internally before storing in `Cell::ArrayAddr`.
 ///
 /// The `ArrayRef` from the popped `Cell::Array` is stored directly in `Cell::ArrayAddr`.
+///
+/// A 2D array (declared with `DIM @A[w, h]`) is rejected with a rank mismatch
+/// error; use `&@A[x, y]` (ARRAY_ADDR_2D) for 2D arrays.
 pub fn array_addr_prim(vm: &mut VM) -> Result<(), TbxError> {
     let elem_idx_raw = vm.pop_int()?;
     let ar = match vm.pop()? {
@@ -325,6 +338,13 @@ pub fn array_addr_prim(vm: &mut VM) -> Result<(), TbxError> {
             })
         }
     };
+    // Reject 2D arrays: use &@A[x, y] instead.
+    if matches!(ar.shape(), ArrayShape::TwoD { .. }) {
+        return Err(TbxError::TypeError {
+            expected: "1D Array (declared with DIM @A[n]); use &@A[x, y] for 2D arrays",
+            got: "2D Array",
+        });
+    }
     let size = ar.len();
     // Translate 1-based user index to 0-based internal index.
     // Index 0 or negative is out of bounds.
@@ -796,5 +816,106 @@ mod tests {
         vm.push(Cell::Int(1)).unwrap(); // y
         array_get_2d_prim(&mut vm).unwrap();
         assert_eq!(vm.pop(), Ok(Cell::Int(99)));
+    }
+
+    // --- array_get_2d_prim: additional bounds tests ---
+
+    #[test]
+    fn test_array_get_2d_y_zero_is_out_of_bounds() {
+        // y = 0 is invalid in 1-based indexing.
+        let mut vm = VM::new();
+        vm.push(Cell::Array(make_3x2_array())).unwrap();
+        vm.push(Cell::Int(1)).unwrap();
+        vm.push(Cell::Int(0)).unwrap(); // y = 0 invalid
+        assert!(matches!(
+            array_get_2d_prim(&mut vm),
+            Err(TbxError::ArrayIndexOutOfBounds { index: 0, .. })
+        ));
+    }
+
+    #[test]
+    fn test_array_get_2d_x_negative_is_out_of_bounds() {
+        let mut vm = VM::new();
+        vm.push(Cell::Array(make_3x2_array())).unwrap();
+        vm.push(Cell::Int(-1)).unwrap(); // x < 1
+        vm.push(Cell::Int(1)).unwrap();
+        assert!(matches!(
+            array_get_2d_prim(&mut vm),
+            Err(TbxError::ArrayIndexOutOfBounds { index: -1, .. })
+        ));
+    }
+
+    #[test]
+    fn test_array_get_2d_y_negative_is_out_of_bounds() {
+        let mut vm = VM::new();
+        vm.push(Cell::Array(make_3x2_array())).unwrap();
+        vm.push(Cell::Int(1)).unwrap();
+        vm.push(Cell::Int(-1)).unwrap(); // y < 1
+        assert!(matches!(
+            array_get_2d_prim(&mut vm),
+            Err(TbxError::ArrayIndexOutOfBounds { index: -1, .. })
+        ));
+    }
+
+    // --- array_addr_2d_prim: additional bounds tests ---
+
+    #[test]
+    fn test_array_addr_2d_x_zero_is_out_of_bounds() {
+        // x = 0 is invalid in 1-based indexing.
+        let mut vm = VM::new();
+        vm.push(Cell::Array(make_3x2_array())).unwrap();
+        vm.push(Cell::Int(0)).unwrap(); // x = 0 invalid
+        vm.push(Cell::Int(1)).unwrap();
+        assert!(matches!(
+            array_addr_2d_prim(&mut vm),
+            Err(TbxError::ArrayIndexOutOfBounds { index: 0, .. })
+        ));
+    }
+
+    #[test]
+    fn test_array_addr_2d_y_zero_is_out_of_bounds() {
+        // y = 0 is invalid in 1-based indexing.
+        let mut vm = VM::new();
+        vm.push(Cell::Array(make_3x2_array())).unwrap();
+        vm.push(Cell::Int(1)).unwrap();
+        vm.push(Cell::Int(0)).unwrap(); // y = 0 invalid
+        assert!(matches!(
+            array_addr_2d_prim(&mut vm),
+            Err(TbxError::ArrayIndexOutOfBounds { index: 0, .. })
+        ));
+    }
+
+    // --- array_get_prim: rank mismatch (2D array via 1D accessor) ---
+
+    #[test]
+    fn test_array_get_1d_accessor_on_2d_array_returns_type_error() {
+        // @A[i] on a 2D array must be rejected with TypeError (rank mismatch).
+        let mut vm = VM::new();
+        vm.push(Cell::Array(make_3x2_array())).unwrap();
+        vm.push(Cell::Int(1)).unwrap();
+        assert!(matches!(
+            array_get_prim(&mut vm),
+            Err(TbxError::TypeError {
+                expected: "1D Array (declared with DIM @A[n]); use @A[x, y] for 2D arrays",
+                got: "2D Array",
+            })
+        ));
+    }
+
+    // --- array_addr_prim: rank mismatch (2D array via 1D accessor) ---
+
+    #[test]
+    fn test_array_addr_1d_accessor_on_2d_array_returns_type_error() {
+        // &@A[i] on a 2D array must be rejected with TypeError (rank mismatch).
+        let mut vm = VM::new();
+        vm.push(Cell::Array(make_3x2_array())).unwrap();
+        vm.push(Cell::Int(1)).unwrap();
+        assert!(matches!(
+            array_addr_prim(&mut vm),
+            Err(TbxError::TypeError {
+                expected: "1D Array (declared with DIM @A[n]); use &@A[x, y] for 2D arrays",
+                got: "2D Array",
+            })
+        ));
     }
 }

--- a/tests/tbx_lib_tests.rs
+++ b/tests/tbx_lib_tests.rs
@@ -1486,3 +1486,359 @@ fn test_let_at_array_2d_arity_3_is_compile_error() {
         "LET @A[x, y, z] with arity >= 3 must be a compile error"
     );
 }
+
+// ---------------------------------------------------------------------------
+// 2D array bounds and rank mismatch errors (issue #750)
+// ---------------------------------------------------------------------------
+
+// --- @A[x, y] bounds errors (ARRAY_GET_2D) ---
+
+/// `@A[0, 1]` must be rejected: x=0 is invalid in 1-based indexing.
+#[test]
+fn test_2d_array_get_x_zero_is_out_of_bounds() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF F()\n",
+        "  DIM @A[3, 2]\n",
+        "  RETURN @A[0, 1]\n",
+        "END\n",
+        "F\n",
+    );
+    interp
+        .exec_source(src)
+        .expect_err("@A[0, 1] must fail: x=0 is out of bounds (1-based)");
+}
+
+/// `@A[1, 0]` must be rejected: y=0 is invalid in 1-based indexing.
+#[test]
+fn test_2d_array_get_y_zero_is_out_of_bounds() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF F()\n",
+        "  DIM @A[3, 2]\n",
+        "  RETURN @A[1, 0]\n",
+        "END\n",
+        "F\n",
+    );
+    interp
+        .exec_source(src)
+        .expect_err("@A[1, 0] must fail: y=0 is out of bounds (1-based)");
+}
+
+/// `@A[width + 1, 1]` must be rejected: x exceeds declared width.
+#[test]
+fn test_2d_array_get_x_exceeds_width_is_out_of_bounds() {
+    let mut interp = Interpreter::new();
+    // DIM @A[3, 2] → width=3; @A[4, 1] is out of bounds.
+    let src = concat!(
+        "DEF F()\n",
+        "  DIM @A[3, 2]\n",
+        "  RETURN @A[4, 1]\n",
+        "END\n",
+        "F\n",
+    );
+    interp
+        .exec_source(src)
+        .expect_err("@A[4, 1] must fail: x exceeds width=3");
+}
+
+/// `@A[1, height + 1]` must be rejected: y exceeds declared height.
+#[test]
+fn test_2d_array_get_y_exceeds_height_is_out_of_bounds() {
+    let mut interp = Interpreter::new();
+    // DIM @A[3, 2] → height=2; @A[1, 3] is out of bounds.
+    let src = concat!(
+        "DEF F()\n",
+        "  DIM @A[3, 2]\n",
+        "  RETURN @A[1, 3]\n",
+        "END\n",
+        "F\n",
+    );
+    interp
+        .exec_source(src)
+        .expect_err("@A[1, 3] must fail: y exceeds height=2");
+}
+
+// --- &@A[x, y] bounds errors (ARRAY_ADDR_2D) ---
+
+/// `&@A[0, 1]` via `SET` must be rejected: x=0 is out of bounds.
+#[test]
+fn test_2d_array_addr_x_zero_is_out_of_bounds() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF F()\n",
+        "  DIM @A[3, 2]\n",
+        "  SET &@A[0, 1], 10\n",
+        "END\n",
+        "F\n",
+    );
+    interp
+        .exec_source(src)
+        .expect_err("SET &@A[0, 1], 10 must fail: x=0 is out of bounds (1-based)");
+}
+
+/// `&@A[1, 0]` via `SET` must be rejected: y=0 is out of bounds.
+#[test]
+fn test_2d_array_addr_y_zero_is_out_of_bounds() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF F()\n",
+        "  DIM @A[3, 2]\n",
+        "  SET &@A[1, 0], 10\n",
+        "END\n",
+        "F\n",
+    );
+    interp
+        .exec_source(src)
+        .expect_err("SET &@A[1, 0], 10 must fail: y=0 is out of bounds (1-based)");
+}
+
+/// `&@A[width + 1, 1]` via `SET` must be rejected: x exceeds declared width.
+#[test]
+fn test_2d_array_addr_x_exceeds_width_is_out_of_bounds() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF F()\n",
+        "  DIM @A[3, 2]\n",
+        "  SET &@A[4, 1], 10\n",
+        "END\n",
+        "F\n",
+    );
+    interp
+        .exec_source(src)
+        .expect_err("SET &@A[4, 1], 10 must fail: x exceeds width=3");
+}
+
+/// `&@A[1, height + 1]` via `SET` must be rejected: y exceeds declared height.
+#[test]
+fn test_2d_array_addr_y_exceeds_height_is_out_of_bounds() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF F()\n",
+        "  DIM @A[3, 2]\n",
+        "  SET &@A[1, 3], 10\n",
+        "END\n",
+        "F\n",
+    );
+    interp
+        .exec_source(src)
+        .expect_err("SET &@A[1, 3], 10 must fail: y exceeds height=2");
+}
+
+// --- LET @A[x, y] = expr bounds errors (same checks via ARRAY_ADDR_2D) ---
+
+/// `LET @A[0, 1] = expr` must be rejected: x=0 is out of bounds.
+#[test]
+fn test_2d_let_x_zero_is_out_of_bounds() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF F()\n",
+        "  DIM @A[3, 2]\n",
+        "  LET @A[0, 1] = 10\n",
+        "END\n",
+        "F\n",
+    );
+    interp
+        .exec_source(src)
+        .expect_err("LET @A[0, 1] = 10 must fail: x=0 is out of bounds (1-based)");
+}
+
+/// `LET @A[1, 0] = expr` must be rejected: y=0 is out of bounds.
+#[test]
+fn test_2d_let_y_zero_is_out_of_bounds() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF F()\n",
+        "  DIM @A[3, 2]\n",
+        "  LET @A[1, 0] = 10\n",
+        "END\n",
+        "F\n",
+    );
+    interp
+        .exec_source(src)
+        .expect_err("LET @A[1, 0] = 10 must fail: y=0 is out of bounds (1-based)");
+}
+
+/// `LET @A[width + 1, 1] = expr` must be rejected: x exceeds declared width.
+#[test]
+fn test_2d_let_x_exceeds_width_is_out_of_bounds() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF F()\n",
+        "  DIM @A[3, 2]\n",
+        "  LET @A[4, 1] = 10\n",
+        "END\n",
+        "F\n",
+    );
+    interp
+        .exec_source(src)
+        .expect_err("LET @A[4, 1] = 10 must fail: x exceeds width=3");
+}
+
+/// `LET @A[1, height + 1] = expr` must be rejected: y exceeds declared height.
+#[test]
+fn test_2d_let_y_exceeds_height_is_out_of_bounds() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF F()\n",
+        "  DIM @A[3, 2]\n",
+        "  LET @A[1, 3] = 10\n",
+        "END\n",
+        "F\n",
+    );
+    interp
+        .exec_source(src)
+        .expect_err("LET @A[1, 3] = 10 must fail: y exceeds height=2");
+}
+
+// --- Rank mismatch: 1D array binding + 2D accessor ---
+
+/// `@A[x, y]` on a 1D array binding must be rejected with a type error.
+#[test]
+fn test_2d_get_on_1d_array_is_rank_mismatch() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF F()\n",
+        "  DIM @A[6]\n",
+        "  RETURN @A[1, 1]\n",
+        "END\n",
+        "F\n",
+    );
+    interp
+        .exec_source(src)
+        .expect_err("@A[1, 1] on a 1D array must fail with rank mismatch");
+}
+
+/// `&@A[x, y]` on a 1D array binding must be rejected with a type error.
+#[test]
+fn test_2d_addr_on_1d_array_is_rank_mismatch() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF F()\n",
+        "  DIM @A[6]\n",
+        "  SET &@A[1, 1], 10\n",
+        "END\n",
+        "F\n",
+    );
+    interp
+        .exec_source(src)
+        .expect_err("&@A[1, 1] on a 1D array must fail with rank mismatch");
+}
+
+/// `LET @A[x, y] = expr` on a 1D array binding must be rejected with a type error.
+#[test]
+fn test_2d_let_on_1d_array_is_rank_mismatch() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF F()\n",
+        "  DIM @A[6]\n",
+        "  LET @A[1, 1] = 10\n",
+        "END\n",
+        "F\n",
+    );
+    interp
+        .exec_source(src)
+        .expect_err("LET @A[1, 1] on a 1D array must fail with rank mismatch");
+}
+
+// --- Rank mismatch: 2D array binding + 1D accessor ---
+
+/// `@A[i]` on a 2D array binding must be rejected with a rank mismatch error.
+#[test]
+fn test_1d_get_on_2d_array_is_rank_mismatch() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF F()\n",
+        "  DIM @A[3, 2]\n",
+        "  RETURN @A[1]\n",
+        "END\n",
+        "F\n",
+    );
+    interp
+        .exec_source(src)
+        .expect_err("@A[1] on a 2D array must fail with rank mismatch");
+}
+
+/// `&@A[i]` on a 2D array binding must be rejected with a rank mismatch error.
+#[test]
+fn test_1d_addr_on_2d_array_is_rank_mismatch() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF F()\n",
+        "  DIM @A[3, 2]\n",
+        "  SET &@A[1], 10\n",
+        "END\n",
+        "F\n",
+    );
+    interp
+        .exec_source(src)
+        .expect_err("&@A[1] on a 2D array must fail with rank mismatch");
+}
+
+/// `LET @A[i] = expr` on a 2D array binding must be rejected with a rank mismatch error.
+#[test]
+fn test_1d_let_on_2d_array_is_rank_mismatch() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF F()\n",
+        "  DIM @A[3, 2]\n",
+        "  LET @A[1] = 10\n",
+        "END\n",
+        "F\n",
+    );
+    interp
+        .exec_source(src)
+        .expect_err("LET @A[1] on a 2D array must fail with rank mismatch");
+}
+
+// --- Regression: 1D array bounds behavior must be unchanged ---
+
+/// 1D array: index 0 must still be rejected.
+#[test]
+fn test_1d_array_index_zero_is_still_out_of_bounds() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF F()\n",
+        "  DIM @A[3]\n",
+        "  RETURN @A[0]\n",
+        "END\n",
+        "F\n",
+    );
+    interp
+        .exec_source(src)
+        .expect_err("@A[0] on a 1D array must still fail after 2D changes");
+}
+
+/// 1D array: index exceeding size must still be rejected.
+#[test]
+fn test_1d_array_index_exceeding_size_is_still_out_of_bounds() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF F()\n",
+        "  DIM @A[3]\n",
+        "  RETURN @A[4]\n",
+        "END\n",
+        "F\n",
+    );
+    interp
+        .exec_source(src)
+        .expect_err("@A[4] on a 3-element 1D array must still fail after 2D changes");
+}
+
+/// 1D array: valid access must still work.
+#[test]
+fn test_1d_array_valid_access_regression() {
+    let mut interp = Interpreter::new();
+    let src = concat!(
+        "DEF F()\n",
+        "  DIM @A[3]\n",
+        "  LET @A[2] = 42\n",
+        "  RETURN @A[2]\n",
+        "END\n",
+        "PUTDEC F()\n",
+    );
+    interp
+        .exec_source(src)
+        .expect("1D array valid access must still work after 2D changes");
+    assert_eq!(interp.take_output(), "42");
+}


### PR DESCRIPTION
## 概要

2D 配列アクセスの bounds check / rank mismatch エラーを整理・補強する (#750)。
`@A[x, y]` / `&@A[x, y]` / `LET @A[x, y] = expr` に対する全ての検査を一貫させ、安全で予測しやすい動作にする。

## 変更内容

### 実装 (src/primitives/arrays.rs)

- `array_get_prim` (1D accessor `@A[i]`) に `ArrayShape::TwoD` の rank mismatch チェックを追加  
  → 2D 配列への 1D-style アクセスを `TypeError { got: "2D Array" }` で拒否する
- `array_addr_prim` (1D accessor `&@A[i]`) に同等の rank mismatch チェックを追加  
  → `LET @A[i] = expr` は内部的に `array_addr_prim` を経由するため自動的に対象となる

### unit test の補強 (src/primitives/arrays.rs)

- `array_get_2d_prim`: y=0, x 負値, y 負値 ケースを追加
- `array_addr_2d_prim`: x=0, y=0 ケースを追加
- `array_get_prim` / `array_addr_prim`: 2D 配列への rank mismatch ケースを追加

### E2E テスト追加 (tests/tbx_lib_tests.rs)

- `@A[0, 1]` / `@A[1, 0]` が拒否されること
- `@A[width+1, 1]` / `@A[1, height+1]` が拒否されること
- `&@A[x, y]` / `LET @A[x, y] = expr` でも同等の bounds check が適用されること
- 1D 配列への 2D-style アクセス (`@A[x, y]`, `&@A[x, y]`, `LET @A[x, y]`) が rank mismatch で拒否されること
- 2D 配列への 1D-style アクセス (`@A[i]`, `&@A[i]`, `LET @A[i]`) が rank mismatch で拒否されること
- 1D 配列の既存 bounds behavior が変わらないことのリグレッションテスト

### 既存テスト修正 (src/primitives.rs)

- `test_2d_array_read_top_left` / `test_2d_array_read_index_formula` が 2D 配列に対して 1D accessor (`LET @A[i]`) を使って初期化していたため、正しい 2D accessor (`LET @A[x, y]`) を使うよう修正

## defer した内容

なし。issueに記載された全ての受け入れ条件を実装した。

- 2D 配列への 1D-style アクセス (`@A[i]` on 2D array) は、注意事項の「tighten するか defer するか」の判断として **tighten (拒否)** を選択した。
  `array_get_prim` / `array_addr_prim` への `ArrayShape::TwoD` チェック追加は低コストであり、flat linear access を許容し続けることによる混乱リスクの方が大きいと判断した。

Closes #750
