### PR TITLE
STTR1のshort range scan空セクタをドット表示に変更

### DIFF
--- a/examples/trek/scan.tbx
+++ b/examples/trek/scan.tbx
@@ -34,7 +34,9 @@ DEF SECTOR_SYMBOL(VAL)
   CASE 4
     RETURN " * "
   CASE_ELSE
-    RETURN "   "
+    # Intentional deviation from Mayfield STTR1: use dots for empty sectors
+    # so the short range scan grid remains readable.
+    RETURN " . "
   ENDSEL
 END
 

--- a/examples/trek/test_scan.tbx
+++ b/examples/trek/test_scan.tbx
@@ -1,5 +1,6 @@
 # trek/test_scan.tbx — SHORT_RANGE_SCAN() smoke test
 # SECTOR_SYMBOL の変換と INIT_GAME 後の初期状態を検証する
+# empty sector は原典の空白ではなく readability 改善のため " . " を使う
 
 USE "state.tbx"
 USE "util.tbx"
@@ -10,8 +11,8 @@ USE "../../lib/tests/helper.tbx"
 DEF RUN_SMOKE_TEST()
   INIT_GAME
 
-  # SECTOR_SYMBOL の変換が正しいか検証する
-  ASSERT (SECTOR_SYMBOL(0) = "   ")
+  # Intentional deviation from Mayfield STTR1: empty sector uses " . ".
+  ASSERT (SECTOR_SYMBOL(0) = " . ")
   ASSERT (SECTOR_SYMBOL(1) = "<*>")
   ASSERT (SECTOR_SYMBOL(2) = "+++")
   ASSERT (SECTOR_SYMBOL(3) = ">!<")


### PR DESCRIPTION
## 概要

Closes #950

short range scan の empty sector 表示を空白から ` . ` に変更し、視認性を上げました。
Mayfield STTR1 原典との差分であることが分かるコメントもあわせて追加しています。

## 変更内容

- `examples/trek/scan.tbx` の `SECTOR_SYMBOL(0)` を `"   "` から `" . "` に変更
- `examples/trek/test_scan.tbx` の期待値を更新
- intentional readability improvement であることをコメントで明記

## 確認

- `cargo run --quiet -- examples/trek/test_scan.tbx`
- `for f in examples/trek/test_*.tbx; do cargo run --quiet -- "$f" || exit 1; done`
- `cargo run --quiet -- examples/star_trek.tbx`
  - 起動して short range scan / command menu 表示まで確認
  - 対話ループに入るため継続実行はしていません
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
