### PR TITLE
lexer の識別子末尾に ? suffix を許可する

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -372,8 +372,34 @@ impl<'a> Lexer<'a> {
             self.advance();
         }
         // Consume a single trailing '?' if present (e.g. GETDEC?, EMPTY?).
+        // If '?' is followed immediately by an alphanumeric character or '_',
+        // it is a lexer error (e.g. GET?DEC): '?' must be the true end of the identifier.
         if self.peek_char() == Some('?') {
             self.advance();
+            let end_off = self.peek_offset();
+            let raw_len = end_off - start_off;
+            if matches!(self.peek_char(), Some(c) if c.is_alphanumeric() || c == '_') {
+                // Consume the offending character to include it in the error span.
+                self.advance();
+                let err_end_off = self.peek_offset();
+                let err_len = err_end_off - start_off;
+                let raw = &self.source[start_off..err_end_off];
+                return SpannedToken {
+                    token: Token::Error(format!(
+                        "invalid identifier: '?' must be the last character (got {raw:?})"
+                    )),
+                    pos: start_pos,
+                    source_offset: start_off,
+                    source_len: err_len,
+                };
+            }
+            let name = self.source[start_off..end_off].to_string();
+            return SpannedToken {
+                token: Token::Ident(name),
+                pos: start_pos,
+                source_offset: start_off,
+                source_len: raw_len,
+            };
         }
         let end_off = self.peek_offset();
         let name = self.source[start_off..end_off].to_string();
@@ -1504,12 +1530,15 @@ mod tests {
     }
 
     #[test]
-    fn test_question_mid_ident_not_consumed() {
-        // GET?DEC: the '?' is consumed as the suffix of GET, making Ident("GET?"),
-        // then DEC starts a new identifier. This is intentionally NOT a single token.
+    fn test_question_mid_ident_is_error() {
+        // GET?DEC: '?' followed immediately by an alphanumeric character is a lexer
+        // error. This guards against typos being silently accepted as two tokens.
         let toks = tokens("GET?DEC");
-        assert_eq!(toks[0], Token::Ident("GET?".to_string()));
-        assert_eq!(toks[1], Token::Ident("DEC".to_string()));
+        assert!(
+            matches!(toks[0], Token::Error(_)),
+            "expected Error for '?' not at identifier end, got {:?}",
+            toks[0]
+        );
     }
 
     #[test]

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -363,8 +363,16 @@ impl<'a> Lexer<'a> {
     }
 
     /// Scan an identifier.  If the identifier is `REM`, set `rem_pending`.
+    ///
+    /// Identifiers follow the pattern `[A-Za-z_][A-Za-z0-9_]*\??`:
+    /// a standard alphanumeric body followed by at most one trailing `?`.
+    /// The `?` suffix is used for recoverable-API / predicate words (e.g. `GETDEC?`).
     fn scan_ident(&mut self, start_pos: Position, start_off: usize) -> SpannedToken {
         while matches!(self.peek_char(), Some(c) if c.is_alphanumeric() || c == '_') {
+            self.advance();
+        }
+        // Consume a single trailing '?' if present (e.g. GETDEC?, EMPTY?).
+        if self.peek_char() == Some('?') {
             self.advance();
         }
         let end_off = self.peek_offset();
@@ -1430,6 +1438,91 @@ mod tests {
             matches!(toks[0], Token::Error(_)),
             "expected Error, got {:?}",
             toks[0]
+        );
+    }
+
+    // --- ? suffix identifiers ---
+
+    #[test]
+    fn test_ident_question_suffix_getdec() {
+        // GETDEC? must be tokenised as a single Ident token.
+        assert_eq!(
+            tokens("GETDEC?"),
+            vec![Token::Ident("GETDEC?".to_string()), Token::Eof]
+        );
+    }
+
+    #[test]
+    fn test_ident_question_suffix_empty() {
+        // EMPTY? must be tokenised as a single Ident token.
+        assert_eq!(
+            tokens("EMPTY?"),
+            vec![Token::Ident("EMPTY?".to_string()), Token::Eof]
+        );
+    }
+
+    #[test]
+    fn test_ident_question_suffix_is_num() {
+        // IS_NUM? must be tokenised as a single Ident token.
+        assert_eq!(
+            tokens("IS_NUM?"),
+            vec![Token::Ident("IS_NUM?".to_string()), Token::Eof]
+        );
+    }
+
+    #[test]
+    fn test_ident_plain_unchanged() {
+        // Existing plain identifiers must not be affected.
+        assert_eq!(
+            tokens("GETDEC"),
+            vec![Token::Ident("GETDEC".to_string()), Token::Eof]
+        );
+    }
+
+    #[test]
+    fn test_ident_question_suffix_only_one_question_mark() {
+        // A?? must yield Ident("A?") followed by an Error token for the second '?'.
+        let toks = tokens("A??");
+        assert_eq!(toks[0], Token::Ident("A?".to_string()));
+        assert!(
+            matches!(toks[1], Token::Error(_)),
+            "expected Error for second '?', got {:?}",
+            toks[1]
+        );
+    }
+
+    #[test]
+    fn test_question_prefix_not_ident() {
+        // ?GETDEC: leading '?' is not an identifier start; must produce Error then Ident.
+        let toks = tokens("?GETDEC");
+        assert!(
+            matches!(toks[0], Token::Error(_)),
+            "expected Error for leading '?', got {:?}",
+            toks[0]
+        );
+        assert_eq!(toks[1], Token::Ident("GETDEC".to_string()));
+    }
+
+    #[test]
+    fn test_question_mid_ident_not_consumed() {
+        // GET?DEC: the '?' is consumed as the suffix of GET, making Ident("GET?"),
+        // then DEC starts a new identifier. This is intentionally NOT a single token.
+        let toks = tokens("GET?DEC");
+        assert_eq!(toks[0], Token::Ident("GET?".to_string()));
+        assert_eq!(toks[1], Token::Ident("DEC".to_string()));
+    }
+
+    #[test]
+    fn test_ident_question_suffix_in_call_context() {
+        // GETDEC?() must tokenise as Ident("GETDEC?"), LParen, RParen.
+        assert_eq!(
+            tokens("GETDEC?()"),
+            vec![
+                Token::Ident("GETDEC?".to_string()),
+                Token::LParen,
+                Token::RParen,
+                Token::Eof,
+            ]
         );
     }
 


### PR DESCRIPTION
## 概要

`GETDEC?` のような recoverable API / predicate 風の word 名を tokenize できるよう、lexer の識別子ルールを拡張する。識別子本体（`[A-Za-z_][A-Za-z0-9_]*`）の末尾に `?` を1つ許可することで、`?` suffix 付き識別子が `Token::Ident` として扱えるようになる。

## 変更内容

- `src/lexer.rs` の `scan_ident` を変更し、通常の識別子本体を読んだ後に直後の `?` を1文字だけ consume するよう修正
- `scan_ident` の doc comment に識別子パターン `[A-Za-z_][A-Za-z0-9_]*\??` を記載
- 以下の lexer unit test を追加:
  - `GETDEC?` → `Ident("GETDEC?")`
  - `EMPTY?` → `Ident("EMPTY?")`
  - `IS_NUM?` → `Ident("IS_NUM?")`
  - 通常 identifier は変化なし (`GETDEC` → `Ident("GETDEC")`)
  - `A??` → `Ident("A?")` + `Error`（2つ目の `?` は別トークン）
  - `?GETDEC` → `Error` + `Ident("GETDEC")`（先頭 `?` は識別子開始文字でない）
  - `GET?DEC` → Error
  - `GETDEC?()` → `Ident("GETDEC?")` + `LParen` + `RParen`

Closes #787
