### PR TITLE
STTR1 tracker整理でKlingon attack後続スコープを分離

### DIFF
--- a/docs/notes/sttr1-klingon-attack-tracker.md
+++ b/docs/notes/sttr1-klingon-attack-tracker.md
@@ -1,0 +1,102 @@
+# STTR1 Klingon Attack Tracker Notes
+
+`issue #917` で整理した、`#893` (Klingon retaliation / attack tracker) の棚卸しメモ。
+
+## `#893` で完了した範囲
+
+- deterministic な Klingon attack helper
+  - `KLINGON_ATTACK_AMOUNT()`
+  - `KLINGON_ATTACK_AMOUNT_FOR_INDEX_AND_ROLL()`
+- `KLINGON_ATTACK()` core の safe boundary
+  - docked 時は Starbase protection を表示して return
+  - `KLINGONS_HERE <= 0` なら no-op
+  - dead / unused Klingon slot を安全に無視
+- phaser command 後の retaliation 接続
+  - `FIRE_PHASERS_WITH_UNITS_AND_ROLL()`
+  - `MAYBE_KLINGON_ATTACK_AFTER_PLAYER_ACTION_WITH_ROLL()`
+- shield underflow defeat hook
+  - retaliation で `SHIELDS` を減算
+  - `SHIELDS < 0` で `GAME_OVER = TRUE`
+  - 現状の defeat message は `"THE ENTERPRISE HAS BEEN DESTROYED"`
+
+この時点で、最小戦闘ループは次まで接続済み。
+
+```text
+command 3 = FIRE PHASERS
+  ↓
+Klingon に hit / destroy
+  ↓
+生存 Klingon がいれば retaliation
+  ↓
+SHIELDS 減少
+  ↓
+SHIELDS < 0 なら GAME_OVER
+```
+
+## `#893` に残さないもの
+
+以下は `#893` の完了条件には含めず、後続 issue へ分離する。
+
+### Damage system foundation
+
+- `@DAMAGE[1..8]` の意味づけ整理
+- device damage 発生条件
+- damage control report command
+- repair / dock repair
+- phaser computer penalty の実処理
+
+### Shield / retaliation expansion
+
+- shield control command
+- shield energy transfer
+- docked 時の shield / energy 回復境界
+- navigation 後の Klingon attack
+- photon torpedo 後の Klingon attack
+- shield command 後の Klingon attack
+- shield collapse 後の表示整理
+- Starbase protection message の精密化
+
+### Full endgame / score
+
+- defeat report の原典寄せ
+- victory report
+- final score
+- mission summary
+- `GAME_OVER` 後の quit / endgame flow 完成
+
+## `command 3` の確認観点
+
+`integration/470-sttr1-porting` 上では、`command 3 = FIRE PHASERS` の確認を次の 3 層に分ける。
+
+1. dispatch smoke
+   - `examples/trek/test_command.tbx`
+   - `DISPATCH_COMMAND(3)` が通常起動経路から `PHASER_CONTROL()` を呼んでも落ちないこと
+   - stdin なし実行では `READ_NUMBER_OR(0)` が `0` になり safe return する
+2. valid fire path
+   - `examples/trek/test_phaser.tbx`
+   - `TRY_FIRE_PHASERS_UNITS()` と `FIRE_PHASERS_WITH_UNITS_AND_ROLL()` で command 3 の実処理を確認する
+3. retaliation / defeat path
+   - `examples/trek/test_phaser.tbx`
+   - retaliation 発生条件、last Klingon destroy の no retaliation、shield underflow の `GAME_OVER` を確認する
+
+この分割により、入出力付き command path と deterministic combat core を分離したまま、通常起動の確認観点を維持する。
+
+## `#893` の完了判断
+
+`#893` は「Klingon retaliation / attack の最小戦闘ループを成立させる tracker」としては完了扱いでよい。
+
+根拠:
+
+- deterministic helper test がある
+- `KLINGON_ATTACK()` core の safe boundary がある
+- phaser 後 retaliation が接続済み
+- shield underflow defeat hook が接続済み
+- command `3` の dispatch smoke と combat regression の両方がある
+
+未完了なのは、damage system / shield control / full endgame の次段階であり、`#893` とは別 tracker に切り出すほうが粒度がよい。
+
+## 次に切る issue 候補
+
+1. STTR1: damage system foundation を実装する
+2. STTR1: shield control と retaliation 接続拡張を実装する
+3. STTR1: full endgame / score を実装する

--- a/examples/trek/combat.tbx
+++ b/examples/trek/combat.tbx
@@ -1,8 +1,8 @@
 # trek/combat.tbx — フェイザー・魚雷・クリンゴン攻撃手続き
 #
-# #849 phaser integration scope:
-# - command 3 dispatch, energy input/validation, hit calculation, and kill handling are implemented
-# - Klingon retaliation, full device damage behavior, and victory/defeat endgame stay behind explicit TODO hooks
+# Current STTR1 combat scope after #893/#917 tracker cleanup:
+# - command 3 fire path, Klingon retaliation, and shield-underflow defeat hook are implemented
+# - damage system, shield control expansion, and full endgame/score remain in follow-up issues
 
 # Damage slot 4 is phaser control per Mayfield D[4].
 DEF PHASER_CONTROL_DISABLED()
@@ -85,7 +85,8 @@ DEF KLINGON_ATTACK_AMOUNT_FOR_INDEX(I)
   RETURN KLINGON_ATTACK_AMOUNT_FOR_INDEX_AND_ROLL(I, RAND_FACTOR_0_TO_2_100())
 END
 
-# Placeholder hook for the later full defeat / endgame flow.
+# Minimal defeat hook for the current retaliation scope.
+# Follow-up issues still need defeat report / score / quit flow.
 DEF MAYBE_DEFEAT_AFTER_KLINGON_ATTACK()
   IF SHIELDS >= 0
     RETURN
@@ -187,6 +188,7 @@ DEF UPDATE_CURRENT_QUADRANT_KLINGON_SUMMARY(KLINGON_COUNT)
 END
 
 # Placeholder hook for the later full victory flow.
+# Final victory report / score stay outside the current tracker scope.
 DEF MAYBE_VICTORY_AFTER_KLINGON_DESTROYED()
   IF KLINGONS_LEFT <= 0
     # TODO: full victory / score / endgame

--- a/examples/trek/test_command.tbx
+++ b/examples/trek/test_command.tbx
@@ -30,8 +30,9 @@ DEF TEST_DISPATCH_CMD0_NAVIGATE()
   DISPATCH_COMMAND 0
 END
 
-# Verify that DISPATCH_COMMAND(3) calls PHASER_CONTROL and does not crash.
-# stdin がない環境では READ_NUMBER_OR(0) が 0 を返し、safe return する。
+# Verify that DISPATCH_COMMAND(3) reaches the normal command-3 entrypoint.
+# stdin がない環境では READ_NUMBER_OR(0) が 0 を返し、ここでは dispatch smoke のみを見る。
+# actual fire / retaliation / shield defeat behavior is covered in test_phaser.tbx.
 DEF TEST_DISPATCH_CMD3_PHASER_CONTROL()
   INIT_GAME
   DISPATCH_COMMAND 3

--- a/examples/trek/test_phaser.tbx
+++ b/examples/trek/test_phaser.tbx
@@ -402,7 +402,7 @@ DEF TEST_FIRE_PHASERS_DOES_NOT_TRIGGER_RETALIATION_AFTER_LAST_KLINGON_DIES()
   ASSERT (KLINGONS_LEFT = 0)
 END
 
-# damage gate and command boundary behavior
+# command 3 valid-fire path, retaliation, and damage-gate behavior
 DEF TEST_INIT_GAME_INITIALIZES_DAMAGE_SLOTS()
   INIT_GAME
   ASSERT_FALSE PHASER_CONTROL_DISABLED()


### PR DESCRIPTION
## 概要

Closes #917

Klingon retaliation / shield defeat 実装後の tracker 整理を反映しました。

## 変更内容

- `docs/notes/sttr1-klingon-attack-tracker.md` を追加し、`#893` の完了範囲、残 TODO、`command 3` の確認観点、次 issue 候補を明文化
- `examples/trek/combat.tbx` の scope コメントを現状に合わせて更新し、defeat / victory hook の残スコープを明記
- `examples/trek/test_command.tbx` と `examples/trek/test_phaser.tbx` のコメントを更新し、dispatch smoke と実処理 regression の役割分担を明確化
- GitHub issue `#918` `#919` `#920` を作成し、damage system / shield expansion / full endgame を分離
- `#893` に棚卸し結果と完了判断コメントを投稿

## 確認

- `cargo run --quiet -- examples/trek/test_command.tbx`
- `cargo run --quiet -- examples/trek/test_phaser.tbx`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
