### PR TITLE
MOVE_WITHIN_QUADRANT を step-wise movement に変更する (#813)

### DIFF
--- a/examples/trek/nav.tbx
+++ b/examples/trek/nav.tbx
@@ -38,30 +38,47 @@ END
 # COURSE: validated integer course (1..8)
 # STEPS:  validated integer step count (>= 1)
 # Uses GET_COURSE_DX / GET_COURSE_DY to obtain the direction vector.
-# Destination is computed as ENT_SX + DX*STEPS, ENT_SY + DY*STEPS.
-# If destination is outside sector bounds (1..8), movement is aborted without crashing.
-# On success: updates @SECTOR (old cell -> 0=empty, new cell -> 1=Enterprise)
-#             and updates ENT_SX / ENT_SY.
+# Advances 1 step at a time (Mayfield 原典 FOR I=1 TO N 方式).
+# If a next sector is outside sector bounds (1..8): prints TODO and returns
+#   without moving (quadrant crossing は未実装のため abort).
+# If a next sector is occupied (star / starbase / Klingon 等): stops at the
+#   previous (last valid) sector; obstacle cell は上書きしない.
+# On completion: updates @SECTOR (old cell -> 0=empty, new cell -> 1=Enterprise)
+#                and updates ENT_SX / ENT_SY to the final position.
 DEF MOVE_WITHIN_QUADRANT(COURSE, STEPS)
   VAR DX = GET_COURSE_DX(COURSE)
   VAR DY = GET_COURSE_DY(COURSE)
-  # Compute destination after all steps
-  VAR NEW_SX = ENT_SX + DX * STEPS
-  VAR NEW_SY = ENT_SY + DY * STEPS
-  # Abort if destination is outside quadrant bounds
-  IF IS_IN_SECTOR_BOUNDS(NEW_SX, NEW_SY) = 0
-    PRINTLN "COURSE OUT OF QUADRANT BOUNDS -- MOVEMENT ABORTED (TODO: quadrant crossing)"
-    RETURN
-  ENDIF
-  # Abort if destination cell is already occupied (star, starbase, Klingon, etc.)
-  IF @SECTOR[NEW_SX, NEW_SY] <> 0
-    PRINTLN "COURSE BLOCKED -- MOVEMENT ABORTED (TODO: collision)"
-    RETURN
-  ENDIF
-  # Clear old sector and place Enterprise at new sector
+  # CURR_SX / CURR_SY は各 step 後の有効位置を追跡する
+  VAR CURR_SX = ENT_SX
+  VAR CURR_SY = ENT_SY
+  VAR NEXT_SX = CURR_SX
+  VAR NEXT_SY = CURR_SY
+  VAR I = 1
+  VAR DONE = 0
+  WHILE I <= STEPS
+    IF DONE = 0
+      LET NEXT_SX = CURR_SX + DX
+      LET NEXT_SY = CURR_SY + DY
+      # bounds 外: quadrant crossing は未実装のため全体を abort して元の位置に残す
+      IF IS_IN_SECTOR_BOUNDS(NEXT_SX, NEXT_SY) = 0
+        PRINTLN "COURSE OUT OF QUADRANT BOUNDS -- MOVEMENT ABORTED (TODO: quadrant crossing)"
+        RETURN
+      ENDIF
+      # 非空 cell: Enterprise は CURR 位置に残り、障害物は上書きしない
+      IF @SECTOR[NEXT_SX, NEXT_SY] <> 0
+        PRINTLN "COURSE BLOCKED -- MOVEMENT ABORTED (TODO: collision)"
+        LET DONE = 1
+      ELSE
+        LET CURR_SX = NEXT_SX
+        LET CURR_SY = NEXT_SY
+      ENDIF
+    ENDIF
+    LET I = I + 1
+  ENDWH
+  # Enterprise を元の sector から最終 sector へ移動する
   LET @SECTOR[ENT_SX, ENT_SY] = 0
-  LET ENT_SX = NEW_SX
-  LET ENT_SY = NEW_SY
+  LET ENT_SX = CURR_SX
+  LET ENT_SY = CURR_SY
   LET @SECTOR[ENT_SX, ENT_SY] = 1
 END
 

--- a/examples/trek/test_navigation_collision.tbx
+++ b/examples/trek/test_navigation_collision.tbx
@@ -1,0 +1,105 @@
+# trek/test_navigation_collision.tbx — MOVE_WITHIN_QUADRANT() step-wise collision tests
+#
+# 検証観点:
+#   - path 途中に star がある場合、star 手前で停止する
+#   - 障害物 cell は上書きされない
+#   - 衝突後 Enterprise は直前の有効 sector に残る
+#   - ENT_SX / ENT_SY と @SECTOR の Enterprise 位置が一致する
+#   - @SECTOR 上に Enterprise が重複しない
+#   - final destination が非空でも正しく停止する
+
+USE "state.tbx"
+USE "util.tbx"
+USE "init.tbx"
+USE "scan.tbx"
+USE "nav.tbx"
+USE "../../lib/tests/helper.tbx"
+
+# Helper: sector を全クリアし Enterprise を指定位置に配置する。
+# CLEAR_SECTOR で全セルを 0 にしてから Enterprise だけを置く。
+DEF SET_ENTERPRISE(SX, SY)
+  CLEAR_SECTOR
+  LET ENT_SX = SX
+  LET ENT_SY = SY
+  LET @SECTOR[ENT_SX, ENT_SY] = 1
+END
+
+# path 途中に star がある場合、star の 1 つ手前で停止する
+# (4,4) から east 3 steps、(6,4) に star -> Enterprise は (5,4) に停止
+DEF TEST_BLOCKED_MID_PATH_STOPS_BEFORE_STAR()
+  INIT_GAME
+  SET_ENTERPRISE 4, 4
+  # (6,4) に star を配置 (2 steps east)
+  LET @SECTOR[6, 4] = 4
+  MOVE_WITHIN_QUADRANT 1, 3
+  # 1 step 進んで (5,4) に停止するはず
+  ASSERT (ENT_SX = 5)
+  ASSERT (ENT_SY = 4)
+  ASSERT (@SECTOR[5, 4] = 1)
+  # 元の sector は空になっている
+  ASSERT (@SECTOR[4, 4] = 0)
+  # star は上書きされていない
+  ASSERT (@SECTOR[6, 4] = 4)
+END
+
+# 衝突後 @SECTOR 上に Enterprise が重複しないこと
+# (4,4) から east 3 steps、(6,4) に star -> (5,4) に停止
+DEF TEST_NO_DUPLICATE_ENTERPRISE_AFTER_COLLISION()
+  INIT_GAME
+  SET_ENTERPRISE 4, 4
+  LET @SECTOR[6, 4] = 4
+  MOVE_WITHIN_QUADRANT 1, 3
+  # 元の位置 (4,4) は空になっている
+  ASSERT (@SECTOR[4, 4] = 0)
+  # Enterprise は (5,4) にだけ存在する
+  ASSERT (@SECTOR[5, 4] = 1)
+  # star は保持されている
+  ASSERT (@SECTOR[6, 4] = 4)
+END
+
+# final step の目的地が非空の場合、1 つ手前で停止する
+# (4,4) から east 3 steps、(7,4) に star -> Enterprise は (6,4) に停止
+DEF TEST_BLOCKED_AT_FINAL_STEP()
+  INIT_GAME
+  SET_ENTERPRISE 4, 4
+  LET @SECTOR[7, 4] = 4
+  MOVE_WITHIN_QUADRANT 1, 3
+  ASSERT (ENT_SX = 6)
+  ASSERT (ENT_SY = 4)
+  ASSERT (@SECTOR[6, 4] = 1)
+  ASSERT (@SECTOR[4, 4] = 0)
+  ASSERT (@SECTOR[7, 4] = 4)
+END
+
+# 障害物 cell は上書きされない (1 step で即 collision)
+# (4,4) から east 1 step、(5,4) に star -> Enterprise は (4,4) に残る
+DEF TEST_OBSTACLE_NOT_OVERWRITTEN_ON_IMMEDIATE_COLLISION()
+  INIT_GAME
+  SET_ENTERPRISE 4, 4
+  LET @SECTOR[5, 4] = 4
+  MOVE_WITHIN_QUADRANT 1, 1
+  # Enterprise は元の位置に残る
+  ASSERT (ENT_SX = 4)
+  ASSERT (ENT_SY = 4)
+  ASSERT (@SECTOR[4, 4] = 1)
+  # star は上書きされていない
+  ASSERT (@SECTOR[5, 4] = 4)
+END
+
+# path が空の場合は正常に destination まで移動する (step-wise でも既存動作を壊さない)
+# (4,4) から east 2 steps -> (6,4) に移動
+DEF TEST_CLEAR_PATH_MOVES_TO_DESTINATION()
+  INIT_GAME
+  SET_ENTERPRISE 4, 4
+  MOVE_WITHIN_QUADRANT 1, 2
+  ASSERT (ENT_SX = 6)
+  ASSERT (ENT_SY = 4)
+  ASSERT (@SECTOR[6, 4] = 1)
+  ASSERT (@SECTOR[4, 4] = 0)
+END
+
+TEST_BLOCKED_MID_PATH_STOPS_BEFORE_STAR
+TEST_NO_DUPLICATE_ENTERPRISE_AFTER_COLLISION
+TEST_BLOCKED_AT_FINAL_STEP
+TEST_OBSTACLE_NOT_OVERWRITTEN_ON_IMMEDIATE_COLLISION
+TEST_CLEAR_PATH_MOVES_TO_DESTINATION


### PR DESCRIPTION
## 概要

issue #813 の実装。`MOVE_WITHIN_QUADRANT(COURSE, STEPS)` を一括計算方式から 1 step ずつ進む方式に変更する。

## 変更内容

### `examples/trek/nav.tbx`

`MOVE_WITHIN_QUADRANT` を Mayfield 原典の `FOR I=1 TO N` ループに相当する step-wise 方式に書き換えた。

**変更前（一括計算）:**
```tbx
VAR NEW_SX = ENT_SX + DX * STEPS
VAR NEW_SY = ENT_SY + DY * STEPS
IF IS_IN_SECTOR_BOUNDS(NEW_SX, NEW_SY) = 0 ... ENDIF
IF @SECTOR[NEW_SX, NEW_SY] <> 0 ... ENDIF
```

**変更後（step-wise loop）:**
```tbx
VAR CURR_SX = ENT_SX
VAR CURR_SY = ENT_SY
VAR I = 1
VAR DONE = 0
WHILE I <= STEPS
  IF DONE = 0
    LET NEXT_SX = CURR_SX + DX
    LET NEXT_SY = CURR_SY + DY
    IF IS_IN_SECTOR_BOUNDS(NEXT_SX, NEXT_SY) = 0
      PRINTLN "..."; RETURN   # bounds 外: abort して元の位置に残す
    ENDIF
    IF @SECTOR[NEXT_SX, NEXT_SY] <> 0
      PRINTLN "..."; LET DONE = 1   # 非空: 直前の CURR に停止
    ELSE
      LET CURR_SX = NEXT_SX; LET CURR_SY = NEXT_SY
    ENDIF
  ENDIF
  LET I = I + 1
ENDWH
# @SECTOR 更新は loop 後にのみ実施
LET @SECTOR[ENT_SX, ENT_SY] = 0
LET ENT_SX = CURR_SX; LET ENT_SY = CURR_SY
LET @SECTOR[ENT_SX, ENT_SY] = 1
```

### `examples/trek/test_navigation_collision.tbx`（新規）

step-wise collision に関するテストを追加:

| テスト | 内容 |
|---|---|
| TEST_BLOCKED_MID_PATH_STOPS_BEFORE_STAR | (4,4) から east 3 steps、(6,4) に star → (5,4) で停止 |
| TEST_NO_DUPLICATE_ENTERPRISE_AFTER_COLLISION | 衝突後 @SECTOR に Enterprise が重複しないことを確認 |
| TEST_BLOCKED_AT_FINAL_STEP | final step の目的地が非空の場合も正しく 1 つ手前で停止 |
| TEST_OBSTACLE_NOT_OVERWRITTEN_ON_IMMEDIATE_COLLISION | 即衝突時に障害物 cell が上書きされないことを確認 |
| TEST_CLEAR_PATH_MOVES_TO_DESTINATION | path が空の場合は destination まで正常移動することを確認 |

## 確認方法と実行結果

```
$ cargo run --bin tbx -- examples/trek/test_navigation_move.tbx
COURSE OUT OF QUADRANT BOUNDS -- MOVEMENT ABORTED (TODO: quadrant crossing)
COURSE OUT OF QUADRANT BOUNDS -- MOVEMENT ABORTED (TODO: quadrant crossing)
COURSE BLOCKED -- MOVEMENT ABORTED (TODO: collision)
```
（ASSERT 失敗なし: 既存 9 テストすべてパス）

```
$ cargo run --bin tbx -- examples/trek/test_navigation_collision.tbx
COURSE BLOCKED -- MOVEMENT ABORTED (TODO: collision)
COURSE BLOCKED -- MOVEMENT ABORTED (TODO: collision)
COURSE BLOCKED -- MOVEMENT ABORTED (TODO: collision)
COURSE BLOCKED -- MOVEMENT ABORTED (TODO: collision)
```
（ASSERT 失敗なし: 新規 5 テストすべてパス）

その他の trek テストも引き続きパス:
```
$ cargo run --bin tbx -- examples/trek/test_scan.tbx
$ cargo run --bin tbx -- examples/trek/test_init_quadrant.tbx
$ cargo run --bin tbx -- examples/trek/test_navigation_input.tbx
```

## 受け入れ条件チェック

- [x] `MOVE_WITHIN_QUADRANT` が destination 一括計算ではなく、1 step ごとに next sector を確認している
- [x] empty sector の場合だけ移動を継続する
- [x] path 上の非空 cell で移動が停止する
- [x] 障害物 cell を上書きしない
- [x] 衝突後、Enterprise は直前の有効 sector に残る
- [x] `ENT_SX` / `ENT_SY` と `@SECTOR` の Enterprise 位置が一致する
- [x] `@SECTOR` 上に Enterprise が重複しない
- [x] bounds 外 destination で crash しない既存挙動を壊さない
- [x] `[x, y]` convention を守っている

🤖 Generated with [Claude Code](https://claude.com/claude-code)