### PR TITLE
tbx16のCell・メモリ・スタック基盤を実装

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod interpreter;
 pub mod lexer;
 pub mod primitives;
 pub mod statement_reader;
+pub mod tbx16;
 pub mod vm;
 
 /// Create a VM with all system primitives registered and sealed.

--- a/src/tbx16/address.rs
+++ b/src/tbx16/address.rs
@@ -1,0 +1,50 @@
+use std::fmt;
+
+/// A 16-bit byte address in the tbx16 address space.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Address(u16);
+
+impl Address {
+    /// Creates an address from its raw 16-bit value.
+    pub const fn new(value: u16) -> Self {
+        Self(value)
+    }
+
+    /// Returns the raw 16-bit value.
+    pub const fn get(self) -> u16 {
+        self.0
+    }
+
+    /// Returns `true` when the address is aligned to a 2-byte cell boundary.
+    pub const fn is_even(self) -> bool {
+        self.0 % 2 == 0
+    }
+
+    /// Adds a byte offset without wrapping.
+    pub fn checked_add(self, offset: u16) -> Option<Self> {
+        self.0.checked_add(offset).map(Self)
+    }
+
+    /// Adds a byte offset without wrapping.
+    pub fn checked_add_usize(self, offset: usize) -> Option<Self> {
+        let offset = u16::try_from(offset).ok()?;
+        self.checked_add(offset)
+    }
+
+    /// Subtracts a byte offset without wrapping.
+    pub fn checked_sub(self, offset: u16) -> Option<Self> {
+        self.0.checked_sub(offset).map(Self)
+    }
+}
+
+impl From<u16> for Address {
+    fn from(value: u16) -> Self {
+        Self::new(value)
+    }
+}
+
+impl fmt::Display for Address {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "${:04x}", self.0)
+    }
+}

--- a/src/tbx16/cell.rs
+++ b/src/tbx16/cell.rs
@@ -1,0 +1,67 @@
+/// A raw 16-bit value in the tbx16 VM.
+///
+/// The cell does not carry a runtime tag. Primitive semantics decide whether a
+/// given bit-pattern is interpreted as an integer, boolean, address, XT, or
+/// other VM-level value.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Cell(u16);
+
+impl Cell {
+    pub const FALSE: Self = Self(0x0000);
+    pub const TRUE: Self = Self(0xffff);
+
+    /// Creates a cell from its raw bits.
+    pub const fn new(raw: u16) -> Self {
+        Self(raw)
+    }
+
+    /// Returns the raw 16-bit bits.
+    pub const fn raw(self) -> u16 {
+        self.0
+    }
+
+    /// Returns the little-endian byte encoding.
+    pub const fn to_le_bytes(self) -> [u8; 2] {
+        self.0.to_le_bytes()
+    }
+
+    /// Creates a cell from little-endian bytes.
+    pub const fn from_le_bytes(bytes: [u8; 2]) -> Self {
+        Self(u16::from_le_bytes(bytes))
+    }
+
+    /// Interprets the raw bits as a signed 16-bit integer.
+    pub const fn as_i16(self) -> i16 {
+        self.0 as i16
+    }
+
+    /// Reinterprets a signed 16-bit integer as raw cell bits.
+    pub const fn from_i16(value: i16) -> Self {
+        Self(value as u16)
+    }
+
+    /// Returns `true` for any non-zero value.
+    pub const fn is_truthy(self) -> bool {
+        self.0 != 0
+    }
+
+    /// Normalizes the current value to the canonical tbx16 boolean encoding.
+    pub const fn to_canonical_bool(self) -> Self {
+        Self::from_bool(self.is_truthy())
+    }
+
+    /// Creates a canonical boolean cell.
+    pub const fn from_bool(value: bool) -> Self {
+        if value {
+            Self::TRUE
+        } else {
+            Self::FALSE
+        }
+    }
+}
+
+impl From<u16> for Cell {
+    fn from(value: u16) -> Self {
+        Self::new(value)
+    }
+}

--- a/src/tbx16/error.rs
+++ b/src/tbx16/error.rs
@@ -16,7 +16,7 @@ pub enum Tbx16Error {
     },
     InvalidStackRegion {
         start: Address,
-        end: usize,
+        end: Address,
         reason: &'static str,
     },
     MisalignedStackPointer {
@@ -46,7 +46,7 @@ impl fmt::Display for Tbx16Error {
                 write!(f, "invalid memory access during {operation} at {addr}")
             }
             Tbx16Error::InvalidStackRegion { start, end, reason } => {
-                write!(f, "invalid stack region {start}..${end:04x}: {reason}")
+                write!(f, "invalid stack region {start}..{end}: {reason}")
             }
             Tbx16Error::MisalignedStackPointer { stack, addr } => {
                 write!(f, "misaligned {stack} stack pointer at {addr}")

--- a/src/tbx16/error.rs
+++ b/src/tbx16/error.rs
@@ -1,0 +1,68 @@
+use std::fmt;
+
+use crate::tbx16::address::Address;
+use crate::tbx16::cell::Cell;
+
+/// Trap and configuration errors for the tbx16 execution substrate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Tbx16Error {
+    DataStackUnderflow,
+    DataStackOverflow,
+    ReturnStackUnderflow,
+    ReturnStackOverflow,
+    InvalidMemoryAccess {
+        addr: Address,
+        operation: &'static str,
+    },
+    InvalidStackRegion {
+        start: Address,
+        end: Address,
+        reason: &'static str,
+    },
+    MisalignedStackPointer {
+        stack: &'static str,
+        addr: Address,
+    },
+    DivisionByZero,
+    InvalidExecutionToken {
+        xt: Cell,
+    },
+    InstructionPointerOutOfRange {
+        ip: Address,
+    },
+    ExplicitTrap {
+        code: Cell,
+    },
+}
+
+impl fmt::Display for Tbx16Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Tbx16Error::DataStackUnderflow => write!(f, "data stack underflow"),
+            Tbx16Error::DataStackOverflow => write!(f, "data stack overflow"),
+            Tbx16Error::ReturnStackUnderflow => write!(f, "return stack underflow"),
+            Tbx16Error::ReturnStackOverflow => write!(f, "return stack overflow"),
+            Tbx16Error::InvalidMemoryAccess { addr, operation } => {
+                write!(f, "invalid memory access during {operation} at {addr}")
+            }
+            Tbx16Error::InvalidStackRegion { start, end, reason } => {
+                write!(f, "invalid stack region {start}..{end}: {reason}")
+            }
+            Tbx16Error::MisalignedStackPointer { stack, addr } => {
+                write!(f, "misaligned {stack} stack pointer at {addr}")
+            }
+            Tbx16Error::DivisionByZero => write!(f, "division by zero"),
+            Tbx16Error::InvalidExecutionToken { xt } => {
+                write!(f, "invalid execution token ${:04x}", xt.raw())
+            }
+            Tbx16Error::InstructionPointerOutOfRange { ip } => {
+                write!(f, "instruction pointer out of range at {ip}")
+            }
+            Tbx16Error::ExplicitTrap { code } => {
+                write!(f, "explicit trap ${:04x}", code.raw())
+            }
+        }
+    }
+}
+
+impl std::error::Error for Tbx16Error {}

--- a/src/tbx16/error.rs
+++ b/src/tbx16/error.rs
@@ -16,7 +16,7 @@ pub enum Tbx16Error {
     },
     InvalidStackRegion {
         start: Address,
-        end: Address,
+        end: usize,
         reason: &'static str,
     },
     MisalignedStackPointer {
@@ -46,7 +46,7 @@ impl fmt::Display for Tbx16Error {
                 write!(f, "invalid memory access during {operation} at {addr}")
             }
             Tbx16Error::InvalidStackRegion { start, end, reason } => {
-                write!(f, "invalid stack region {start}..{end}: {reason}")
+                write!(f, "invalid stack region {start}..${end:04x}: {reason}")
             }
             Tbx16Error::MisalignedStackPointer { stack, addr } => {
                 write!(f, "misaligned {stack} stack pointer at {addr}")

--- a/src/tbx16/memory.rs
+++ b/src/tbx16/memory.rs
@@ -56,14 +56,14 @@ impl Memory {
     /// Loads raw bytes into memory without wrapping.
     pub fn load_bytes(&mut self, start: Address, bytes: &[u8]) -> Result<(), Tbx16Error> {
         let end = checked_range_end(start, bytes.len(), "byte load")?;
-        self.bytes[usize::from(start.get())..usize::from(end.get())].copy_from_slice(bytes);
+        self.bytes[usize::from(start.get())..end].copy_from_slice(bytes);
         Ok(())
     }
 
     /// Zeroes the half-open range `[start, start + len)`.
     pub fn zero_range(&mut self, start: Address, len: usize) -> Result<(), Tbx16Error> {
         let end = checked_range_end(start, len, "zero fill")?;
-        self.bytes[usize::from(start.get())..usize::from(end.get())].fill(0);
+        self.bytes[usize::from(start.get())..end].fill(0);
         Ok(())
     }
 
@@ -82,11 +82,14 @@ fn checked_range_end(
     start: Address,
     len: usize,
     operation: &'static str,
-) -> Result<Address, Tbx16Error> {
-    start
-        .checked_add_usize(len)
+) -> Result<usize, Tbx16Error> {
+    let start_index = usize::from(start.get());
+    let end = start_index
+        .checked_add(len)
+        .filter(|end| *end <= MEMORY_SIZE)
         .ok_or(Tbx16Error::InvalidMemoryAccess {
             addr: start,
             operation,
-        })
+        })?;
+    Ok(end)
 }

--- a/src/tbx16/memory.rs
+++ b/src/tbx16/memory.rs
@@ -1,0 +1,92 @@
+use crate::tbx16::address::Address;
+use crate::tbx16::cell::Cell;
+use crate::tbx16::error::Tbx16Error;
+
+pub const MEMORY_SIZE: usize = 65_536;
+
+/// Unified 64 KiB memory owned by the tbx16 VM.
+#[derive(Debug, Clone)]
+pub struct Memory {
+    bytes: [u8; MEMORY_SIZE],
+}
+
+impl Default for Memory {
+    fn default() -> Self {
+        Self {
+            bytes: [0; MEMORY_SIZE],
+        }
+    }
+}
+
+impl Memory {
+    /// Returns the byte at `addr`.
+    pub fn read_byte(&self, addr: Address) -> Result<u8, Tbx16Error> {
+        Ok(self.bytes[usize::from(addr.get())])
+    }
+
+    /// Writes one byte at `addr`.
+    pub fn write_byte(&mut self, addr: Address, value: u8) -> Result<(), Tbx16Error> {
+        self.bytes[usize::from(addr.get())] = value;
+        Ok(())
+    }
+
+    /// Reads one little-endian cell from `addr`.
+    pub fn read_cell(&self, addr: Address) -> Result<Cell, Tbx16Error> {
+        let next = addr.checked_add(1).ok_or(Tbx16Error::InvalidMemoryAccess {
+            addr,
+            operation: "cell read",
+        })?;
+        let lo = self.read_byte(addr)?;
+        let hi = self.read_byte(next)?;
+        Ok(Cell::from_le_bytes([lo, hi]))
+    }
+
+    /// Writes one little-endian cell at `addr`.
+    pub fn write_cell(&mut self, addr: Address, value: Cell) -> Result<(), Tbx16Error> {
+        let next = addr.checked_add(1).ok_or(Tbx16Error::InvalidMemoryAccess {
+            addr,
+            operation: "cell write",
+        })?;
+        let [lo, hi] = value.to_le_bytes();
+        self.write_byte(addr, lo)?;
+        self.write_byte(next, hi)?;
+        Ok(())
+    }
+
+    /// Loads raw bytes into memory without wrapping.
+    pub fn load_bytes(&mut self, start: Address, bytes: &[u8]) -> Result<(), Tbx16Error> {
+        let end = checked_range_end(start, bytes.len(), "byte load")?;
+        self.bytes[usize::from(start.get())..usize::from(end.get())].copy_from_slice(bytes);
+        Ok(())
+    }
+
+    /// Zeroes the half-open range `[start, start + len)`.
+    pub fn zero_range(&mut self, start: Address, len: usize) -> Result<(), Tbx16Error> {
+        let end = checked_range_end(start, len, "zero fill")?;
+        self.bytes[usize::from(start.get())..usize::from(end.get())].fill(0);
+        Ok(())
+    }
+
+    /// Returns the full memory image.
+    pub fn as_bytes(&self) -> &[u8; MEMORY_SIZE] {
+        &self.bytes
+    }
+
+    /// Returns mutable access to the full memory image.
+    pub fn as_bytes_mut(&mut self) -> &mut [u8; MEMORY_SIZE] {
+        &mut self.bytes
+    }
+}
+
+fn checked_range_end(
+    start: Address,
+    len: usize,
+    operation: &'static str,
+) -> Result<Address, Tbx16Error> {
+    start
+        .checked_add_usize(len)
+        .ok_or(Tbx16Error::InvalidMemoryAccess {
+            addr: start,
+            operation,
+        })
+}

--- a/src/tbx16/mod.rs
+++ b/src/tbx16/mod.rs
@@ -22,8 +22,8 @@ use stack::{ensure_pointer_in_region, peek_cell, pop_cell, push_cell, ReturnFram
 pub const DATA_STACK_START: Address = Address::new(0x0080);
 pub const DATA_STACK_END: Address = Address::new(0x0100);
 pub const DEFAULT_RETURN_STACK_START: Address = Address::new(0x0200);
-pub const DEFAULT_RETURN_STACK_END: Address = Address::new(0x0300);
-const PAGE_ONE_END: Address = Address::new(0x0200);
+pub const DEFAULT_RETURN_STACK_END: usize = 0x0300;
+const PAGE_ONE_END_EXCLUSIVE: usize = 0x0200;
 
 /// tbx16 VM substrate with unified memory and byte-addressed registers.
 #[derive(Debug)]
@@ -51,12 +51,13 @@ impl Tbx16Vm {
     /// the target rule `BP + slot_index * 2` from the beginning of execution.
     pub fn new(return_stack_region: StackRegion) -> Result<Self, Tbx16Error> {
         validate_return_stack_region(return_stack_region)?;
-        let data_stack_region = StackRegion::new(DATA_STACK_START, DATA_STACK_END)
-            .expect("fixed data stack region is valid");
+        let data_stack_region =
+            StackRegion::new(DATA_STACK_START, usize::from(DATA_STACK_END.get()))
+                .expect("fixed data stack region is valid");
         if data_stack_region.overlaps(return_stack_region) {
             return Err(Tbx16Error::InvalidStackRegion {
                 start: return_stack_region.start(),
-                end: return_stack_region.end(),
+                end: return_stack_region.end_exclusive(),
                 reason: "return stack region overlaps the fixed data stack region",
             });
         }
@@ -237,7 +238,7 @@ impl Tbx16Vm {
         if !self.data_stack_region.contains_pointer(self.registers.bp) {
             return Err(Tbx16Error::InvalidStackRegion {
                 start: self.data_stack_region.start(),
-                end: self.data_stack_region.end(),
+                end: self.data_stack_region.end_exclusive(),
                 reason: "base pointer must stay within the data stack region",
             });
         }
@@ -251,7 +252,7 @@ impl Tbx16Vm {
         if self.data_stack_region.overlaps(self.return_stack_region) {
             return Err(Tbx16Error::InvalidStackRegion {
                 start: self.return_stack_region.start(),
-                end: self.return_stack_region.end(),
+                end: self.return_stack_region.end_exclusive(),
                 reason: "return stack region overlaps the fixed data stack region",
             });
         }
@@ -260,17 +261,17 @@ impl Tbx16Vm {
 }
 
 fn validate_return_stack_region(region: StackRegion) -> Result<(), Tbx16Error> {
-    if region.start() < PAGE_ONE_END {
+    if usize::from(region.start().get()) < PAGE_ONE_END_EXCLUSIVE {
         return Err(Tbx16Error::InvalidStackRegion {
             start: region.start(),
-            end: region.end(),
+            end: region.end_exclusive(),
             reason: "return stack region must not overlap zero page or page 1",
         });
     }
     if region.len_bytes() % 2 != 0 {
         return Err(Tbx16Error::InvalidStackRegion {
             start: region.start(),
-            end: region.end(),
+            end: region.end_exclusive(),
             reason: "return stack region length must be an even number of bytes",
         });
     }

--- a/src/tbx16/mod.rs
+++ b/src/tbx16/mod.rs
@@ -1,0 +1,278 @@
+//! Low-level execution substrate for the future 16-bit tbx16 VM.
+//!
+//! This module models the target exactly as a single 64 KiB memory image plus
+//! byte-addressed registers. Data stack cells, return stack cells, and future
+//! threaded code all live in the same `Memory`; stack operations are expressed
+//! strictly as reads and writes against that memory.
+
+pub mod address;
+pub mod cell;
+pub mod error;
+pub mod memory;
+pub mod registers;
+pub mod stack;
+
+use address::Address;
+use cell::Cell;
+use error::Tbx16Error;
+use memory::Memory;
+use registers::Registers;
+use stack::{ensure_pointer_in_region, peek_cell, pop_cell, push_cell, ReturnFrame, StackRegion};
+
+pub const DATA_STACK_START: Address = Address::new(0x0080);
+pub const DATA_STACK_END: Address = Address::new(0x0100);
+pub const DEFAULT_RETURN_STACK_START: Address = Address::new(0x0200);
+pub const DEFAULT_RETURN_STACK_END: Address = Address::new(0x0300);
+const PAGE_ONE_END: Address = Address::new(0x0200);
+
+/// tbx16 VM substrate with unified memory and byte-addressed registers.
+#[derive(Debug)]
+pub struct Tbx16Vm {
+    memory: Memory,
+    registers: Registers,
+    data_stack_region: StackRegion,
+    return_stack_region: StackRegion,
+}
+
+impl Default for Tbx16Vm {
+    fn default() -> Self {
+        Self::new(
+            StackRegion::new(DEFAULT_RETURN_STACK_START, DEFAULT_RETURN_STACK_END)
+                .expect("default return stack region is valid"),
+        )
+        .expect("default tbx16 VM configuration is valid")
+    }
+}
+
+impl Tbx16Vm {
+    /// Creates a VM with zeroed memory and the configured return-stack region.
+    ///
+    /// `BP` starts at `DATA_STACK_START`, so slot address calculation follows
+    /// the target rule `BP + slot_index * 2` from the beginning of execution.
+    pub fn new(return_stack_region: StackRegion) -> Result<Self, Tbx16Error> {
+        validate_return_stack_region(return_stack_region)?;
+        let data_stack_region = StackRegion::new(DATA_STACK_START, DATA_STACK_END)
+            .expect("fixed data stack region is valid");
+        if data_stack_region.overlaps(return_stack_region) {
+            return Err(Tbx16Error::InvalidStackRegion {
+                start: return_stack_region.start(),
+                end: return_stack_region.end(),
+                reason: "return stack region overlaps the fixed data stack region",
+            });
+        }
+
+        let registers = Registers {
+            ip: None,
+            dsp: DATA_STACK_START,
+            rsp: return_stack_region.start(),
+            bp: DATA_STACK_START,
+        };
+        let vm = Self {
+            memory: Memory::default(),
+            registers,
+            data_stack_region,
+            return_stack_region,
+        };
+        vm.validate_invariants()?;
+        Ok(vm)
+    }
+
+    pub fn memory(&self) -> &Memory {
+        &self.memory
+    }
+
+    pub fn memory_mut(&mut self) -> &mut Memory {
+        &mut self.memory
+    }
+
+    pub fn registers(&self) -> &Registers {
+        &self.registers
+    }
+
+    pub fn set_instruction_pointer(&mut self, ip: Address) -> Result<(), Tbx16Error> {
+        if usize::from(ip.get()) >= memory::MEMORY_SIZE {
+            return Err(Tbx16Error::InstructionPointerOutOfRange { ip });
+        }
+        self.registers.ip = Some(ip);
+        Ok(())
+    }
+
+    pub fn data_stack_region(&self) -> StackRegion {
+        self.data_stack_region
+    }
+
+    pub fn return_stack_region(&self) -> StackRegion {
+        self.return_stack_region
+    }
+
+    pub fn data_slot_address(&self, slot_index: u16) -> Result<Address, Tbx16Error> {
+        let offset = slot_index
+            .checked_mul(2)
+            .ok_or(Tbx16Error::InvalidMemoryAccess {
+                addr: self.registers.bp,
+                operation: "data slot address calculation",
+            })?;
+        self.registers
+            .bp
+            .checked_add(offset)
+            .ok_or(Tbx16Error::InvalidMemoryAccess {
+                addr: self.registers.bp,
+                operation: "data slot address calculation",
+            })
+    }
+
+    pub fn push_data_cell(&mut self, value: Cell) -> Result<(), Tbx16Error> {
+        push_cell(
+            &mut self.memory,
+            &mut self.registers.dsp,
+            self.data_stack_region,
+            "data",
+            value,
+            Tbx16Error::DataStackOverflow,
+        )
+    }
+
+    pub fn pop_data_cell(&mut self) -> Result<Cell, Tbx16Error> {
+        pop_cell(
+            &self.memory,
+            &mut self.registers.dsp,
+            self.data_stack_region,
+            "data",
+            Tbx16Error::DataStackUnderflow,
+        )
+    }
+
+    pub fn peek_data_cell(&self, depth: usize) -> Result<Cell, Tbx16Error> {
+        peek_cell(
+            &self.memory,
+            self.registers.dsp,
+            self.data_stack_region,
+            "data",
+            depth,
+            Tbx16Error::DataStackUnderflow,
+        )
+    }
+
+    pub fn push_return_cell(&mut self, value: Cell) -> Result<(), Tbx16Error> {
+        push_cell(
+            &mut self.memory,
+            &mut self.registers.rsp,
+            self.return_stack_region,
+            "return",
+            value,
+            Tbx16Error::ReturnStackOverflow,
+        )
+    }
+
+    pub fn pop_return_cell(&mut self) -> Result<Cell, Tbx16Error> {
+        pop_cell(
+            &self.memory,
+            &mut self.registers.rsp,
+            self.return_stack_region,
+            "return",
+            Tbx16Error::ReturnStackUnderflow,
+        )
+    }
+
+    pub fn peek_return_cell(&self, depth: usize) -> Result<Cell, Tbx16Error> {
+        peek_cell(
+            &self.memory,
+            self.registers.rsp,
+            self.return_stack_region,
+            "return",
+            depth,
+            Tbx16Error::ReturnStackUnderflow,
+        )
+    }
+
+    pub fn push_return_frame(&mut self, frame: ReturnFrame) -> Result<(), Tbx16Error> {
+        let next = self
+            .registers
+            .rsp
+            .checked_add(4)
+            .ok_or(Tbx16Error::ReturnStackOverflow)?;
+        ensure_pointer_in_region(self.registers.rsp, self.return_stack_region, "return")?;
+        if !self.return_stack_region.contains_pointer(next) {
+            return Err(Tbx16Error::ReturnStackOverflow);
+        }
+        self.memory
+            .write_cell(self.registers.rsp, Cell::new(frame.return_ip.get()))?;
+        self.memory.write_cell(
+            self.registers
+                .rsp
+                .checked_add(2)
+                .expect("aligned stack pointer has room for second frame cell"),
+            Cell::new(frame.caller_bp.get()),
+        )?;
+        self.registers.rsp = next;
+        Ok(())
+    }
+
+    pub fn pop_return_frame(&mut self) -> Result<ReturnFrame, Tbx16Error> {
+        ensure_pointer_in_region(self.registers.rsp, self.return_stack_region, "return")?;
+        let frame_start = self
+            .registers
+            .rsp
+            .checked_sub(4)
+            .ok_or(Tbx16Error::ReturnStackUnderflow)?;
+        if frame_start < self.return_stack_region.start() {
+            return Err(Tbx16Error::ReturnStackUnderflow);
+        }
+        let return_ip = self.memory.read_cell(frame_start)?;
+        let caller_bp = self.memory.read_cell(
+            frame_start
+                .checked_add(2)
+                .expect("aligned frame start always has space for caller_bp"),
+        )?;
+        self.registers.rsp = frame_start;
+        Ok(ReturnFrame {
+            return_ip: Address::new(return_ip.raw()),
+            caller_bp: Address::new(caller_bp.raw()),
+        })
+    }
+
+    pub fn validate_invariants(&self) -> Result<(), Tbx16Error> {
+        ensure_pointer_in_region(self.registers.dsp, self.data_stack_region, "data")?;
+        ensure_pointer_in_region(self.registers.rsp, self.return_stack_region, "return")?;
+        if !self.data_stack_region.contains_pointer(self.registers.bp) {
+            return Err(Tbx16Error::InvalidStackRegion {
+                start: self.data_stack_region.start(),
+                end: self.data_stack_region.end(),
+                reason: "base pointer must stay within the data stack region",
+            });
+        }
+        if ((self.registers.bp.get() - self.data_stack_region.start().get()) % 2) != 0 {
+            return Err(Tbx16Error::MisalignedStackPointer {
+                stack: "base",
+                addr: self.registers.bp,
+            });
+        }
+        validate_return_stack_region(self.return_stack_region)?;
+        if self.data_stack_region.overlaps(self.return_stack_region) {
+            return Err(Tbx16Error::InvalidStackRegion {
+                start: self.return_stack_region.start(),
+                end: self.return_stack_region.end(),
+                reason: "return stack region overlaps the fixed data stack region",
+            });
+        }
+        Ok(())
+    }
+}
+
+fn validate_return_stack_region(region: StackRegion) -> Result<(), Tbx16Error> {
+    if region.start() < PAGE_ONE_END {
+        return Err(Tbx16Error::InvalidStackRegion {
+            start: region.start(),
+            end: region.end(),
+            reason: "return stack region must not overlap zero page or page 1",
+        });
+    }
+    if region.len_bytes() % 2 != 0 {
+        return Err(Tbx16Error::InvalidStackRegion {
+            start: region.start(),
+            end: region.end(),
+            reason: "return stack region length must be an even number of bytes",
+        });
+    }
+    Ok(())
+}

--- a/src/tbx16/mod.rs
+++ b/src/tbx16/mod.rs
@@ -22,8 +22,8 @@ use stack::{ensure_pointer_in_region, peek_cell, pop_cell, push_cell, ReturnFram
 pub const DATA_STACK_START: Address = Address::new(0x0080);
 pub const DATA_STACK_END: Address = Address::new(0x0100);
 pub const DEFAULT_RETURN_STACK_START: Address = Address::new(0x0200);
-pub const DEFAULT_RETURN_STACK_END: usize = 0x0300;
-const PAGE_ONE_END_EXCLUSIVE: usize = 0x0200;
+pub const DEFAULT_RETURN_STACK_END: Address = Address::new(0x0300);
+const PAGE_ONE_END: Address = Address::new(0x0200);
 
 /// tbx16 VM substrate with unified memory and byte-addressed registers.
 #[derive(Debug)]
@@ -51,13 +51,12 @@ impl Tbx16Vm {
     /// the target rule `BP + slot_index * 2` from the beginning of execution.
     pub fn new(return_stack_region: StackRegion) -> Result<Self, Tbx16Error> {
         validate_return_stack_region(return_stack_region)?;
-        let data_stack_region =
-            StackRegion::new(DATA_STACK_START, usize::from(DATA_STACK_END.get()))
-                .expect("fixed data stack region is valid");
+        let data_stack_region = StackRegion::new(DATA_STACK_START, DATA_STACK_END)
+            .expect("fixed data stack region is valid");
         if data_stack_region.overlaps(return_stack_region) {
             return Err(Tbx16Error::InvalidStackRegion {
                 start: return_stack_region.start(),
-                end: return_stack_region.end_exclusive(),
+                end: return_stack_region.end(),
                 reason: "return stack region overlaps the fixed data stack region",
             });
         }
@@ -238,7 +237,7 @@ impl Tbx16Vm {
         if !self.data_stack_region.contains_pointer(self.registers.bp) {
             return Err(Tbx16Error::InvalidStackRegion {
                 start: self.data_stack_region.start(),
-                end: self.data_stack_region.end_exclusive(),
+                end: self.data_stack_region.end(),
                 reason: "base pointer must stay within the data stack region",
             });
         }
@@ -252,7 +251,7 @@ impl Tbx16Vm {
         if self.data_stack_region.overlaps(self.return_stack_region) {
             return Err(Tbx16Error::InvalidStackRegion {
                 start: self.return_stack_region.start(),
-                end: self.return_stack_region.end_exclusive(),
+                end: self.return_stack_region.end(),
                 reason: "return stack region overlaps the fixed data stack region",
             });
         }
@@ -261,17 +260,17 @@ impl Tbx16Vm {
 }
 
 fn validate_return_stack_region(region: StackRegion) -> Result<(), Tbx16Error> {
-    if usize::from(region.start().get()) < PAGE_ONE_END_EXCLUSIVE {
+    if region.start() < PAGE_ONE_END {
         return Err(Tbx16Error::InvalidStackRegion {
             start: region.start(),
-            end: region.end_exclusive(),
+            end: region.end(),
             reason: "return stack region must not overlap zero page or page 1",
         });
     }
     if region.len_bytes() % 2 != 0 {
         return Err(Tbx16Error::InvalidStackRegion {
             start: region.start(),
-            end: region.end_exclusive(),
+            end: region.end(),
             reason: "return stack region length must be an even number of bytes",
         });
     }

--- a/src/tbx16/registers.rs
+++ b/src/tbx16/registers.rs
@@ -1,0 +1,10 @@
+use crate::tbx16::address::Address;
+
+/// Byte-addressed VM registers for tbx16.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Registers {
+    pub ip: Option<Address>,
+    pub dsp: Address,
+    pub rsp: Address,
+    pub bp: Address,
+}

--- a/src/tbx16/stack.rs
+++ b/src/tbx16/stack.rs
@@ -1,0 +1,145 @@
+use crate::tbx16::address::Address;
+use crate::tbx16::cell::Cell;
+use crate::tbx16::error::Tbx16Error;
+use crate::tbx16::memory::Memory;
+
+/// A byte-addressed half-open stack region `[start, end)`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StackRegion {
+    start: Address,
+    end: Address,
+}
+
+impl StackRegion {
+    /// Creates a stack region with aligned endpoints and an even byte length.
+    pub fn new(start: Address, end: Address) -> Result<Self, Tbx16Error> {
+        if start >= end {
+            return Err(Tbx16Error::InvalidStackRegion {
+                start,
+                end,
+                reason: "start must be lower than end",
+            });
+        }
+        if !start.is_even() || !end.is_even() {
+            return Err(Tbx16Error::InvalidStackRegion {
+                start,
+                end,
+                reason: "stack region endpoints must be 2-byte aligned",
+            });
+        }
+        Ok(Self { start, end })
+    }
+
+    pub const fn start(self) -> Address {
+        self.start
+    }
+
+    pub const fn end(self) -> Address {
+        self.end
+    }
+
+    pub fn len_bytes(self) -> u16 {
+        self.end.get() - self.start.get()
+    }
+
+    pub fn contains(self, addr: Address) -> bool {
+        self.start <= addr && addr < self.end
+    }
+
+    pub fn contains_pointer(self, addr: Address) -> bool {
+        self.start <= addr && addr <= self.end
+    }
+
+    pub fn overlaps(self, other: Self) -> bool {
+        self.start < other.end && other.start < self.end
+    }
+}
+
+/// A return-stack frame stored as two cells in unified memory.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReturnFrame {
+    pub return_ip: Address,
+    pub caller_bp: Address,
+}
+
+pub(crate) fn ensure_pointer_in_region(
+    pointer: Address,
+    region: StackRegion,
+    stack_name: &'static str,
+) -> Result<(), Tbx16Error> {
+    if !region.contains_pointer(pointer) {
+        return Err(Tbx16Error::InvalidStackRegion {
+            start: region.start(),
+            end: region.end(),
+            reason: match stack_name {
+                "data" => "data stack pointer escaped its fixed region",
+                _ => "stack pointer escaped its configured region",
+            },
+        });
+    }
+    if ((pointer.get() - region.start().get()) % 2) != 0 {
+        return Err(Tbx16Error::MisalignedStackPointer {
+            stack: stack_name,
+            addr: pointer,
+        });
+    }
+    Ok(())
+}
+
+pub(crate) fn push_cell(
+    memory: &mut Memory,
+    pointer: &mut Address,
+    region: StackRegion,
+    stack_name: &'static str,
+    value: Cell,
+    overflow: Tbx16Error,
+) -> Result<(), Tbx16Error> {
+    ensure_pointer_in_region(*pointer, region, stack_name)?;
+    let next = pointer.checked_add(2).ok_or(overflow.clone())?;
+    if !region.contains_pointer(next) {
+        return Err(overflow);
+    }
+    memory.write_cell(*pointer, value)?;
+    *pointer = next;
+    Ok(())
+}
+
+pub(crate) fn pop_cell(
+    memory: &Memory,
+    pointer: &mut Address,
+    region: StackRegion,
+    stack_name: &'static str,
+    underflow: Tbx16Error,
+) -> Result<Cell, Tbx16Error> {
+    ensure_pointer_in_region(*pointer, region, stack_name)?;
+    if *pointer == region.start() {
+        return Err(underflow);
+    }
+    let next = pointer.checked_sub(2).ok_or(underflow.clone())?;
+    if !region.contains_pointer(next) {
+        return Err(underflow);
+    }
+    *pointer = next;
+    memory.read_cell(*pointer)
+}
+
+pub(crate) fn peek_cell(
+    memory: &Memory,
+    pointer: Address,
+    region: StackRegion,
+    stack_name: &'static str,
+    depth: usize,
+    underflow: Tbx16Error,
+) -> Result<Cell, Tbx16Error> {
+    ensure_pointer_in_region(pointer, region, stack_name)?;
+    let byte_depth = depth
+        .checked_add(1)
+        .and_then(|n| n.checked_mul(2))
+        .ok_or(underflow.clone())?;
+    let byte_depth = u16::try_from(byte_depth).map_err(|_| underflow.clone())?;
+    let addr = pointer.checked_sub(byte_depth).ok_or(underflow.clone())?;
+    if addr < region.start() {
+        return Err(underflow);
+    }
+    memory.read_cell(addr)
+}

--- a/src/tbx16/stack.rs
+++ b/src/tbx16/stack.rs
@@ -7,51 +7,58 @@ use crate::tbx16::memory::Memory;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct StackRegion {
     start: Address,
-    end: Address,
+    end_exclusive: usize,
 }
 
 impl StackRegion {
     /// Creates a stack region with aligned endpoints and an even byte length.
-    pub fn new(start: Address, end: Address) -> Result<Self, Tbx16Error> {
-        if start >= end {
+    pub fn new(start: Address, end_exclusive: usize) -> Result<Self, Tbx16Error> {
+        let start_index = usize::from(start.get());
+        if start_index >= end_exclusive {
             return Err(Tbx16Error::InvalidStackRegion {
                 start,
-                end,
+                end: end_exclusive,
                 reason: "start must be lower than end",
             });
         }
-        if !start.is_even() || !end.is_even() {
+        if !start.is_even() || (end_exclusive % 2) != 0 {
             return Err(Tbx16Error::InvalidStackRegion {
                 start,
-                end,
+                end: end_exclusive,
                 reason: "stack region endpoints must be 2-byte aligned",
             });
         }
-        Ok(Self { start, end })
+        Ok(Self {
+            start,
+            end_exclusive,
+        })
     }
 
     pub const fn start(self) -> Address {
         self.start
     }
 
-    pub const fn end(self) -> Address {
-        self.end
+    pub const fn end_exclusive(self) -> usize {
+        self.end_exclusive
     }
 
-    pub fn len_bytes(self) -> u16 {
-        self.end.get() - self.start.get()
+    pub fn len_bytes(self) -> usize {
+        self.end_exclusive - usize::from(self.start.get())
     }
 
     pub fn contains(self, addr: Address) -> bool {
-        self.start <= addr && addr < self.end
+        let index = usize::from(addr.get());
+        usize::from(self.start.get()) <= index && index < self.end_exclusive
     }
 
     pub fn contains_pointer(self, addr: Address) -> bool {
-        self.start <= addr && addr <= self.end
+        let index = usize::from(addr.get());
+        usize::from(self.start.get()) <= index && index <= self.end_exclusive
     }
 
     pub fn overlaps(self, other: Self) -> bool {
-        self.start < other.end && other.start < self.end
+        usize::from(self.start.get()) < other.end_exclusive
+            && usize::from(other.start.get()) < self.end_exclusive
     }
 }
 
@@ -70,7 +77,7 @@ pub(crate) fn ensure_pointer_in_region(
     if !region.contains_pointer(pointer) {
         return Err(Tbx16Error::InvalidStackRegion {
             start: region.start(),
-            end: region.end(),
+            end: region.end_exclusive(),
             reason: match stack_name {
                 "data" => "data stack pointer escaped its fixed region",
                 _ => "stack pointer escaped its configured region",

--- a/src/tbx16/stack.rs
+++ b/src/tbx16/stack.rs
@@ -7,58 +7,51 @@ use crate::tbx16::memory::Memory;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct StackRegion {
     start: Address,
-    end_exclusive: usize,
+    end: Address,
 }
 
 impl StackRegion {
     /// Creates a stack region with aligned endpoints and an even byte length.
-    pub fn new(start: Address, end_exclusive: usize) -> Result<Self, Tbx16Error> {
-        let start_index = usize::from(start.get());
-        if start_index >= end_exclusive {
+    pub fn new(start: Address, end: Address) -> Result<Self, Tbx16Error> {
+        if start >= end {
             return Err(Tbx16Error::InvalidStackRegion {
                 start,
-                end: end_exclusive,
+                end,
                 reason: "start must be lower than end",
             });
         }
-        if !start.is_even() || (end_exclusive % 2) != 0 {
+        if !start.is_even() || !end.is_even() {
             return Err(Tbx16Error::InvalidStackRegion {
                 start,
-                end: end_exclusive,
+                end,
                 reason: "stack region endpoints must be 2-byte aligned",
             });
         }
-        Ok(Self {
-            start,
-            end_exclusive,
-        })
+        Ok(Self { start, end })
     }
 
     pub const fn start(self) -> Address {
         self.start
     }
 
-    pub const fn end_exclusive(self) -> usize {
-        self.end_exclusive
+    pub const fn end(self) -> Address {
+        self.end
     }
 
-    pub fn len_bytes(self) -> usize {
-        self.end_exclusive - usize::from(self.start.get())
+    pub fn len_bytes(self) -> u16 {
+        self.end.get() - self.start.get()
     }
 
     pub fn contains(self, addr: Address) -> bool {
-        let index = usize::from(addr.get());
-        usize::from(self.start.get()) <= index && index < self.end_exclusive
+        self.start <= addr && addr < self.end
     }
 
     pub fn contains_pointer(self, addr: Address) -> bool {
-        let index = usize::from(addr.get());
-        usize::from(self.start.get()) <= index && index <= self.end_exclusive
+        self.start <= addr && addr <= self.end
     }
 
     pub fn overlaps(self, other: Self) -> bool {
-        usize::from(self.start.get()) < other.end_exclusive
-            && usize::from(other.start.get()) < self.end_exclusive
+        self.start < other.end && other.start < self.end
     }
 }
 
@@ -77,7 +70,7 @@ pub(crate) fn ensure_pointer_in_region(
     if !region.contains_pointer(pointer) {
         return Err(Tbx16Error::InvalidStackRegion {
             start: region.start(),
-            end: region.end_exclusive(),
+            end: region.end(),
             reason: match stack_name {
                 "data" => "data stack pointer escaped its fixed region",
                 _ => "stack pointer escaped its configured region",

--- a/tests/tbx16.rs
+++ b/tests/tbx16.rs
@@ -1,0 +1,259 @@
+use tbx::tbx16::address::Address;
+use tbx::tbx16::cell::Cell;
+use tbx::tbx16::error::Tbx16Error;
+use tbx::tbx16::memory::MEMORY_SIZE;
+use tbx::tbx16::stack::{ReturnFrame, StackRegion};
+use tbx::tbx16::{
+    Tbx16Vm, DATA_STACK_END, DATA_STACK_START, DEFAULT_RETURN_STACK_END, DEFAULT_RETURN_STACK_START,
+};
+
+#[test]
+fn cell_reinterprets_u16_and_i16_bits() {
+    let cell = Cell::from_i16(-2);
+    assert_eq!(cell.raw(), 0xfffe);
+    assert_eq!(cell.as_i16(), -2);
+}
+
+#[test]
+fn cell_normalizes_truthy_values_to_canonical_booleans() {
+    assert_eq!(Cell::new(0x0000).to_canonical_bool(), Cell::FALSE);
+    assert_eq!(Cell::new(0x0001).to_canonical_bool(), Cell::TRUE);
+    assert_eq!(Cell::new(0x1234).to_canonical_bool(), Cell::TRUE);
+}
+
+#[test]
+fn memory_reads_and_writes_little_endian_cells() {
+    let mut vm = Tbx16Vm::default();
+    vm.memory_mut()
+        .write_cell(Address::new(0x0200), Cell::new(0x1234))
+        .unwrap();
+    assert_eq!(vm.memory().as_bytes()[0x0200], 0x34);
+    assert_eq!(vm.memory().as_bytes()[0x0201], 0x12);
+    assert_eq!(
+        vm.memory().read_cell(Address::new(0x0200)).unwrap(),
+        Cell::new(0x1234)
+    );
+}
+
+#[test]
+fn memory_allows_unaligned_cell_access() {
+    let mut vm = Tbx16Vm::default();
+    vm.memory_mut()
+        .write_cell(Address::new(0x0201), Cell::new(0xabcd))
+        .unwrap();
+    assert_eq!(
+        vm.memory().read_cell(Address::new(0x0201)).unwrap(),
+        Cell::new(0xabcd)
+    );
+}
+
+#[test]
+fn memory_rejects_cell_access_from_ffff() {
+    let mut vm = Tbx16Vm::default();
+    let write_err = vm
+        .memory_mut()
+        .write_cell(Address::new(0xffff), Cell::new(1))
+        .unwrap_err();
+    assert_eq!(
+        write_err,
+        Tbx16Error::InvalidMemoryAccess {
+            addr: Address::new(0xffff),
+            operation: "cell write",
+        }
+    );
+
+    let read_err = vm.memory().read_cell(Address::new(0xffff)).unwrap_err();
+    assert_eq!(
+        read_err,
+        Tbx16Error::InvalidMemoryAccess {
+            addr: Address::new(0xffff),
+            operation: "cell read",
+        }
+    );
+}
+
+#[test]
+fn memory_starts_fully_zeroed() {
+    let vm = Tbx16Vm::default();
+    assert_eq!(vm.memory().as_bytes().len(), MEMORY_SIZE);
+    assert!(vm.memory().as_bytes().iter().all(|byte| *byte == 0));
+}
+
+#[test]
+fn data_stack_starts_at_0080() {
+    let vm = Tbx16Vm::default();
+    assert_eq!(vm.registers().dsp, DATA_STACK_START);
+    assert_eq!(vm.registers().bp, DATA_STACK_START);
+}
+
+#[test]
+fn data_stack_push_and_pop_moves_dsp_by_two_bytes() {
+    let mut vm = Tbx16Vm::default();
+    vm.push_data_cell(Cell::new(0x1111)).unwrap();
+    assert_eq!(vm.registers().dsp, Address::new(0x0082));
+    vm.push_data_cell(Cell::new(0x2222)).unwrap();
+    assert_eq!(vm.registers().dsp, Address::new(0x0084));
+
+    assert_eq!(vm.pop_data_cell().unwrap(), Cell::new(0x2222));
+    assert_eq!(vm.registers().dsp, Address::new(0x0082));
+    assert_eq!(vm.pop_data_cell().unwrap(), Cell::new(0x1111));
+    assert_eq!(vm.registers().dsp, DATA_STACK_START);
+}
+
+#[test]
+fn data_stack_reaches_0100_after_64_pushes_and_then_overflows() {
+    let mut vm = Tbx16Vm::default();
+    for i in 0..64u16 {
+        vm.push_data_cell(Cell::new(i)).unwrap();
+    }
+    assert_eq!(vm.registers().dsp, DATA_STACK_END);
+    assert_eq!(
+        vm.push_data_cell(Cell::new(65)).unwrap_err(),
+        Tbx16Error::DataStackOverflow
+    );
+}
+
+#[test]
+fn data_stack_underflow_is_reported_for_pop_and_peek() {
+    let mut vm = Tbx16Vm::default();
+    assert_eq!(
+        vm.pop_data_cell().unwrap_err(),
+        Tbx16Error::DataStackUnderflow
+    );
+    assert_eq!(
+        vm.peek_data_cell(0).unwrap_err(),
+        Tbx16Error::DataStackUnderflow
+    );
+}
+
+#[test]
+fn data_stack_values_are_written_into_fixed_memory_region_in_push_order() {
+    let mut vm = Tbx16Vm::default();
+    vm.push_data_cell(Cell::new(0x1001)).unwrap();
+    vm.push_data_cell(Cell::new(0x1002)).unwrap();
+    vm.push_data_cell(Cell::new(0x1003)).unwrap();
+
+    assert_eq!(
+        vm.memory().read_cell(Address::new(0x0080)).unwrap(),
+        Cell::new(0x1001)
+    );
+    assert_eq!(
+        vm.memory().read_cell(Address::new(0x0082)).unwrap(),
+        Cell::new(0x1002)
+    );
+    assert_eq!(
+        vm.memory().read_cell(Address::new(0x0084)).unwrap(),
+        Cell::new(0x1003)
+    );
+}
+
+#[test]
+fn return_stack_starts_at_configured_region_start() {
+    let vm = Tbx16Vm::default();
+    assert_eq!(vm.registers().rsp, DEFAULT_RETURN_STACK_START);
+    assert_eq!(
+        vm.return_stack_region(),
+        StackRegion::new(DEFAULT_RETURN_STACK_START, DEFAULT_RETURN_STACK_END).unwrap()
+    );
+}
+
+#[test]
+fn return_stack_push_and_pop_moves_rsp_by_two_bytes() {
+    let mut vm = Tbx16Vm::default();
+    vm.push_return_cell(Cell::new(0x2001)).unwrap();
+    assert_eq!(vm.registers().rsp, Address::new(0x0202));
+    vm.push_return_cell(Cell::new(0x2002)).unwrap();
+    assert_eq!(vm.registers().rsp, Address::new(0x0204));
+
+    assert_eq!(vm.pop_return_cell().unwrap(), Cell::new(0x2002));
+    assert_eq!(vm.registers().rsp, Address::new(0x0202));
+    assert_eq!(vm.pop_return_cell().unwrap(), Cell::new(0x2001));
+    assert_eq!(vm.registers().rsp, DEFAULT_RETURN_STACK_START);
+}
+
+#[test]
+fn return_frame_is_stored_as_two_cells_in_memory() {
+    let mut vm = Tbx16Vm::default();
+    let frame = ReturnFrame {
+        return_ip: Address::new(0x3456),
+        caller_bp: Address::new(0x00a0),
+    };
+
+    vm.push_return_frame(frame).unwrap();
+    assert_eq!(vm.registers().rsp, Address::new(0x0204));
+    assert_eq!(
+        vm.memory().read_cell(Address::new(0x0200)).unwrap(),
+        Cell::new(0x3456)
+    );
+    assert_eq!(
+        vm.memory().read_cell(Address::new(0x0202)).unwrap(),
+        Cell::new(0x00a0)
+    );
+    assert_eq!(vm.peek_return_cell(0).unwrap(), Cell::new(0x00a0));
+}
+
+#[test]
+fn return_frame_round_trips_return_ip_and_caller_bp() {
+    let mut vm = Tbx16Vm::default();
+    let frame = ReturnFrame {
+        return_ip: Address::new(0x4567),
+        caller_bp: Address::new(0x00c0),
+    };
+
+    vm.push_return_frame(frame).unwrap();
+    assert_eq!(vm.pop_return_frame().unwrap(), frame);
+    assert_eq!(vm.registers().rsp, DEFAULT_RETURN_STACK_START);
+}
+
+#[test]
+fn return_stack_reports_overflow_and_underflow() {
+    let region = StackRegion::new(Address::new(0x0200), Address::new(0x0204)).unwrap();
+    let mut vm = Tbx16Vm::new(region).unwrap();
+
+    vm.push_return_cell(Cell::new(1)).unwrap();
+    vm.push_return_cell(Cell::new(2)).unwrap();
+    assert_eq!(
+        vm.push_return_cell(Cell::new(3)).unwrap_err(),
+        Tbx16Error::ReturnStackOverflow
+    );
+
+    let mut empty_vm = Tbx16Vm::new(region).unwrap();
+    assert_eq!(
+        empty_vm.pop_return_cell().unwrap_err(),
+        Tbx16Error::ReturnStackUnderflow
+    );
+    assert_eq!(
+        empty_vm.pop_return_frame().unwrap_err(),
+        Tbx16Error::ReturnStackUnderflow
+    );
+}
+
+#[test]
+fn invalid_return_stack_regions_are_rejected() {
+    let page_one_overlap = StackRegion::new(Address::new(0x0180), Address::new(0x0280)).unwrap();
+    let err = Tbx16Vm::new(page_one_overlap).unwrap_err();
+    assert!(matches!(err, Tbx16Error::InvalidStackRegion { .. }));
+
+    let data_stack_overlap = StackRegion::new(Address::new(0x00f0), Address::new(0x0120)).unwrap();
+    let err = Tbx16Vm::new(data_stack_overlap).unwrap_err();
+    assert!(matches!(err, Tbx16Error::InvalidStackRegion { .. }));
+}
+
+#[test]
+fn stack_state_is_observed_through_memory_not_shadow_containers() {
+    let mut vm = Tbx16Vm::default();
+    vm.push_data_cell(Cell::new(0x1111)).unwrap();
+    vm.push_data_cell(Cell::new(0x2222)).unwrap();
+    vm.memory_mut()
+        .write_cell(Address::new(0x0082), Cell::new(0x9999))
+        .unwrap();
+    assert_eq!(vm.peek_data_cell(0).unwrap(), Cell::new(0x9999));
+}
+
+#[test]
+fn bp_slot_addresses_use_two_byte_steps() {
+    let vm = Tbx16Vm::default();
+    assert_eq!(vm.data_slot_address(0).unwrap(), Address::new(0x0080));
+    assert_eq!(vm.data_slot_address(1).unwrap(), Address::new(0x0082));
+    assert_eq!(vm.data_slot_address(5).unwrap(), Address::new(0x008a));
+}

--- a/tests/tbx16.rs
+++ b/tests/tbx16.rs
@@ -236,7 +236,7 @@ fn return_frame_round_trips_return_ip_and_caller_bp() {
 
 #[test]
 fn return_stack_reports_overflow_and_underflow() {
-    let region = StackRegion::new(Address::new(0x0200), 0x0204).unwrap();
+    let region = StackRegion::new(Address::new(0x0200), Address::new(0x0204)).unwrap();
     let mut vm = Tbx16Vm::new(region).unwrap();
 
     vm.push_return_cell(Cell::new(1)).unwrap();
@@ -259,20 +259,37 @@ fn return_stack_reports_overflow_and_underflow() {
 
 #[test]
 fn invalid_return_stack_regions_are_rejected() {
-    let page_one_overlap = StackRegion::new(Address::new(0x0180), 0x0280).unwrap();
+    let page_one_overlap = StackRegion::new(Address::new(0x0180), Address::new(0x0280)).unwrap();
     let err = Tbx16Vm::new(page_one_overlap).unwrap_err();
     assert!(matches!(err, Tbx16Error::InvalidStackRegion { .. }));
 
-    let data_stack_overlap = StackRegion::new(Address::new(0x00f0), 0x0120).unwrap();
+    let data_stack_overlap = StackRegion::new(Address::new(0x00f0), Address::new(0x0120)).unwrap();
     let err = Tbx16Vm::new(data_stack_overlap).unwrap_err();
     assert!(matches!(err, Tbx16Error::InvalidStackRegion { .. }));
 }
 
 #[test]
-fn return_stack_region_can_extend_to_10000_exclusive() {
-    let region = StackRegion::new(Address::new(0xff00), MEMORY_SIZE).unwrap();
+fn return_stack_capacity_matches_pushable_cell_count() {
+    let region = StackRegion::new(Address::new(0x0200), Address::new(0x0208)).unwrap();
     let vm = Tbx16Vm::new(region).unwrap();
+    assert_eq!(usize::from(region.len_bytes()) / 2, 4);
     assert_eq!(vm.return_stack_region(), region);
+}
+
+#[test]
+fn return_stack_full_region_ends_with_rsp_at_region_end() {
+    let region = StackRegion::new(Address::new(0x0200), Address::new(0x0208)).unwrap();
+    let mut vm = Tbx16Vm::new(region).unwrap();
+
+    for i in 0..(usize::from(region.len_bytes()) / 2) {
+        vm.push_return_cell(Cell::new(i as u16)).unwrap();
+    }
+
+    assert_eq!(vm.registers().rsp, region.end());
+    assert_eq!(
+        vm.push_return_cell(Cell::new(0xffff)).unwrap_err(),
+        Tbx16Error::ReturnStackOverflow
+    );
 }
 
 #[test]

--- a/tests/tbx16.rs
+++ b/tests/tbx16.rs
@@ -80,6 +80,35 @@ fn memory_starts_fully_zeroed() {
 }
 
 #[test]
+fn memory_load_bytes_allows_single_byte_at_ffff() {
+    let mut vm = Tbx16Vm::default();
+    vm.memory_mut()
+        .load_bytes(Address::new(0xffff), &[0xaa])
+        .unwrap();
+    assert_eq!(vm.memory().read_byte(Address::new(0xffff)).unwrap(), 0xaa);
+}
+
+#[test]
+fn memory_zero_range_allows_single_byte_at_ffff() {
+    let mut vm = Tbx16Vm::default();
+    vm.memory_mut()
+        .write_byte(Address::new(0xffff), 0xaa)
+        .unwrap();
+    vm.memory_mut().zero_range(Address::new(0xffff), 1).unwrap();
+    assert_eq!(vm.memory().read_byte(Address::new(0xffff)).unwrap(), 0x00);
+}
+
+#[test]
+fn memory_load_bytes_allows_full_64k_image() {
+    let mut vm = Tbx16Vm::default();
+    let image = vec![0x5a; MEMORY_SIZE];
+    vm.memory_mut()
+        .load_bytes(Address::new(0x0000), &image)
+        .unwrap();
+    assert!(vm.memory().as_bytes().iter().all(|byte| *byte == 0x5a));
+}
+
+#[test]
 fn data_stack_starts_at_0080() {
     let vm = Tbx16Vm::default();
     assert_eq!(vm.registers().dsp, DATA_STACK_START);
@@ -207,7 +236,7 @@ fn return_frame_round_trips_return_ip_and_caller_bp() {
 
 #[test]
 fn return_stack_reports_overflow_and_underflow() {
-    let region = StackRegion::new(Address::new(0x0200), Address::new(0x0204)).unwrap();
+    let region = StackRegion::new(Address::new(0x0200), 0x0204).unwrap();
     let mut vm = Tbx16Vm::new(region).unwrap();
 
     vm.push_return_cell(Cell::new(1)).unwrap();
@@ -230,13 +259,20 @@ fn return_stack_reports_overflow_and_underflow() {
 
 #[test]
 fn invalid_return_stack_regions_are_rejected() {
-    let page_one_overlap = StackRegion::new(Address::new(0x0180), Address::new(0x0280)).unwrap();
+    let page_one_overlap = StackRegion::new(Address::new(0x0180), 0x0280).unwrap();
     let err = Tbx16Vm::new(page_one_overlap).unwrap_err();
     assert!(matches!(err, Tbx16Error::InvalidStackRegion { .. }));
 
-    let data_stack_overlap = StackRegion::new(Address::new(0x00f0), Address::new(0x0120)).unwrap();
+    let data_stack_overlap = StackRegion::new(Address::new(0x00f0), 0x0120).unwrap();
     let err = Tbx16Vm::new(data_stack_overlap).unwrap_err();
     assert!(matches!(err, Tbx16Error::InvalidStackRegion { .. }));
+}
+
+#[test]
+fn return_stack_region_can_extend_to_10000_exclusive() {
+    let region = StackRegion::new(Address::new(0xff00), MEMORY_SIZE).unwrap();
+    let vm = Tbx16Vm::new(region).unwrap();
+    assert_eq!(vm.return_stack_region(), region);
 }
 
 #[test]


### PR DESCRIPTION
## 概要

Closes #997

`tbx16` 向けの低レベル実行基盤を追加し、既存TBX VMとは独立した 16bit cell / 64KiB 統一メモリ / byte address レジスタ / データスタック / リターンスタックを実装しました。

## 変更内容

- `src/tbx16/` を追加し、`Cell`、`Address`、`Memory`、`Registers`、`StackRegion`、`Tbx16Error`、`Tbx16Vm` を分離実装
- データスタックを `$0080-$00ff` 固定領域、リターンスタックを差し替え可能な通常RAM領域として実装
- `DSP` / `RSP` / `BP` / `IP` を 16bit byte address として扱う API を追加
- Cell の little-endian 変換、`u16` / `i16` 再解釈、canonical boolean 正規化を実装
- Return frame を 2 Cell / 4 byte のメモリ表現で push/pop できるようにした
- stack region の重複、page 1 との衝突、misaligned pointer などを `Tbx16Error` で区別して返すようにした
- `src/lib.rs` から `tbx16` モジュールを公開
- `tests/tbx16.rs` を追加し、Cell / memory / data stack / return stack / register 契約を固定

## 確認

- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
