### PR TITLE
feat(sttr1): INIT_GALAXY() を実装する (#772)

### DIFF
--- a/examples/trek/init.tbx
+++ b/examples/trek/init.tbx
@@ -24,16 +24,52 @@ DEF INIT_COURSE_TABLE()
   LET @COURSE_DX[9] = 1
 END
 
-# ゲーム全体の初期化 (STTR1.BAS lines 240-490)
-DEF INIT_GAME()
-  INIT_COURSE_TABLE
-  # TODO: Mayfield STTR1 initialization
-END
-
 # 8x8 ギャラクシーサマリーを生成する (STTR1.BAS lines 500-770)
-# 各クアドラントに K*100 + B*10 + S を格納する
+# 各クアドラントに K3*100 + B3*10 + S3 を格納する
+# Klingon 数または Starbase 数が 0 なら galaxy generation をやり直す
 DEF INIT_GALAXY()
-  # TODO: generate 8x8 galaxy summary
+  VAR DONE = 0
+  WHILE DONE = 0
+    LET KLINGONS_LEFT = 0
+    LET BASES_LEFT = 0
+    VAR QY = 1
+    WHILE QY <= 8
+      VAR QX = 1
+      WHILE QX <= 8
+        # Klingon 数: RND(100) を1回引いて区間分岐 (STTR1.BAS lines 520-640)
+        # >98 -> 3体(2%), >95 -> 2体(3%), >80 -> 1体(15%), otherwise -> 0体(80%)
+        VAR R1 = RND(100)
+        VAR K3 = 0
+        IF R1 > 98
+          LET K3 = 3
+        ELSIF R1 > 95
+          LET K3 = 2
+        ELSIF R1 > 80
+          LET K3 = 1
+        ENDIF
+        # Starbase 数: RND(100) > 96 -> 1基(4%), otherwise -> 0基(96%) (STTR1.BAS lines 660-700)
+        VAR B3 = 0
+        IF RND(100) > 96
+          LET B3 = 1
+        ENDIF
+        # Star 数: 1..8 の一様分布 (STTR1.BAS line 720)
+        VAR S3 = RND(8)
+        # クアドラントサマリーを格納 (STTR1.BAS line 730)
+        LET @GALAXY[QX, QY] = K3 * 100 + B3 * 10 + S3
+        LET KLINGONS_LEFT = KLINGONS_LEFT + K3
+        LET BASES_LEFT = BASES_LEFT + B3
+        LET QX = QX + 1
+      ENDWH
+      LET QY = QY + 1
+    ENDWH
+    LET KLINGONS_INITIAL = KLINGONS_LEFT
+    # B9 <= 0 OR K9 <= 0 のとき galaxy generation をやり直す (STTR1.BAS line 775)
+    IF KLINGONS_LEFT > 0
+      IF BASES_LEFT > 0
+        LET DONE = 1
+      ENDIF
+    ENDIF
+  ENDWH
 END
 
 # Enterprise の初期クアドラント・セクター位置を決める
@@ -58,4 +94,12 @@ END
 DEF INIT_QUADRANT()
   CLEAR_SECTOR
   # TODO: place Enterprise, Klingons, starbases, stars in @SECTOR
+END
+
+# ゲーム全体の初期化 (STTR1.BAS lines 240-490)
+# 前方参照を避けるため、呼び出す DEF より後に定義する
+DEF INIT_GAME()
+  INIT_COURSE_TABLE
+  INIT_GALAXY
+  # TODO: remaining Mayfield STTR1 initialization
 END


### PR DESCRIPTION
## 概要

issue #772 の実装。STTR1 の galaxy 初期生成（行 490-770 相当）を `INIT_GALAXY()` として実装する。

## 変更内容

### `examples/trek/init.tbx`

- `INIT_GALAXY()` を実装
  - Klingon 数: `RND(100)` を1回引いて `>98/3体`, `>95/2体`, `>80/1体`, それ以外/0体 に区間分岐（Mayfield 原典 lines 520-640 相当）
  - Starbase 数: `RND(100) > 96` で 1基、それ以外 0基（lines 660-700 相当）
  - Star 数: `RND(8)` による 1..8 一様分布（line 720 相当）
  - `@GALAXY[QX, QY]` に `K3 * 100 + B3 * 10 + S3` を格納（line 730 相当）
  - `KLINGONS_LEFT` / `KLINGONS_INITIAL` / `BASES_LEFT` に合計値を反映
  - Klingon 数または Starbase 数が 0 の場合、galaxy generation をやり直す（line 775 相当）
- `INIT_GAME()` から `INIT_GALAXY` を呼び出す
- 前方参照ルール遵守のため `INIT_GAME()` を全 callee 定義の後に移動

## 確認方法

`.tmp/test_galaxy_smoke.tbx` による smoke test を実施し、以下を確認した:

- `@GALAXY[QX, QY]` の値が全クアドラントで `K*100 + B*10 + S` 形式になっていること（K: 0-3, B: 0-1, S: 1-8）
- `KLINGONS_LEFT` / `KLINGONS_INITIAL` / `BASES_LEFT` が正の値になっていること
- 複数回実行して値が変動すること（乱数が機能していること）

実行結果:

```
GALAXY OK: 20 klingons, 2 starbases (initial=20)
GALAXY OK: 7 klingons, 3 starbases (initial=7)
GALAXY OK: 23 klingons, 2 starbases (initial=23)
GALAXY OK: 22 klingons, 1 starbases (initial=22)
GALAXY OK: 16 klingons, 5 starbases (initial=16)
```

- `cargo test`: 138 passed / 0 failed
- `examples/star_trek.tbx`: パースエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)