### PR TITLE
count_top_level_arity で LBracket / RBracket も depth 追跡する

### DIFF
--- a/lib/tests/test_array_index_comma.tbx
+++ b/lib/tests/test_array_index_comma.tbx
@@ -1,0 +1,54 @@
+# lib/tests/test_array_index_comma.tbx
+# Regression test for issue #776:
+# count_top_level_arity must not count commas inside [...] as top-level
+# argument separators.  Before the fix, calling F(@A[1], @B[1]) was
+# misinterpreted as a 3-argument call because the comma inside @A[...] was
+# counted at depth 0.
+USE "lib/tests/helper.tbx"
+
+# --- Two-argument call where each argument contains an array index ---
+
+DEF ADD_ELEMS(X, Y)
+  RETURN X + Y
+END
+
+DEF TEST_TWO_ARRAY_ARGS()
+  DIM @A[2]
+  DIM @B[2]
+  LET @A[1] = 10
+  LET @B[1] = 20
+  # Both @A[1] and @B[1] must be recognised as separate arguments, not three.
+  RETURN ADD_ELEMS(@A[1], @B[1])
+END
+
+ASSERT TEST_TWO_ARRAY_ARGS() = 30
+
+# --- Three-argument call with array-indexed arguments ---
+
+DEF SUM3(X, Y, Z)
+  RETURN X + Y + Z
+END
+
+DEF TEST_THREE_ARRAY_ARGS()
+  DIM @A[3]
+  LET @A[1] = 1
+  LET @A[2] = 2
+  LET @A[3] = 3
+  RETURN SUM3(@A[1], @A[2], @A[3])
+END
+
+ASSERT TEST_THREE_ARRAY_ARGS() = 6
+
+# --- Array index expression containing arithmetic must not split arguments ---
+
+DEF TEST_EXPR_INDEX_COMMA()
+  DIM @A[4]
+  DIM @B[4]
+  LET @A[2] = 100
+  LET @B[2] = 200
+  VAR I = 1
+  # @A[I + 1] and @B[I + 1] each contain an expression; commas must not escape.
+  RETURN ADD_ELEMS(@A[I + 1], @B[I + 1])
+END
+
+ASSERT TEST_EXPR_INDEX_COMMA() = 300

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1380,10 +1380,10 @@ fn count_top_level_arity(tokens: &[SpannedToken]) -> Result<usize, TbxError> {
     let mut commas: usize = 0;
     for st in tokens {
         match &st.token {
-            Token::LParen => depth += 1,
-            Token::RParen => {
+            Token::LParen | Token::LBracket => depth += 1,
+            Token::RParen | Token::RBracket => {
                 depth = depth.checked_sub(1).ok_or(TbxError::InvalidExpression {
-                    reason: "unmatched ')' in argument list",
+                    reason: "unmatched ')' or ']' in argument list",
                 })?;
             }
             Token::Comma if depth == 0 => commas += 1,
@@ -1683,6 +1683,22 @@ GREET";
             count_top_level_arity(&tokens),
             Err(TbxError::InvalidExpression { .. })
         ));
+    }
+
+    #[test]
+    fn test_count_top_level_arity_nested_brackets() {
+        // Commas inside brackets must not be counted as top-level separators.
+        // Regression test for issue #776: @A[1, 2] inside a call argument must
+        // not be misinterpreted as two separate arguments.
+        let tokens = tokenize_args("@A[1 , 2]");
+        assert_eq!(count_top_level_arity(&tokens), Ok(1));
+    }
+
+    #[test]
+    fn test_count_top_level_arity_mixed_brackets_and_parens() {
+        // f(@A[1, 2], @B[3, 4]) must count as 2 top-level arguments.
+        let tokens = tokenize_args("f(@A[1 , 2]) , g(@B[3 , 4])");
+        assert_eq!(count_top_level_arity(&tokens), Ok(2));
     }
 
     #[test]


### PR DESCRIPTION
## 概要

`count_top_level_arity` が `[` / `]` を depth 追跡していなかったため、`@A[1]` のような配列インデックス式内のカンマがトップレベルの引数区切りとして誤カウントされていた。

## 変更内容

- `src/interpreter.rs`: `count_top_level_arity` の match アームで `Token::LParen | Token::LBracket => depth += 1` / `Token::RParen | Token::RBracket => depth -= 1` に変更
- `src/interpreter.rs`: ブラケット内カンマのユニットテスト2件を追加（`test_count_top_level_arity_nested_brackets`、`test_count_top_level_arity_mixed_brackets_and_parens`）
- `lib/tests/test_array_index_comma.tbx`: 統合テストを追加（2引数・3引数・式インデックスの各パターン）

Closes #776
