### PR TITLE
STTR1: course table を初期化する

### DIFF
--- a/docs/notes/star-trek-mayfield-1972.md
+++ b/docs/notes/star-trek-mayfield-1972.md
@@ -176,6 +176,33 @@ LET @SECTOR[SX, SY] = 1
 
 コースは 1 以上 9 未満。実数値が許可され、`C2=INT(C1)` のあと `C[C2]` と `C[C2+1]` の線形補間で vector を作る。
 
+### TBX `@COURSE_DX` / `@COURSE_DY` への読み替え
+
+Mayfield では `C[course, 1]` が row delta（縦方向）、`C[course, 2]` が col delta（横方向）。
+TBX は `[x, y]` convention なので次のように読み替える。
+
+| Mayfield | 意味 | TBX |
+| --- | --- | --- |
+| `C[course, 1]` | row delta | `@COURSE_DY[course]` |
+| `C[course, 2]` | col delta | `@COURSE_DX[course]` |
+
+TBX における展開後の値:
+
+| course | `@COURSE_DY` | `@COURSE_DX` | 方角 |
+| ---: | ---: | ---: | --- |
+| 1 | 0 | 1 | 東 |
+| 2 | -1 | 1 | 北東 |
+| 3 | -1 | 0 | 北 |
+| 4 | -1 | -1 | 北西 |
+| 5 | 0 | -1 | 西 |
+| 6 | 1 | -1 | 南西 |
+| 7 | 1 | 0 | 南 |
+| 8 | 1 | 1 | 南東 |
+| 9 | 0 | 1 | コース補間センチネル |
+
+後続の navigation 実装では配列を直接参照する方針:
+`LET DX = @COURSE_DX[COURSE]`、`LET DY = @COURSE_DY[COURSE]`。
+
 ## ギャラクシー生成
 
 行 490-770 で、Klingon 数・starbase 数・star 数を生成する。

--- a/docs/notes/star-trek-mayfield-1972.md
+++ b/docs/notes/star-trek-mayfield-1972.md
@@ -200,8 +200,8 @@ TBX における展開後の値:
 | 8 | 1 | 1 | 南東 |
 | 9 | 0 | 1 | コース補間センチネル |
 
-後続の navigation 実装では配列を直接参照する方針:
-`LET DX = @COURSE_DX[COURSE]`、`LET DY = @COURSE_DY[COURSE]`。
+後続の navigation 実装では accessor を通して参照する方針:
+`LET DX = GET_COURSE_DX(COURSE)`、`LET DY = GET_COURSE_DY(COURSE)`。
 
 ## ギャラクシー生成
 

--- a/examples/trek/init.tbx
+++ b/examples/trek/init.tbx
@@ -1,7 +1,32 @@
 # trek/init.tbx — ゲーム初期化手続き
 
+# コーステーブルを初期化する (STTR1.BAS lines 420-440 C[9,2] 相当)
+# Mayfield C[I,1] = row delta -> TBX @COURSE_DY[I]
+# Mayfield C[I,2] = col delta -> TBX @COURSE_DX[I]
+DEF INIT_COURSE_TABLE()
+  LET @COURSE_DY[1] = 0   # 東
+  LET @COURSE_DX[1] = 1
+  LET @COURSE_DY[2] = -1  # 北東
+  LET @COURSE_DX[2] = 1
+  LET @COURSE_DY[3] = -1  # 北
+  LET @COURSE_DX[3] = 0
+  LET @COURSE_DY[4] = -1  # 北西
+  LET @COURSE_DX[4] = -1
+  LET @COURSE_DY[5] = 0   # 西
+  LET @COURSE_DX[5] = -1
+  LET @COURSE_DY[6] = 1   # 南西
+  LET @COURSE_DX[6] = -1
+  LET @COURSE_DY[7] = 1   # 南
+  LET @COURSE_DX[7] = 0
+  LET @COURSE_DY[8] = 1   # 南東
+  LET @COURSE_DX[8] = 1
+  LET @COURSE_DY[9] = 0   # コース補間センチネル (course 1 と同値)
+  LET @COURSE_DX[9] = 1
+END
+
 # ゲーム全体の初期化 (STTR1.BAS lines 240-490)
 DEF INIT_GAME()
+  INIT_COURSE_TABLE
   # TODO: Mayfield STTR1 initialization
 END
 
@@ -14,12 +39,6 @@ END
 # Enterprise の初期クアドラント・セクター位置を決める
 DEF INIT_ENTERPRISE_POSITION()
   # TODO: random starting position
-END
-
-# コーステーブルを初期化する (STTR1.BAS C[9,2] 相当)
-# @COURSE_DX[1..9], @COURSE_DY[1..9] を設定する
-DEF INIT_COURSE_TABLE()
-  # TODO: Mayfield STTR1 course vector table
 END
 
 # @SECTOR[8, 8] を 0 でクリアする

--- a/examples/trek/nav.tbx
+++ b/examples/trek/nav.tbx
@@ -6,13 +6,13 @@ DEF NAVIGATE()
 END
 
 # コース番号 (1..9) に対応する X 方向移動量を返す
-# 実装時は @COURSE_DX[COURSE] を参照する
-DEF COURSE_DX(COURSE)
-  # TODO: return @COURSE_DX[COURSE]
+# 配列 @COURSE_DX との混同を避けるため GET_COURSE_DX と命名する
+DEF GET_COURSE_DX(COURSE)
+  RETURN @COURSE_DX[COURSE]
 END
 
 # コース番号 (1..9) に対応する Y 方向移動量を返す
-# 実装時は @COURSE_DY[COURSE] を参照する
-DEF COURSE_DY(COURSE)
-  # TODO: return @COURSE_DY[COURSE]
+# 配列 @COURSE_DY との混同を避けるため GET_COURSE_DY と命名する
+DEF GET_COURSE_DY(COURSE)
+  RETURN @COURSE_DY[COURSE]
 END


### PR DESCRIPTION
## 概要

Mayfield 1972 HP BASIC 版 `STTR1` の course table `C[1..9, 1..2]` を、TBX 実装の `@COURSE_DX[1..9]` / `@COURSE_DY[1..9]` として初期化する。後続の navigation 実装が使えるよう、course 番号から sector 移動ベクトルを取得するための土台を作る。

## 変更内容

- `docs/notes/star-trek-mayfield-1972.md`: コースベクトルテーブルの TBX `@COURSE_DX` / `@COURSE_DY` への読み替え（row/col delta → [x, y] convention）を追記
- `examples/trek/init.tbx`: `INIT_COURSE_TABLE()` を実装し、`INIT_GAME()` から呼び出す
  - 前方参照を避けるため `INIT_COURSE_TABLE` を `INIT_GAME` より先に定義
- `examples/trek/nav.tbx`: accessor を `GET_COURSE_DX` / `GET_COURSE_DY` にリネームして実装
  - 配列名 `@COURSE_DX` / `@COURSE_DY` との混同を避けるため `GET_` prefix を付与

Closes #768

🤖 Generated with [Claude Code](https://claude.com/claude-code)
