### PR TITLE
quadrant 越境成功時に状態更新と INIT_QUADRANT を行う

### DIFF
--- a/examples/trek/nav.tbx
+++ b/examples/trek/nav.tbx
@@ -41,54 +41,6 @@ DEF PRINT_NAV_BLOCKED_MESSAGE(CELL)
   ENDSEL
 END
 
-# Move Enterprise within the current quadrant (STTR1.BAS lines 1500-2320, partial)
-# COURSE: validated integer course (1..8)
-# STEPS:  validated integer step count (>= 1)
-# Uses GET_COURSE_DX / GET_COURSE_DY to obtain the direction vector.
-# Advances 1 step at a time (Mayfield 原典 FOR I=1 TO N 方式).
-# If a next sector is outside sector bounds (1..8): prints TODO and returns
-#   without moving (quadrant crossing は未実装のため abort).
-# If a next sector is occupied (star / starbase / Klingon 等): stops at the
-#   previous (last valid) sector; obstacle cell は上書きしない.
-# On completion: updates @SECTOR (old cell -> 0=empty, new cell -> 1=Enterprise)
-#                and updates ENT_SX / ENT_SY to the final position.
-DEF MOVE_WITHIN_QUADRANT(COURSE, STEPS)
-  VAR DX = GET_COURSE_DX(COURSE)
-  VAR DY = GET_COURSE_DY(COURSE)
-  # CURR_SX / CURR_SY は各 step 後の有効位置を追跡する
-  VAR CURR_SX = ENT_SX
-  VAR CURR_SY = ENT_SY
-  VAR NEXT_SX = CURR_SX
-  VAR NEXT_SY = CURR_SY
-  VAR I = 1
-  VAR DONE = 0
-  WHILE I <= STEPS
-    IF DONE = 0
-      LET NEXT_SX = CURR_SX + DX
-      LET NEXT_SY = CURR_SY + DY
-      # bounds 外: quadrant crossing は未実装のため全体を abort して元の位置に残す
-      IF IS_IN_SECTOR_BOUNDS(NEXT_SX, NEXT_SY) = 0
-        PRINTLN "COURSE OUT OF QUADRANT BOUNDS -- MOVEMENT ABORTED (TODO: quadrant crossing)"
-        RETURN
-      ENDIF
-      # 非空 cell: Enterprise は CURR 位置に残り、障害物は上書きしない
-      IF @SECTOR[NEXT_SX, NEXT_SY] <> 0
-        PRINT_NAV_BLOCKED_MESSAGE @SECTOR[NEXT_SX, NEXT_SY]
-        LET DONE = 1
-      ELSE
-        LET CURR_SX = NEXT_SX
-        LET CURR_SY = NEXT_SY
-      ENDIF
-    ENDIF
-    LET I = I + 1
-  ENDWH
-  # Enterprise を元の sector から最終 sector へ移動する
-  LET @SECTOR[ENT_SX, ENT_SY] = 0
-  LET ENT_SX = CURR_SX
-  LET ENT_SY = CURR_SY
-  LET @SECTOR[ENT_SX, ENT_SY] = 1
-END
-
 # sector 座標が 1..8 の外に出たとき、隣接 quadrant と wrap 後 sector 座標に変換する
 # 結果は NORM_QX / NORM_QY / NORM_SX / NORM_SY / NORM_CROSSED / NORM_IN_GALAXY に書き込む
 # galaxy bounds 判定は IS_IN_QUAD_BOUNDS を再利用する (quadrant と galaxy は同じ 1..8 x 1..8)
@@ -124,6 +76,64 @@ DEF NORMALIZE_SECTOR_CROSSING(QX, QY, SX, SY)
   LET NORM_SY = NSY
   LET NORM_CROSSED = CROSSED
   LET NORM_IN_GALAXY = IS_IN_QUAD_BOUNDS(NQX, NQY)
+END
+
+# Move Enterprise within the current quadrant (STTR1.BAS lines 1500-2320, partial)
+# COURSE: validated integer course (1..8)
+# STEPS:  validated integer step count (>= 1)
+# Uses GET_COURSE_DX / GET_COURSE_DY to obtain the direction vector.
+# Advances 1 step at a time (Mayfield 原典 FOR I=1 TO N 方式).
+# If a next sector is outside sector bounds (1..8): uses NORMALIZE_SECTOR_CROSSING to
+#   attempt quadrant crossing. On success, updates ENT_QX/QY/SX/SY and calls
+#   INIT_QUADRANT. On galaxy edge, prints a message. Movement ends at the crossing point.
+# If a next sector is occupied (star / starbase / Klingon 等): stops at the
+#   previous (last valid) sector; obstacle cell は上書きしない.
+# On completion: updates @SECTOR (old cell -> 0=empty, new cell -> 1=Enterprise)
+#                and updates ENT_SX / ENT_SY to the final position.
+DEF MOVE_WITHIN_QUADRANT(COURSE, STEPS)
+  VAR DX = GET_COURSE_DX(COURSE)
+  VAR DY = GET_COURSE_DY(COURSE)
+  # CURR_SX / CURR_SY は各 step 後の有効位置を追跡する
+  VAR CURR_SX = ENT_SX
+  VAR CURR_SY = ENT_SY
+  VAR NEXT_SX = CURR_SX
+  VAR NEXT_SY = CURR_SY
+  VAR I = 1
+  VAR DONE = 0
+  WHILE I <= STEPS
+    IF DONE = 0
+      LET NEXT_SX = CURR_SX + DX
+      LET NEXT_SY = CURR_SY + DY
+      # bounds 外: sector 越境正規化 helper で隣接 quadrant へ crossing する
+      IF IS_IN_SECTOR_BOUNDS(NEXT_SX, NEXT_SY) = 0
+        NORMALIZE_SECTOR_CROSSING ENT_QX, ENT_QY, NEXT_SX, NEXT_SY
+        IF NORM_IN_GALAXY
+          LET ENT_QX = NORM_QX
+          LET ENT_QY = NORM_QY
+          LET ENT_SX = NORM_SX
+          LET ENT_SY = NORM_SY
+          INIT_QUADRANT
+        ELSE
+          PRINTLN "NAVIGATION BLOCKED: GALAXY EDGE"
+        ENDIF
+        RETURN
+      ENDIF
+      # 非空 cell: Enterprise は CURR 位置に残り、障害物は上書きしない
+      IF @SECTOR[NEXT_SX, NEXT_SY] <> 0
+        PRINT_NAV_BLOCKED_MESSAGE @SECTOR[NEXT_SX, NEXT_SY]
+        LET DONE = 1
+      ELSE
+        LET CURR_SX = NEXT_SX
+        LET CURR_SY = NEXT_SY
+      ENDIF
+    ENDIF
+    LET I = I + 1
+  ENDWH
+  # Enterprise を元の sector から最終 sector へ移動する
+  LET @SECTOR[ENT_SX, ENT_SY] = 0
+  LET ENT_SX = CURR_SX
+  LET ENT_SY = CURR_SY
+  LET @SECTOR[ENT_SX, ENT_SY] = 1
 END
 
 # コース・ワープエンジン制御コマンド (STTR1.BAS lines 1410-2320)

--- a/examples/trek/test_navigation_move.tbx
+++ b/examples/trek/test_navigation_move.tbx
@@ -60,11 +60,12 @@ DEF TEST_MOVE_SOUTH_1_STEP()
   ASSERT (@SECTOR[4, 4] = 0)
 END
 
-# Out-of-bounds: course 1 (East) 10 steps from (4,4) should abort without crashing
+# Galaxy edge: course 1 (East) from QX=8 -> crossing leads to QX=9 (galaxy 外) -> abort
 DEF TEST_MOVE_OUT_OF_BOUNDS_NO_CRASH()
   INIT_GAME
+  LET ENT_QX = 8
   SET_ENTERPRISE 4, 4
-  # 4 + 10 = 14, which is outside 1..8 -> should print TODO and not move
+  # SX=4 から east: NEXT_SX が 9 になると NORMALIZE -> QX=9 (galaxy 外) -> abort
   MOVE_WITHIN_QUADRANT 1, 10
   # Enterprise must remain at original position
   ASSERT (ENT_SX = 4)
@@ -72,10 +73,12 @@ DEF TEST_MOVE_OUT_OF_BOUNDS_NO_CRASH()
   ASSERT (@SECTOR[4, 4] = 1)
 END
 
-# Out-of-bounds: course 3 (North) 5 steps from (4,4) -> Y=4-5=-1, abort
+# Galaxy edge: course 3 (North) from QY=1 -> crossing leads to QY=0 (galaxy 外) -> abort
 DEF TEST_MOVE_NORTH_OUT_OF_BOUNDS()
   INIT_GAME
+  LET ENT_QY = 1
   SET_ENTERPRISE 4, 4
+  # SY=4 から north (DY=-1): NEXT_SY が 0 になると NORMALIZE -> QY=0 (galaxy 外) -> abort
   MOVE_WITHIN_QUADRANT 3, 5
   ASSERT (ENT_SX = 4)
   ASSERT (ENT_SY = 4)

--- a/examples/trek/test_navigation_quadrant.tbx
+++ b/examples/trek/test_navigation_quadrant.tbx
@@ -18,6 +18,16 @@ USE "scan.tbx"
 USE "nav.tbx"
 USE "../../lib/tests/helper.tbx"
 
+# Helper: quadrant と sector を指定して Enterprise を配置する
+DEF SET_POS(QX, QY, SX, SY)
+  LET ENT_QX = QX
+  LET ENT_QY = QY
+  CLEAR_SECTOR
+  LET ENT_SX = SX
+  LET ENT_SY = SY
+  LET @SECTOR[ENT_SX, ENT_SY] = 1
+END
+
 # X+ 越境: QX=4, SX=9 -> QX=5, SX=1
 DEF TEST_WRAP_X_PLUS()
   NORMALIZE_SECTOR_CROSSING 4, 4, 9, 4
@@ -120,3 +130,68 @@ TEST_WRAP_XY_MINUS
 TEST_OUT_OF_GALAXY
 TEST_OUT_OF_GALAXY_Y
 TEST_NO_CROSSING
+
+# ---- MOVE_WITHIN_QUADRANT quadrant crossing 接続テスト ----
+
+# East crossing: QX=4, SX=8 から east 1 step -> QX=5, SX=1
+DEF TEST_CROSS_EAST()
+  INIT_GAME
+  SET_POS 4, 4, 8, 4
+  MOVE_WITHIN_QUADRANT 1, 1
+  ASSERT (ENT_QX = 5)
+  ASSERT (ENT_SX = 1)
+  ASSERT (ENT_QY = 4)
+  ASSERT (ENT_SY = 4)
+  ASSERT (@SECTOR[ENT_SX, ENT_SY] = 1)
+END
+
+# West crossing: QX=4, SX=1 から west 1 step -> QX=3, SX=8
+DEF TEST_CROSS_WEST()
+  INIT_GAME
+  SET_POS 4, 4, 1, 4
+  MOVE_WITHIN_QUADRANT 5, 1
+  ASSERT (ENT_QX = 3)
+  ASSERT (ENT_SX = 8)
+  ASSERT (ENT_QY = 4)
+  ASSERT (ENT_SY = 4)
+  ASSERT (@SECTOR[ENT_SX, ENT_SY] = 1)
+END
+
+# South crossing: QY=4, SY=8 から south 1 step -> QY=5, SY=1
+DEF TEST_CROSS_SOUTH()
+  INIT_GAME
+  SET_POS 4, 4, 4, 8
+  MOVE_WITHIN_QUADRANT 7, 1
+  ASSERT (ENT_QX = 4)
+  ASSERT (ENT_SX = 4)
+  ASSERT (ENT_QY = 5)
+  ASSERT (ENT_SY = 1)
+  ASSERT (@SECTOR[ENT_SX, ENT_SY] = 1)
+END
+
+# North crossing: QY=4, SY=1 から north 1 step -> QY=3, SY=8
+DEF TEST_CROSS_NORTH()
+  INIT_GAME
+  SET_POS 4, 4, 4, 1
+  MOVE_WITHIN_QUADRANT 3, 1
+  ASSERT (ENT_QX = 4)
+  ASSERT (ENT_SX = 4)
+  ASSERT (ENT_QY = 3)
+  ASSERT (ENT_SY = 8)
+  ASSERT (@SECTOR[ENT_SX, ENT_SY] = 1)
+END
+
+# crossing 後 INIT_QUADRANT が呼ばれて @SECTOR が再構築される (scan が crash しない)
+DEF TEST_CROSS_SCAN_NO_CRASH()
+  INIT_GAME
+  SET_POS 4, 4, 8, 4
+  MOVE_WITHIN_QUADRANT 1, 1
+  # crossing 後に短距離スキャンが crash しないことを確認する
+  SHORT_RANGE_SCAN
+END
+
+TEST_CROSS_EAST
+TEST_CROSS_WEST
+TEST_CROSS_SOUTH
+TEST_CROSS_NORTH
+TEST_CROSS_SCAN_NO_CRASH


### PR DESCRIPTION
## 概要

sector 境界を越えた移動を quadrant crossing として処理する。
galaxy bounds 内への越境では `ENT_QX/QY/SX/SY` を更新して `INIT_QUADRANT()` を呼び出す。
**この PR では crossing 時点で movement を終了する**（remaining steps の継続は後続 issue に委ねる）。

## 変更内容

- `nav.tbx`:
  - `NORMALIZE_SECTOR_CROSSING` を `MOVE_WITHIN_QUADRANT` より前に移動（前方参照エラー修正）
  - `MOVE_WITHIN_QUADRANT` の bounds 外 abort を crossing ロジックに差し替え
    - galaxy bounds 内への越境: `ENT_QX/QY/SX/SY` を正規化後の値に更新し `INIT_QUADRANT()` を呼び出す
    - galaxy edge（bounds 外）: `"NAVIGATION BLOCKED: GALAXY EDGE"` を表示して abort（crash しない暫定挙動）
- `test_navigation_move.tbx`:
  - `TEST_MOVE_OUT_OF_BOUNDS_NO_CRASH`: `ENT_QX=8` を明示して galaxy edge abort テストに更新
  - `TEST_MOVE_NORTH_OUT_OF_BOUNDS`: `ENT_QY=1` を明示して galaxy edge abort テストに更新
- `test_navigation_quadrant.tbx`:
  - `SET_POS` helper を追加
  - east/west/south/north の crossing 接続テスト（`ENT_QX/QY/SX/SY` と `@SECTOR` の確認）を追加
  - crossing 後に `SHORT_RANGE_SCAN` が crash しないことを確認するテストを追加

## 確認方法

```
cargo run --bin tbx -- examples/trek/test_navigation_quadrant.tbx
cargo run --bin tbx -- examples/trek/test_navigation_move.tbx
cargo run --bin tbx -- examples/trek/test_navigation_collision.tbx
cargo run --bin tbx -- examples/trek/test_scan.tbx
```

## 実行結果

```
$ cargo run --bin tbx -- examples/trek/test_navigation_quadrant.tbx
---------------------------------
              *                    STARDATE        2400
                                   CONDITION       GREEN
                                   QUADRANT        5,4
 <*>                               SECTOR          1,4
          *                        ENERGY          3000
              *                    TORPEDOES       10
                                   SHIELDS         0
                                   KLINGONS LEFT   16
---------------------------------
(エラーなし・終了コード 0)

$ cargo run --bin tbx -- examples/trek/test_navigation_move.tbx
NAVIGATION BLOCKED: GALAXY EDGE
NAVIGATION BLOCKED: GALAXY EDGE
COURSE BLOCKED BY STAR -- MOVEMENT ABORTED
(エラーなし・終了コード 0)

$ cargo run --bin tbx -- examples/trek/test_navigation_collision.tbx
COURSE BLOCKED BY STAR -- MOVEMENT ABORTED  (×4)
COURSE BLOCKED BY STARBASE -- MOVEMENT ABORTED  (×2)
COURSE BLOCKED BY KLINGON -- MOVEMENT ABORTED  (×2)
(エラーなし・終了コード 0)

$ cargo run --bin tbx -- examples/trek/test_scan.tbx
(エラーなし・終了コード 0)
```

Closes #818
