### PR TITLE
RESULT_* ヘルパーライブラリを lib/result.tbx に追加する

### DIFF
--- a/lib/result.tbx
+++ b/lib/result.tbx
@@ -1,0 +1,41 @@
+# result.tbx — helper functions for TUPLE(value, ok) result values
+
+# RESULT_VAL(R) — extract the value from a result tuple (R[1])
+DEF RESULT_VAL(R)
+  RETURN R[1]
+END
+
+# RESULT_OK(R) — extract the ok flag from a result tuple (R[2])
+DEF RESULT_OK(R)
+  RETURN R[2]
+END
+
+# RESULT_OR(R, DEFAULT) — return R[1] if ok, otherwise DEFAULT
+DEF RESULT_OR(R, DEFAULT)
+  IF R[2]
+    RETURN R[1]
+  ELSE
+    RETURN DEFAULT
+  ENDIF
+END
+
+# RESULT_EXPECT(R, MSG) — return R[1] if ok, otherwise abort with MSG
+DEF RESULT_EXPECT(R, MSG)
+  IF R[2]
+    RETURN R[1]
+  ELSE
+    ASSERT_FAIL_MSG MSG
+  ENDIF
+END
+
+# RESULT_OK_OF(V) — wrap V as a successful result: TUPLE(V, Bool(true))
+# Bool(true) is produced by the tautology (1 = 1).
+DEF RESULT_OK_OF(V)
+  RETURN TUPLE(V, 1 = 1)
+END
+
+# RESULT_ERR_OF(V) — wrap V as a failed result: TUPLE(V, Bool(false))
+# Bool(false) is produced by the contradiction (1 = 0).
+DEF RESULT_ERR_OF(V)
+  RETURN TUPLE(V, 1 = 0)
+END

--- a/lib/tests/test_result_helpers.tbx
+++ b/lib/tests/test_result_helpers.tbx
@@ -1,0 +1,105 @@
+# lib/tests/test_result_helpers.tbx — TBX tests for the RESULT_* helper library
+USE "lib/tests/helper.tbx"
+
+# --- RESULT_VAL: extract value from a result tuple ---
+
+ASSERT RESULT_VAL(TUPLE(123, 1 = 1)) = 123
+ASSERT RESULT_VAL(TUPLE(0, 1 = 0)) = 0
+
+# --- RESULT_OK: extract ok flag from a result tuple ---
+
+DEF CHECK_RESULT_OK_TRUE()
+  # Bool(true) is obtained via comparison (1 = 1)
+  VAR R
+  LET R = TUPLE(123, 1 = 1)
+  RETURN RESULT_OK(R) = (1 = 1)
+END
+ASSERT CHECK_RESULT_OK_TRUE()
+
+DEF CHECK_RESULT_OK_FALSE()
+  # Bool(false) is obtained via comparison (1 = 0)
+  VAR R
+  LET R = TUPLE(0, 1 = 0)
+  RETURN RESULT_OK(R) = (1 = 0)
+END
+ASSERT CHECK_RESULT_OK_FALSE()
+
+# --- RESULT_OR: return value on success, default on failure ---
+
+ASSERT RESULT_OR(TUPLE(123, 1 = 1), 0) = 123
+ASSERT RESULT_OR(TUPLE(0, 1 = 0), 9) = 9
+
+# --- RESULT_EXPECT: return value on success ---
+
+DEF CHECK_RESULT_EXPECT()
+  VAR V
+  LET V = RESULT_EXPECT(TUPLE(123, 1 = 1), "msg")
+  RETURN V = 123
+END
+ASSERT CHECK_RESULT_EXPECT()
+
+# --- RESULT_OK_OF: wrap value as successful result ---
+
+DEF CHECK_RESULT_OK_OF_VAL()
+  VAR R
+  LET R = RESULT_OK_OF(42)
+  RETURN R[1] = 42
+END
+ASSERT CHECK_RESULT_OK_OF_VAL()
+
+DEF CHECK_RESULT_OK_OF_FLAG()
+  VAR R
+  LET R = RESULT_OK_OF(42)
+  RETURN R[2] = (1 = 1)
+END
+ASSERT CHECK_RESULT_OK_OF_FLAG()
+
+# --- RESULT_ERR_OF: wrap value as failed result ---
+
+DEF CHECK_RESULT_ERR_OF_VAL()
+  VAR R
+  LET R = RESULT_ERR_OF(0)
+  RETURN R[1] = 0
+END
+ASSERT CHECK_RESULT_ERR_OF_VAL()
+
+DEF CHECK_RESULT_ERR_OF_FLAG()
+  VAR R
+  LET R = RESULT_ERR_OF(0)
+  RETURN R[2] = (1 = 0)
+END
+ASSERT CHECK_RESULT_ERR_OF_FLAG()
+
+# --- Round-trip: RESULT_OK_OF then RESULT_VAL / RESULT_OK ---
+
+DEF CHECK_OK_OF_ROUND_TRIP_VAL()
+  VAR R
+  LET R = RESULT_OK_OF(99)
+  RETURN RESULT_VAL(R) = 99
+END
+ASSERT CHECK_OK_OF_ROUND_TRIP_VAL()
+
+DEF CHECK_OK_OF_ROUND_TRIP_OK()
+  VAR R
+  LET R = RESULT_OK_OF(99)
+  RETURN RESULT_OK(R) = (1 = 1)
+END
+ASSERT CHECK_OK_OF_ROUND_TRIP_OK()
+
+# --- Round-trip: RESULT_ERR_OF then RESULT_OR uses default ---
+
+DEF CHECK_ERR_OF_ROUND_TRIP()
+  VAR R
+  LET R = RESULT_ERR_OF(0)
+  RETURN RESULT_OR(R, 7) = 7
+END
+ASSERT CHECK_ERR_OF_ROUND_TRIP()
+
+# --- RESULT_OR with success result returns value not default ---
+
+DEF CHECK_RESULT_OR_SUCCESS()
+  VAR R
+  LET R = TUPLE(42, 1 = 1)
+  RETURN RESULT_OR(R, 0) = 42
+END
+ASSERT CHECK_RESULT_OR_SUCCESS()

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -165,17 +165,18 @@ impl Default for Interpreter {
 impl Interpreter {
     /// Create a new `Interpreter` backed by a fully initialized VM.
     ///
-    /// Loads the standard library (`lib/basic.tbx`) embedded at compile time.
-    /// Panics if the standard library fails to load, which indicates a bug in
-    /// the library source rather than a runtime failure.
+    /// Loads the standard library (`lib/basic.tbx` and `lib/result.tbx`) embedded at
+    /// compile time. Panics if the standard library fails to load, which indicates a bug
+    /// in the library source rather than a runtime failure.
     ///
     /// For a fallible variant that returns an error instead of panicking,
     /// use [`Interpreter::try_new`].
     pub fn new() -> Self {
-        // lib/basic.tbx is embedded at compile time and is always syntactically valid TBX.
-        // A panic here indicates a bug in the standard library source, not a runtime failure.
+        // lib/basic.tbx and lib/result.tbx are embedded at compile time and are always
+        // syntactically valid TBX. A panic here indicates a bug in the standard library
+        // source, not a runtime failure.
         Self::try_new().unwrap_or_else(|e| {
-            panic!("internal error: failed to load lib/basic.tbx: {e}");
+            panic!("internal error: failed to load standard library: {e}");
         })
     }
 
@@ -194,6 +195,8 @@ impl Interpreter {
         };
         const STDLIB: &str = include_str!("../lib/basic.tbx");
         interp.exec_source(STDLIB)?;
+        const RESULT_LIB: &str = include_str!("../lib/result.tbx");
+        interp.exec_source(RESULT_LIB)?;
         interp.vm.seal_lib();
         Ok(interp)
     }


### PR DESCRIPTION
## 概要

`TUPLE(value, ok)` 形式の結果値を扱いやすくする `RESULT_*` ヘルパーライブラリを追加する。
`lib/result.tbx` に TBX 通常関数として実装し、Interpreter 初期化時に自動ロードする。

## 変更内容

- `lib/result.tbx` を新規作成し、以下の API を TBX 関数として実装する
  - `RESULT_VAL(R)` — `R[1]` (value) を返す
  - `RESULT_OK(R)` — `R[2]` (ok フラグ) を返す
  - `RESULT_OR(R, DEFAULT)` — ok なら value、そうでなければ DEFAULT を返す
  - `RESULT_EXPECT(R, MSG)` — ok なら value、そうでなければ `ASSERT_FAIL_MSG` でアボートする
  - `RESULT_OK_OF(V)` — `TUPLE(V, Bool(true))` を返す
  - `RESULT_ERR_OF(V)` — `TUPLE(V, Bool(false))` を返す
- `src/interpreter.rs` の `try_new` で `lib/result.tbx` を `include_str!` で組み込み、
  `lib/basic.tbx` ロード後に自動実行するよう変更する
- `lib/tests/test_result_helpers.tbx` を追加して全 API の動作を検証するテストを追加する

Close #791
