### PR TITLE
式コンパイラ: ExprAst / BinaryOp / UnaryOp の内部型を追加する

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -12,6 +12,91 @@ use crate::error::TbxError;
 use crate::lexer::{SpannedToken, Token};
 use crate::vm::VM;
 
+#[allow(dead_code)]
+mod ast {
+    use crate::cell::{Cell, Xt};
+
+    #[derive(Debug, Clone)]
+    pub(super) enum ExprAst {
+        Literal(Cell),
+        LocalRead {
+            index: usize,
+        },
+        GlobalRead {
+            addr: usize,
+        },
+        AddressOfLocal {
+            index: usize,
+        },
+        AddressOfGlobal {
+            addr: usize,
+        },
+        Call {
+            xt: Xt,
+            arity: usize,
+            args: Vec<ExprAst>,
+        },
+        Unary {
+            op: UnaryOp,
+            expr: Box<ExprAst>,
+        },
+        Binary {
+            op: BinaryOp,
+            lhs: Box<ExprAst>,
+            rhs: Box<ExprAst>,
+        },
+        Comma {
+            lhs: Box<ExprAst>,
+            rhs: Box<ExprAst>,
+        },
+        TupleGet {
+            base: Box<ExprAst>,
+            index: Box<ExprAst>,
+        },
+        ArrayGet {
+            array: ArrayDesignator,
+            index: Box<ExprAst>,
+        },
+        ArrayAddr {
+            array: ArrayDesignator,
+            index: Box<ExprAst>,
+        },
+        ArrayLen {
+            array: ArrayDesignator,
+        },
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub(super) enum BinaryOp {
+        Add,
+        Sub,
+        Mul,
+        Div,
+        Mod,
+        Lt,
+        Gt,
+        Le,
+        Ge,
+        Eq,
+        Neq,
+        BitAnd,
+        BitOr,
+        And,
+        Or,
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub(super) enum UnaryOp {
+        Neg,
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub(super) enum ArrayDesignator {
+        Local { index: usize },
+        Global { addr: usize },
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Operator stack item
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## 概要

Refs #840

`src/expr.rs` に、後続の `tokens -> ExprAst -> Vec<Cell>` 移行で使う内部 AST 型を追加しました。既存の `compile_expr()` の処理フローや意味論は変更していません。

## 変更内容

- `ExprAst` を追加
- `BinaryOp` / `UnaryOp` を追加
- `ArrayDesignator` を追加
- 未使用 warning を移行用の内部モジュールに限定

## 確認

- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo fmt --check`
