### PR TITLE
RawExprAst / ResolvedExprAst 二段階化の必要性を再評価する

### DIFF
--- a/docs/agent-notes.md
+++ b/docs/agent-notes.md
@@ -14,6 +14,34 @@
 
 ---
 
+## 式コンパイラの責務メモ
+
+### `ExprAst` は当面「解決済み寄り」の単一 AST として扱う
+
+`src/expr.rs` の現行パイプラインは `tokens -> ExprResolver-assisted ExprAst -> Vec<Cell)` であり、`ExprAst` は純粋な raw parse tree ではない。
+
+- `LocalRead` / `GlobalRead` による local-global 解決
+- `Invoke { xt, ... }` による callable `Xt` の確定
+- `ArrayDesignator::{Local, Global}` による配列参照先の確定
+
+これらは AST 構築時にすでに解決される。
+
+issue #864 の時点では、`RawExprAst -> ResolvedExprAst` の二段階化は **保留** とする。
+
+- 現状の codegen は解決済みノードを前提に責務分離できている
+- raw AST を別導入しても、現時点では利用者が codegen 以外にほぼ存在しない
+- `Xt` / local-global / array designator を二重管理すると差分が大きい割に利益が小さい
+
+再評価の条件は次のようなもの。
+
+- source span を各 AST node に保持して、resolve 前後で診断を比較したくなったとき
+- unresolved syntax を別の consumer が読む必要が出たとき
+- `EntryKind` 依存情報を codegen からさらに切り離す価値が明確になったとき
+
+後続の小粒タスクでは、まず resolver と codegen の責務境界を整え、Raw/Resolved 二段階化は必要性が具体化してから着手すること。
+
+---
+
 ## TBX 構文上の落とし穴
 
 ### 文終端と1行1文の運用

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -3,6 +3,21 @@
 //! Converts a slice of `SpannedToken`s representing an infix expression into a
 //! flat RPN instruction sequence (`Vec<Cell>`) that can be appended to the VM
 //! dictionary or executed directly.
+//!
+//! Current layering is intentionally:
+//!
+//! `tokens -> ExprResolver-assisted ExprAst -> Vec<Cell)`
+//!
+//! `ExprAst` is therefore not a purely raw parse tree. Identifier class,
+//! local/global storage selection, callable `Xt`, and array designators are
+//! resolved while building the AST so that expression codegen can stay focused
+//! on lowering already-classified nodes.
+//!
+//! As of issue #864, TBX intentionally does not split this into
+//! `RawExprAst -> ResolvedExprAst` yet. A two-stage AST would only pay off once
+//! source-span-carrying diagnostics or other consumers need to preserve
+//! unresolved syntax independently from codegen. Until then, keeping one
+//! resolved-leaning `ExprAst` avoids a large migration for limited benefit.
 
 use std::collections::HashMap;
 
@@ -17,6 +32,11 @@ use ast::{BinaryOp, ExprAst, UnaryOp};
 mod ast {
     use crate::cell::{Cell, Xt};
 
+    /// Expression AST used between parsing/resolution and codegen.
+    ///
+    /// This enum intentionally carries resolved information such as local/global
+    /// storage class, callable `Xt`, and array designators. It is not a raw
+    /// syntax tree; `ExprResolver` folds name resolution into AST construction.
     #[derive(Debug, Clone)]
     pub(super) enum ExprAst {
         Literal(Cell),
@@ -172,6 +192,8 @@ impl<'a> ExprResolver<'a> {
         name: &str,
         next_is_lparen: bool,
     ) -> Result<ResolvedIdentExpr, TbxError> {
+        // Resolution stays intentionally narrow here: classify the identifier for
+        // the current `ExprAst` shape, but leave call lowering details in codegen.
         if let Some(local_read) = self.resolve_local_read(name) {
             return Ok(local_read);
         }


### PR DESCRIPTION
## 概要

Closes #864

`ExprAst` / `ExprResolver` の現状を踏まえて、`RawExprAst -> ResolvedExprAst` 二段階化は現時点では保留とする判断をコード近傍と共有ノートに明文化しました。

## 変更内容

- `src/expr.rs` のモジュールコメントに、現行パイプラインが `tokens -> ExprResolver-assisted ExprAst -> Vec<Cell)` であることを追記
- `ExprAst` が raw AST ではなく、local/global 解決・callable `Xt`・array designator を持つ resolved 寄り AST であることをコメント化
- `ExprResolver` の責務を「AST 構築時の分類まで」と明記
- `docs/agent-notes.md` に、二段階 AST を今は導入しない理由と再評価条件を追加

## 判断

- 現時点では `ExprAst + ExprResolver` を継続
- 二段階化は、source span を載せた診断改善や unresolved syntax の別 consumer が必要になった時点で再評価

## 確認

- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo fmt --check`
