### PR TITLE
STTR1 long-range scan を実装する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,57 +1,57 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main, phase5b-rc-str]
+    push:
+        branches: [main]
+    pull_request:
+        branches: [main, issue/470-sttr1-porting]
 
 env:
-  CARGO_TERM_COLOR: always
-  RUSTFLAGS: -Dwarnings
+    CARGO_TERM_COLOR: always
+    RUSTFLAGS: -Dwarnings
 
 jobs:
-  check:
-    name: Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-      - uses: Swatinem/rust-cache@v2
-      - run: cargo check --all-targets
+    check:
+        name: Check
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: dtolnay/rust-toolchain@stable
+              with:
+                  toolchain: stable
+            - uses: Swatinem/rust-cache@v2
+            - run: cargo check --all-targets
 
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-      - uses: Swatinem/rust-cache@v2
-      - run: cargo test
+    test:
+        name: Test
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: dtolnay/rust-toolchain@stable
+              with:
+                  toolchain: stable
+            - uses: Swatinem/rust-cache@v2
+            - run: cargo test
 
-  clippy:
-    name: Clippy
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-          components: clippy
-      - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy --all-targets
+    clippy:
+        name: Clippy
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: dtolnay/rust-toolchain@stable
+              with:
+                  toolchain: stable
+                  components: clippy
+            - uses: Swatinem/rust-cache@v2
+            - run: cargo clippy --all-targets
 
-  fmt:
-    name: Format
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-          components: rustfmt
-      - run: cargo fmt --check
+    fmt:
+        name: Format
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: dtolnay/rust-toolchain@stable
+              with:
+                  toolchain: stable
+                  components: rustfmt
+            - run: cargo fmt --check

--- a/docs/agent-notes.md
+++ b/docs/agent-notes.md
@@ -175,24 +175,6 @@ Markdown の code fence は backtick 3つ（` ``` `）で統一する。backtick
 
 ## テスト記述上の注意
 
-### `ASSERT` に 2D 配列アクセスを渡すときは括弧が必要
-
-`ASSERT @ARRAY[X, Y] = VALUE` のように 2D 配列インデックスのカンマが引数トークン列に含まれると、TBX は `argc=2` の 2 引数呼び出しと解釈してアサーションが失敗する。
-
-**根本原因**: TBX の `count_top_level_arity`（`interpreter.rs`）は `(` / `)` でのみネスト深度を追跡し、`[` / `]` は追跡しない。そのため `@SECTOR[ENT_SX, ENT_SY]` 内のカンマを深度0のトップレベル区切りとみなし、arity を 2 と算定する。
-
-```tbx
-# NG: [ENT_SX, ENT_SY] 内のカンマが argc=2 を引き起こし assertion failed
-ASSERT @SECTOR[ENT_SX, ENT_SY] = 1
-
-# OK: 外側の () でカンマを depth=1 に押し込み argc=1 にする
-ASSERT (@SECTOR[ENT_SX, ENT_SY] = 1)
-```
-
-変数同士の比較（`ASSERT VAR1 = VAR2`）はカンマを含まないため argc=1 となり問題ない。
-関数呼び出し結果との比較（`ASSERT FOO() = 1`）も `()` でカンマが囲まれるため問題ない。
-**2D 配列アクセスを含む比較は必ず外側を `()` で包む**（PR #775 の事例）。
-
 ### `VAR x = expr` はトップレベルでは使えない
 
 `VAR x = expr`（初期化付き宣言）は `DEF ... END` ブロックの中でのみ有効。トップレベルに書くと `VAR initializer '= expr' is not allowed outside DEF` エラーになる。

--- a/examples/trek/scan.tbx
+++ b/examples/trek/scan.tbx
@@ -17,6 +17,34 @@ DEF IS_IN_SECTOR_BOUNDS(X, Y)
   RETURN 1
 END
 
+# 座標が quadrant 境界内 (1..8 × 1..8) か判定する
+DEF IS_IN_QUAD_BOUNDS(QX, QY)
+  IF QX < 1
+    RETURN 0
+  ENDIF
+  IF QX > 8
+    RETURN 0
+  ENDIF
+  IF QY < 1
+    RETURN 0
+  ENDIF
+  IF QY > 8
+    RETURN 0
+  ENDIF
+  RETURN 1
+END
+
+# 整数 N を 3 桁ゼロ埋め形式で出力する (改行なし)
+# 原典 Mayfield STTR1 IMAGE 2510 の "3D" に対応する
+DEF PRINT_3D(N)
+  IF N < 10
+    PUTSTR "00"
+  ELSIF N < 100
+    PUTSTR "0"
+  ENDIF
+  PUTDEC N
+END
+
 # セクター値を表示記号に変換する (STTR1.BAS lines 5820-5860)
 # 0=空, 1=Enterprise, 2=Klingon, 3=Starbase, 4=Star
 DEF SECTOR_SYMBOL(VAL)
@@ -113,8 +141,63 @@ END
 
 # 長距離センサースキャン (STTR1.BAS lines 2330-2500)
 # 周囲 3x3 クアドラントの @GALAXY サマリーを表示し @CHART を更新する
+#
+# 座標読み替え:
+#   Mayfield Q1 (row) -> ENT_QY,  Mayfield Q2 (col) -> ENT_QX
+#   Mayfield I (row ループ) -> LQY,  Mayfield J (col ループ) -> LQX
+#   Mayfield G[I,J] -> @GALAXY[LQX, LQY]  (TBX は [x, y] = [col, row] 順)
+#   Mayfield Z[I,J] -> @CHART[LQX, LQY]
+#
+# 表示ヘッダーは原典に寄せて QY,QX 順 (Mayfield の Q1,Q2 = row,col に対応)
+# 内部アクセスは TBX convention の @GALAXY[QX, QY] に統一する
 DEF LONG_RANGE_SCAN()
-  # TODO: Mayfield STTR1 long range sensor scan
+  # TODO: @DAMAGE[3] < 0 の場合は "LONG RANGE SENSORS ARE INOPERABLE" を表示してスキップ (Mayfield 2330-2360, damage check は後続 issue で実装)
+  # 原典 2370: PRINT USING 2350;Q1,Q2 → ヘッダーは原典に寄せて QY,QX 順
+  PUTSTR "LONG RANGE SENSOR SCAN FOR QUADRANT "
+  PUTDEC ENT_QY
+  PUTSTR ","
+  PUTDEC ENT_QX
+  PRINTLN
+  PRINTLN "-----------------"
+  # 外側ループ: LQY=ENT_QY-1..ENT_QY+1 (Mayfield I=Q1-1..Q1+1, row方向)
+  VAR LQY = ENT_QY - 1
+  WHILE LQY <= ENT_QY + 1
+    VAR N1 = 0
+    VAR N2 = 0
+    VAR N3 = 0
+    VAR GVAL = 0
+    # 内側ループ: LQX=ENT_QX-1..ENT_QX+1 (Mayfield J=Q2-1..Q2+1, col方向)
+    VAR LQX = ENT_QX - 1
+    WHILE LQX <= ENT_QX + 1
+      LET GVAL = 0
+      # 範囲外は 0 として扱う (Mayfield 2420: IF I<1 OR I>8 OR J<1 OR J>8 THEN 2460)
+      IF IS_IN_QUAD_BOUNDS(LQX, LQY)
+        LET GVAL = @GALAXY[LQX, LQY]
+        # TODO: @DAMAGE[7] < 0 の場合は @CHART 更新をスキップ (Mayfield 2440, damage check は後続 issue で実装)
+        LET @CHART[LQX, LQY] = GVAL
+      ENDIF
+      # Mayfield N[J-Q2+2] への格納 (Mayfield 2430): LQX=ENT_QX-1->N1, ENT_QX->N2, ENT_QX+1->N3
+      IF LQX = ENT_QX - 1
+        LET N1 = GVAL
+      ELSIF LQX = ENT_QX
+        LET N2 = GVAL
+      ELSE
+        LET N3 = GVAL
+      ENDIF
+      LET LQX = LQX + 1
+    ENDWH
+    # 原典 2470: PRINT USING 2510;N[1],N[2],N[3] → ": NNN : NNN : NNN :"
+    PUTSTR ": "
+    PRINT_3D N1
+    PUTSTR " : "
+    PRINT_3D N2
+    PUTSTR " : "
+    PRINT_3D N3
+    PRINTLN " :"
+    # 原典 2480: PRINT USING 2520 → "-----------------"
+    PRINTLN "-----------------"
+    LET LQY = LQY + 1
+  ENDWH
 END
 
 # ミッションブリーフィングを表示する (STTR1.BAS line 780)

--- a/examples/trek/test_long_range_scan.tbx
+++ b/examples/trek/test_long_range_scan.tbx
@@ -35,15 +35,15 @@ DEF TEST_LONG_RANGE_SCAN_CENTER()
   # LONG_RANGE_SCAN を呼び出してもクラッシュしないこと
   LONG_RANGE_SCAN
   # @CHART が @GALAXY の値で更新されていること
-  ASSERT (@CHART[3, 3] = @GALAXY[3, 3])
-  ASSERT (@CHART[4, 3] = @GALAXY[4, 3])
-  ASSERT (@CHART[5, 3] = @GALAXY[5, 3])
-  ASSERT (@CHART[3, 4] = @GALAXY[3, 4])
-  ASSERT (@CHART[4, 4] = @GALAXY[4, 4])
-  ASSERT (@CHART[5, 4] = @GALAXY[5, 4])
-  ASSERT (@CHART[3, 5] = @GALAXY[3, 5])
-  ASSERT (@CHART[4, 5] = @GALAXY[4, 5])
-  ASSERT (@CHART[5, 5] = @GALAXY[5, 5])
+  ASSERT @CHART[3, 3] = @GALAXY[3, 3]
+  ASSERT @CHART[4, 3] = @GALAXY[4, 3]
+  ASSERT @CHART[5, 3] = @GALAXY[5, 3]
+  ASSERT @CHART[3, 4] = @GALAXY[3, 4]
+  ASSERT @CHART[4, 4] = @GALAXY[4, 4]
+  ASSERT @CHART[5, 4] = @GALAXY[5, 4]
+  ASSERT @CHART[3, 5] = @GALAXY[3, 5]
+  ASSERT @CHART[4, 5] = @GALAXY[4, 5]
+  ASSERT @CHART[5, 5] = @GALAXY[5, 5]
 END
 
 # 角 (1, 1) の quadrant で LONG_RANGE_SCAN を呼び出し、境界外でエラーにならないこと・範囲内 @CHART が更新されることを検証する
@@ -64,10 +64,10 @@ DEF TEST_LONG_RANGE_SCAN_CORNER()
   # LONG_RANGE_SCAN を呼び出してもクラッシュしないこと (境界外は 0 として扱う)
   LONG_RANGE_SCAN
   # 範囲内クアドラントの @CHART が更新されていること
-  ASSERT (@CHART[1, 1] = @GALAXY[1, 1])
-  ASSERT (@CHART[2, 1] = @GALAXY[2, 1])
-  ASSERT (@CHART[1, 2] = @GALAXY[1, 2])
-  ASSERT (@CHART[2, 2] = @GALAXY[2, 2])
+  ASSERT @CHART[1, 1] = @GALAXY[1, 1]
+  ASSERT @CHART[2, 1] = @GALAXY[2, 1]
+  ASSERT @CHART[1, 2] = @GALAXY[1, 2]
+  ASSERT @CHART[2, 2] = @GALAXY[2, 2]
 END
 
 # 辺 (8, 8) の quadrant で LONG_RANGE_SCAN を呼び出し、境界外でエラーにならないことを検証する
@@ -88,10 +88,10 @@ DEF TEST_LONG_RANGE_SCAN_EDGE()
   # LONG_RANGE_SCAN を呼び出してもクラッシュしないこと
   LONG_RANGE_SCAN
   # 範囲内クアドラントの @CHART が更新されていること
-  ASSERT (@CHART[7, 7] = @GALAXY[7, 7])
-  ASSERT (@CHART[8, 7] = @GALAXY[8, 7])
-  ASSERT (@CHART[7, 8] = @GALAXY[7, 8])
-  ASSERT (@CHART[8, 8] = @GALAXY[8, 8])
+  ASSERT @CHART[7, 7] = @GALAXY[7, 7]
+  ASSERT @CHART[8, 7] = @GALAXY[8, 7]
+  ASSERT @CHART[7, 8] = @GALAXY[7, 8]
+  ASSERT @CHART[8, 8] = @GALAXY[8, 8]
 END
 
 TEST_LONG_RANGE_SCAN_CENTER

--- a/examples/trek/test_long_range_scan.tbx
+++ b/examples/trek/test_long_range_scan.tbx
@@ -1,0 +1,99 @@
+# trek/test_long_range_scan.tbx — LONG_RANGE_SCAN() smoke test
+
+USE "state.tbx"
+USE "util.tbx"
+USE "init.tbx"
+USE "scan.tbx"
+USE "../../lib/tests/helper.tbx"
+
+# 中央付近の quadrant で LONG_RANGE_SCAN を呼び出し、クラッシュしないこと・@CHART が更新されることを検証する
+DEF TEST_LONG_RANGE_SCAN_CENTER()
+  INIT_GAME
+  # Enterprise を中央付近のクアドラント (4, 4) に固定して境界を外す
+  LET ENT_QX = 4
+  LET ENT_QY = 4
+  # @GALAXY の値を既知値に設定する (周囲 3x3 = QX:3..5, QY:3..5)
+  LET @GALAXY[3, 3] = 101
+  LET @GALAXY[4, 3] = 010
+  LET @GALAXY[5, 3] = 205
+  LET @GALAXY[3, 4] = 300
+  LET @GALAXY[4, 4] = 007
+  LET @GALAXY[5, 4] = 100
+  LET @GALAXY[3, 5] = 050
+  LET @GALAXY[4, 5] = 002
+  LET @GALAXY[5, 5] = 103
+  # @CHART をクリアしておく
+  LET @CHART[3, 3] = 0
+  LET @CHART[4, 3] = 0
+  LET @CHART[5, 3] = 0
+  LET @CHART[3, 4] = 0
+  LET @CHART[4, 4] = 0
+  LET @CHART[5, 4] = 0
+  LET @CHART[3, 5] = 0
+  LET @CHART[4, 5] = 0
+  LET @CHART[5, 5] = 0
+  # LONG_RANGE_SCAN を呼び出してもクラッシュしないこと
+  LONG_RANGE_SCAN
+  # @CHART が @GALAXY の値で更新されていること
+  ASSERT (@CHART[3, 3] = @GALAXY[3, 3])
+  ASSERT (@CHART[4, 3] = @GALAXY[4, 3])
+  ASSERT (@CHART[5, 3] = @GALAXY[5, 3])
+  ASSERT (@CHART[3, 4] = @GALAXY[3, 4])
+  ASSERT (@CHART[4, 4] = @GALAXY[4, 4])
+  ASSERT (@CHART[5, 4] = @GALAXY[5, 4])
+  ASSERT (@CHART[3, 5] = @GALAXY[3, 5])
+  ASSERT (@CHART[4, 5] = @GALAXY[4, 5])
+  ASSERT (@CHART[5, 5] = @GALAXY[5, 5])
+END
+
+# 角 (1, 1) の quadrant で LONG_RANGE_SCAN を呼び出し、境界外でエラーにならないこと・範囲内 @CHART が更新されることを検証する
+DEF TEST_LONG_RANGE_SCAN_CORNER()
+  INIT_GAME
+  # Enterprise を左上角 (1, 1) に固定する
+  LET ENT_QX = 1
+  LET ENT_QY = 1
+  # 範囲内クアドラントを既知値に設定する (QX:1..2, QY:1..2)
+  LET @GALAXY[1, 1] = 111
+  LET @GALAXY[2, 1] = 022
+  LET @GALAXY[1, 2] = 033
+  LET @GALAXY[2, 2] = 044
+  LET @CHART[1, 1] = 0
+  LET @CHART[2, 1] = 0
+  LET @CHART[1, 2] = 0
+  LET @CHART[2, 2] = 0
+  # LONG_RANGE_SCAN を呼び出してもクラッシュしないこと (境界外は 0 として扱う)
+  LONG_RANGE_SCAN
+  # 範囲内クアドラントの @CHART が更新されていること
+  ASSERT (@CHART[1, 1] = @GALAXY[1, 1])
+  ASSERT (@CHART[2, 1] = @GALAXY[2, 1])
+  ASSERT (@CHART[1, 2] = @GALAXY[1, 2])
+  ASSERT (@CHART[2, 2] = @GALAXY[2, 2])
+END
+
+# 辺 (8, 8) の quadrant で LONG_RANGE_SCAN を呼び出し、境界外でエラーにならないことを検証する
+DEF TEST_LONG_RANGE_SCAN_EDGE()
+  INIT_GAME
+  # Enterprise を右下角 (8, 8) に固定する
+  LET ENT_QX = 8
+  LET ENT_QY = 8
+  # 範囲内クアドラントを既知値に設定する (QX:7..8, QY:7..8)
+  LET @GALAXY[7, 7] = 200
+  LET @GALAXY[8, 7] = 110
+  LET @GALAXY[7, 8] = 301
+  LET @GALAXY[8, 8] = 005
+  LET @CHART[7, 7] = 0
+  LET @CHART[8, 7] = 0
+  LET @CHART[7, 8] = 0
+  LET @CHART[8, 8] = 0
+  # LONG_RANGE_SCAN を呼び出してもクラッシュしないこと
+  LONG_RANGE_SCAN
+  # 範囲内クアドラントの @CHART が更新されていること
+  ASSERT (@CHART[7, 7] = @GALAXY[7, 7])
+  ASSERT (@CHART[8, 7] = @GALAXY[8, 7])
+  ASSERT (@CHART[7, 8] = @GALAXY[7, 8])
+  ASSERT (@CHART[8, 8] = @GALAXY[8, 8])
+END
+
+TEST_LONG_RANGE_SCAN_CENTER
+TEST_LONG_RANGE_SCAN_CORNER
+TEST_LONG_RANGE_SCAN_EDGE


### PR DESCRIPTION
## 概要

issue #781 の実装。STTR1 Mayfield 原典 command 2 に相当する long-range scan を `examples/trek/scan.tbx` に実装する。現在 quadrant 周辺 3x3 の `@GALAXY` サマリーを表示し、`@CHART` を更新する。

## 変更内容

- `IS_IN_QUAD_BOUNDS(QX, QY)` を追加する — quadrant が 1..8 × 1..8 境界内かを判定するヘルパー
- `PRINT_3D(N)` を追加する — Mayfield IMAGE 2510 の `3D` に対応した 3桁ゼロ埋め出力ヘルパー
- `LONG_RANGE_SCAN()` を実装する — 原典 STTR1.BAS lines 2330-2500 に対応
  - 外側ループ `QY = ENT_QY-1..ENT_QY+1`、内側ループ `QX = ENT_QX-1..ENT_QX+1` で走査
  - 境界外クアドラントは 0 として扱い、境界エラーを発生させない
  - 範囲内クアドラントの `@CHART[QX, QY]` を `@GALAXY[QX, QY]` で更新する
  - 表示ヘッダーは原典に寄せて `QY,QX` 順（Mayfield Q1=row=QY, Q2=col=QX）
  - 内部アクセスは TBX convention の `@GALAXY[QX, QY]` に統一
  - damage check (`@DAMAGE[3]`, `@DAMAGE[7]`) は TODO コメントで後続 issue に委ねる
- `examples/trek/test_long_range_scan.tbx` を追加する — 3ケースの smoke test
  - 中央付近 (4,4): 周囲 3x3 全クアドラントが `@CHART` に反映される
  - 角 (1,1): 境界外 quadrant でクラッシュしない、境界内 `@CHART` が更新される
  - 角 (8,8): 境界外 quadrant でクラッシュしない、境界内 `@CHART` が更新される

Closes #781
