### PR TITLE
tbx16 VMを実装

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod interpreter;
 pub mod lexer;
 pub mod primitives;
 pub mod statement_reader;
+pub mod tbx16;
 pub mod vm;
 
 /// Create a VM with all system primitives registered and sealed.

--- a/src/tbx16/cell.rs
+++ b/src/tbx16/cell.rs
@@ -1,0 +1,24 @@
+pub type Cell = u16;
+
+pub const WORD_BYTES: usize = 2;
+pub const FALSE: Cell = 0x0000;
+pub const TRUE: Cell = 0xffff;
+
+#[must_use]
+pub fn cell_to_i16(cell: Cell) -> i16 {
+    i16::from_le_bytes(cell.to_le_bytes())
+}
+
+#[must_use]
+pub fn cell_from_i16(value: i16) -> Cell {
+    u16::from_le_bytes(value.to_le_bytes())
+}
+
+#[must_use]
+pub fn canonical_bool(value: Cell) -> Cell {
+    if value == FALSE {
+        FALSE
+    } else {
+        TRUE
+    }
+}

--- a/src/tbx16/dict.rs
+++ b/src/tbx16/dict.rs
@@ -1,0 +1,202 @@
+use crate::tbx16::cell::Cell;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct WordId(pub u16);
+
+impl WordId {
+    #[must_use]
+    pub fn as_usize(self) -> usize {
+        usize::from(self.0)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct StringId(pub u16);
+
+impl StringId {
+    #[must_use]
+    pub fn as_usize(self) -> usize {
+        usize::from(self.0)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReturnMode {
+    Void,
+    Value,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Primitive {
+    Dup,
+    Drop,
+    Swap,
+    Over,
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Mod,
+    Negate,
+    Eq,
+    Ne,
+    Lt,
+    Le,
+    Gt,
+    Ge,
+    Not,
+    And,
+    Or,
+    BitAnd,
+    BitOr,
+    Fetch,
+    Store,
+    PutDec,
+    PutChr,
+    PutStr,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Instr {
+    Call(WordId),
+    Lit(Cell),
+    Branch(usize),
+    BranchIfZero(usize),
+    BranchIfNonZero(usize),
+    LoadLocal(u8),
+    StoreLocal(u8),
+    Exit,
+    Halt,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UserWord {
+    pub arity: u8,
+    pub frame_slots: u8,
+    pub return_mode: ReturnMode,
+    pub code: Vec<Instr>,
+}
+
+impl UserWord {
+    #[must_use]
+    pub fn new(arity: u8, frame_slots: u8, return_mode: ReturnMode, code: Vec<Instr>) -> Self {
+        assert!(
+            frame_slots >= arity,
+            "frame_slots must cover every argument slot"
+        );
+        Self {
+            arity,
+            frame_slots,
+            return_mode,
+            code,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Word {
+    Primitive(Primitive),
+    User(UserWord),
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Program {
+    words: Vec<Word>,
+    strings: Vec<Vec<u8>>,
+}
+
+impl Program {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn add_word(&mut self, word: Word) -> Result<WordId, ProgramError> {
+        let index = u16::try_from(self.words.len()).map_err(|_| ProgramError::TooManyWords)?;
+        self.words.push(word);
+        Ok(WordId(index))
+    }
+
+    pub fn add_string(&mut self, bytes: impl Into<Vec<u8>>) -> Result<StringId, ProgramError> {
+        let index = u16::try_from(self.strings.len()).map_err(|_| ProgramError::TooManyStrings)?;
+        self.strings.push(bytes.into());
+        Ok(StringId(index))
+    }
+
+    #[must_use]
+    pub fn word(&self, id: WordId) -> Option<&Word> {
+        self.words.get(id.as_usize())
+    }
+
+    #[must_use]
+    pub fn string(&self, id: StringId) -> Option<&[u8]> {
+        self.strings.get(id.as_usize()).map(Vec::as_slice)
+    }
+
+    pub fn install_core_words(&mut self) -> Result<CoreWords, ProgramError> {
+        Ok(CoreWords {
+            dup: self.add_word(Word::Primitive(Primitive::Dup))?,
+            drop: self.add_word(Word::Primitive(Primitive::Drop))?,
+            swap: self.add_word(Word::Primitive(Primitive::Swap))?,
+            over: self.add_word(Word::Primitive(Primitive::Over))?,
+            add: self.add_word(Word::Primitive(Primitive::Add))?,
+            sub: self.add_word(Word::Primitive(Primitive::Sub))?,
+            mul: self.add_word(Word::Primitive(Primitive::Mul))?,
+            div: self.add_word(Word::Primitive(Primitive::Div))?,
+            modulo: self.add_word(Word::Primitive(Primitive::Mod))?,
+            negate: self.add_word(Word::Primitive(Primitive::Negate))?,
+            eq: self.add_word(Word::Primitive(Primitive::Eq))?,
+            ne: self.add_word(Word::Primitive(Primitive::Ne))?,
+            lt: self.add_word(Word::Primitive(Primitive::Lt))?,
+            le: self.add_word(Word::Primitive(Primitive::Le))?,
+            gt: self.add_word(Word::Primitive(Primitive::Gt))?,
+            ge: self.add_word(Word::Primitive(Primitive::Ge))?,
+            not: self.add_word(Word::Primitive(Primitive::Not))?,
+            and: self.add_word(Word::Primitive(Primitive::And))?,
+            or: self.add_word(Word::Primitive(Primitive::Or))?,
+            bit_and: self.add_word(Word::Primitive(Primitive::BitAnd))?,
+            bit_or: self.add_word(Word::Primitive(Primitive::BitOr))?,
+            fetch: self.add_word(Word::Primitive(Primitive::Fetch))?,
+            store: self.add_word(Word::Primitive(Primitive::Store))?,
+            putdec: self.add_word(Word::Primitive(Primitive::PutDec))?,
+            putchr: self.add_word(Word::Primitive(Primitive::PutChr))?,
+            putstr: self.add_word(Word::Primitive(Primitive::PutStr))?,
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CoreWords {
+    pub dup: WordId,
+    pub drop: WordId,
+    pub swap: WordId,
+    pub over: WordId,
+    pub add: WordId,
+    pub sub: WordId,
+    pub mul: WordId,
+    pub div: WordId,
+    pub modulo: WordId,
+    pub negate: WordId,
+    pub eq: WordId,
+    pub ne: WordId,
+    pub lt: WordId,
+    pub le: WordId,
+    pub gt: WordId,
+    pub ge: WordId,
+    pub not: WordId,
+    pub and: WordId,
+    pub or: WordId,
+    pub bit_and: WordId,
+    pub bit_or: WordId,
+    pub fetch: WordId,
+    pub store: WordId,
+    pub putdec: WordId,
+    pub putchr: WordId,
+    pub putstr: WordId,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ProgramError {
+    TooManyWords,
+    TooManyStrings,
+}

--- a/src/tbx16/mod.rs
+++ b/src/tbx16/mod.rs
@@ -1,0 +1,10 @@
+pub mod cell;
+pub mod dict;
+pub mod vm;
+
+pub use cell::{canonical_bool, cell_from_i16, cell_to_i16, Cell, FALSE, TRUE, WORD_BYTES};
+pub use dict::{
+    CoreWords, Instr, Primitive, Program, ProgramError, ReturnMode, StringId, UserWord, Word,
+    WordId,
+};
+pub use vm::{CallFrame, Trap, Vm, DEFAULT_DATA_STACK_LIMIT, DEFAULT_RETURN_STACK_LIMIT};

--- a/src/tbx16/vm.rs
+++ b/src/tbx16/vm.rs
@@ -12,8 +12,19 @@ pub enum Trap {
     InvalidEntryWord(WordId),
     InvalidWord(WordId),
     InvalidString(StringId),
-    InvalidBranchTarget { word: WordId, target: usize },
-    InvalidLocalSlot { word: WordId, slot: u8 },
+    InvalidBranchTarget {
+        word: WordId,
+        target: usize,
+    },
+    InvalidFrameLayout {
+        word: WordId,
+        arity: u8,
+        frame_slots: u8,
+    },
+    InvalidLocalSlot {
+        word: WordId,
+        slot: u8,
+    },
     StackUnderflow,
     StackOverflow,
     ReturnStackOverflow,
@@ -26,14 +37,14 @@ pub enum Trap {
 pub struct CallFrame {
     pub word: WordId,
     pub pc: usize,
-    pub locals: Vec<Cell>,
+    pub frame_base: usize,
     pub return_mode: ReturnMode,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct RunningWord {
     id: WordId,
-    locals: Vec<Cell>,
+    frame_base: usize,
     return_mode: ReturnMode,
     pc: usize,
 }
@@ -94,10 +105,12 @@ impl Vm {
             Word::User(word) => word,
             Word::Primitive(_) => return Err(Trap::InvalidEntryWord(entry)),
         };
+        self.validate_frame_layout(entry, entry_user)?;
+        self.reserve_frame(usize::from(entry_user.frame_slots))?;
 
         let mut current = RunningWord {
             id: entry,
-            locals: vec![0; usize::from(entry_user.frame_slots)],
+            frame_base: 0,
             return_mode: ReturnMode::Void,
             pc: 0,
         };
@@ -142,43 +155,36 @@ impl Vm {
                     }
                 }
                 Instr::LoadLocal(slot) => {
-                    let value =
-                        *current
-                            .locals
-                            .get(usize::from(slot))
-                            .ok_or(Trap::InvalidLocalSlot {
-                                word: current.id,
-                                slot,
-                            })?;
+                    let value = self.read_local(&current, slot)?;
                     self.push(value)?;
                 }
                 Instr::StoreLocal(slot) => {
                     let value = self.pop()?;
-                    let local = current.locals.get_mut(usize::from(slot)).ok_or(
-                        Trap::InvalidLocalSlot {
-                            word: current.id,
-                            slot,
-                        },
-                    )?;
-                    *local = value;
+                    self.write_local(&current, slot, value)?;
                 }
                 Instr::Exit => {
+                    let return_value = match current.return_mode {
+                        ReturnMode::Void => None,
+                        ReturnMode::Value => Some(self.pop()?),
+                    };
+                    self.data_stack.truncate(current.frame_base);
+
                     if let Some(frame) = self.return_stack.pop() {
-                        let return_value = match current.return_mode {
-                            ReturnMode::Void => None,
-                            ReturnMode::Value => Some(self.pop()?),
-                        };
                         current = RunningWord {
                             id: frame.word,
-                            locals: frame.locals,
+                            frame_base: frame.frame_base,
                             return_mode: frame.return_mode,
                             pc: frame.pc,
                         };
+                    } else {
                         if let Some(value) = return_value {
                             self.push(value)?;
                         }
-                    } else {
                         return Ok(());
+                    }
+
+                    if let Some(value) = return_value {
+                        self.push(value)?;
                     }
                 }
                 Instr::Halt => return Ok(()),
@@ -223,6 +229,7 @@ impl Vm {
         if self.return_stack.len() >= self.return_stack_limit {
             return Err(Trap::ReturnStackOverflow);
         }
+        self.validate_frame_layout(word_id, user_word)?;
 
         let arity = usize::from(user_word.arity);
         if self.data_stack.len() < arity {
@@ -231,20 +238,18 @@ impl Vm {
 
         let frame_len = usize::from(user_word.frame_slots);
         let base = self.data_stack.len() - arity;
-        let args = self.data_stack.split_off(base);
-        let mut locals = vec![0; frame_len];
-        locals[..arity].copy_from_slice(&args);
+        self.reserve_frame(frame_len - arity)?;
 
         self.return_stack.push(CallFrame {
             word: current.id,
             pc: current.pc,
-            locals: std::mem::take(&mut current.locals),
+            frame_base: current.frame_base,
             return_mode: current.return_mode,
         });
 
         *current = RunningWord {
             id: word_id,
-            locals,
+            frame_base: base,
             return_mode: user_word.return_mode,
             pc: 0,
         };
@@ -263,6 +268,52 @@ impl Vm {
                 target,
             });
         }
+        Ok(())
+    }
+
+    fn validate_frame_layout(&self, word_id: WordId, user_word: &UserWord) -> Result<(), Trap> {
+        if user_word.frame_slots < user_word.arity {
+            return Err(Trap::InvalidFrameLayout {
+                word: word_id,
+                arity: user_word.arity,
+                frame_slots: user_word.frame_slots,
+            });
+        }
+        Ok(())
+    }
+
+    fn reserve_frame(&mut self, slots: usize) -> Result<(), Trap> {
+        let Some(new_len) = self.data_stack.len().checked_add(slots) else {
+            return Err(Trap::StackOverflow);
+        };
+        if new_len > self.data_stack_limit {
+            return Err(Trap::StackOverflow);
+        }
+        self.data_stack.resize(new_len, 0);
+        Ok(())
+    }
+
+    fn read_local(&self, current: &RunningWord, slot: u8) -> Result<Cell, Trap> {
+        let index = current.frame_base + usize::from(slot);
+        self.data_stack
+            .get(index)
+            .copied()
+            .ok_or(Trap::InvalidLocalSlot {
+                word: current.id,
+                slot,
+            })
+    }
+
+    fn write_local(&mut self, current: &RunningWord, slot: u8, value: Cell) -> Result<(), Trap> {
+        let index = current.frame_base + usize::from(slot);
+        let local = self
+            .data_stack
+            .get_mut(index)
+            .ok_or(Trap::InvalidLocalSlot {
+                word: current.id,
+                slot,
+            })?;
+        *local = value;
         Ok(())
     }
 
@@ -630,6 +681,89 @@ mod tests {
     }
 
     #[test]
+    fn exit_discards_temporary_values_for_value_words() {
+        let (mut program, _core) = install_program().expect("core words");
+        let producer = program
+            .add_word(Word::User(UserWord::new(
+                0,
+                0,
+                ReturnMode::Value,
+                vec![Instr::Lit(1), Instr::Lit(2), Instr::Exit],
+            )))
+            .expect("producer word");
+        let entry = program
+            .add_word(Word::User(UserWord::new(
+                0,
+                0,
+                ReturnMode::Void,
+                vec![Instr::Call(producer), Instr::Halt],
+            )))
+            .expect("entry word");
+
+        let mut vm = Vm::new();
+        vm.run(&program, entry).expect("program should run");
+
+        assert_eq!(vm.data_stack(), &[2]);
+    }
+
+    #[test]
+    fn exit_discards_temporary_values_for_void_words() {
+        let (mut program, _core) = install_program().expect("core words");
+        let worker = program
+            .add_word(Word::User(UserWord::new(
+                0,
+                1,
+                ReturnMode::Void,
+                vec![
+                    Instr::Lit(10),
+                    Instr::StoreLocal(0),
+                    Instr::Lit(99),
+                    Instr::Exit,
+                ],
+            )))
+            .expect("worker word");
+        let entry = program
+            .add_word(Word::User(UserWord::new(
+                0,
+                0,
+                ReturnMode::Void,
+                vec![Instr::Call(worker), Instr::Halt],
+            )))
+            .expect("entry word");
+
+        let mut vm = Vm::new();
+        vm.run(&program, entry).expect("program should run");
+
+        assert!(vm.data_stack().is_empty());
+    }
+
+    #[test]
+    fn locals_and_arguments_count_toward_data_stack_limit() {
+        let (mut program, _core) = install_program().expect("core words");
+        let large_frame = program
+            .add_word(Word::User(UserWord::new(
+                1,
+                64,
+                ReturnMode::Void,
+                vec![Instr::Exit],
+            )))
+            .expect("large frame word");
+        let entry = program
+            .add_word(Word::User(UserWord::new(
+                0,
+                1,
+                ReturnMode::Void,
+                vec![Instr::Lit(1), Instr::Call(large_frame), Instr::Halt],
+            )))
+            .expect("entry word");
+
+        let mut vm = Vm::new();
+        let err = vm.run(&program, entry).expect_err("frame should overflow");
+
+        assert_eq!(err, Trap::StackOverflow);
+    }
+
+    #[test]
     fn output_words_emit_decimal_char_and_static_string_bytes() {
         let (mut program, core) = install_program().expect("core words");
         let hello = program.add_string(b"HI".to_vec()).expect("string");
@@ -677,5 +811,40 @@ mod tests {
         let err = vm.run(&program, entry).expect_err("division should trap");
 
         assert_eq!(err, Trap::DivisionByZero);
+    }
+
+    #[test]
+    fn invalid_frame_layout_traps_instead_of_panicking() {
+        let (mut program, _core) = install_program().expect("core words");
+        let invalid = program
+            .add_word(Word::User(UserWord {
+                arity: 1,
+                frame_slots: 0,
+                return_mode: ReturnMode::Void,
+                code: vec![Instr::Exit],
+            }))
+            .expect("invalid word");
+        let entry = program
+            .add_word(Word::User(UserWord::new(
+                0,
+                0,
+                ReturnMode::Void,
+                vec![Instr::Lit(7), Instr::Call(invalid), Instr::Halt],
+            )))
+            .expect("entry word");
+
+        let mut vm = Vm::new();
+        let err = vm
+            .run(&program, entry)
+            .expect_err("invalid frame should trap");
+
+        assert_eq!(
+            err,
+            Trap::InvalidFrameLayout {
+                word: invalid,
+                arity: 1,
+                frame_slots: 0,
+            }
+        );
     }
 }

--- a/src/tbx16/vm.rs
+++ b/src/tbx16/vm.rs
@@ -1,0 +1,681 @@
+use crate::tbx16::cell::{
+    canonical_bool, cell_from_i16, cell_to_i16, Cell, FALSE, TRUE, WORD_BYTES,
+};
+use crate::tbx16::dict::{Instr, Primitive, Program, ReturnMode, StringId, UserWord, Word, WordId};
+
+pub const DEFAULT_DATA_STACK_LIMIT: usize = 64;
+pub const DEFAULT_RETURN_STACK_LIMIT: usize = 64;
+const DEFAULT_MEMORY_SIZE: usize = 65_536;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Trap {
+    InvalidEntryWord(WordId),
+    InvalidWord(WordId),
+    InvalidString(StringId),
+    InvalidBranchTarget { word: WordId, target: usize },
+    InvalidLocalSlot { word: WordId, slot: u8 },
+    StackUnderflow,
+    StackOverflow,
+    ReturnStackOverflow,
+    DivisionByZero,
+    InvalidMemoryAddress(u16),
+    MissingExit(WordId),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CallFrame {
+    pub word: WordId,
+    pub pc: usize,
+    pub locals: Vec<Cell>,
+    pub return_mode: ReturnMode,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct RunningWord {
+    id: WordId,
+    locals: Vec<Cell>,
+    return_mode: ReturnMode,
+    pc: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Vm {
+    memory: Vec<u8>,
+    data_stack: Vec<Cell>,
+    return_stack: Vec<CallFrame>,
+    output: Vec<u8>,
+    data_stack_limit: usize,
+    return_stack_limit: usize,
+}
+
+impl Default for Vm {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Vm {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_memory_size(DEFAULT_MEMORY_SIZE)
+    }
+
+    #[must_use]
+    pub fn with_memory_size(memory_size: usize) -> Self {
+        Self {
+            memory: vec![0; memory_size],
+            data_stack: Vec::with_capacity(DEFAULT_DATA_STACK_LIMIT),
+            return_stack: Vec::with_capacity(DEFAULT_RETURN_STACK_LIMIT),
+            output: Vec::new(),
+            data_stack_limit: DEFAULT_DATA_STACK_LIMIT,
+            return_stack_limit: DEFAULT_RETURN_STACK_LIMIT,
+        }
+    }
+
+    #[must_use]
+    pub fn with_limits(
+        memory_size: usize,
+        data_stack_limit: usize,
+        return_stack_limit: usize,
+    ) -> Self {
+        Self {
+            memory: vec![0; memory_size],
+            data_stack: Vec::with_capacity(data_stack_limit),
+            return_stack: Vec::with_capacity(return_stack_limit),
+            output: Vec::new(),
+            data_stack_limit,
+            return_stack_limit,
+        }
+    }
+
+    pub fn run(&mut self, program: &Program, entry: WordId) -> Result<(), Trap> {
+        let entry_word = program.word(entry).ok_or(Trap::InvalidEntryWord(entry))?;
+        let entry_user = match entry_word {
+            Word::User(word) => word,
+            Word::Primitive(_) => return Err(Trap::InvalidEntryWord(entry)),
+        };
+
+        let mut current = RunningWord {
+            id: entry,
+            locals: vec![0; usize::from(entry_user.frame_slots)],
+            return_mode: ReturnMode::Void,
+            pc: 0,
+        };
+
+        loop {
+            let word = program
+                .word(current.id)
+                .ok_or(Trap::InvalidWord(current.id))?;
+            let user_word = match word {
+                Word::User(word) => word,
+                Word::Primitive(_) => return Err(Trap::InvalidWord(current.id)),
+            };
+
+            let instr = user_word
+                .code
+                .get(current.pc)
+                .ok_or(Trap::MissingExit(current.id))?
+                .clone();
+            current.pc += 1;
+
+            match instr {
+                Instr::Call(word_id) => {
+                    self.invoke(program, word_id, &mut current)?;
+                }
+                Instr::Lit(value) => self.push(value)?,
+                Instr::Branch(target) => {
+                    self.ensure_branch_target(user_word, current.id, target)?;
+                    current.pc = target;
+                }
+                Instr::BranchIfZero(target) => {
+                    let value = self.pop()?;
+                    if value == FALSE {
+                        self.ensure_branch_target(user_word, current.id, target)?;
+                        current.pc = target;
+                    }
+                }
+                Instr::BranchIfNonZero(target) => {
+                    let value = self.pop()?;
+                    if value != FALSE {
+                        self.ensure_branch_target(user_word, current.id, target)?;
+                        current.pc = target;
+                    }
+                }
+                Instr::LoadLocal(slot) => {
+                    let value =
+                        *current
+                            .locals
+                            .get(usize::from(slot))
+                            .ok_or(Trap::InvalidLocalSlot {
+                                word: current.id,
+                                slot,
+                            })?;
+                    self.push(value)?;
+                }
+                Instr::StoreLocal(slot) => {
+                    let value = self.pop()?;
+                    let local = current.locals.get_mut(usize::from(slot)).ok_or(
+                        Trap::InvalidLocalSlot {
+                            word: current.id,
+                            slot,
+                        },
+                    )?;
+                    *local = value;
+                }
+                Instr::Exit => {
+                    if let Some(frame) = self.return_stack.pop() {
+                        let return_value = match current.return_mode {
+                            ReturnMode::Void => None,
+                            ReturnMode::Value => Some(self.pop()?),
+                        };
+                        current = RunningWord {
+                            id: frame.word,
+                            locals: frame.locals,
+                            return_mode: frame.return_mode,
+                            pc: frame.pc,
+                        };
+                        if let Some(value) = return_value {
+                            self.push(value)?;
+                        }
+                    } else {
+                        return Ok(());
+                    }
+                }
+                Instr::Halt => return Ok(()),
+            }
+        }
+    }
+
+    #[must_use]
+    pub fn data_stack(&self) -> &[Cell] {
+        &self.data_stack
+    }
+
+    #[must_use]
+    pub fn memory(&self) -> &[u8] {
+        &self.memory
+    }
+
+    #[must_use]
+    pub fn output(&self) -> &[u8] {
+        &self.output
+    }
+
+    fn invoke(
+        &mut self,
+        program: &Program,
+        word_id: WordId,
+        current: &mut RunningWord,
+    ) -> Result<(), Trap> {
+        let word = program.word(word_id).ok_or(Trap::InvalidWord(word_id))?;
+        match word {
+            Word::Primitive(primitive) => self.exec_primitive(program, *primitive),
+            Word::User(user_word) => self.enter_word(word_id, user_word, current),
+        }
+    }
+
+    fn enter_word(
+        &mut self,
+        word_id: WordId,
+        user_word: &UserWord,
+        current: &mut RunningWord,
+    ) -> Result<(), Trap> {
+        if self.return_stack.len() >= self.return_stack_limit {
+            return Err(Trap::ReturnStackOverflow);
+        }
+
+        let arity = usize::from(user_word.arity);
+        if self.data_stack.len() < arity {
+            return Err(Trap::StackUnderflow);
+        }
+
+        let frame_len = usize::from(user_word.frame_slots);
+        let base = self.data_stack.len() - arity;
+        let args = self.data_stack.split_off(base);
+        let mut locals = vec![0; frame_len];
+        locals[..arity].copy_from_slice(&args);
+
+        self.return_stack.push(CallFrame {
+            word: current.id,
+            pc: current.pc,
+            locals: std::mem::take(&mut current.locals),
+            return_mode: current.return_mode,
+        });
+
+        *current = RunningWord {
+            id: word_id,
+            locals,
+            return_mode: user_word.return_mode,
+            pc: 0,
+        };
+        Ok(())
+    }
+
+    fn ensure_branch_target(
+        &self,
+        word: &UserWord,
+        word_id: WordId,
+        target: usize,
+    ) -> Result<(), Trap> {
+        if target >= word.code.len() {
+            return Err(Trap::InvalidBranchTarget {
+                word: word_id,
+                target,
+            });
+        }
+        Ok(())
+    }
+
+    fn exec_primitive(&mut self, program: &Program, primitive: Primitive) -> Result<(), Trap> {
+        match primitive {
+            Primitive::Dup => {
+                let value = *self.data_stack.last().ok_or(Trap::StackUnderflow)?;
+                self.push(value)
+            }
+            Primitive::Drop => {
+                self.pop()?;
+                Ok(())
+            }
+            Primitive::Swap => {
+                let len = self.data_stack.len();
+                if len < 2 {
+                    return Err(Trap::StackUnderflow);
+                }
+                self.data_stack.swap(len - 1, len - 2);
+                Ok(())
+            }
+            Primitive::Over => {
+                let len = self.data_stack.len();
+                if len < 2 {
+                    return Err(Trap::StackUnderflow);
+                }
+                let value = self.data_stack[len - 2];
+                self.push(value)
+            }
+            Primitive::Add => {
+                let rhs = self.pop()?;
+                let lhs = self.pop()?;
+                self.push(lhs.wrapping_add(rhs))
+            }
+            Primitive::Sub => {
+                let rhs = self.pop()?;
+                let lhs = self.pop()?;
+                self.push(lhs.wrapping_sub(rhs))
+            }
+            Primitive::Mul => {
+                let rhs = self.pop()?;
+                let lhs = self.pop()?;
+                self.push(lhs.wrapping_mul(rhs))
+            }
+            Primitive::Div => {
+                let rhs = cell_to_i16(self.pop()?);
+                let lhs = cell_to_i16(self.pop()?);
+                let value = signed_div(lhs, rhs)?;
+                self.push(cell_from_i16(value))
+            }
+            Primitive::Mod => {
+                let rhs = cell_to_i16(self.pop()?);
+                let lhs = cell_to_i16(self.pop()?);
+                let value = signed_mod(lhs, rhs)?;
+                self.push(cell_from_i16(value))
+            }
+            Primitive::Negate => {
+                let value = self.pop()?;
+                let signed = cell_to_i16(value);
+                self.push(cell_from_i16(signed.wrapping_neg()))
+            }
+            Primitive::Eq => {
+                let rhs = self.pop()?;
+                let lhs = self.pop()?;
+                self.push(bool_cell(lhs == rhs))
+            }
+            Primitive::Ne => {
+                let rhs = self.pop()?;
+                let lhs = self.pop()?;
+                self.push(bool_cell(lhs != rhs))
+            }
+            Primitive::Lt => {
+                let rhs = cell_to_i16(self.pop()?);
+                let lhs = cell_to_i16(self.pop()?);
+                self.push(bool_cell(lhs < rhs))
+            }
+            Primitive::Le => {
+                let rhs = cell_to_i16(self.pop()?);
+                let lhs = cell_to_i16(self.pop()?);
+                self.push(bool_cell(lhs <= rhs))
+            }
+            Primitive::Gt => {
+                let rhs = cell_to_i16(self.pop()?);
+                let lhs = cell_to_i16(self.pop()?);
+                self.push(bool_cell(lhs > rhs))
+            }
+            Primitive::Ge => {
+                let rhs = cell_to_i16(self.pop()?);
+                let lhs = cell_to_i16(self.pop()?);
+                self.push(bool_cell(lhs >= rhs))
+            }
+            Primitive::Not => {
+                let value = self.pop()?;
+                self.push(bool_cell(value == FALSE))
+            }
+            Primitive::And => {
+                let rhs = self.pop()?;
+                let lhs = self.pop()?;
+                self.push(canonical_bool(lhs) & canonical_bool(rhs))
+            }
+            Primitive::Or => {
+                let rhs = self.pop()?;
+                let lhs = self.pop()?;
+                self.push(canonical_bool(lhs) | canonical_bool(rhs))
+            }
+            Primitive::BitAnd => {
+                let rhs = self.pop()?;
+                let lhs = self.pop()?;
+                self.push(lhs & rhs)
+            }
+            Primitive::BitOr => {
+                let rhs = self.pop()?;
+                let lhs = self.pop()?;
+                self.push(lhs | rhs)
+            }
+            Primitive::Fetch => {
+                let addr = self.pop()?;
+                let value = self.read_cell(addr)?;
+                self.push(value)
+            }
+            Primitive::Store => {
+                let value = self.pop()?;
+                let addr = self.pop()?;
+                self.write_cell(addr, value)
+            }
+            Primitive::PutDec => {
+                let value = cell_to_i16(self.pop()?);
+                self.output.extend_from_slice(value.to_string().as_bytes());
+                Ok(())
+            }
+            Primitive::PutChr => {
+                let value = self.pop()?;
+                self.output.push(value.to_le_bytes()[0]);
+                Ok(())
+            }
+            Primitive::PutStr => {
+                let string_id = StringId(self.pop()?);
+                let bytes = program
+                    .string(string_id)
+                    .ok_or(Trap::InvalidString(string_id))?;
+                self.output.extend_from_slice(bytes);
+                Ok(())
+            }
+        }
+    }
+
+    fn push(&mut self, value: Cell) -> Result<(), Trap> {
+        if self.data_stack.len() >= self.data_stack_limit {
+            return Err(Trap::StackOverflow);
+        }
+        self.data_stack.push(value);
+        Ok(())
+    }
+
+    fn pop(&mut self) -> Result<Cell, Trap> {
+        self.data_stack.pop().ok_or(Trap::StackUnderflow)
+    }
+
+    fn read_cell(&self, addr: u16) -> Result<Cell, Trap> {
+        let index = usize::from(addr);
+        let Some(end) = index.checked_add(WORD_BYTES - 1) else {
+            return Err(Trap::InvalidMemoryAddress(addr));
+        };
+        if end >= self.memory.len() {
+            return Err(Trap::InvalidMemoryAddress(addr));
+        }
+        Ok(u16::from_le_bytes([
+            self.memory[index],
+            self.memory[index + 1],
+        ]))
+    }
+
+    fn write_cell(&mut self, addr: u16, value: Cell) -> Result<(), Trap> {
+        let index = usize::from(addr);
+        let Some(end) = index.checked_add(WORD_BYTES - 1) else {
+            return Err(Trap::InvalidMemoryAddress(addr));
+        };
+        if end >= self.memory.len() {
+            return Err(Trap::InvalidMemoryAddress(addr));
+        }
+        let [lo, hi] = value.to_le_bytes();
+        self.memory[index] = lo;
+        self.memory[index + 1] = hi;
+        Ok(())
+    }
+}
+
+fn bool_cell(value: bool) -> Cell {
+    if value {
+        TRUE
+    } else {
+        FALSE
+    }
+}
+
+fn signed_div(lhs: i16, rhs: i16) -> Result<i16, Trap> {
+    if rhs == 0 {
+        return Err(Trap::DivisionByZero);
+    }
+    if lhs == i16::MIN && rhs == -1 {
+        return Ok(i16::MIN);
+    }
+    Ok(lhs / rhs)
+}
+
+fn signed_mod(lhs: i16, rhs: i16) -> Result<i16, Trap> {
+    if rhs == 0 {
+        return Err(Trap::DivisionByZero);
+    }
+    if lhs == i16::MIN && rhs == -1 {
+        return Ok(0);
+    }
+    Ok(lhs % rhs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tbx16::dict::{CoreWords, ProgramError, ReturnMode};
+
+    fn install_program() -> Result<(Program, CoreWords), ProgramError> {
+        let mut program = Program::new();
+        let core = program.install_core_words()?;
+        Ok((program, core))
+    }
+
+    #[test]
+    fn arithmetic_wraps_and_signed_division_follow_profile() {
+        let (mut program, core) = install_program().expect("core words");
+        let entry = program
+            .add_word(Word::User(UserWord::new(
+                0,
+                0,
+                ReturnMode::Void,
+                vec![
+                    Instr::Lit(0x7fff),
+                    Instr::Lit(1),
+                    Instr::Call(core.add),
+                    Instr::Lit(cell_from_i16(-7)),
+                    Instr::Lit(3),
+                    Instr::Call(core.div),
+                    Instr::Lit(cell_from_i16(-7)),
+                    Instr::Lit(3),
+                    Instr::Call(core.modulo),
+                    Instr::Lit(cell_from_i16(i16::MIN)),
+                    Instr::Lit(cell_from_i16(-1)),
+                    Instr::Call(core.div),
+                    Instr::Halt,
+                ],
+            )))
+            .expect("entry word");
+
+        let mut vm = Vm::new();
+        vm.run(&program, entry).expect("program should run");
+
+        assert_eq!(
+            vm.data_stack(),
+            &[
+                cell_from_i16(i16::MIN),
+                cell_from_i16(-2),
+                cell_from_i16(-1),
+                cell_from_i16(i16::MIN),
+            ]
+        );
+    }
+
+    #[test]
+    fn logical_ops_normalize_to_canonical_booleans_and_branch_on_zero() {
+        let (mut program, core) = install_program().expect("core words");
+        let entry = program
+            .add_word(Word::User(UserWord::new(
+                0,
+                0,
+                ReturnMode::Void,
+                vec![
+                    Instr::Lit(5),
+                    Instr::BranchIfZero(4),
+                    Instr::Lit(1),
+                    Instr::Branch(5),
+                    Instr::Lit(2),
+                    Instr::Lit(5),
+                    Instr::Call(core.not),
+                    Instr::Lit(1),
+                    Instr::Lit(2),
+                    Instr::Call(core.and),
+                    Instr::Lit(0),
+                    Instr::Lit(9),
+                    Instr::Call(core.or),
+                    Instr::Halt,
+                ],
+            )))
+            .expect("entry word");
+
+        let mut vm = Vm::new();
+        vm.run(&program, entry).expect("program should run");
+
+        assert_eq!(vm.data_stack(), &[1, FALSE, TRUE, TRUE]);
+    }
+
+    #[test]
+    fn fetch_and_store_use_little_endian_cells_on_byte_addresses() {
+        let (mut program, core) = install_program().expect("core words");
+        let entry = program
+            .add_word(Word::User(UserWord::new(
+                0,
+                0,
+                ReturnMode::Void,
+                vec![
+                    Instr::Lit(1),
+                    Instr::Lit(0x1234),
+                    Instr::Call(core.store),
+                    Instr::Lit(1),
+                    Instr::Call(core.fetch),
+                    Instr::Halt,
+                ],
+            )))
+            .expect("entry word");
+
+        let mut vm = Vm::with_memory_size(8);
+        vm.run(&program, entry).expect("program should run");
+
+        assert_eq!(vm.memory()[1], 0x34);
+        assert_eq!(vm.memory()[2], 0x12);
+        assert_eq!(vm.data_stack(), &[0x1234]);
+    }
+
+    #[test]
+    fn user_words_can_read_arguments_and_locals_and_return_one_value() {
+        let (mut program, core) = install_program().expect("core words");
+        let doubler = program
+            .add_word(Word::User(UserWord::new(
+                2,
+                3,
+                ReturnMode::Value,
+                vec![
+                    Instr::LoadLocal(0),
+                    Instr::LoadLocal(1),
+                    Instr::Call(core.add),
+                    Instr::StoreLocal(2),
+                    Instr::LoadLocal(2),
+                    Instr::LoadLocal(2),
+                    Instr::Call(core.add),
+                    Instr::Exit,
+                ],
+            )))
+            .expect("helper word");
+        let entry = program
+            .add_word(Word::User(UserWord::new(
+                0,
+                0,
+                ReturnMode::Void,
+                vec![
+                    Instr::Lit(10),
+                    Instr::Lit(7),
+                    Instr::Call(doubler),
+                    Instr::Halt,
+                ],
+            )))
+            .expect("entry word");
+
+        let mut vm = Vm::new();
+        vm.run(&program, entry).expect("program should run");
+
+        assert_eq!(vm.data_stack(), &[34]);
+    }
+
+    #[test]
+    fn output_words_emit_decimal_char_and_static_string_bytes() {
+        let (mut program, core) = install_program().expect("core words");
+        let hello = program.add_string(b"HI".to_vec()).expect("string");
+        let entry = program
+            .add_word(Word::User(UserWord::new(
+                0,
+                0,
+                ReturnMode::Void,
+                vec![
+                    Instr::Lit(hello.0),
+                    Instr::Call(core.putstr),
+                    Instr::Lit(u16::from(b' ')),
+                    Instr::Call(core.putchr),
+                    Instr::Lit(cell_from_i16(-2)),
+                    Instr::Call(core.putdec),
+                    Instr::Halt,
+                ],
+            )))
+            .expect("entry word");
+
+        let mut vm = Vm::new();
+        vm.run(&program, entry).expect("program should run");
+
+        assert_eq!(vm.output(), b"HI -2");
+    }
+
+    #[test]
+    fn division_by_zero_traps_deterministically() {
+        let (mut program, core) = install_program().expect("core words");
+        let entry = program
+            .add_word(Word::User(UserWord::new(
+                0,
+                0,
+                ReturnMode::Void,
+                vec![
+                    Instr::Lit(1),
+                    Instr::Lit(0),
+                    Instr::Call(core.div),
+                    Instr::Halt,
+                ],
+            )))
+            .expect("entry word");
+
+        let mut vm = Vm::new();
+        let err = vm.run(&program, entry).expect_err("division should trap");
+
+        assert_eq!(err, Trap::DivisionByZero);
+    }
+}


### PR DESCRIPTION
## 概要

Closes #963

`tbx-6502` M2 向けに、ホストVMの `Cell` に依存しない小さな `tbx16` 実行系を追加しました。

## 変更内容

- `src/tbx16/` を追加し、16bitセル、canonical boolean、最小辞書、手書きプログラム用の命令表現を実装
- `Vm` に 64 セル上限のデータスタック、little-endian メモリ、固定 arity の call/frame、決定的な trap を実装
- 最小 primitive 群として算術、比較、論理/bitwise、stack 操作、`FETCH` / `STORE`、`PUTDEC` / `PUTCHR` / `PUTSTR` を追加
- ユニットテストで wrap 算術、signed 除算/剰余、canonical boolean、branch、call/return、locals、little-endian fetch/store、出力、0除算 trap を確認

## 確認

- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo fmt --check`
