### PR TITLE
input primitive の prompt flush をテストモードで抑制可能にする

### DIFF
--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -4,7 +4,7 @@ use crate::constants::{MAX_ARRAY_ELEMENTS, MAX_DICTIONARY_CELLS};
 use crate::dict::{EntryKind, WordEntry, FLAG_HIDDEN, FLAG_IMMEDIATE, FLAG_SYSTEM};
 use crate::error::TbxError;
 use crate::expr::ExprCompiler;
-use crate::vm::{CompileState, VM};
+use crate::vm::{CompileState, InputFlushMode, VM};
 use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -1975,22 +1975,29 @@ fn use_prim(vm: &mut VM) -> Result<(), TbxError> {
 ///
 /// Internal helper used by `getdec_prim`. Reads until a newline (or EOF) and
 /// strips the trailing newline characters.
-fn accept_prim(vm: &mut VM) -> Result<String, TbxError> {
+fn flush_output_before_input_if_needed(vm: &mut VM) -> Result<(), TbxError> {
+    if vm.input_flush_mode == InputFlushMode::KeepBufferedForTest || vm.output_buffer.is_empty() {
+        return Ok(());
+    }
+
     // Flush any pending output before blocking on user input, so that prompt
     // strings written with PUTSTR are visible before the interpreter waits.
-    if !vm.output_buffer.is_empty() {
-        let pending = std::mem::take(&mut vm.output_buffer);
-        vm.output_writer
-            .write_all(pending.as_bytes())
-            .map_err(|e| TbxError::OutputIoError {
-                reason: e.to_string(),
-            })?;
-        vm.output_writer
-            .flush()
-            .map_err(|e| TbxError::OutputIoError {
-                reason: e.to_string(),
-            })?;
-    }
+    let pending = std::mem::take(&mut vm.output_buffer);
+    vm.output_writer
+        .write_all(pending.as_bytes())
+        .map_err(|e| TbxError::OutputIoError {
+            reason: e.to_string(),
+        })?;
+    vm.output_writer
+        .flush()
+        .map_err(|e| TbxError::OutputIoError {
+            reason: e.to_string(),
+        })?;
+    Ok(())
+}
+
+fn accept_prim(vm: &mut VM) -> Result<String, TbxError> {
+    flush_output_before_input_if_needed(vm)?;
     let mut line = String::new();
     vm.input_reader
         .read_line(&mut line)
@@ -2553,6 +2560,32 @@ mod tests {
     use super::*;
     use crate::cell::{Cell, CompileEntry};
     use crate::constants::MAX_DICTIONARY_CELLS;
+    use std::io::Cursor;
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Clone, Default)]
+    struct SharedOutput(Arc<Mutex<Vec<u8>>>);
+
+    impl SharedOutput {
+        fn into_string(self) -> String {
+            let bytes = self.0.lock().expect("shared output lock poisoned").clone();
+            String::from_utf8(bytes).expect("shared output must be valid UTF-8")
+        }
+    }
+
+    impl std::io::Write for SharedOutput {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0
+                .lock()
+                .expect("shared output lock poisoned")
+                .extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
 
     // --- drop_prim ---
 
@@ -6477,13 +6510,28 @@ mod tests {
 
     #[test]
     fn test_getstr_flushes_output_before_read() {
-        use std::io::Cursor;
         let mut vm = VM::new();
+        let flushed = SharedOutput::default();
         vm.output_buffer = "prompt: ".to_string();
         vm.input_reader = Box::new(Cursor::new("answer\n"));
+        vm.output_writer = Box::new(flushed.clone());
         getstr_prim(&mut vm).unwrap();
         // After reading, the output buffer should have been flushed (empty).
         assert!(vm.output_buffer.is_empty());
+        assert_eq!(flushed.into_string(), "prompt: ");
+    }
+
+    #[test]
+    fn test_getstr_keeps_output_buffered_in_test_mode() {
+        let mut vm = VM::new();
+        let flushed = SharedOutput::default();
+        vm.set_input_flush_mode(InputFlushMode::KeepBufferedForTest);
+        vm.output_buffer = "prompt: ".to_string();
+        vm.input_reader = Box::new(Cursor::new("answer\n"));
+        vm.output_writer = Box::new(flushed.clone());
+        getstr_prim(&mut vm).unwrap();
+        assert_eq!(vm.output_buffer, "prompt: ");
+        assert_eq!(flushed.into_string(), "");
     }
 
     // --- array_get_prim ---

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -100,6 +100,14 @@ impl CompileState {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InputFlushMode {
+    /// Flush buffered output before blocking on input.
+    FlushBeforeRead,
+    /// Keep prompt/menu output buffered so tests can inspect it with GET_OUTPUT().
+    KeepBufferedForTest,
+}
+
 /// The TBX virtual machine.
 ///
 /// The dictionary is split into two layers:
@@ -192,6 +200,8 @@ pub struct VM {
     /// The field is not included in the `Debug` output because `dyn Write` does
     /// not implement `Debug`.
     pub output_writer: Box<dyn Write + Send>,
+    /// Policy controlling whether input primitives flush pending output before reading.
+    pub input_flush_mode: InputFlushMode,
     /// Random number generator state.
     ///
     /// Uses `SmallRng` (non-cryptographic, fast) for game and simulation use cases.
@@ -239,8 +249,14 @@ impl VM {
             input_buffer: None,
             input_reader: Box::new(BufReader::new(std::io::stdin())),
             output_writer: Box::new(std::io::stdout()),
+            input_flush_mode: InputFlushMode::FlushBeforeRead,
             rng: rand::rngs::SmallRng::from_entropy(),
         }
+    }
+
+    /// Configure whether input primitives flush pending output before reading.
+    pub fn set_input_flush_mode(&mut self, mode: InputFlushMode) {
+        self.input_flush_mode = mode;
     }
 
     /// Return the current call stack as human-readable frames, innermost first.

--- a/tests/tbx_lib_tests.rs
+++ b/tests/tbx_lib_tests.rs
@@ -6,6 +6,7 @@
 // process CWD.
 use std::path::{Path, PathBuf};
 use tbx::interpreter::Interpreter;
+use tbx::vm::InputFlushMode;
 
 fn run_tbx_test(path: &PathBuf, base_dir: &Path) -> Result<(), String> {
     let mut interp = Interpreter::new();
@@ -1948,10 +1949,19 @@ fn test_1d_array_valid_access_regression() {
 
 /// Helper: run TBX source with a given mock input string, return output.
 fn run_with_input(tbx_src: &str, mock_input: &str) -> String {
+    run_with_input_and_flush_mode(tbx_src, mock_input, InputFlushMode::FlushBeforeRead)
+}
+
+fn run_with_input_and_flush_mode(
+    tbx_src: &str,
+    mock_input: &str,
+    input_flush_mode: InputFlushMode,
+) -> String {
     use std::io::Cursor;
 
     let mut interp = Interpreter::new();
     interp.vm_mut().input_reader = Box::new(Cursor::new(mock_input.to_string()));
+    interp.vm_mut().set_input_flush_mode(input_flush_mode);
     interp
         .exec_source(tbx_src)
         .unwrap_or_else(|e| panic!("exec_source failed: {e}"));
@@ -2035,6 +2045,22 @@ fn run_trek_src_with_input_and_flushed_output(tbx_src: &str, mock_input: &str) -
         .exec_source(tbx_src)
         .unwrap_or_else(|e| panic!("exec_source failed: {e}"));
     (interp.take_output(), flushed.into_string())
+}
+
+#[test]
+fn test_getdec_safe_test_mode_keeps_prompt_in_output_buffer() {
+    let src = concat!(
+        "DEF CHECK()\n",
+        "  PUTSTR \"COMMAND:\"\n",
+        "  VAR CMD = GETDEC?()\n",
+        "  PUTSTR GET_OUTPUT()\n",
+        "  PUTSTR \" \"\n",
+        "  PUTVAL CMD[2]\n",
+        "END\n",
+        "CHECK\n",
+    );
+    let out = run_with_input_and_flush_mode(src, "123\n", InputFlushMode::KeepBufferedForTest);
+    assert_eq!(out, "COMMAND: TRUE");
 }
 
 #[test]


### PR DESCRIPTION
## 概要

Closes #985

input primitive が入力待ち前に `output_buffer` を flush する挙動を policy 化し、TBX テストでは flush を抑止できるようにしました。

## 変更内容

- `VM` に `InputFlushMode` を追加し、既定値を従来どおり `FlushBeforeRead` に設定
- `GETDEC?` / `GETSTR` などが使う入力 helper を `flush_output_before_input_if_needed + read` に分離
- テスト helper から `KeepBufferedForTest` を設定できるようにして、mock input 実行時に prompt を `GET_OUTPUT()` で検査可能に変更
- 通常 flush とテストモード抑止の両方を Rust/TBX テストで固定

## 確認

- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo fmt --check`
