### PR TITLE
tbx16 M2.2a のXT解決とdispatch核を実装

### DIFF
--- a/src/tbx16/error.rs
+++ b/src/tbx16/error.rs
@@ -10,6 +10,7 @@ pub enum Tbx16Error {
     DataStackOverflow,
     ReturnStackUnderflow,
     ReturnStackOverflow,
+    StepLimitExceeded,
     InvalidMemoryAccess {
         addr: Address,
         operation: &'static str,
@@ -42,6 +43,7 @@ impl fmt::Display for Tbx16Error {
             Tbx16Error::DataStackOverflow => write!(f, "data stack overflow"),
             Tbx16Error::ReturnStackUnderflow => write!(f, "return stack underflow"),
             Tbx16Error::ReturnStackOverflow => write!(f, "return stack overflow"),
+            Tbx16Error::StepLimitExceeded => write!(f, "step limit exceeded"),
             Tbx16Error::InvalidMemoryAccess { addr, operation } => {
                 write!(f, "invalid memory access during {operation} at {addr}")
             }

--- a/src/tbx16/mod.rs
+++ b/src/tbx16/mod.rs
@@ -1,9 +1,9 @@
 //! Low-level execution substrate for the future 16-bit tbx16 VM.
 //!
 //! This module models the target exactly as a single 64 KiB memory image plus
-//! byte-addressed registers. Data stack cells, return stack cells, and future
-//! threaded code all live in the same `Memory`; stack operations are expressed
-//! strictly as reads and writes against that memory.
+//! byte-addressed registers. Data stack cells, return stack cells, and threaded
+//! code all live in the same `Memory`; stack operations and threaded dispatch
+//! are expressed strictly as reads and writes against that memory.
 
 pub mod address;
 pub mod cell;
@@ -24,6 +24,53 @@ pub const DATA_STACK_END: Address = Address::new(0x0100);
 pub const DEFAULT_RETURN_STACK_START: Address = Address::new(0x0200);
 pub const DEFAULT_RETURN_STACK_END: Address = Address::new(0x0300);
 const PAGE_ONE_END: Address = Address::new(0x0200);
+const NO_IP: Address = Address::new(0xffff);
+
+pub const CODE_TOKEN_PRIMITIVE: Cell = Cell::new(0x0001);
+
+/// Result of one `tbx16` execution entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExecutionOutcome {
+    Halted,
+    Returned,
+    Trapped(Tbx16Error),
+}
+
+/// Primitive registry for the M2.2a threaded kernel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u16)]
+pub enum PrimitiveId {
+    Lit = 1,
+    Branch = 2,
+    ZBranch = 3,
+    Halt = 4,
+}
+
+impl PrimitiveId {
+    pub const fn as_cell(self) -> Cell {
+        Cell::new(self as u16)
+    }
+}
+
+impl TryFrom<Cell> for PrimitiveId {
+    type Error = ();
+
+    fn try_from(value: Cell) -> Result<Self, Self::Error> {
+        match value.raw() {
+            1 => Ok(Self::Lit),
+            2 => Ok(Self::Branch),
+            3 => Ok(Self::ZBranch),
+            4 => Ok(Self::Halt),
+            _ => Err(()),
+        }
+    }
+}
+
+/// Resolved word metadata for the shared XT namespace.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResolvedWord {
+    Primitive(PrimitiveId),
+}
 
 /// tbx16 VM substrate with unified memory and byte-addressed registers.
 #[derive(Debug)]
@@ -32,6 +79,8 @@ pub struct Tbx16Vm {
     registers: Registers,
     data_stack_region: StackRegion,
     return_stack_region: StackRegion,
+    step_limit: Option<usize>,
+    step_counter: usize,
 }
 
 impl Default for Tbx16Vm {
@@ -72,6 +121,8 @@ impl Tbx16Vm {
             registers,
             data_stack_region,
             return_stack_region,
+            step_limit: None,
+            step_counter: 0,
         };
         vm.validate_invariants()?;
         Ok(vm)
@@ -90,9 +141,7 @@ impl Tbx16Vm {
     }
 
     pub fn set_instruction_pointer(&mut self, ip: Address) -> Result<(), Tbx16Error> {
-        if usize::from(ip.get()) >= memory::MEMORY_SIZE {
-            return Err(Tbx16Error::InstructionPointerOutOfRange { ip });
-        }
+        validate_instruction_pointer_target(ip)?;
         self.registers.ip = Some(ip);
         Ok(())
     }
@@ -103,6 +152,37 @@ impl Tbx16Vm {
 
     pub fn return_stack_region(&self) -> StackRegion {
         self.return_stack_region
+    }
+
+    pub fn set_step_limit(&mut self, step_limit: Option<usize>) {
+        self.step_limit = step_limit;
+    }
+
+    pub fn step_counter(&self) -> usize {
+        self.step_counter
+    }
+
+    pub fn resolve_xt(&self, xt: Cell) -> Result<ResolvedWord, Tbx16Error> {
+        let xt_addr = validate_execution_token_address(xt)?;
+        let code_token = self
+            .memory
+            .read_cell(xt_addr)
+            .map_err(|_| invalid_execution_token(xt))?;
+
+        if code_token != CODE_TOKEN_PRIMITIVE {
+            return Err(invalid_execution_token(xt));
+        }
+
+        let primitive_id_addr = xt_addr
+            .checked_add(2)
+            .ok_or_else(|| invalid_execution_token(xt))?;
+        let primitive_id = self
+            .memory
+            .read_cell(primitive_id_addr)
+            .map_err(|_| invalid_execution_token(xt))?;
+        let primitive =
+            PrimitiveId::try_from(primitive_id).map_err(|_| invalid_execution_token(xt))?;
+        Ok(ResolvedWord::Primitive(primitive))
     }
 
     pub fn data_slot_address(&self, slot_index: u16) -> Result<Address, Tbx16Error> {
@@ -231,9 +311,44 @@ impl Tbx16Vm {
         })
     }
 
+    pub fn run(&mut self, entry_xt: Cell) -> ExecutionOutcome {
+        self.step_counter = 0;
+
+        let outcome = (|| -> Result<ExecutionOutcome, Tbx16Error> {
+            self.begin_step()?;
+            let ResolvedWord::Primitive(primitive) = self.resolve_xt(entry_xt)?;
+            self.step_counter += 1;
+            self.execute_entry_primitive(primitive)
+        })();
+
+        match outcome {
+            Ok(outcome) => outcome,
+            Err(err) => ExecutionOutcome::Trapped(err),
+        }
+    }
+
+    pub fn run_threaded(&mut self, start_ip: Address) -> ExecutionOutcome {
+        self.step_counter = 0;
+        if let Err(err) = self.set_instruction_pointer(start_ip) {
+            return ExecutionOutcome::Trapped(err);
+        }
+
+        loop {
+            let step = self.dispatch_step();
+            match step {
+                Ok(Some(outcome)) => return outcome,
+                Ok(None) => {}
+                Err(err) => return ExecutionOutcome::Trapped(err),
+            }
+        }
+    }
+
     pub fn validate_invariants(&self) -> Result<(), Tbx16Error> {
         ensure_pointer_in_region(self.registers.dsp, self.data_stack_region, "data")?;
         ensure_pointer_in_region(self.registers.rsp, self.return_stack_region, "return")?;
+        if let Some(ip) = self.registers.ip {
+            validate_instruction_pointer_target(ip)?;
+        }
         if !self.data_stack_region.contains_pointer(self.registers.bp) {
             return Err(Tbx16Error::InvalidStackRegion {
                 start: self.data_stack_region.start(),
@@ -247,6 +362,13 @@ impl Tbx16Vm {
                 addr: self.registers.bp,
             });
         }
+        if self.registers.bp > self.registers.dsp {
+            return Err(Tbx16Error::InvalidStackRegion {
+                start: self.data_stack_region.start(),
+                end: self.data_stack_region.end(),
+                reason: "base pointer must not exceed the data stack pointer",
+            });
+        }
         validate_return_stack_region(self.return_stack_region)?;
         if self.data_stack_region.overlaps(self.return_stack_region) {
             return Err(Tbx16Error::InvalidStackRegion {
@@ -254,6 +376,130 @@ impl Tbx16Vm {
                 end: self.return_stack_region.end(),
                 reason: "return stack region overlaps the fixed data stack region",
             });
+        }
+        Ok(())
+    }
+
+    fn execute_entry_primitive(
+        &mut self,
+        primitive: PrimitiveId,
+    ) -> Result<ExecutionOutcome, Tbx16Error> {
+        match primitive {
+            PrimitiveId::Halt => Ok(ExecutionOutcome::Halted),
+            PrimitiveId::Lit | PrimitiveId::Branch | PrimitiveId::ZBranch => {
+                self.execute_primitive(primitive)?;
+                Ok(ExecutionOutcome::Returned)
+            }
+        }
+    }
+
+    fn dispatch_step(&mut self) -> Result<Option<ExecutionOutcome>, Tbx16Error> {
+        self.begin_step()?;
+
+        let ip = self.current_ip()?;
+        let xt = self.read_ip_cell(ip)?;
+        let continuation_ip = validated_successor_ip(ip)?;
+        self.step_counter += 1;
+
+        let ResolvedWord::Primitive(primitive) = self.resolve_xt(xt)?;
+        self.registers.ip = Some(ip);
+        self.execute_primitive_from_dispatch(primitive, continuation_ip)
+    }
+
+    fn execute_primitive_from_dispatch(
+        &mut self,
+        primitive: PrimitiveId,
+        continuation_ip: Address,
+    ) -> Result<Option<ExecutionOutcome>, Tbx16Error> {
+        match primitive {
+            PrimitiveId::Halt => {
+                self.registers.ip = Some(continuation_ip);
+                Ok(Some(ExecutionOutcome::Halted))
+            }
+            PrimitiveId::Lit => {
+                self.execute_lit_from_operand(continuation_ip)?;
+                Ok(None)
+            }
+            PrimitiveId::Branch => {
+                self.execute_branch_from_operand(continuation_ip)?;
+                Ok(None)
+            }
+            PrimitiveId::ZBranch => {
+                self.execute_zbranch_from_operand(continuation_ip)?;
+                Ok(None)
+            }
+        }
+    }
+
+    fn execute_primitive(&mut self, primitive: PrimitiveId) -> Result<(), Tbx16Error> {
+        match primitive {
+            PrimitiveId::Lit => self.execute_lit_from_operand(self.current_ip()?),
+            PrimitiveId::Branch => self.execute_branch_from_operand(self.current_ip()?),
+            PrimitiveId::ZBranch => self.execute_zbranch_from_operand(self.current_ip()?),
+            PrimitiveId::Halt => Ok(()),
+        }
+    }
+
+    fn execute_lit_from_operand(&mut self, operand_ip: Address) -> Result<(), Tbx16Error> {
+        let literal = self.read_ip_cell(operand_ip)?;
+        let next_ip = validated_successor_ip(operand_ip)?;
+        self.ensure_data_stack_pushable(self.registers.dsp)?;
+        self.push_data_cell(literal)?;
+        self.registers.ip = Some(next_ip);
+        Ok(())
+    }
+
+    fn execute_branch_from_operand(&mut self, operand_ip: Address) -> Result<(), Tbx16Error> {
+        let target = self.read_ip_cell(operand_ip)?;
+        let target_ip = validate_instruction_pointer_target(Address::new(target.raw()))?;
+        self.registers.ip = Some(target_ip);
+        Ok(())
+    }
+
+    fn execute_zbranch_from_operand(&mut self, operand_ip: Address) -> Result<(), Tbx16Error> {
+        let target = self.read_ip_cell(operand_ip)?;
+        let target_ip = validate_instruction_pointer_target(Address::new(target.raw()))?;
+        let condition = self.peek_data_cell(0)?;
+        let fallthrough_ip = validated_successor_ip(operand_ip)?;
+        self.pop_data_cell()?;
+        self.registers.ip = Some(if condition.raw() == 0 {
+            target_ip
+        } else {
+            fallthrough_ip
+        });
+        Ok(())
+    }
+
+    fn begin_step(&self) -> Result<(), Tbx16Error> {
+        if self
+            .step_limit
+            .is_some_and(|limit| self.step_counter >= limit)
+        {
+            return Err(Tbx16Error::StepLimitExceeded);
+        }
+        Ok(())
+    }
+
+    fn current_ip(&self) -> Result<Address, Tbx16Error> {
+        let ip = self
+            .registers
+            .ip
+            .ok_or(Tbx16Error::InstructionPointerOutOfRange { ip: NO_IP })?;
+        validate_instruction_pointer_target(ip)
+    }
+
+    fn read_ip_cell(&self, ip: Address) -> Result<Cell, Tbx16Error> {
+        validate_instruction_pointer_target(ip)?;
+        self.memory.read_cell(ip)
+    }
+
+    fn ensure_data_stack_pushable(&self, pointer: Address) -> Result<(), Tbx16Error> {
+        let next = pointer
+            .checked_add(2)
+            .ok_or(Tbx16Error::DataStackOverflow)?;
+        ensure_pointer_in_region(pointer, self.data_stack_region, "data")?;
+        if !self.data_stack_region.contains_pointer(next) {
+            return Err(Tbx16Error::DataStackOverflow);
         }
         Ok(())
     }
@@ -275,4 +521,30 @@ fn validate_return_stack_region(region: StackRegion) -> Result<(), Tbx16Error> {
         });
     }
     Ok(())
+}
+
+fn validate_execution_token_address(xt: Cell) -> Result<Address, Tbx16Error> {
+    let xt_addr = Address::new(xt.raw());
+    if xt_addr.get() == NO_IP.get() || !xt_addr.is_even() {
+        return Err(invalid_execution_token(xt));
+    }
+    Ok(xt_addr)
+}
+
+fn validate_instruction_pointer_target(ip: Address) -> Result<Address, Tbx16Error> {
+    if ip.get() == NO_IP.get() || !ip.is_even() {
+        return Err(Tbx16Error::InstructionPointerOutOfRange { ip });
+    }
+    Ok(ip)
+}
+
+fn validated_successor_ip(ip: Address) -> Result<Address, Tbx16Error> {
+    let next_ip = ip
+        .checked_add(2)
+        .ok_or(Tbx16Error::InstructionPointerOutOfRange { ip })?;
+    validate_instruction_pointer_target(next_ip)
+}
+
+fn invalid_execution_token(xt: Cell) -> Tbx16Error {
+    Tbx16Error::InvalidExecutionToken { xt }
 }

--- a/tests/tbx16.rs
+++ b/tests/tbx16.rs
@@ -1,11 +1,100 @@
+use std::collections::HashMap;
+
 use tbx::tbx16::address::Address;
 use tbx::tbx16::cell::Cell;
 use tbx::tbx16::error::Tbx16Error;
 use tbx::tbx16::memory::MEMORY_SIZE;
 use tbx::tbx16::stack::{ReturnFrame, StackRegion};
 use tbx::tbx16::{
-    Tbx16Vm, DATA_STACK_END, DATA_STACK_START, DEFAULT_RETURN_STACK_END, DEFAULT_RETURN_STACK_START,
+    ExecutionOutcome, PrimitiveId, ResolvedWord, Tbx16Vm, CODE_TOKEN_PRIMITIVE, DATA_STACK_END,
+    DATA_STACK_START, DEFAULT_RETURN_STACK_END, DEFAULT_RETURN_STACK_START,
 };
+
+const CODE_START: u16 = 0x0400;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct VmSnapshot {
+    ip: Option<Address>,
+    dsp: Address,
+    step_counter: usize,
+    memory: Vec<u8>,
+}
+
+fn snapshot(vm: &Tbx16Vm) -> VmSnapshot {
+    VmSnapshot {
+        ip: vm.registers().ip,
+        dsp: vm.registers().dsp,
+        step_counter: vm.step_counter(),
+        memory: vm.memory().as_bytes().to_vec(),
+    }
+}
+
+enum PendingCell {
+    Raw(Cell),
+    Label(&'static str),
+}
+
+struct ImageBuilder {
+    cursor: Address,
+    cells: Vec<(Address, PendingCell)>,
+    labels: HashMap<&'static str, Address>,
+}
+
+impl ImageBuilder {
+    fn new(start: u16) -> Self {
+        Self {
+            cursor: Address::new(start),
+            cells: Vec::new(),
+            labels: HashMap::new(),
+        }
+    }
+
+    fn primitive(&mut self, primitive: PrimitiveId) -> Cell {
+        let xt = Cell::new(self.cursor.get());
+        self.emit_cell(CODE_TOKEN_PRIMITIVE);
+        self.emit_cell(primitive.as_cell());
+        xt
+    }
+
+    fn emit_xt(&mut self, xt: Cell) {
+        self.emit_cell(xt);
+    }
+
+    fn emit_cell(&mut self, cell: Cell) {
+        let addr = self.cursor;
+        self.cells.push((addr, PendingCell::Raw(cell)));
+        self.cursor = self
+            .cursor
+            .checked_add(2)
+            .expect("test image stays within 64 KiB");
+    }
+
+    fn emit_label_ref(&mut self, label: &'static str) {
+        let addr = self.cursor;
+        self.cells.push((addr, PendingCell::Label(label)));
+        self.cursor = self
+            .cursor
+            .checked_add(2)
+            .expect("test image stays within 64 KiB");
+    }
+
+    fn mark_label(&mut self, label: &'static str) {
+        self.labels.insert(label, self.cursor);
+    }
+
+    fn load_into(self, vm: &mut Tbx16Vm) {
+        for (addr, pending) in self.cells {
+            let cell = match pending {
+                PendingCell::Raw(cell) => cell,
+                PendingCell::Label(label) => {
+                    let target = self.labels.get(label).expect("label must be defined");
+                    Cell::new(target.get())
+                }
+            };
+            vm.memory_mut().write_cell(addr, cell).unwrap();
+        }
+    }
+}
 
 #[test]
 fn cell_reinterprets_u16_and_i16_bits() {
@@ -309,4 +398,428 @@ fn bp_slot_addresses_use_two_byte_steps() {
     assert_eq!(vm.data_slot_address(0).unwrap(), Address::new(0x0080));
     assert_eq!(vm.data_slot_address(1).unwrap(), Address::new(0x0082));
     assert_eq!(vm.data_slot_address(5).unwrap(), Address::new(0x008a));
+}
+
+#[test]
+fn primitive_xt_resolve_returns_registered_primitive_metadata() {
+    let mut vm = Tbx16Vm::default();
+    let mut image = ImageBuilder::new(CODE_START);
+    let halt_xt = image.primitive(PrimitiveId::Halt);
+    image.load_into(&mut vm);
+
+    assert_eq!(
+        vm.resolve_xt(halt_xt).unwrap(),
+        ResolvedWord::Primitive(PrimitiveId::Halt)
+    );
+}
+
+#[test]
+fn invalid_xts_and_malformed_primitive_words_trap() {
+    let mut vm = Tbx16Vm::default();
+    vm.memory_mut()
+        .write_cell(Address::new(CODE_START), Cell::new(0x9999))
+        .unwrap();
+    vm.memory_mut()
+        .write_cell(Address::new(0xfffe), CODE_TOKEN_PRIMITIVE)
+        .unwrap();
+    vm.memory_mut()
+        .write_cell(Address::new(CODE_START + 4), CODE_TOKEN_PRIMITIVE)
+        .unwrap();
+    vm.memory_mut()
+        .write_cell(Address::new(CODE_START + 6), Cell::new(0x9999))
+        .unwrap();
+
+    assert_eq!(
+        vm.resolve_xt(Cell::new(CODE_START)).unwrap_err(),
+        Tbx16Error::InvalidExecutionToken {
+            xt: Cell::new(CODE_START),
+        }
+    );
+    assert_eq!(
+        vm.resolve_xt(Cell::new(CODE_START + 1)).unwrap_err(),
+        Tbx16Error::InvalidExecutionToken {
+            xt: Cell::new(CODE_START + 1),
+        }
+    );
+    assert_eq!(
+        vm.resolve_xt(Cell::new(0xffff)).unwrap_err(),
+        Tbx16Error::InvalidExecutionToken {
+            xt: Cell::new(0xffff),
+        }
+    );
+    assert_eq!(
+        vm.resolve_xt(Cell::new(0xfffe)).unwrap_err(),
+        Tbx16Error::InvalidExecutionToken {
+            xt: Cell::new(0xfffe),
+        }
+    );
+    assert_eq!(
+        vm.resolve_xt(Cell::new(CODE_START + 4)).unwrap_err(),
+        Tbx16Error::InvalidExecutionToken {
+            xt: Cell::new(CODE_START + 4),
+        }
+    );
+}
+
+#[test]
+fn threaded_lit_branch_and_zbranch_execute_handwritten_code() {
+    let mut forward_vm = Tbx16Vm::default();
+    let mut forward = ImageBuilder::new(CODE_START);
+    let lit_xt = forward.primitive(PrimitiveId::Lit);
+    let branch_xt = forward.primitive(PrimitiveId::Branch);
+    let halt_xt = forward.primitive(PrimitiveId::Halt);
+    forward.mark_label("start");
+    forward.emit_xt(branch_xt);
+    forward.emit_label_ref("target");
+    forward.emit_xt(lit_xt);
+    forward.emit_cell(Cell::new(0xdead));
+    forward.mark_label("target");
+    forward.emit_xt(lit_xt);
+    forward.emit_cell(Cell::new(0x1234));
+    forward.emit_xt(halt_xt);
+    forward.load_into(&mut forward_vm);
+    assert_eq!(
+        forward_vm.run_threaded(Address::new(CODE_START + 12)),
+        ExecutionOutcome::Halted
+    );
+    assert_eq!(forward_vm.peek_data_cell(0).unwrap(), Cell::new(0x1234));
+
+    let mut backward_vm = Tbx16Vm::default();
+    let mut backward = ImageBuilder::new(CODE_START);
+    let lit_xt = backward.primitive(PrimitiveId::Lit);
+    let branch_xt = backward.primitive(PrimitiveId::Branch);
+    let halt_xt = backward.primitive(PrimitiveId::Halt);
+    backward.mark_label("target");
+    backward.emit_xt(lit_xt);
+    backward.emit_cell(Cell::new(0x5678));
+    backward.emit_xt(halt_xt);
+    backward.mark_label("start");
+    backward.emit_xt(branch_xt);
+    backward.emit_label_ref("target");
+    backward.load_into(&mut backward_vm);
+    assert_eq!(
+        backward_vm.run_threaded(Address::new(CODE_START + 18)),
+        ExecutionOutcome::Halted
+    );
+    assert_eq!(backward_vm.peek_data_cell(0).unwrap(), Cell::new(0x5678));
+
+    let mut zero_vm = Tbx16Vm::default();
+    let mut zero = ImageBuilder::new(CODE_START);
+    let lit_xt = zero.primitive(PrimitiveId::Lit);
+    let zbranch_xt = zero.primitive(PrimitiveId::ZBranch);
+    let halt_xt = zero.primitive(PrimitiveId::Halt);
+    zero.mark_label("start");
+    zero.emit_xt(lit_xt);
+    zero.emit_cell(Cell::new(0));
+    zero.emit_xt(zbranch_xt);
+    zero.emit_label_ref("target");
+    zero.emit_xt(lit_xt);
+    zero.emit_cell(Cell::new(0x9999));
+    zero.mark_label("target");
+    zero.emit_xt(lit_xt);
+    zero.emit_cell(Cell::new(0x2222));
+    zero.emit_xt(halt_xt);
+    zero.load_into(&mut zero_vm);
+    assert_eq!(
+        zero_vm.run_threaded(Address::new(CODE_START + 12)),
+        ExecutionOutcome::Halted
+    );
+    assert_eq!(zero_vm.peek_data_cell(0).unwrap(), Cell::new(0x2222));
+
+    let mut nonzero_vm = Tbx16Vm::default();
+    let mut nonzero = ImageBuilder::new(CODE_START);
+    let lit_xt = nonzero.primitive(PrimitiveId::Lit);
+    let zbranch_xt = nonzero.primitive(PrimitiveId::ZBranch);
+    let halt_xt = nonzero.primitive(PrimitiveId::Halt);
+    nonzero.mark_label("start");
+    nonzero.emit_xt(lit_xt);
+    nonzero.emit_cell(Cell::new(1));
+    nonzero.emit_xt(zbranch_xt);
+    nonzero.emit_label_ref("target");
+    nonzero.emit_xt(lit_xt);
+    nonzero.emit_cell(Cell::new(0x3333));
+    nonzero.emit_xt(halt_xt);
+    nonzero.mark_label("target");
+    nonzero.emit_xt(lit_xt);
+    nonzero.emit_cell(Cell::new(0x4444));
+    nonzero.emit_xt(halt_xt);
+    nonzero.load_into(&mut nonzero_vm);
+    assert_eq!(
+        nonzero_vm.run_threaded(Address::new(CODE_START + 12)),
+        ExecutionOutcome::Halted
+    );
+    assert_eq!(nonzero_vm.peek_data_cell(0).unwrap(), Cell::new(0x3333));
+}
+
+#[test]
+fn entry_primitives_execute_with_normal_primitive_semantics_once() {
+    let mut lit_vm = Tbx16Vm::default();
+    let mut lit_image = ImageBuilder::new(CODE_START);
+    let lit_xt = lit_image.primitive(PrimitiveId::Lit);
+    lit_image.emit_cell(Cell::new(0x4321));
+    lit_image.load_into(&mut lit_vm);
+    lit_vm
+        .set_instruction_pointer(Address::new(CODE_START + 4))
+        .unwrap();
+    assert_eq!(lit_vm.run(lit_xt), ExecutionOutcome::Returned);
+    assert_eq!(lit_vm.peek_data_cell(0).unwrap(), Cell::new(0x4321));
+
+    let mut branch_vm = Tbx16Vm::default();
+    let mut branch_image = ImageBuilder::new(CODE_START);
+    let branch_xt = branch_image.primitive(PrimitiveId::Branch);
+    branch_image.emit_cell(Cell::new(0x0410));
+    branch_image.load_into(&mut branch_vm);
+    branch_vm
+        .set_instruction_pointer(Address::new(CODE_START + 4))
+        .unwrap();
+    assert_eq!(branch_vm.run(branch_xt), ExecutionOutcome::Returned);
+    assert_eq!(branch_vm.registers().ip, Some(Address::new(0x0410)));
+
+    let mut zbranch_vm = Tbx16Vm::default();
+    let mut zbranch_image = ImageBuilder::new(CODE_START);
+    let zbranch_xt = zbranch_image.primitive(PrimitiveId::ZBranch);
+    zbranch_image.emit_cell(Cell::new(0x0412));
+    zbranch_image.load_into(&mut zbranch_vm);
+    zbranch_vm
+        .set_instruction_pointer(Address::new(CODE_START + 4))
+        .unwrap();
+    zbranch_vm.push_data_cell(Cell::new(0)).unwrap();
+    assert_eq!(zbranch_vm.run(zbranch_xt), ExecutionOutcome::Returned);
+    assert_eq!(zbranch_vm.registers().ip, Some(Address::new(0x0412)));
+
+    let mut halt_vm = Tbx16Vm::default();
+    let mut halt_image = ImageBuilder::new(CODE_START);
+    let halt_xt = halt_image.primitive(PrimitiveId::Halt);
+    halt_image.load_into(&mut halt_vm);
+    assert_eq!(halt_vm.run(halt_xt), ExecutionOutcome::Halted);
+}
+
+#[test]
+fn entry_primitives_trap_when_required_context_is_missing() {
+    let mut lit_vm = Tbx16Vm::default();
+    let mut lit_image = ImageBuilder::new(CODE_START);
+    let lit_xt = lit_image.primitive(PrimitiveId::Lit);
+    lit_image.load_into(&mut lit_vm);
+    assert_eq!(
+        lit_vm.run(lit_xt),
+        ExecutionOutcome::Trapped(Tbx16Error::InstructionPointerOutOfRange {
+            ip: Address::new(0xffff),
+        })
+    );
+
+    let mut zbranch_vm = Tbx16Vm::default();
+    let mut zbranch_image = ImageBuilder::new(CODE_START);
+    let zbranch_xt = zbranch_image.primitive(PrimitiveId::ZBranch);
+    zbranch_image.emit_cell(Cell::new(0x0410));
+    zbranch_image.load_into(&mut zbranch_vm);
+    zbranch_vm
+        .set_instruction_pointer(Address::new(CODE_START + 4))
+        .unwrap();
+    assert_eq!(
+        zbranch_vm.run(zbranch_xt),
+        ExecutionOutcome::Trapped(Tbx16Error::DataStackUnderflow)
+    );
+}
+
+#[test]
+fn invalid_branch_targets_trap_for_threaded_and_entry_execution() {
+    let mut odd_vm = Tbx16Vm::default();
+    let mut odd_image = ImageBuilder::new(CODE_START);
+    let branch_xt = odd_image.primitive(PrimitiveId::Branch);
+    odd_image.mark_label("start");
+    odd_image.emit_xt(branch_xt);
+    odd_image.emit_cell(Cell::new(0x0401));
+    odd_image.load_into(&mut odd_vm);
+    assert_eq!(
+        odd_vm.run_threaded(Address::new(CODE_START + 4)),
+        ExecutionOutcome::Trapped(Tbx16Error::InstructionPointerOutOfRange {
+            ip: Address::new(0x0401),
+        })
+    );
+
+    let mut ffff_vm = Tbx16Vm::default();
+    let mut ffff_image = ImageBuilder::new(CODE_START);
+    let branch_xt = ffff_image.primitive(PrimitiveId::Branch);
+    ffff_image.emit_cell(Cell::new(0xffff));
+    ffff_image.load_into(&mut ffff_vm);
+    ffff_vm
+        .set_instruction_pointer(Address::new(CODE_START + 4))
+        .unwrap();
+    assert_eq!(
+        ffff_vm.run(branch_xt),
+        ExecutionOutcome::Trapped(Tbx16Error::InstructionPointerOutOfRange {
+            ip: Address::new(0xffff),
+        })
+    );
+}
+
+#[test]
+fn step_limit_stops_before_the_next_threaded_dispatch() {
+    let mut limited_vm = Tbx16Vm::default();
+    let mut image = ImageBuilder::new(CODE_START);
+    let lit_xt = image.primitive(PrimitiveId::Lit);
+    let halt_xt = image.primitive(PrimitiveId::Halt);
+    image.mark_label("start");
+    image.emit_xt(lit_xt);
+    image.emit_cell(Cell::new(0x1111));
+    image.emit_xt(halt_xt);
+    image.load_into(&mut limited_vm);
+
+    limited_vm.set_step_limit(Some(1));
+    assert_eq!(
+        limited_vm.run_threaded(Address::new(CODE_START + 8)),
+        ExecutionOutcome::Trapped(Tbx16Error::StepLimitExceeded)
+    );
+    assert_eq!(limited_vm.step_counter(), 1);
+    assert_eq!(
+        limited_vm.registers().ip,
+        Some(Address::new(CODE_START + 12))
+    );
+
+    let mut ok_vm = Tbx16Vm::default();
+    let mut ok_image = ImageBuilder::new(CODE_START);
+    let lit_xt = ok_image.primitive(PrimitiveId::Lit);
+    let halt_xt = ok_image.primitive(PrimitiveId::Halt);
+    ok_image.emit_xt(lit_xt);
+    ok_image.emit_cell(Cell::new(0x1111));
+    ok_image.emit_xt(halt_xt);
+    ok_image.load_into(&mut ok_vm);
+    ok_vm.set_step_limit(Some(2));
+    assert_eq!(
+        ok_vm.run_threaded(Address::new(CODE_START + 8)),
+        ExecutionOutcome::Halted
+    );
+    assert_eq!(ok_vm.step_counter(), 2);
+}
+
+#[test]
+fn threaded_failures_after_fetch_still_increment_step_counter() {
+    let mut invalid_xt_vm = Tbx16Vm::default();
+    invalid_xt_vm
+        .memory_mut()
+        .write_cell(Address::new(CODE_START), Cell::new(0x9999))
+        .unwrap();
+    assert_eq!(
+        invalid_xt_vm.run_threaded(Address::new(CODE_START)),
+        ExecutionOutcome::Trapped(Tbx16Error::InvalidExecutionToken {
+            xt: Cell::new(0x9999),
+        })
+    );
+    assert_eq!(invalid_xt_vm.step_counter(), 1);
+
+    let mut lit_vm = Tbx16Vm::default();
+    let mut lit_image = ImageBuilder::new(CODE_START);
+    let lit_xt = lit_image.primitive(PrimitiveId::Lit);
+    lit_image.emit_xt(lit_xt);
+    lit_image.emit_cell(Cell::new(0x1111));
+    lit_image.load_into(&mut lit_vm);
+    for i in 0..64u16 {
+        lit_vm.push_data_cell(Cell::new(i)).unwrap();
+    }
+    assert_eq!(
+        lit_vm.run_threaded(Address::new(CODE_START + 4)),
+        ExecutionOutcome::Trapped(Tbx16Error::DataStackOverflow)
+    );
+    assert_eq!(lit_vm.step_counter(), 1);
+
+    let mut zbranch_vm = Tbx16Vm::default();
+    let mut zbranch_image = ImageBuilder::new(CODE_START);
+    let zbranch_xt = zbranch_image.primitive(PrimitiveId::ZBranch);
+    zbranch_image.emit_xt(zbranch_xt);
+    zbranch_image.emit_cell(Cell::new(0x0410));
+    zbranch_image.load_into(&mut zbranch_vm);
+    assert_eq!(
+        zbranch_vm.run_threaded(Address::new(CODE_START + 4)),
+        ExecutionOutcome::Trapped(Tbx16Error::DataStackUnderflow)
+    );
+    assert_eq!(zbranch_vm.step_counter(), 1);
+}
+
+#[test]
+fn threaded_atomic_failures_preserve_ip_stack_and_memory() {
+    let mut invalid_xt_vm = Tbx16Vm::default();
+    invalid_xt_vm
+        .memory_mut()
+        .write_cell(Address::new(CODE_START), Cell::new(0x9999))
+        .unwrap();
+    invalid_xt_vm
+        .set_instruction_pointer(Address::new(CODE_START))
+        .unwrap();
+    let before = snapshot(&invalid_xt_vm);
+    assert_eq!(
+        invalid_xt_vm.run_threaded(Address::new(CODE_START)),
+        ExecutionOutcome::Trapped(Tbx16Error::InvalidExecutionToken {
+            xt: Cell::new(0x9999),
+        })
+    );
+    let after = snapshot(&invalid_xt_vm);
+    assert_eq!(after.ip, before.ip);
+    assert_eq!(after.dsp, before.dsp);
+    assert_eq!(after.memory, before.memory);
+    assert_eq!(after.step_counter, 1);
+
+    let mut lit_vm = Tbx16Vm::default();
+    let mut lit_image = ImageBuilder::new(CODE_START);
+    let lit_xt = lit_image.primitive(PrimitiveId::Lit);
+    lit_image.emit_xt(lit_xt);
+    lit_image.emit_cell(Cell::new(0x5555));
+    lit_image.load_into(&mut lit_vm);
+    for i in 0..64u16 {
+        lit_vm.push_data_cell(Cell::new(i)).unwrap();
+    }
+    lit_vm
+        .set_instruction_pointer(Address::new(CODE_START + 4))
+        .unwrap();
+    let before = snapshot(&lit_vm);
+    assert_eq!(
+        lit_vm.run_threaded(Address::new(CODE_START + 4)),
+        ExecutionOutcome::Trapped(Tbx16Error::DataStackOverflow)
+    );
+    let after = snapshot(&lit_vm);
+    assert_eq!(after.ip, before.ip);
+    assert_eq!(after.dsp, before.dsp);
+    assert_eq!(after.memory, before.memory);
+    assert_eq!(after.step_counter, 1);
+
+    let mut branch_vm = Tbx16Vm::default();
+    let mut branch_image = ImageBuilder::new(CODE_START);
+    let branch_xt = branch_image.primitive(PrimitiveId::Branch);
+    branch_image.emit_xt(branch_xt);
+    branch_image.emit_cell(Cell::new(0xffff));
+    branch_image.load_into(&mut branch_vm);
+    branch_vm
+        .set_instruction_pointer(Address::new(CODE_START + 4))
+        .unwrap();
+    let before = snapshot(&branch_vm);
+    assert_eq!(
+        branch_vm.run_threaded(Address::new(CODE_START + 4)),
+        ExecutionOutcome::Trapped(Tbx16Error::InstructionPointerOutOfRange {
+            ip: Address::new(0xffff),
+        })
+    );
+    let after = snapshot(&branch_vm);
+    assert_eq!(after.ip, before.ip);
+    assert_eq!(after.dsp, before.dsp);
+    assert_eq!(after.memory, before.memory);
+    assert_eq!(after.step_counter, 1);
+
+    let mut zbranch_vm = Tbx16Vm::default();
+    let mut zbranch_image = ImageBuilder::new(CODE_START);
+    let zbranch_xt = zbranch_image.primitive(PrimitiveId::ZBranch);
+    zbranch_image.emit_xt(zbranch_xt);
+    zbranch_image.emit_cell(Cell::new(0x0410));
+    zbranch_image.load_into(&mut zbranch_vm);
+    zbranch_vm
+        .set_instruction_pointer(Address::new(CODE_START + 4))
+        .unwrap();
+    let before = snapshot(&zbranch_vm);
+    assert_eq!(
+        zbranch_vm.run_threaded(Address::new(CODE_START + 4)),
+        ExecutionOutcome::Trapped(Tbx16Error::DataStackUnderflow)
+    );
+    let after = snapshot(&zbranch_vm);
+    assert_eq!(after.ip, before.ip);
+    assert_eq!(after.dsp, before.dsp);
+    assert_eq!(after.memory, before.memory);
+    assert_eq!(after.step_counter, 1);
 }


### PR DESCRIPTION
## 概要

Closes #1003

tbx16 の M2.2a 範囲として、primitive word の XT 解決、hand-written threaded code を実行する dispatch 核、entry primitive 実行、`LIT` / `BRANCH` / `ZBRANCH` / `HALT`、step limit を実装しました。

## 変更内容

- `tbx16` に `CODE_TOKEN_PRIMITIVE`、`PrimitiveId`、`ResolvedWord`、`ExecutionOutcome` を追加
- primitive word layout から XT を解決する `resolve_xt` を追加し、odd XT / `$ffff` / unknown code token / malformed metadata を `InvalidExecutionToken` に統一
- `run_threaded` と entry primitive 用 `run` を追加し、step counter / step limit 契約を実装
- `LIT` / `BRANCH` / `ZBRANCH` の失敗時に `IP` / `DSP` / memory を変更しないよう、dispatch 更新順を原子化
- `tests/tbx16.rs` に threaded 実行、entry primitive、step limit、trap 時 step 計上、原子性の回帰テストを追加

## 確認

- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo fmt --check`
