### PR TITLE
STTR1 乱数計算の移植方針を整理する

### DIFF
--- a/docs/notes/star-trek-mayfield-1972.md
+++ b/docs/notes/star-trek-mayfield-1972.md
@@ -608,12 +608,31 @@ Enterprise に隣接するすべてのセクター（斜め含む）にスター
 
 ### `RND(1)` 互換性
 
-原典は floating `RND(1)` を多用する。現行 TBX の `RND(n)` は整数 `[1,n]` なので、Mayfield 版を自然に移植するには以下のどちらかが必要。
+Mayfield HP BASIC の `RND(1)` は `0 <= r < 1` の浮動小数乱数として使われている。TBX の `RND(n)` は `1..n` の整数乱数なので、STTR1 移植では次の方針で読み替える。
 
-1. `RND_FLOAT()` primitive を追加する
-2. 高解像度整数乱数から `0 <= x < 1` を作る helper を用意する
+| Mayfield pattern | TBX policy |
+| --- | --- |
+| `INT(RND(1)*N + A)` | `RND(N) + A - 1` |
+| `RND(1) > p` | `RND(100)` による percent check |
+| `R1=RND(1)` 後に複数 `IF` | TBX でも乱数を1回だけ引き、同じ値で区間分岐する |
+| `2*RND(1)` | `RND(200)-1` を scale 100 の `0..199` 係数として扱う |
 
-ゲームプレイの計算式が `RND(1)>.98` や `2*RND(1)` に依存するため、単純に `RND(100)` へ置き換える場合も helper 名を分けて意図を残す。
+Examples:
+
+```tbx
+# INT(RND(1)*20+20)*100
+(RND(20) + 19) * 100
+
+# R1=RND(1); IF R1>.98; IF R1>.95; IF R1>.8
+VAR R1 = RND(100)
+IF R1 > 98 ; ...
+IF R1 > 95 ; ...
+IF R1 > 80 ; ...
+````
+
+`2*RND(1)` は phaser / Klingon attack の damage multiplier として使われる。整数除算の早すぎる丸めを避けるため、可能な限り先に乱数係数を掛けてから割る。
+
+`FND(0)` は Enterprise と Klingon `I` の距離であり、TBX では `DIST_TO_KLINGON(I)` helper に寄せる。
 
 ### セクター表現
 

--- a/docs/notes/star-trek-mayfield-1972.md
+++ b/docs/notes/star-trek-mayfield-1972.md
@@ -625,10 +625,17 @@ Examples:
 
 # R1=RND(1); IF R1>.98; IF R1>.95; IF R1>.8
 VAR R1 = RND(100)
-IF R1 > 98 ; ...
-IF R1 > 95 ; ...
-IF R1 > 80 ; ...
-````
+IF R1 > 98
+  # line 580 相当
+ELSIF R1 > 95
+  # line 610 相当
+ELSIF R1 > 80
+  # line 640 相当
+ELSE
+  # fallthrough
+ENDIF
+```
+
 
 `2*RND(1)` は phaser / Klingon attack の damage multiplier として使われる。整数除算の早すぎる丸めを避けるため、可能な限り先に乱数係数を掛けてから割る。
 

--- a/examples/trek/util.tbx
+++ b/examples/trek/util.tbx
@@ -11,11 +11,19 @@ DEF PROMPT_NUM(PROMPT)
   RETURN GETDEC
 END
 
-# 0 以上 2 未満の乱数 (整数 0..199 を 100.0 で割った値に相当)
-# Mayfield RND(1) * 2 の近似
-# TODO: issue #763 で RND 互換方針が確定したら更新する
+# 0..99 の整数 percent roll
+DEF ROLL_PERCENT()
+  RETURN RND(100)
+END
+
+# 0..199 2*RND(1) を scale=100 で表現する係数
 DEF RAND_FACTOR_0_TO_2_100()
   RETURN RND(200) - 1
+END
+
+# true_percent は 0..100
+DEF CHANCE(true_percent)
+  RETURN RND(100) <= true_percent
 END
 
 # コンディション文字列を更新する


### PR DESCRIPTION
## 概要

issue #763 の実装。

Mayfield 1972 HP BASIC 版 `STTR1` の `RND(1)` 由来の乱数計算について、現行 TBX の整数型 `RND(n)` へ移植するための方針を整理する。

## 変更内容

- `docs/notes/star-trek-mayfield-1972.md` に `RND(1)` compatibility 方針を追記
- `INT(RND(1)*N + A)` 型を `RND(N) + A - 1` へ読み替える方針を明記
- `RND(1) > p` 型を `RND(100)` による percent check として扱う方針を明記
- `R1=RND(1)` 後に複数 `IF` で区間分岐する型では、TBX でも乱数を1回だけ引く方針を明記
- `2*RND(1)` 型を `RND(200)-1` の scale 100 係数として扱う方針を明記
- `FND(0)` は Enterprise と Klingon の距離として扱い、`DIST_TO_KLINGON(I)` helper に寄せる方針を明記

## 非目標

- TBX 言語本体の `RND` semantics 変更
- 浮動小数乱数 primitive の追加
- STTR1 gameplay 本体の実装
- 乱数分布の完全な統計的一致

Closes #763