### PR TITLE
STTR1 ゲーム本体実装のスケルトンを作成する

### DIFF
--- a/examples/star_trek.tbx
+++ b/examples/star_trek.tbx
@@ -1,0 +1,18 @@
+# star_trek.tbx — STTR1 エントリポイント
+# Mike Mayfield 1972 HP BASIC 版 Star Trek の TBX 移植
+# 参照: docs/notes/star-trek-mayfield-1972.md
+
+USE "trek/state.tbx"
+USE "trek/util.tbx"
+USE "trek/init.tbx"
+USE "trek/scan.tbx"
+USE "trek/nav.tbx"
+USE "trek/combat.tbx"
+
+DEF MAIN()
+  INIT_GAME
+  PRINT_INTRO
+  SHORT_RANGE_SCAN
+END
+
+MAIN

--- a/examples/trek/combat.tbx
+++ b/examples/trek/combat.tbx
@@ -1,0 +1,29 @@
+# trek/combat.tbx — フェイザー・魚雷・クリンゴン攻撃手続き
+
+# フェイザー攻撃コマンド (STTR1.BAS lines 2530-2790)
+DEF PHASER_CONTROL()
+  # TODO: Mayfield STTR1 phaser control (cmd 3)
+END
+
+# 光子魚雷発射コマンド (STTR1.BAS lines 2800-3450)
+DEF TORPEDO_CONTROL()
+  # TODO: Mayfield STTR1 photon torpedo control (cmd 4)
+END
+
+# クリンゴンによる攻撃 (STTR1.BAS lines 3790-3910)
+DEF KLINGON_ATTACK()
+  # TODO: Mayfield STTR1 Klingon attack
+END
+
+# Enterprise から Klingon I までのセクター内距離を返す
+# Klingon 座標は @K_X[I], @K_Y[I]
+DEF DIST_TO_KLINGON(I)
+  VAR DX = @K_X[I] - ENT_SX
+  VAR DY = @K_Y[I] - ENT_SY
+  RETURN SQRT(DX * DX + DY * DY)
+END
+
+# クリンゴンを撃破する (STTR1.BAS lines 3670-3780)
+DEF DESTROY_KLINGON(I)
+  # TODO: remove Klingon I from sector and galaxy summary
+END

--- a/examples/trek/init.tbx
+++ b/examples/trek/init.tbx
@@ -1,0 +1,42 @@
+# trek/init.tbx — ゲーム初期化手続き
+
+# ゲーム全体の初期化 (STTR1.BAS lines 240-490)
+DEF INIT_GAME()
+  # TODO: Mayfield STTR1 initialization
+END
+
+# 8x8 ギャラクシーサマリーを生成する (STTR1.BAS lines 500-770)
+# 各クアドラントに K*100 + B*10 + S を格納する
+DEF INIT_GALAXY()
+  # TODO: generate 8x8 galaxy summary
+END
+
+# Enterprise の初期クアドラント・セクター位置を決める
+DEF INIT_ENTERPRISE_POSITION()
+  # TODO: random starting position
+END
+
+# コーステーブルを初期化する (STTR1.BAS C[9,2] 相当)
+# @COURSE_DX[1..9], @COURSE_DY[1..9] を設定する
+DEF INIT_COURSE_TABLE()
+  # TODO: Mayfield STTR1 course vector table
+END
+
+# @SECTOR[8, 8] を 0 でクリアする
+DEF CLEAR_SECTOR()
+  VAR Y = 1
+  WHILE Y <= 8
+    VAR X = 1
+    WHILE X <= 8
+      LET @SECTOR[X, Y] = 0
+      LET X = X + 1
+    ENDWH
+    LET Y = Y + 1
+  ENDWH
+END
+
+# 現在のクアドラントをセットアップする (STTR1.BAS lines 810-1260)
+DEF INIT_QUADRANT()
+  CLEAR_SECTOR
+  # TODO: place Enterprise, Klingons, starbases, stars in @SECTOR
+END

--- a/examples/trek/nav.tbx
+++ b/examples/trek/nav.tbx
@@ -1,0 +1,18 @@
+# trek/nav.tbx — 航法・コース・ワープ手続き
+
+# コース・ワープエンジン制御コマンド (STTR1.BAS lines 1410-2320)
+DEF NAVIGATE()
+  # TODO: Mayfield STTR1 navigation (cmd 0)
+END
+
+# コース番号 (1..9) に対応する X 方向移動量を返す
+# 実装時は @COURSE_DX[COURSE] を参照する
+DEF COURSE_DX(COURSE)
+  # TODO: return @COURSE_DX[COURSE]
+END
+
+# コース番号 (1..9) に対応する Y 方向移動量を返す
+# 実装時は @COURSE_DY[COURSE] を参照する
+DEF COURSE_DY(COURSE)
+  # TODO: return @COURSE_DY[COURSE]
+END

--- a/examples/trek/scan.tbx
+++ b/examples/trek/scan.tbx
@@ -1,0 +1,24 @@
+# trek/scan.tbx — 短距離スキャン・長距離スキャン手続き
+
+# 短距離センサースキャン (STTR1.BAS lines 4120-4530)
+# @SECTOR[8, 8] の内容を 8x8 グリッドで表示する
+DEF SHORT_RANGE_SCAN()
+  # TODO: Mayfield STTR1 short range sensor scan
+END
+
+# 長距離センサースキャン (STTR1.BAS lines 2330-2500)
+# 周囲 3x3 クアドラントの @GALAXY サマリーを表示し @CHART を更新する
+DEF LONG_RANGE_SCAN()
+  # TODO: Mayfield STTR1 long range sensor scan
+END
+
+# ステータス行を表示する (短距離スキャン右列)
+# LINE_NO: 1..8 の行番号
+DEF PRINT_STATUS_LINE(LINE_NO)
+  # TODO: Mayfield STTR1 status line display
+END
+
+# ミッションブリーフィングを表示する (STTR1.BAS line 780)
+DEF PRINT_MISSION_BRIEFING()
+  # TODO: mission orders
+END

--- a/examples/trek/state.tbx
+++ b/examples/trek/state.tbx
@@ -1,0 +1,60 @@
+# trek/state.tbx — STTR1 グローバル状態・定数・配列宣言
+
+# --- 8x8 盤面データ (2D 配列) ---
+# galaxy summary: K*100 + B*10 + S で各クアドラントの内容を保持
+DIM @GALAXY[8, 8]
+
+# cumulative galactic record (library computer memory)
+DIM @CHART[8, 8]
+
+# 現在クアドラント内のセクターマップ
+# 0=空, 1=Enterprise, 2=Klingon, 3=Starbase, 4=Star
+DIM @SECTOR[8, 8]
+
+# --- Klingon 座標・エネルギー (最大 3 体) ---
+DIM @K_X[3]
+DIM @K_Y[3]
+DIM @K_E[3]
+
+# --- デバイス損傷状態 (1..8) ---
+DIM @DAMAGE[8]
+
+# --- コース方向テーブル (1..9) ---
+DIM @COURSE_DX[9]
+DIM @COURSE_DY[9]
+
+# --- Enterprise 位置 ---
+VAR ENT_QX
+VAR ENT_QY
+VAR ENT_SX
+VAR ENT_SY
+
+# --- 時間管理 ---
+VAR STARDATE
+VAR START_STARDATE
+VAR MISSION_DAYS
+
+# --- エネルギー・武装 ---
+VAR ENERGY
+VAR MAX_ENERGY
+VAR SHIELDS
+VAR TORPEDOES
+VAR MAX_TORPEDOES
+
+# --- Klingon 統計 ---
+VAR KLINGONS_LEFT
+VAR KLINGONS_INITIAL
+VAR KLINGON_INIT_ENERGY
+
+# --- スターベース統計 ---
+VAR BASES_LEFT
+
+# --- 現クアドラント内カウント ---
+VAR KLINGONS_HERE
+VAR BASES_HERE
+VAR STARS_HERE
+
+# --- ゲーム状態 ---
+VAR DOCKED
+VAR GAME_OVER
+VAR CONDITION

--- a/examples/trek/util.tbx
+++ b/examples/trek/util.tbx
@@ -1,0 +1,30 @@
+# trek/util.tbx — 座標・乱数・表示補助 helper
+
+# ゲームタイトルとクレジットを表示する
+DEF PRINT_INTRO()
+  # TODO: Mayfield STTR1 instructions / title screen (STTR1.BAS lines 5820-6410)
+END
+
+# プロンプトを表示して数値入力を受け取る
+DEF PROMPT_NUM(PROMPT)
+  PUTSTR PROMPT
+  RETURN GETDEC
+END
+
+# 0 以上 2 未満の乱数 (整数 0..199 を 100.0 で割った値に相当)
+# Mayfield RND(1) * 2 の近似
+# TODO: issue #763 で RND 互換方針が確定したら更新する
+DEF RAND_FACTOR_0_TO_2_100()
+  RETURN RND(200) - 1
+END
+
+# コンディション文字列を更新する
+# GREEN / YELLOW / RED / DOCKED
+DEF UPDATE_CONDITION()
+  # TODO: Mayfield STTR1 condition logic
+END
+
+# デバイス番号に対応する名称を表示する
+DEF PRINT_DEVICE_NAME(D)
+  # TODO: Mayfield STTR1 device names (STTR1.BAS lines 5610-5670)
+END


### PR DESCRIPTION
## 概要

issue #764 の実装。Mike Mayfield 1972 HP BASIC 版 STTR1 を TBX で移植するための、ゲーム本体の最小スケルトンを作成した。今後の実装 PR を積み上げやすいファイル構成・エントリポイント・状態変数・空の手続き群を用意する。

## 変更内容

- `examples/star_trek.tbx`: トップレベルエントリポイント。`USE` を 6 モジュール分並べ `MAIN` を定義して呼び出す
- `examples/trek/state.tbx`: グローバル状態・定数・配列宣言。`DIM @GALAXY[8, 8]` / `@CHART[8, 8]` / `@SECTOR[8, 8]` の 2D 配列、Klingon 座標・エネルギー配列、デバイス損傷配列、コース方向テーブル、各種スカラー変数を集約
- `examples/trek/util.tbx`: 表示補助・乱数 helper のスケルトン（`PRINT_INTRO`、`PROMPT_NUM`、`RAND_FACTOR_0_TO_2_100` など）
- `examples/trek/init.tbx`: 初期化手続きのスケルトン。`CLEAR_SECTOR`（2D 配列方針確認用の最小 helper 実装済み）と各初期化 stub を含む
- `examples/trek/scan.tbx`: 短距離・長距離スキャン手続きのスケルトン
- `examples/trek/nav.tbx`: 航法・コース手続きのスケルトン
- `examples/trek/combat.tbx`: フェイザー・魚雷・クリンゴン攻撃手続きのスケルトン。`DIST_TO_KLINGON` は `@K_X[I]` / `@K_Y[I]` と `SQRT` を使った 2D 配列方針の実装例として実装済み

## ファイル分割方針の補足

issue 本文の推奨ファイル構成に従った。`PRINT_MISSION_BRIEFING` は scan と深く結びついているため `scan.tbx` に配置した。

## 実装上の判断事項

- `COURSE_DX(COURSE)` / `COURSE_DY(COURSE)` 関数は、同名の配列変数 `@COURSE_DX` / `@COURSE_DY` と名前が衝突するため、本体を空 stub とし、実装時の参照方法をコメントで残した
- `^` 演算子が TBX 未対応のため、`DIST_TO_KLINGON` では `DX * DX + DY * DY` に展開した

Closes #764
