### PR TITLE
draft: tbx16間接スレッディング実行核の分割元実装

### DIFF
--- a/src/tbx16/error.rs
+++ b/src/tbx16/error.rs
@@ -10,6 +10,7 @@ pub enum Tbx16Error {
     DataStackOverflow,
     ReturnStackUnderflow,
     ReturnStackOverflow,
+    StepLimitExceeded,
     InvalidMemoryAccess {
         addr: Address,
         operation: &'static str,
@@ -30,6 +31,9 @@ pub enum Tbx16Error {
     InstructionPointerOutOfRange {
         ip: Address,
     },
+    InvalidReturnCount {
+        count: Cell,
+    },
     ExplicitTrap {
         code: Cell,
     },
@@ -42,6 +46,7 @@ impl fmt::Display for Tbx16Error {
             Tbx16Error::DataStackOverflow => write!(f, "data stack overflow"),
             Tbx16Error::ReturnStackUnderflow => write!(f, "return stack underflow"),
             Tbx16Error::ReturnStackOverflow => write!(f, "return stack overflow"),
+            Tbx16Error::StepLimitExceeded => write!(f, "step limit exceeded"),
             Tbx16Error::InvalidMemoryAccess { addr, operation } => {
                 write!(f, "invalid memory access during {operation} at {addr}")
             }
@@ -57,6 +62,9 @@ impl fmt::Display for Tbx16Error {
             }
             Tbx16Error::InstructionPointerOutOfRange { ip } => {
                 write!(f, "instruction pointer out of range at {ip}")
+            }
+            Tbx16Error::InvalidReturnCount { count } => {
+                write!(f, "invalid return count ${:04x}", count.raw())
             }
             Tbx16Error::ExplicitTrap { code } => {
                 write!(f, "explicit trap ${:04x}", code.raw())

--- a/src/tbx16/mod.rs
+++ b/src/tbx16/mod.rs
@@ -1,9 +1,9 @@
 //! Low-level execution substrate for the future 16-bit tbx16 VM.
 //!
 //! This module models the target exactly as a single 64 KiB memory image plus
-//! byte-addressed registers. Data stack cells, return stack cells, and future
-//! threaded code all live in the same `Memory`; stack operations are expressed
-//! strictly as reads and writes against that memory.
+//! byte-addressed registers. Data stack cells, return stack cells, and threaded
+//! code all live in the same `Memory`; stack operations and threaded dispatch
+//! are expressed strictly as reads and writes against that memory.
 
 pub mod address;
 pub mod cell;
@@ -24,6 +24,86 @@ pub const DATA_STACK_END: Address = Address::new(0x0100);
 pub const DEFAULT_RETURN_STACK_START: Address = Address::new(0x0200);
 pub const DEFAULT_RETURN_STACK_END: Address = Address::new(0x0300);
 const PAGE_ONE_END: Address = Address::new(0x0200);
+const NO_IP: Address = Address::new(0xffff);
+const RETURN_FRAME_BYTES: u16 = 4;
+
+pub const CODE_TOKEN_PRIMITIVE: Cell = Cell::new(0x0001);
+pub const CODE_TOKEN_DOCOL: Cell = Cell::new(0x0002);
+
+/// Result of one `tbx16` run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExecutionOutcome {
+    Halted,
+    Returned,
+    Trapped(Tbx16Error),
+}
+
+/// Minimal primitive registry for the M2.2 threaded kernel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u16)]
+pub enum PrimitiveId {
+    Lit = 1,
+    Branch = 2,
+    ZBranch = 3,
+    Exit = 4,
+    Halt = 5,
+}
+
+impl PrimitiveId {
+    pub const fn as_cell(self) -> Cell {
+        Cell::new(self as u16)
+    }
+
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Lit => "LIT",
+            Self::Branch => "BRANCH",
+            Self::ZBranch => "ZBRANCH",
+            Self::Exit => "EXIT",
+            Self::Halt => "HALT",
+        }
+    }
+}
+
+impl TryFrom<Cell> for PrimitiveId {
+    type Error = ();
+
+    fn try_from(value: Cell) -> Result<Self, Self::Error> {
+        match value.raw() {
+            1 => Ok(Self::Lit),
+            2 => Ok(Self::Branch),
+            3 => Ok(Self::ZBranch),
+            4 => Ok(Self::Exit),
+            5 => Ok(Self::Halt),
+            _ => Err(()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct EntryContext {
+    initial_bp: Address,
+    frame_base: Address,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ColonWord {
+    arity: u16,
+    local_count: u16,
+    parameter_ip: Address,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ResolvedWord {
+    Primitive(PrimitiveId),
+    Colon(ColonWord),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum StepControl {
+    Continue,
+    Final(ExecutionOutcome),
+}
 
 /// tbx16 VM substrate with unified memory and byte-addressed registers.
 #[derive(Debug)]
@@ -32,6 +112,10 @@ pub struct Tbx16Vm {
     registers: Registers,
     data_stack_region: StackRegion,
     return_stack_region: StackRegion,
+    step_limit: Option<usize>,
+    step_counter: usize,
+    call_depth: u16,
+    entry_context: Option<EntryContext>,
 }
 
 impl Default for Tbx16Vm {
@@ -72,6 +156,10 @@ impl Tbx16Vm {
             registers,
             data_stack_region,
             return_stack_region,
+            step_limit: None,
+            step_counter: 0,
+            call_depth: 0,
+            entry_context: None,
         };
         vm.validate_invariants()?;
         Ok(vm)
@@ -90,9 +178,7 @@ impl Tbx16Vm {
     }
 
     pub fn set_instruction_pointer(&mut self, ip: Address) -> Result<(), Tbx16Error> {
-        if usize::from(ip.get()) >= memory::MEMORY_SIZE {
-            return Err(Tbx16Error::InstructionPointerOutOfRange { ip });
-        }
+        validate_instruction_pointer_target(ip)?;
         self.registers.ip = Some(ip);
         Ok(())
     }
@@ -103,6 +189,18 @@ impl Tbx16Vm {
 
     pub fn return_stack_region(&self) -> StackRegion {
         self.return_stack_region
+    }
+
+    pub fn set_step_limit(&mut self, step_limit: Option<usize>) {
+        self.step_limit = step_limit;
+    }
+
+    pub fn step_counter(&self) -> usize {
+        self.step_counter
+    }
+
+    pub fn call_depth(&self) -> u16 {
+        self.call_depth
     }
 
     pub fn data_slot_address(&self, slot_index: u16) -> Result<Address, Tbx16Error> {
@@ -189,7 +287,7 @@ impl Tbx16Vm {
         let next = self
             .registers
             .rsp
-            .checked_add(4)
+            .checked_add(RETURN_FRAME_BYTES)
             .ok_or(Tbx16Error::ReturnStackOverflow)?;
         ensure_pointer_in_region(self.registers.rsp, self.return_stack_region, "return")?;
         if !self.return_stack_region.contains_pointer(next) {
@@ -209,31 +307,46 @@ impl Tbx16Vm {
     }
 
     pub fn pop_return_frame(&mut self) -> Result<ReturnFrame, Tbx16Error> {
-        ensure_pointer_in_region(self.registers.rsp, self.return_stack_region, "return")?;
-        let frame_start = self
+        let frame = self.peek_return_frame()?;
+        self.registers.rsp = self
             .registers
             .rsp
-            .checked_sub(4)
+            .checked_sub(RETURN_FRAME_BYTES)
             .ok_or(Tbx16Error::ReturnStackUnderflow)?;
-        if frame_start < self.return_stack_region.start() {
-            return Err(Tbx16Error::ReturnStackUnderflow);
+        Ok(frame)
+    }
+
+    pub fn run(&mut self, entry_xt: Cell) -> ExecutionOutcome {
+        self.step_counter = 0;
+        self.call_depth = 0;
+        self.entry_context = None;
+
+        let start_control = match self.start_entry(entry_xt) {
+            Ok(control) => control,
+            Err(err) => return self.finish_run(ExecutionOutcome::Trapped(err)),
+        };
+
+        if let StepControl::Final(outcome) = start_control {
+            return self.finish_run(outcome);
         }
-        let return_ip = self.memory.read_cell(frame_start)?;
-        let caller_bp = self.memory.read_cell(
-            frame_start
-                .checked_add(2)
-                .expect("aligned frame start always has space for caller_bp"),
-        )?;
-        self.registers.rsp = frame_start;
-        Ok(ReturnFrame {
-            return_ip: Address::new(return_ip.raw()),
-            caller_bp: Address::new(caller_bp.raw()),
-        })
+
+        loop {
+            let control = match self.dispatch_step() {
+                Ok(control) => control,
+                Err(err) => return self.finish_run(ExecutionOutcome::Trapped(err)),
+            };
+            if let StepControl::Final(outcome) = control {
+                return self.finish_run(outcome);
+            }
+        }
     }
 
     pub fn validate_invariants(&self) -> Result<(), Tbx16Error> {
         ensure_pointer_in_region(self.registers.dsp, self.data_stack_region, "data")?;
         ensure_pointer_in_region(self.registers.rsp, self.return_stack_region, "return")?;
+        if let Some(ip) = self.registers.ip {
+            validate_instruction_pointer_target(ip)?;
+        }
         if !self.data_stack_region.contains_pointer(self.registers.bp) {
             return Err(Tbx16Error::InvalidStackRegion {
                 start: self.data_stack_region.start(),
@@ -247,6 +360,13 @@ impl Tbx16Vm {
                 addr: self.registers.bp,
             });
         }
+        if self.registers.bp > self.registers.dsp {
+            return Err(Tbx16Error::InvalidStackRegion {
+                start: self.data_stack_region.start(),
+                end: self.data_stack_region.end(),
+                reason: "base pointer must not exceed the data stack pointer",
+            });
+        }
         validate_return_stack_region(self.return_stack_region)?;
         if self.data_stack_region.overlaps(self.return_stack_region) {
             return Err(Tbx16Error::InvalidStackRegion {
@@ -255,7 +375,403 @@ impl Tbx16Vm {
                 reason: "return stack region overlaps the fixed data stack region",
             });
         }
+        if self.entry_context.is_some() {
+            let used = self.registers.rsp.get() - self.return_stack_region.start().get();
+            let expected = self.call_depth.checked_mul(RETURN_FRAME_BYTES).ok_or(
+                Tbx16Error::InvalidStackRegion {
+                    start: self.return_stack_region.start(),
+                    end: self.return_stack_region.end(),
+                    reason: "call depth overflowed the return stack accounting",
+                },
+            )?;
+            if used != expected {
+                return Err(Tbx16Error::InvalidStackRegion {
+                    start: self.return_stack_region.start(),
+                    end: self.return_stack_region.end(),
+                    reason: "return stack usage does not match call depth",
+                });
+            }
+        }
         Ok(())
+    }
+
+    fn start_entry(&mut self, entry_xt: Cell) -> Result<StepControl, Tbx16Error> {
+        self.begin_step()?;
+        match self.resolve_word(entry_xt)? {
+            ResolvedWord::Primitive(primitive) => {
+                let control = self.execute_entry_primitive(primitive)?;
+                self.step_counter += 1;
+                self.debug_validate_state();
+                Ok(control)
+            }
+            ResolvedWord::Colon(word) => {
+                let initial_bp = self.registers.bp;
+                let frame_base = self.compute_frame_base(word.arity)?;
+                let locals_start = self.registers.dsp;
+                let new_dsp = self.checked_extend_data_stack(locals_start, word.local_count)?;
+
+                if word.local_count != 0 {
+                    self.memory
+                        .zero_range(locals_start, usize::from(word.local_count) * 2)?;
+                }
+                self.registers.bp = frame_base;
+                self.registers.dsp = new_dsp;
+                self.registers.ip = Some(word.parameter_ip);
+                self.entry_context = Some(EntryContext {
+                    initial_bp,
+                    frame_base,
+                });
+                self.step_counter += 1;
+                self.debug_validate_state();
+                Ok(StepControl::Continue)
+            }
+        }
+    }
+
+    fn execute_entry_primitive(
+        &mut self,
+        primitive: PrimitiveId,
+    ) -> Result<StepControl, Tbx16Error> {
+        match primitive {
+            PrimitiveId::Halt => Ok(StepControl::Final(ExecutionOutcome::Halted)),
+            PrimitiveId::Lit | PrimitiveId::Branch | PrimitiveId::ZBranch | PrimitiveId::Exit => {
+                let _ = self.current_ip()?;
+                Ok(StepControl::Final(ExecutionOutcome::Returned))
+            }
+        }
+    }
+
+    fn dispatch_step(&mut self) -> Result<StepControl, Tbx16Error> {
+        self.begin_step()?;
+
+        let ip = self.current_ip()?;
+        let xt = self.read_ip_cell(ip)?;
+        let continuation_ip = validate_instruction_pointer_target(
+            ip.checked_add(2)
+                .ok_or(Tbx16Error::InstructionPointerOutOfRange { ip })?,
+        )?;
+
+        let control = match self.resolve_word(xt)? {
+            ResolvedWord::Primitive(primitive) => {
+                self.execute_primitive(primitive, continuation_ip)?
+            }
+            ResolvedWord::Colon(word) => {
+                self.execute_colon_call(word, continuation_ip)?;
+                StepControl::Continue
+            }
+        };
+
+        self.step_counter += 1;
+        self.debug_validate_state();
+        Ok(control)
+    }
+
+    fn execute_primitive(
+        &mut self,
+        primitive: PrimitiveId,
+        continuation_ip: Address,
+    ) -> Result<StepControl, Tbx16Error> {
+        match primitive {
+            PrimitiveId::Lit => {
+                let literal = self.read_ip_cell(continuation_ip)?;
+                let next_ip =
+                    validate_instruction_pointer_target(continuation_ip.checked_add(2).ok_or(
+                        Tbx16Error::InstructionPointerOutOfRange {
+                            ip: continuation_ip,
+                        },
+                    )?)?;
+                self.ensure_data_stack_pushable(self.registers.dsp)?;
+                self.push_data_cell(literal)?;
+                self.registers.ip = Some(next_ip);
+                Ok(StepControl::Continue)
+            }
+            PrimitiveId::Branch => {
+                let target = self.read_ip_cell(continuation_ip)?;
+                let target_ip = validate_instruction_pointer_target(Address::new(target.raw()))?;
+                self.registers.ip = Some(target_ip);
+                Ok(StepControl::Continue)
+            }
+            PrimitiveId::ZBranch => {
+                let target = self.read_ip_cell(continuation_ip)?;
+                let target_ip = validate_instruction_pointer_target(Address::new(target.raw()))?;
+                let condition = self.peek_data_cell(0)?;
+                let fallthrough_ip =
+                    validate_instruction_pointer_target(continuation_ip.checked_add(2).ok_or(
+                        Tbx16Error::InstructionPointerOutOfRange {
+                            ip: continuation_ip,
+                        },
+                    )?)?;
+                self.pop_data_cell()?;
+                self.registers.ip = Some(if condition.raw() == 0 {
+                    target_ip
+                } else {
+                    fallthrough_ip
+                });
+                Ok(StepControl::Continue)
+            }
+            PrimitiveId::Exit => self.execute_exit(continuation_ip),
+            PrimitiveId::Halt => {
+                self.registers.ip = Some(continuation_ip);
+                Ok(StepControl::Final(ExecutionOutcome::Halted))
+            }
+        }
+    }
+
+    fn execute_exit(&mut self, continuation_ip: Address) -> Result<StepControl, Tbx16Error> {
+        let return_count = self.read_ip_cell(continuation_ip)?;
+        let return_value = match return_count.raw() {
+            0 => None,
+            1 => Some(self.peek_data_cell(0)?),
+            _ => {
+                return Err(Tbx16Error::InvalidReturnCount {
+                    count: return_count,
+                })
+            }
+        };
+
+        if self.call_depth == 0 {
+            let entry = self.entry_context.ok_or(Tbx16Error::InvalidReturnCount {
+                count: return_count,
+            })?;
+            if return_value.is_some() {
+                self.ensure_data_stack_pushable(entry.frame_base)?;
+            }
+            if let Some(value) = return_value {
+                self.memory.write_cell(entry.frame_base, value)?;
+                self.registers.dsp = entry
+                    .frame_base
+                    .checked_add(2)
+                    .expect("validated top-level return slot has room");
+            } else {
+                self.registers.dsp = entry.frame_base;
+            }
+            self.registers.bp = entry.initial_bp;
+            self.registers.ip = Some(continuation_ip);
+            return Ok(StepControl::Final(ExecutionOutcome::Returned));
+        }
+
+        let frame = self.peek_return_frame()?;
+        let return_ip = validate_instruction_pointer_target(frame.return_ip)?;
+        if return_value.is_some() {
+            self.ensure_data_stack_pushable(self.registers.bp)?;
+        }
+
+        let new_rsp = self
+            .registers
+            .rsp
+            .checked_sub(RETURN_FRAME_BYTES)
+            .ok_or(Tbx16Error::ReturnStackUnderflow)?;
+
+        if let Some(value) = return_value {
+            self.memory.write_cell(self.registers.bp, value)?;
+            self.registers.dsp = self
+                .registers
+                .bp
+                .checked_add(2)
+                .expect("validated nested return slot has room");
+        } else {
+            self.registers.dsp = self.registers.bp;
+        }
+        self.registers.rsp = new_rsp;
+        self.registers.bp = frame.caller_bp;
+        self.registers.ip = Some(return_ip);
+        self.call_depth -= 1;
+        Ok(StepControl::Continue)
+    }
+
+    fn execute_colon_call(
+        &mut self,
+        word: ColonWord,
+        return_ip: Address,
+    ) -> Result<(), Tbx16Error> {
+        let new_bp = self.compute_frame_base(word.arity)?;
+        let locals_start = self.registers.dsp;
+        let new_dsp = self.checked_extend_data_stack(locals_start, word.local_count)?;
+        let new_rsp = self
+            .registers
+            .rsp
+            .checked_add(RETURN_FRAME_BYTES)
+            .ok_or(Tbx16Error::ReturnStackOverflow)?;
+        ensure_pointer_in_region(self.registers.rsp, self.return_stack_region, "return")?;
+        if !self.return_stack_region.contains_pointer(new_rsp) {
+            return Err(Tbx16Error::ReturnStackOverflow);
+        }
+
+        let caller_bp = self.registers.bp;
+        self.memory
+            .write_cell(self.registers.rsp, Cell::new(return_ip.get()))?;
+        self.memory.write_cell(
+            self.registers
+                .rsp
+                .checked_add(2)
+                .expect("validated return frame has room for caller bp"),
+            Cell::new(caller_bp.get()),
+        )?;
+        if word.local_count != 0 {
+            self.memory
+                .zero_range(locals_start, usize::from(word.local_count) * 2)?;
+        }
+
+        self.registers.rsp = new_rsp;
+        self.registers.bp = new_bp;
+        self.registers.dsp = new_dsp;
+        self.registers.ip = Some(word.parameter_ip);
+        self.call_depth = self
+            .call_depth
+            .checked_add(1)
+            .expect("call depth fits in u16 for the configured return stack");
+        Ok(())
+    }
+
+    fn resolve_word(&self, xt: Cell) -> Result<ResolvedWord, Tbx16Error> {
+        let xt_addr = validate_execution_token_address(xt)?;
+        let code_token = self
+            .memory
+            .read_cell(xt_addr)
+            .map_err(|_| invalid_execution_token(xt))?;
+
+        if code_token == CODE_TOKEN_PRIMITIVE {
+            let primitive_id_addr = xt_addr
+                .checked_add(2)
+                .ok_or_else(|| invalid_execution_token(xt))?;
+            let primitive_id = self
+                .memory
+                .read_cell(primitive_id_addr)
+                .map_err(|_| invalid_execution_token(xt))?;
+            let primitive =
+                PrimitiveId::try_from(primitive_id).map_err(|_| invalid_execution_token(xt))?;
+            return Ok(ResolvedWord::Primitive(primitive));
+        }
+
+        if code_token == CODE_TOKEN_DOCOL {
+            let arity_addr = xt_addr
+                .checked_add(2)
+                .ok_or_else(|| invalid_execution_token(xt))?;
+            let local_count_addr = xt_addr
+                .checked_add(4)
+                .ok_or_else(|| invalid_execution_token(xt))?;
+            let parameter_ip = validate_instruction_pointer_target(
+                xt_addr
+                    .checked_add(6)
+                    .ok_or_else(|| invalid_execution_token(xt))?,
+            )
+            .map_err(|_| invalid_execution_token(xt))?;
+            let arity = self
+                .memory
+                .read_cell(arity_addr)
+                .map_err(|_| invalid_execution_token(xt))?
+                .raw();
+            let local_count = self
+                .memory
+                .read_cell(local_count_addr)
+                .map_err(|_| invalid_execution_token(xt))?
+                .raw();
+            return Ok(ResolvedWord::Colon(ColonWord {
+                arity,
+                local_count,
+                parameter_ip,
+            }));
+        }
+
+        Err(invalid_execution_token(xt))
+    }
+
+    fn begin_step(&self) -> Result<(), Tbx16Error> {
+        if self
+            .step_limit
+            .is_some_and(|limit| self.step_counter >= limit)
+        {
+            return Err(Tbx16Error::StepLimitExceeded);
+        }
+        Ok(())
+    }
+
+    fn current_ip(&self) -> Result<Address, Tbx16Error> {
+        let ip = self
+            .registers
+            .ip
+            .ok_or(Tbx16Error::InstructionPointerOutOfRange { ip: NO_IP })?;
+        validate_instruction_pointer_target(ip)
+    }
+
+    fn read_ip_cell(&self, ip: Address) -> Result<Cell, Tbx16Error> {
+        validate_instruction_pointer_target(ip)?;
+        self.memory.read_cell(ip)
+    }
+
+    fn compute_frame_base(&self, arity: u16) -> Result<Address, Tbx16Error> {
+        let arg_bytes = arity.checked_mul(2).ok_or(Tbx16Error::DataStackUnderflow)?;
+        let frame_base = self
+            .registers
+            .dsp
+            .checked_sub(arg_bytes)
+            .ok_or(Tbx16Error::DataStackUnderflow)?;
+        if frame_base < self.data_stack_region.start() {
+            return Err(Tbx16Error::DataStackUnderflow);
+        }
+        Ok(frame_base)
+    }
+
+    fn checked_extend_data_stack(
+        &self,
+        base: Address,
+        cell_count: u16,
+    ) -> Result<Address, Tbx16Error> {
+        let byte_len = cell_count
+            .checked_mul(2)
+            .ok_or(Tbx16Error::DataStackOverflow)?;
+        let new_dsp = base
+            .checked_add(byte_len)
+            .ok_or(Tbx16Error::DataStackOverflow)?;
+        ensure_pointer_in_region(base, self.data_stack_region, "data")?;
+        if !self.data_stack_region.contains_pointer(new_dsp) {
+            return Err(Tbx16Error::DataStackOverflow);
+        }
+        Ok(new_dsp)
+    }
+
+    fn ensure_data_stack_pushable(&self, pointer: Address) -> Result<(), Tbx16Error> {
+        let next = pointer
+            .checked_add(2)
+            .ok_or(Tbx16Error::DataStackOverflow)?;
+        ensure_pointer_in_region(pointer, self.data_stack_region, "data")?;
+        if !self.data_stack_region.contains_pointer(next) {
+            return Err(Tbx16Error::DataStackOverflow);
+        }
+        Ok(())
+    }
+
+    fn peek_return_frame(&self) -> Result<ReturnFrame, Tbx16Error> {
+        ensure_pointer_in_region(self.registers.rsp, self.return_stack_region, "return")?;
+        let frame_start = self
+            .registers
+            .rsp
+            .checked_sub(RETURN_FRAME_BYTES)
+            .ok_or(Tbx16Error::ReturnStackUnderflow)?;
+        if frame_start < self.return_stack_region.start() {
+            return Err(Tbx16Error::ReturnStackUnderflow);
+        }
+        let return_ip = self.memory.read_cell(frame_start)?;
+        let caller_bp = self.memory.read_cell(
+            frame_start
+                .checked_add(2)
+                .expect("validated frame start has room for caller bp"),
+        )?;
+        Ok(ReturnFrame {
+            return_ip: Address::new(return_ip.raw()),
+            caller_bp: Address::new(caller_bp.raw()),
+        })
+    }
+
+    fn finish_run(&mut self, outcome: ExecutionOutcome) -> ExecutionOutcome {
+        self.entry_context = None;
+        outcome
+    }
+
+    fn debug_validate_state(&self) {
+        #[cfg(debug_assertions)]
+        self.validate_invariants()
+            .expect("tbx16 invariants must hold after successful state transitions");
     }
 }
 
@@ -275,4 +791,23 @@ fn validate_return_stack_region(region: StackRegion) -> Result<(), Tbx16Error> {
         });
     }
     Ok(())
+}
+
+fn validate_execution_token_address(xt: Cell) -> Result<Address, Tbx16Error> {
+    let xt_addr = Address::new(xt.raw());
+    if xt_addr.get() == NO_IP.get() || !xt_addr.is_even() {
+        return Err(invalid_execution_token(xt));
+    }
+    Ok(xt_addr)
+}
+
+fn validate_instruction_pointer_target(ip: Address) -> Result<Address, Tbx16Error> {
+    if ip.get() == NO_IP.get() || !ip.is_even() {
+        return Err(Tbx16Error::InstructionPointerOutOfRange { ip });
+    }
+    Ok(ip)
+}
+
+fn invalid_execution_token(xt: Cell) -> Tbx16Error {
+    Tbx16Error::InvalidExecutionToken { xt }
 }

--- a/tests/tbx16.rs
+++ b/tests/tbx16.rs
@@ -1,11 +1,114 @@
+use std::collections::HashMap;
+
 use tbx::tbx16::address::Address;
 use tbx::tbx16::cell::Cell;
 use tbx::tbx16::error::Tbx16Error;
 use tbx::tbx16::memory::MEMORY_SIZE;
 use tbx::tbx16::stack::{ReturnFrame, StackRegion};
 use tbx::tbx16::{
-    Tbx16Vm, DATA_STACK_END, DATA_STACK_START, DEFAULT_RETURN_STACK_END, DEFAULT_RETURN_STACK_START,
+    ExecutionOutcome, PrimitiveId, Tbx16Vm, CODE_TOKEN_DOCOL, CODE_TOKEN_PRIMITIVE, DATA_STACK_END,
+    DATA_STACK_START, DEFAULT_RETURN_STACK_END, DEFAULT_RETURN_STACK_START,
 };
+
+const CODE_START: u16 = 0x0400;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct VmSnapshot {
+    registers_ip: Option<Address>,
+    dsp: Address,
+    rsp: Address,
+    bp: Address,
+    step_counter: usize,
+    call_depth: u16,
+    memory: Vec<u8>,
+}
+
+fn snapshot(vm: &Tbx16Vm) -> VmSnapshot {
+    VmSnapshot {
+        registers_ip: vm.registers().ip,
+        dsp: vm.registers().dsp,
+        rsp: vm.registers().rsp,
+        bp: vm.registers().bp,
+        step_counter: vm.step_counter(),
+        call_depth: vm.call_depth(),
+        memory: vm.memory().as_bytes().to_vec(),
+    }
+}
+
+enum PendingCell {
+    Raw(Cell),
+    Label(&'static str),
+}
+
+struct ImageBuilder {
+    cursor: Address,
+    cells: Vec<(Address, PendingCell)>,
+    labels: HashMap<&'static str, Address>,
+}
+
+impl ImageBuilder {
+    fn new(start: u16) -> Self {
+        Self {
+            cursor: Address::new(start),
+            cells: Vec::new(),
+            labels: HashMap::new(),
+        }
+    }
+
+    fn primitive(&mut self, primitive: PrimitiveId) -> Cell {
+        let xt = Cell::new(self.cursor.get());
+        self.emit_cell(CODE_TOKEN_PRIMITIVE);
+        self.emit_cell(primitive.as_cell());
+        xt
+    }
+
+    fn colon_word(&mut self, arity: u16, locals: u16) -> Cell {
+        let xt = Cell::new(self.cursor.get());
+        self.emit_cell(CODE_TOKEN_DOCOL);
+        self.emit_cell(Cell::new(arity));
+        self.emit_cell(Cell::new(locals));
+        xt
+    }
+
+    fn emit_xt(&mut self, xt: Cell) {
+        self.emit_cell(xt);
+    }
+
+    fn emit_cell(&mut self, cell: Cell) {
+        let addr = self.cursor;
+        self.cells.push((addr, PendingCell::Raw(cell)));
+        self.cursor = self
+            .cursor
+            .checked_add(2)
+            .expect("test image stays within 64 KiB");
+    }
+
+    fn emit_label_ref(&mut self, label: &'static str) {
+        let addr = self.cursor;
+        self.cells.push((addr, PendingCell::Label(label)));
+        self.cursor = self
+            .cursor
+            .checked_add(2)
+            .expect("test image stays within 64 KiB");
+    }
+
+    fn mark_label(&mut self, label: &'static str) {
+        self.labels.insert(label, self.cursor);
+    }
+
+    fn load_into(self, vm: &mut Tbx16Vm) {
+        for (addr, pending) in self.cells {
+            let cell = match pending {
+                PendingCell::Raw(cell) => cell,
+                PendingCell::Label(label) => {
+                    let target = self.labels.get(label).expect("label must be defined");
+                    Cell::new(target.get())
+                }
+            };
+            vm.memory_mut().write_cell(addr, cell).unwrap();
+        }
+    }
+}
 
 #[test]
 fn cell_reinterprets_u16_and_i16_bits() {
@@ -309,4 +412,422 @@ fn bp_slot_addresses_use_two_byte_steps() {
     assert_eq!(vm.data_slot_address(0).unwrap(), Address::new(0x0080));
     assert_eq!(vm.data_slot_address(1).unwrap(), Address::new(0x0082));
     assert_eq!(vm.data_slot_address(5).unwrap(), Address::new(0x008a));
+}
+
+#[test]
+fn primitive_and_colon_entries_share_the_same_xt_namespace() {
+    let mut vm = Tbx16Vm::default();
+    let mut image = ImageBuilder::new(CODE_START);
+    let halt_xt = image.primitive(PrimitiveId::Halt);
+    let exit_xt = image.primitive(PrimitiveId::Exit);
+    let entry_xt = image.colon_word(0, 0);
+    image.emit_xt(exit_xt);
+    image.emit_cell(Cell::new(0));
+    image.load_into(&mut vm);
+
+    assert_eq!(halt_xt.raw() % 2, 0);
+    assert_eq!(entry_xt.raw() % 2, 0);
+    assert_eq!(vm.run(halt_xt), ExecutionOutcome::Halted);
+    assert_eq!(vm.run(entry_xt), ExecutionOutcome::Returned);
+}
+
+#[test]
+fn invalid_xts_and_malformed_word_layouts_trap() {
+    let mut vm = Tbx16Vm::default();
+    vm.memory_mut()
+        .write_cell(Address::new(CODE_START), Cell::new(0x9999))
+        .unwrap();
+    vm.memory_mut()
+        .write_cell(Address::new(0xfffe), CODE_TOKEN_PRIMITIVE)
+        .unwrap();
+    vm.memory_mut()
+        .write_cell(Address::new(0xfffc), CODE_TOKEN_DOCOL)
+        .unwrap();
+    vm.memory_mut()
+        .write_cell(Address::new(0xfffe), Cell::new(1))
+        .unwrap();
+
+    assert_eq!(
+        vm.run(Cell::new(CODE_START)),
+        ExecutionOutcome::Trapped(Tbx16Error::InvalidExecutionToken {
+            xt: Cell::new(CODE_START),
+        })
+    );
+    assert_eq!(
+        vm.run(Cell::new(CODE_START + 1)),
+        ExecutionOutcome::Trapped(Tbx16Error::InvalidExecutionToken {
+            xt: Cell::new(CODE_START + 1),
+        })
+    );
+    assert_eq!(
+        vm.run(Cell::new(0xffff)),
+        ExecutionOutcome::Trapped(Tbx16Error::InvalidExecutionToken {
+            xt: Cell::new(0xffff),
+        })
+    );
+    assert_eq!(
+        vm.run(Cell::new(0xfffe)),
+        ExecutionOutcome::Trapped(Tbx16Error::InvalidExecutionToken {
+            xt: Cell::new(0xfffe),
+        })
+    );
+    assert_eq!(
+        vm.run(Cell::new(0xfffc)),
+        ExecutionOutcome::Trapped(Tbx16Error::InvalidExecutionToken {
+            xt: Cell::new(0xfffc),
+        })
+    );
+}
+
+#[test]
+fn entry_colon_initialization_validates_arity_and_zeroes_locals() {
+    let mut vm = Tbx16Vm::default();
+    let mut image = ImageBuilder::new(CODE_START);
+    let halt_xt = image.primitive(PrimitiveId::Halt);
+    let entry_xt = image.colon_word(2, 2);
+    image.emit_xt(halt_xt);
+    image.load_into(&mut vm);
+
+    vm.push_data_cell(Cell::new(0x1111)).unwrap();
+    vm.push_data_cell(Cell::new(0x2222)).unwrap();
+
+    assert_eq!(vm.run(entry_xt), ExecutionOutcome::Halted);
+    assert_eq!(vm.registers().bp, Address::new(0x0080));
+    assert_eq!(vm.registers().dsp, Address::new(0x0088));
+    assert_eq!(
+        vm.memory().read_cell(Address::new(0x0084)).unwrap(),
+        Cell::new(0)
+    );
+    assert_eq!(
+        vm.memory().read_cell(Address::new(0x0086)).unwrap(),
+        Cell::new(0)
+    );
+
+    let mut arity_vm = Tbx16Vm::default();
+    let mut arity_image = ImageBuilder::new(CODE_START);
+    let bad_entry_xt = arity_image.colon_word(1, 0);
+    arity_image.load_into(&mut arity_vm);
+    assert_eq!(
+        arity_vm.run(bad_entry_xt),
+        ExecutionOutcome::Trapped(Tbx16Error::DataStackUnderflow)
+    );
+}
+
+#[test]
+fn lit_and_top_level_exit_one_cell_return_work() {
+    let mut vm = Tbx16Vm::default();
+    let mut image = ImageBuilder::new(CODE_START);
+    let lit_xt = image.primitive(PrimitiveId::Lit);
+    let exit_xt = image.primitive(PrimitiveId::Exit);
+    let entry_xt = image.colon_word(1, 0);
+    image.emit_xt(lit_xt);
+    image.emit_cell(Cell::new(0x7777));
+    image.emit_xt(exit_xt);
+    image.emit_cell(Cell::new(1));
+    image.load_into(&mut vm);
+
+    vm.push_data_cell(Cell::new(0xaaaa)).unwrap();
+    vm.push_data_cell(Cell::new(0x1111)).unwrap();
+    assert_eq!(vm.run(entry_xt), ExecutionOutcome::Returned);
+    assert_eq!(vm.registers().bp, DATA_STACK_START);
+    assert_eq!(vm.registers().dsp, Address::new(0x0084));
+    assert_eq!(vm.peek_data_cell(0).unwrap(), Cell::new(0x7777));
+    assert_eq!(
+        vm.memory().read_cell(Address::new(0x0080)).unwrap(),
+        Cell::new(0xaaaa)
+    );
+}
+
+#[test]
+fn branch_and_zbranch_follow_absolute_targets() {
+    let mut vm = Tbx16Vm::default();
+    let mut image = ImageBuilder::new(CODE_START);
+    let lit_xt = image.primitive(PrimitiveId::Lit);
+    let branch_xt = image.primitive(PrimitiveId::Branch);
+    let zbranch_xt = image.primitive(PrimitiveId::ZBranch);
+    let exit_xt = image.primitive(PrimitiveId::Exit);
+
+    let branch_entry_xt = image.colon_word(0, 0);
+    image.emit_xt(branch_xt);
+    image.emit_label_ref("branch_target");
+    image.emit_xt(lit_xt);
+    image.emit_cell(Cell::new(0xdead));
+    image.mark_label("branch_target");
+    image.emit_xt(lit_xt);
+    image.emit_cell(Cell::new(0x1234));
+    image.emit_xt(exit_xt);
+    image.emit_cell(Cell::new(1));
+
+    let _zbranch_zero_xt = image.colon_word(0, 0);
+    image.emit_xt(lit_xt);
+    image.emit_cell(Cell::new(0));
+    image.emit_xt(zbranch_xt);
+    image.emit_label_ref("z_zero_target");
+    image.emit_xt(lit_xt);
+    image.emit_cell(Cell::new(0x9999));
+    image.mark_label("z_zero_target");
+    image.emit_xt(lit_xt);
+    image.emit_cell(Cell::new(0x2222));
+    image.emit_xt(exit_xt);
+    image.emit_cell(Cell::new(1));
+
+    let _zbranch_nonzero_xt = image.colon_word(0, 0);
+    image.emit_xt(lit_xt);
+    image.emit_cell(Cell::new(1));
+    image.emit_xt(zbranch_xt);
+    image.emit_label_ref("z_nonzero_target");
+    image.emit_xt(lit_xt);
+    image.emit_cell(Cell::new(0x3333));
+    image.emit_xt(exit_xt);
+    image.emit_cell(Cell::new(1));
+    image.mark_label("z_nonzero_target");
+    image.emit_xt(lit_xt);
+    image.emit_cell(Cell::new(0x4444));
+    image.emit_xt(exit_xt);
+    image.emit_cell(Cell::new(1));
+
+    image.load_into(&mut vm);
+
+    assert_eq!(vm.run(branch_entry_xt), ExecutionOutcome::Returned);
+    assert_eq!(vm.peek_data_cell(0).unwrap(), Cell::new(0x1234));
+
+    let mut zero_vm = Tbx16Vm::default();
+    let mut zero_image = ImageBuilder::new(CODE_START);
+    let lit_xt = zero_image.primitive(PrimitiveId::Lit);
+    let zbranch_xt = zero_image.primitive(PrimitiveId::ZBranch);
+    let exit_xt = zero_image.primitive(PrimitiveId::Exit);
+    let entry_xt = zero_image.colon_word(0, 0);
+    zero_image.emit_xt(lit_xt);
+    zero_image.emit_cell(Cell::new(0));
+    zero_image.emit_xt(zbranch_xt);
+    zero_image.emit_label_ref("target");
+    zero_image.emit_xt(lit_xt);
+    zero_image.emit_cell(Cell::new(0x9999));
+    zero_image.mark_label("target");
+    zero_image.emit_xt(lit_xt);
+    zero_image.emit_cell(Cell::new(0x2222));
+    zero_image.emit_xt(exit_xt);
+    zero_image.emit_cell(Cell::new(1));
+    zero_image.load_into(&mut zero_vm);
+    assert_eq!(zero_vm.run(entry_xt), ExecutionOutcome::Returned);
+    assert_eq!(zero_vm.peek_data_cell(0).unwrap(), Cell::new(0x2222));
+
+    let mut nonzero_vm = Tbx16Vm::default();
+    let mut nonzero_image = ImageBuilder::new(CODE_START);
+    let lit_xt = nonzero_image.primitive(PrimitiveId::Lit);
+    let zbranch_xt = nonzero_image.primitive(PrimitiveId::ZBranch);
+    let exit_xt = nonzero_image.primitive(PrimitiveId::Exit);
+    let entry_xt = nonzero_image.colon_word(0, 0);
+    nonzero_image.emit_xt(lit_xt);
+    nonzero_image.emit_cell(Cell::new(1));
+    nonzero_image.emit_xt(zbranch_xt);
+    nonzero_image.emit_label_ref("target");
+    nonzero_image.emit_xt(lit_xt);
+    nonzero_image.emit_cell(Cell::new(0x3333));
+    nonzero_image.emit_xt(exit_xt);
+    nonzero_image.emit_cell(Cell::new(1));
+    nonzero_image.mark_label("target");
+    nonzero_image.emit_xt(lit_xt);
+    nonzero_image.emit_cell(Cell::new(0x4444));
+    nonzero_image.emit_xt(exit_xt);
+    nonzero_image.emit_cell(Cell::new(1));
+    nonzero_image.load_into(&mut nonzero_vm);
+    assert_eq!(nonzero_vm.run(entry_xt), ExecutionOutcome::Returned);
+    assert_eq!(nonzero_vm.peek_data_cell(0).unwrap(), Cell::new(0x3333));
+}
+
+#[test]
+fn invalid_branch_targets_and_return_counts_trap() {
+    let mut odd_vm = Tbx16Vm::default();
+    let mut odd_image = ImageBuilder::new(CODE_START);
+    let branch_xt = odd_image.primitive(PrimitiveId::Branch);
+    let entry_xt = odd_image.colon_word(0, 0);
+    odd_image.emit_xt(branch_xt);
+    odd_image.emit_cell(Cell::new(0x0401));
+    odd_image.load_into(&mut odd_vm);
+    assert_eq!(
+        odd_vm.run(entry_xt),
+        ExecutionOutcome::Trapped(Tbx16Error::InstructionPointerOutOfRange {
+            ip: Address::new(0x0401),
+        })
+    );
+
+    let mut ffff_vm = Tbx16Vm::default();
+    let mut ffff_image = ImageBuilder::new(CODE_START);
+    let branch_xt = ffff_image.primitive(PrimitiveId::Branch);
+    let entry_xt = ffff_image.colon_word(0, 0);
+    ffff_image.emit_xt(branch_xt);
+    ffff_image.emit_cell(Cell::new(0xffff));
+    ffff_image.load_into(&mut ffff_vm);
+    assert_eq!(
+        ffff_vm.run(entry_xt),
+        ExecutionOutcome::Trapped(Tbx16Error::InstructionPointerOutOfRange {
+            ip: Address::new(0xffff),
+        })
+    );
+
+    let mut return_vm = Tbx16Vm::default();
+    let mut return_image = ImageBuilder::new(CODE_START);
+    let exit_xt = return_image.primitive(PrimitiveId::Exit);
+    let entry_xt = return_image.colon_word(0, 0);
+    return_image.emit_xt(exit_xt);
+    return_image.emit_cell(Cell::new(2));
+    return_image.load_into(&mut return_vm);
+    assert_eq!(
+        return_vm.run(entry_xt),
+        ExecutionOutcome::Trapped(Tbx16Error::InvalidReturnCount {
+            count: Cell::new(2),
+        })
+    );
+}
+
+#[test]
+fn nested_calls_restore_frame_state_and_return_values() {
+    let mut vm = Tbx16Vm::default();
+    let mut image = ImageBuilder::new(CODE_START);
+    let lit_xt = image.primitive(PrimitiveId::Lit);
+    let exit_xt = image.primitive(PrimitiveId::Exit);
+    let halt_xt = image.primitive(PrimitiveId::Halt);
+
+    let deep_xt = image.colon_word(0, 0);
+    image.emit_xt(lit_xt);
+    image.emit_cell(Cell::new(0x7777));
+    image.emit_xt(exit_xt);
+    image.emit_cell(Cell::new(1));
+
+    let mid_xt = image.colon_word(1, 0);
+    image.emit_xt(deep_xt);
+    image.emit_xt(exit_xt);
+    image.emit_cell(Cell::new(1));
+
+    let top_xt = image.colon_word(1, 0);
+    image.emit_xt(mid_xt);
+    image.emit_xt(halt_xt);
+    image.load_into(&mut vm);
+
+    vm.push_data_cell(Cell::new(0xaaaa)).unwrap();
+    vm.push_data_cell(Cell::new(0x1111)).unwrap();
+    assert_eq!(vm.run(top_xt), ExecutionOutcome::Halted);
+    assert_eq!(vm.call_depth(), 0);
+    assert_eq!(vm.registers().rsp, DEFAULT_RETURN_STACK_START);
+    assert_eq!(vm.registers().bp, Address::new(0x0082));
+    assert_eq!(vm.registers().dsp, Address::new(0x0084));
+    assert_eq!(vm.peek_data_cell(0).unwrap(), Cell::new(0x7777));
+    assert_eq!(
+        vm.memory().read_cell(Address::new(0x0080)).unwrap(),
+        Cell::new(0xaaaa)
+    );
+}
+
+#[test]
+fn step_limit_counts_entry_resolution_and_stops_before_next_dispatch() {
+    let mut vm = Tbx16Vm::default();
+    let mut image = ImageBuilder::new(CODE_START);
+    let exit_xt = image.primitive(PrimitiveId::Exit);
+    let entry_xt = image.colon_word(0, 0);
+    image.emit_xt(exit_xt);
+    image.emit_cell(Cell::new(0));
+    image.load_into(&mut vm);
+
+    vm.set_step_limit(Some(1));
+    assert_eq!(
+        vm.run(entry_xt),
+        ExecutionOutcome::Trapped(Tbx16Error::StepLimitExceeded)
+    );
+    assert_eq!(vm.step_counter(), 1);
+    assert_eq!(vm.registers().ip, Some(Address::new(CODE_START + 10)));
+
+    let mut ok_vm = Tbx16Vm::default();
+    let mut ok_image = ImageBuilder::new(CODE_START);
+    let exit_xt = ok_image.primitive(PrimitiveId::Exit);
+    let entry_xt = ok_image.colon_word(0, 0);
+    ok_image.emit_xt(exit_xt);
+    ok_image.emit_cell(Cell::new(0));
+    ok_image.load_into(&mut ok_vm);
+    ok_vm.set_step_limit(Some(2));
+    assert_eq!(ok_vm.run(entry_xt), ExecutionOutcome::Returned);
+    assert_eq!(ok_vm.step_counter(), 2);
+}
+
+#[test]
+fn lit_push_failure_is_atomic() {
+    let mut vm = Tbx16Vm::default();
+    let mut image = ImageBuilder::new(CODE_START);
+    let lit_xt = image.primitive(PrimitiveId::Lit);
+    let entry_xt = image.colon_word(0, 0);
+    image.emit_xt(lit_xt);
+    image.emit_cell(Cell::new(0x1111));
+    image.load_into(&mut vm);
+
+    for i in 0..64u16 {
+        vm.push_data_cell(Cell::new(i)).unwrap();
+    }
+    assert_eq!(
+        vm.run(entry_xt),
+        ExecutionOutcome::Trapped(Tbx16Error::DataStackOverflow)
+    );
+    let after = snapshot(&vm);
+    assert_eq!(after.dsp, DATA_STACK_END);
+    assert_eq!(after.rsp, DEFAULT_RETURN_STACK_START);
+    assert_eq!(after.bp, DATA_STACK_END);
+    assert_eq!(after.registers_ip, Some(Address::new(CODE_START + 10)));
+    assert_eq!(
+        vm.memory().read_cell(Address::new(0x00fe)).unwrap(),
+        Cell::new(63)
+    );
+}
+
+#[test]
+fn zbranch_underflow_is_atomic() {
+    let mut vm = Tbx16Vm::default();
+    let mut image = ImageBuilder::new(CODE_START);
+    let zbranch_xt = image.primitive(PrimitiveId::ZBranch);
+    let entry_xt = image.colon_word(0, 0);
+    image.emit_xt(zbranch_xt);
+    image.emit_label_ref("target");
+    image.mark_label("target");
+    image.load_into(&mut vm);
+
+    assert_eq!(
+        vm.run(entry_xt),
+        ExecutionOutcome::Trapped(Tbx16Error::DataStackUnderflow)
+    );
+    assert_eq!(vm.registers().ip, Some(Address::new(CODE_START + 10)));
+    assert_eq!(vm.registers().dsp, DATA_STACK_START);
+}
+
+#[test]
+fn call_and_return_failures_leave_current_frame_state_unchanged() {
+    let mut call_vm = Tbx16Vm::default();
+    let mut call_image = ImageBuilder::new(CODE_START);
+    let bad_callee_xt = call_image.colon_word(1, 0);
+    let entry_xt = call_image.colon_word(0, 0);
+    call_image.emit_xt(bad_callee_xt);
+    call_image.load_into(&mut call_vm);
+    assert_eq!(
+        call_vm.run(entry_xt),
+        ExecutionOutcome::Trapped(Tbx16Error::DataStackUnderflow)
+    );
+    assert_eq!(call_vm.call_depth(), 0);
+    assert_eq!(call_vm.registers().bp, DATA_STACK_START);
+    assert_eq!(call_vm.registers().dsp, DATA_STACK_START);
+    assert_eq!(call_vm.registers().rsp, DEFAULT_RETURN_STACK_START);
+    assert_eq!(call_vm.registers().ip, Some(Address::new(CODE_START + 12)));
+
+    let mut ret_vm = Tbx16Vm::default();
+    let mut ret_image = ImageBuilder::new(CODE_START);
+    let exit_xt = ret_image.primitive(PrimitiveId::Exit);
+    let callee_xt = ret_image.colon_word(0, 0);
+    ret_image.emit_xt(exit_xt);
+    ret_image.emit_cell(Cell::new(1));
+    let ret_entry_xt = ret_image.colon_word(0, 0);
+    ret_image.emit_xt(callee_xt);
+    ret_image.load_into(&mut ret_vm);
+    assert_eq!(
+        ret_vm.run(ret_entry_xt),
+        ExecutionOutcome::Trapped(Tbx16Error::DataStackUnderflow)
+    );
+    assert_eq!(ret_vm.call_depth(), 1);
+    assert_eq!(ret_vm.registers().rsp, Address::new(0x0204));
+    assert_eq!(ret_vm.registers().ip, Some(Address::new(CODE_START + 10)));
 }


### PR DESCRIPTION
## 状態

このPRは #998 の実装を一括で行った分割元です。レビューの結果、責務が大きすぎるためドラフトへ戻し、次の3チケットへ分割しました。

- #1003 — XT解決・dispatch核・制御primitive
- #1004 — colon callとframe管理
- #1006 — EXIT・return・実行終了状態

## 取り扱い

- このPRはそのままマージしません。
- `Closes #998` は外しています。
- 各サブチケットの独立PRで、必要な実装・テストを切り出して再利用してください。
- 各PRのbaseは `integration/961-tbx-6502` とします。

## 参考として含まれる実装

- XT解決とprimitive registry
- threaded dispatchとstep limit
- `LIT`, `BRANCH`, `ZBRANCH`, `HALT`
- colon word metadataとcall frame
- `EXIT`、0/1 Cell return、top-level / nested return
- fixture builderと正常系・異常系テスト

分割後の確定仕様は #1003、#1004、#1006 を正としてください。