### PR TITLE
STTR1 command loop の骨格を実装する

### DIFF
--- a/examples/star_trek.tbx
+++ b/examples/star_trek.tbx
@@ -8,11 +8,12 @@ USE "trek/init.tbx"
 USE "trek/scan.tbx"
 USE "trek/nav.tbx"
 USE "trek/combat.tbx"
+USE "trek/command.tbx"
 
 DEF MAIN()
   INIT_GAME
   PRINT_INTRO
-  SHORT_RANGE_SCAN
+  RUN_COMMAND_LOOP
 END
 
 MAIN

--- a/examples/trek/command.tbx
+++ b/examples/trek/command.tbx
@@ -1,0 +1,56 @@
+# trek/command.tbx — command loop and dispatch (STTR1.BAS lines 1260-1400)
+
+# Print the list of available commands (STTR1.BAS lines 1300-1400)
+# Displayed when an invalid command number is entered
+DEF PRINT_COMMAND_MENU()
+  PRINTLN
+  PRINTLN "   0 = SET COURSE"
+  PRINTLN "   1 = SHORT RANGE SENSOR SCAN"
+  PRINTLN "   2 = LONG RANGE SENSOR SCAN"
+  PRINTLN "   3 = FIRE PHASERS"
+  PRINTLN "   4 = FIRE PHOTON TORPEDOES"
+  PRINTLN "   5 = SHIELD CONTROL"
+  PRINTLN "   6 = DAMAGE CONTROL REPORT"
+  PRINTLN "   7 = CALL ON LIBRARY COMPUTER"
+  PRINTLN
+END
+
+# Dispatch a command by number (STTR1.BAS line 1290)
+# CMD 0: set course (not yet implemented)
+# CMD 1: short range sensor scan
+# CMD 2: long range sensor scan
+# CMD 3..7: not yet implemented
+# Invalid CMD: print command menu
+DEF DISPATCH_COMMAND(CMD)
+  IF CMD = 0
+    PRINTLN "SET COURSE is not implemented yet"
+  ELSIF CMD = 1
+    SHORT_RANGE_SCAN
+  ELSIF CMD = 2
+    LONG_RANGE_SCAN
+  ELSIF CMD = 3
+    PRINTLN "PHASER CONTROL is not implemented yet"
+  ELSIF CMD = 4
+    PRINTLN "PHOTON TORPEDO CONTROL is not implemented yet"
+  ELSIF CMD = 5
+    PRINTLN "SHIELD CONTROL is not implemented yet"
+  ELSIF CMD = 6
+    PRINTLN "DAMAGE CONTROL REPORT is not implemented yet"
+  ELSIF CMD = 7
+    PRINTLN "LIBRARY COMPUTER is not implemented yet"
+  ELSE
+    PRINT_COMMAND_MENU
+  ENDIF
+END
+
+# Command input and dispatch loop (STTR1.BAS lines 1260-1400)
+# Loops while GAME_OVER = 0, prompting for a command number each iteration
+# Calls SHORT_RANGE_SCAN before prompting, matching Mayfield line 1260 GOSUB 4120
+DEF RUN_COMMAND_LOOP()
+  WHILE GAME_OVER = 0
+    SHORT_RANGE_SCAN
+    PUTSTR "COMMAND:"
+    VAR CMD = GETDEC
+    DISPATCH_COMMAND CMD
+  ENDWH
+END

--- a/examples/trek/command.tbx
+++ b/examples/trek/command.tbx
@@ -22,33 +22,39 @@ END
 # CMD 3..7: not yet implemented
 # Invalid CMD: print command menu
 DEF DISPATCH_COMMAND(CMD)
-  IF CMD = 0
+  SELECT CMD
+  CASE 0
     PRINTLN "SET COURSE is not implemented yet"
-  ELSIF CMD = 1
+  CASE 1
     SHORT_RANGE_SCAN
-  ELSIF CMD = 2
+  CASE 2
     LONG_RANGE_SCAN
-  ELSIF CMD = 3
+  CASE 3
     PRINTLN "PHASER CONTROL is not implemented yet"
-  ELSIF CMD = 4
+  CASE 4
     PRINTLN "PHOTON TORPEDO CONTROL is not implemented yet"
-  ELSIF CMD = 5
+  CASE 5
     PRINTLN "SHIELD CONTROL is not implemented yet"
-  ELSIF CMD = 6
+  CASE 6
     PRINTLN "DAMAGE CONTROL REPORT is not implemented yet"
-  ELSIF CMD = 7
+  CASE 7
     PRINTLN "LIBRARY COMPUTER is not implemented yet"
-  ELSE
+  CASE_ELSE
     PRINT_COMMAND_MENU
-  ENDIF
+  ENDSEL
 END
 
 # Command input and dispatch loop (STTR1.BAS lines 1260-1400)
-# Loops while GAME_OVER = 0, prompting for a command number each iteration
-# Calls SHORT_RANGE_SCAN before prompting, matching Mayfield line 1260 GOSUB 4120
+# Mayfield 原典の flow:
+#   line 1260: short-range scan を表示 (GOSUB 4120)
+#   line 1270: COMMAND: prompt を表示して入力を受け付ける
+#   command 1 は line 1260 へ戻り short-range scan を再表示する
+#   その他の command は処理後に line 1270 へ戻る
+# → ループ冒頭で毎回 SHORT_RANGE_SCAN を呼ぶと command 1 で二重表示になるため、
+#   初回のみ SHORT_RANGE_SCAN を呼び、以降は DISPATCH_COMMAND 内の CASE 1 で呼ぶ
 DEF RUN_COMMAND_LOOP()
+  SHORT_RANGE_SCAN
   WHILE GAME_OVER = 0
-    SHORT_RANGE_SCAN
     PUTSTR "COMMAND:"
     VAR CMD = GETDEC
     DISPATCH_COMMAND CMD

--- a/examples/trek/test_command.tbx
+++ b/examples/trek/test_command.tbx
@@ -1,0 +1,81 @@
+# trek/test_command.tbx — DISPATCH_COMMAND() smoke tests
+
+USE "state.tbx"
+USE "util.tbx"
+USE "init.tbx"
+USE "scan.tbx"
+USE "nav.tbx"
+USE "combat.tbx"
+USE "command.tbx"
+USE "../../lib/tests/helper.tbx"
+
+# Verify that DISPATCH_COMMAND(1) calls SHORT_RANGE_SCAN without crashing
+DEF TEST_DISPATCH_CMD1_SHORT_RANGE_SCAN()
+  INIT_GAME
+  # cmd 1 should call SHORT_RANGE_SCAN and produce output
+  DISPATCH_COMMAND 1
+END
+
+# Verify that DISPATCH_COMMAND(2) calls LONG_RANGE_SCAN without crashing
+DEF TEST_DISPATCH_CMD2_LONG_RANGE_SCAN()
+  INIT_GAME
+  # cmd 2 should call LONG_RANGE_SCAN and produce output
+  DISPATCH_COMMAND 2
+END
+
+# Verify that DISPATCH_COMMAND(0) prints placeholder and does not crash
+DEF TEST_DISPATCH_CMD0_NOT_IMPLEMENTED()
+  INIT_GAME
+  DISPATCH_COMMAND 0
+END
+
+# Verify that DISPATCH_COMMAND(3) prints placeholder and does not crash
+DEF TEST_DISPATCH_CMD3_NOT_IMPLEMENTED()
+  INIT_GAME
+  DISPATCH_COMMAND 3
+END
+
+# Verify that DISPATCH_COMMAND(4) prints placeholder and does not crash
+DEF TEST_DISPATCH_CMD4_NOT_IMPLEMENTED()
+  INIT_GAME
+  DISPATCH_COMMAND 4
+END
+
+# Verify that DISPATCH_COMMAND(5) prints placeholder and does not crash
+DEF TEST_DISPATCH_CMD5_NOT_IMPLEMENTED()
+  INIT_GAME
+  DISPATCH_COMMAND 5
+END
+
+# Verify that DISPATCH_COMMAND(6) prints placeholder and does not crash
+DEF TEST_DISPATCH_CMD6_NOT_IMPLEMENTED()
+  INIT_GAME
+  DISPATCH_COMMAND 6
+END
+
+# Verify that DISPATCH_COMMAND(7) prints placeholder and does not crash
+DEF TEST_DISPATCH_CMD7_NOT_IMPLEMENTED()
+  INIT_GAME
+  DISPATCH_COMMAND 7
+END
+
+# Verify that an invalid command number prints the command menu and does not crash
+DEF TEST_DISPATCH_INVALID_CMD()
+  INIT_GAME
+  # cmd -1 is invalid, should show command menu
+  DISPATCH_COMMAND -1
+  # cmd 8 is also invalid
+  DISPATCH_COMMAND 8
+  # cmd 99 is also invalid
+  DISPATCH_COMMAND 99
+END
+
+TEST_DISPATCH_CMD1_SHORT_RANGE_SCAN
+TEST_DISPATCH_CMD2_LONG_RANGE_SCAN
+TEST_DISPATCH_CMD0_NOT_IMPLEMENTED
+TEST_DISPATCH_CMD3_NOT_IMPLEMENTED
+TEST_DISPATCH_CMD4_NOT_IMPLEMENTED
+TEST_DISPATCH_CMD5_NOT_IMPLEMENTED
+TEST_DISPATCH_CMD6_NOT_IMPLEMENTED
+TEST_DISPATCH_CMD7_NOT_IMPLEMENTED
+TEST_DISPATCH_INVALID_CMD


### PR DESCRIPTION
## 概要

Mayfield 1972 HP BASIC 版 STTR1 の lines 1260-1400 に対応する command loop と command dispatch の骨格を実装する。
`MAIN()` を単発の `SHORT_RANGE_SCAN` 実行から `RUN_COMMAND_LOOP` 呼び出しへ変更し、ゲームとして動くループ構造を導入する。

## 変更内容

- `examples/trek/command.tbx` を新規作成する
  - `PRINT_COMMAND_MENU()`: 無効な command number が入力されたときに command 一覧を表示する
  - `DISPATCH_COMMAND(CMD)`: command number に応じて各処理へ dispatch する
    - `1` -> `SHORT_RANGE_SCAN()`
    - `2` -> `LONG_RANGE_SCAN()`
    - `0`, `3`, `4`, `5`, `6`, `7` -> 未実装 message を表示して戻る
    - それ以外 -> `PRINT_COMMAND_MENU()` を呼んで戻る
  - `RUN_COMMAND_LOOP()`: `GAME_OVER = 0` の間 short range scan -> `COMMAND:` prompt -> dispatch を繰り返す
- `examples/trek/test_command.tbx` を新規作成する
  - `DISPATCH_COMMAND` の各 command (0..7) と無効値に対して crash しないことを検証するテストを追加する
- `examples/star_trek.tbx` を更新する
  - `USE "trek/command.tbx"` を追加する
  - `MAIN()` を単発 `SHORT_RANGE_SCAN` 実行から `RUN_COMMAND_LOOP` 呼び出しへ変更する

## テスト確認

```
cargo run --bin tbx -- examples/trek/test_command.tbx
cargo run --bin tbx -- examples/trek/test_scan.tbx
cargo run --bin tbx -- examples/trek/test_long_range_scan.tbx
```

Closes #783
