### PR TITLE
tbx16: EXIT・return・実行状態管理を実装

### DIFF
--- a/src/tbx16/error.rs
+++ b/src/tbx16/error.rs
@@ -10,6 +10,9 @@ pub enum Tbx16Error {
     DataStackOverflow,
     ReturnStackUnderflow,
     ReturnStackOverflow,
+    InvalidReturnCount {
+        count: Cell,
+    },
     StepLimitExceeded,
     InvalidMemoryAccess {
         addr: Address,
@@ -28,6 +31,8 @@ pub enum Tbx16Error {
     InvalidExecutionToken {
         xt: Cell,
     },
+    InvalidExecutionState,
+    DirtyExecutionState,
     InstructionPointerOutOfRange {
         ip: Address,
     },
@@ -43,6 +48,9 @@ impl fmt::Display for Tbx16Error {
             Tbx16Error::DataStackOverflow => write!(f, "data stack overflow"),
             Tbx16Error::ReturnStackUnderflow => write!(f, "return stack underflow"),
             Tbx16Error::ReturnStackOverflow => write!(f, "return stack overflow"),
+            Tbx16Error::InvalidReturnCount { count } => {
+                write!(f, "invalid return count ${:04x}", count.raw())
+            }
             Tbx16Error::StepLimitExceeded => write!(f, "step limit exceeded"),
             Tbx16Error::InvalidMemoryAccess { addr, operation } => {
                 write!(f, "invalid memory access during {operation} at {addr}")
@@ -57,6 +65,8 @@ impl fmt::Display for Tbx16Error {
             Tbx16Error::InvalidExecutionToken { xt } => {
                 write!(f, "invalid execution token ${:04x}", xt.raw())
             }
+            Tbx16Error::InvalidExecutionState => write!(f, "invalid execution state"),
+            Tbx16Error::DirtyExecutionState => write!(f, "dirty execution state"),
             Tbx16Error::InstructionPointerOutOfRange { ip } => {
                 write!(f, "instruction pointer out of range at {ip}")
             }

--- a/src/tbx16/mod.rs
+++ b/src/tbx16/mod.rs
@@ -46,6 +46,7 @@ pub enum PrimitiveId {
     Branch = 2,
     ZBranch = 3,
     Halt = 4,
+    Exit = 5,
 }
 
 impl PrimitiveId {
@@ -63,6 +64,7 @@ impl TryFrom<Cell> for PrimitiveId {
             2 => Ok(Self::Branch),
             3 => Ok(Self::ZBranch),
             4 => Ok(Self::Halt),
+            5 => Ok(Self::Exit),
             _ => Err(()),
         }
     }
@@ -89,6 +91,13 @@ pub struct Tbx16Vm {
     step_limit: Option<usize>,
     step_counter: usize,
     call_depth: u16,
+    entry_context: Option<EntryContext>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct EntryContext {
+    initial_bp: Address,
+    frame_base: Address,
 }
 
 impl Default for Tbx16Vm {
@@ -132,6 +141,7 @@ impl Tbx16Vm {
             step_limit: None,
             step_counter: 0,
             call_depth: 0,
+            entry_context: None,
         };
         vm.validate_invariants()?;
         Ok(vm)
@@ -173,6 +183,22 @@ impl Tbx16Vm {
 
     pub fn call_depth(&self) -> u16 {
         self.call_depth
+    }
+
+    pub fn is_dirty_execution_state(&self) -> bool {
+        self.entry_context.is_some()
+            || self.call_depth != 0
+            || self.registers.rsp != self.return_stack_region.start()
+    }
+
+    pub fn reset_execution_state(&mut self) {
+        self.registers.ip = None;
+        self.registers.bp = DATA_STACK_START;
+        self.registers.rsp = self.return_stack_region.start();
+        self.call_depth = 0;
+        self.entry_context = None;
+        self.step_counter = 0;
+        self.debug_validate_state();
     }
 
     pub fn resolve_xt(&self, xt: Cell) -> Result<ResolvedWord, Tbx16Error> {
@@ -345,8 +371,11 @@ impl Tbx16Vm {
     }
 
     pub fn run(&mut self, entry_xt: Cell) -> ExecutionOutcome {
+        if self.is_dirty_execution_state() {
+            return ExecutionOutcome::Trapped(Tbx16Error::DirtyExecutionState);
+        }
+
         self.step_counter = 0;
-        self.call_depth = 0;
 
         let outcome = (|| -> Result<ExecutionOutcome, Tbx16Error> {
             match self.start_entry(entry_xt)? {
@@ -443,6 +472,7 @@ impl Tbx16Vm {
                 self.execute_primitive(primitive)?;
                 Ok(ExecutionOutcome::Returned)
             }
+            PrimitiveId::Exit => Err(Tbx16Error::InvalidExecutionState),
         }
     }
 
@@ -462,6 +492,7 @@ impl Tbx16Vm {
                 local_count,
                 parameter_ip,
             } => {
+                let initial_bp = self.registers.bp;
                 let frame_base = self.compute_frame_base(arity)?;
                 let locals_start = self.registers.dsp;
                 let new_dsp = self.checked_extend_data_stack(locals_start, local_count)?;
@@ -470,6 +501,10 @@ impl Tbx16Vm {
                     self.memory
                         .zero_range(locals_start, usize::from(local_count) * 2)?;
                 }
+                self.entry_context = Some(EntryContext {
+                    initial_bp,
+                    frame_base,
+                });
                 self.registers.bp = frame_base;
                 self.registers.dsp = new_dsp;
                 self.registers.ip = Some(parameter_ip);
@@ -530,6 +565,7 @@ impl Tbx16Vm {
                 self.execute_zbranch_from_operand(continuation_ip)?;
                 Ok(None)
             }
+            PrimitiveId::Exit => self.execute_exit_from_operand(continuation_ip),
         }
     }
 
@@ -539,6 +575,7 @@ impl Tbx16Vm {
             PrimitiveId::Branch => self.execute_branch_from_operand(self.current_ip()?),
             PrimitiveId::ZBranch => self.execute_zbranch_from_operand(self.current_ip()?),
             PrimitiveId::Halt => Ok(()),
+            PrimitiveId::Exit => Err(Tbx16Error::InvalidExecutionState),
         }
     }
 
@@ -680,6 +717,114 @@ impl Tbx16Vm {
             .call_depth
             .checked_add(1)
             .expect("call depth fits in configured return stack space");
+        Ok(())
+    }
+
+    fn execute_exit_from_operand(
+        &mut self,
+        operand_ip: Address,
+    ) -> Result<Option<ExecutionOutcome>, Tbx16Error> {
+        let return_count = self.read_return_count(operand_ip)?;
+        if self.call_depth > 0 {
+            self.commit_nested_exit(return_count)?;
+            return Ok(None);
+        }
+
+        let outcome = self.commit_top_level_exit(return_count)?;
+        Ok(Some(outcome))
+    }
+
+    fn read_return_count(&self, operand_ip: Address) -> Result<u16, Tbx16Error> {
+        let count = self.read_ip_cell(operand_ip)?;
+        match count.raw() {
+            0 | 1 => Ok(count.raw()),
+            _ => Err(Tbx16Error::InvalidReturnCount { count }),
+        }
+    }
+
+    fn read_exit_return_value(&self) -> Result<Cell, Tbx16Error> {
+        if self.registers.dsp <= self.registers.bp {
+            return Err(Tbx16Error::DataStackUnderflow);
+        }
+        self.peek_data_cell(0)
+    }
+
+    fn commit_nested_exit(&mut self, return_count: u16) -> Result<(), Tbx16Error> {
+        let return_value = if return_count == 1 {
+            Some(self.read_exit_return_value()?)
+        } else {
+            None
+        };
+        let frame = self.peek_return_frame()?;
+        let return_ip = validate_instruction_pointer_target(frame.return_ip)?;
+        self.validate_base_pointer(frame.caller_bp)?;
+
+        let new_dsp = if return_count == 0 {
+            self.registers.bp
+        } else {
+            self.checked_extend_data_stack(self.registers.bp, 1)?
+        };
+        if frame.caller_bp > new_dsp {
+            return Err(Tbx16Error::InvalidExecutionState);
+        }
+
+        if let Some(value) = return_value {
+            self.memory.write_cell(self.registers.bp, value)?;
+        }
+        self.registers.rsp = self
+            .registers
+            .rsp
+            .checked_sub(RETURN_FRAME_BYTES)
+            .ok_or(Tbx16Error::ReturnStackUnderflow)?;
+        self.registers.bp = frame.caller_bp;
+        self.registers.dsp = new_dsp;
+        self.registers.ip = Some(return_ip);
+        self.call_depth = self
+            .call_depth
+            .checked_sub(1)
+            .expect("call depth is positive for nested exit");
+        Ok(())
+    }
+
+    fn commit_top_level_exit(&mut self, return_count: u16) -> Result<ExecutionOutcome, Tbx16Error> {
+        let return_value = if return_count == 1 {
+            Some(self.read_exit_return_value()?)
+        } else {
+            None
+        };
+        let context = self
+            .entry_context
+            .ok_or(Tbx16Error::InvalidExecutionState)?;
+        if self.registers.bp != context.frame_base {
+            return Err(Tbx16Error::InvalidExecutionState);
+        }
+        if self.registers.rsp != self.return_stack_region.start() {
+            return Err(Tbx16Error::InvalidExecutionState);
+        }
+
+        let new_dsp = if return_count == 0 {
+            context.frame_base
+        } else {
+            self.checked_extend_data_stack(context.frame_base, 1)?
+        };
+
+        if let Some(value) = return_value {
+            self.memory.write_cell(context.frame_base, value)?;
+        }
+        self.registers.dsp = new_dsp;
+        self.registers.bp = context.initial_bp;
+        self.registers.ip = None;
+        self.call_depth = 0;
+        self.entry_context = None;
+        Ok(ExecutionOutcome::Returned)
+    }
+
+    fn validate_base_pointer(&self, bp: Address) -> Result<(), Tbx16Error> {
+        if !self.data_stack_region.contains_pointer(bp)
+            || ((bp.get() - self.data_stack_region.start().get()) % 2) != 0
+        {
+            return Err(Tbx16Error::InvalidExecutionState);
+        }
         Ok(())
     }
 

--- a/tests/tbx16.rs
+++ b/tests/tbx16.rs
@@ -1111,3 +1111,306 @@ fn threaded_atomic_failures_preserve_ip_stack_and_memory() {
     assert_eq!(after.memory, before.memory);
     assert_eq!(after.step_counter, 1);
 }
+
+#[test]
+fn top_level_exit_zero_and_one_return_cleanly() {
+    let mut zero_vm = Tbx16Vm::default();
+    let mut zero_image = ImageBuilder::new(CODE_START);
+    let exit_xt = zero_image.primitive(PrimitiveId::Exit);
+    let entry_xt = zero_image.colon_word(0, 0);
+    zero_image.emit_xt(exit_xt);
+    zero_image.emit_cell(Cell::new(0));
+    zero_image.load_into(&mut zero_vm);
+
+    assert_eq!(zero_vm.run(entry_xt), ExecutionOutcome::Returned);
+    assert_eq!(zero_vm.registers().ip, None);
+    assert_eq!(zero_vm.registers().bp, DATA_STACK_START);
+    assert_eq!(zero_vm.registers().dsp, DATA_STACK_START);
+    assert_eq!(zero_vm.registers().rsp, DEFAULT_RETURN_STACK_START);
+    assert_eq!(zero_vm.call_depth(), 0);
+    assert!(!zero_vm.is_dirty_execution_state());
+
+    let mut one_vm = Tbx16Vm::default();
+    let mut one_image = ImageBuilder::new(CODE_START);
+    let lit_xt = one_image.primitive(PrimitiveId::Lit);
+    let exit_xt = one_image.primitive(PrimitiveId::Exit);
+    let entry_xt = one_image.colon_word(1, 0);
+    one_image.emit_xt(lit_xt);
+    one_image.emit_cell(Cell::new(0x4444));
+    one_image.emit_xt(exit_xt);
+    one_image.emit_cell(Cell::new(1));
+    one_image.load_into(&mut one_vm);
+    one_vm.push_data_cell(Cell::new(0x1111)).unwrap();
+    one_vm.push_data_cell(Cell::new(0x2222)).unwrap();
+
+    assert_eq!(one_vm.run(entry_xt), ExecutionOutcome::Returned);
+    assert_eq!(one_vm.registers().ip, None);
+    assert_eq!(one_vm.registers().bp, DATA_STACK_START);
+    assert_eq!(one_vm.registers().dsp, Address::new(0x0084));
+    assert_eq!(one_vm.registers().rsp, DEFAULT_RETURN_STACK_START);
+    assert_eq!(one_vm.call_depth(), 0);
+    assert_eq!(
+        one_vm.memory().read_cell(Address::new(0x0080)).unwrap(),
+        Cell::new(0x1111)
+    );
+    assert_eq!(
+        one_vm.memory().read_cell(Address::new(0x0082)).unwrap(),
+        Cell::new(0x4444)
+    );
+    assert!(!one_vm.is_dirty_execution_state());
+}
+
+#[test]
+fn nested_exit_zero_and_one_restore_caller_frame() {
+    let mut zero_vm = Tbx16Vm::default();
+    let mut zero_image = ImageBuilder::new(CODE_START);
+    let lit_xt = zero_image.primitive(PrimitiveId::Lit);
+    let exit_xt = zero_image.primitive(PrimitiveId::Exit);
+    let callee_xt = zero_image.colon_word(0, 0);
+    zero_image.emit_xt(exit_xt);
+    zero_image.emit_cell(Cell::new(0));
+    let entry_xt = zero_image.colon_word(0, 0);
+    zero_image.emit_xt(lit_xt);
+    zero_image.emit_cell(Cell::new(0x7777));
+    zero_image.emit_xt(callee_xt);
+    zero_image.emit_xt(exit_xt);
+    zero_image.emit_cell(Cell::new(0));
+    zero_image.load_into(&mut zero_vm);
+
+    assert_eq!(zero_vm.run(entry_xt), ExecutionOutcome::Returned);
+    assert_eq!(zero_vm.registers().dsp, DATA_STACK_START);
+    assert_eq!(zero_vm.registers().rsp, DEFAULT_RETURN_STACK_START);
+    assert_eq!(zero_vm.call_depth(), 0);
+
+    let mut one_vm = Tbx16Vm::default();
+    let mut one_image = ImageBuilder::new(CODE_START);
+    let lit_xt = one_image.primitive(PrimitiveId::Lit);
+    let exit_xt = one_image.primitive(PrimitiveId::Exit);
+    let callee_xt = one_image.colon_word(1, 0);
+    one_image.emit_xt(lit_xt);
+    one_image.emit_cell(Cell::new(0x5555));
+    one_image.emit_xt(exit_xt);
+    one_image.emit_cell(Cell::new(1));
+    let entry_xt = one_image.colon_word(0, 0);
+    one_image.emit_xt(lit_xt);
+    one_image.emit_cell(Cell::new(0x1234));
+    one_image.emit_xt(callee_xt);
+    one_image.emit_xt(exit_xt);
+    one_image.emit_cell(Cell::new(1));
+    one_image.load_into(&mut one_vm);
+
+    assert_eq!(one_vm.run(entry_xt), ExecutionOutcome::Returned);
+    assert_eq!(one_vm.registers().ip, None);
+    assert_eq!(one_vm.registers().bp, DATA_STACK_START);
+    assert_eq!(one_vm.registers().dsp, Address::new(0x0082));
+    assert_eq!(one_vm.registers().rsp, DEFAULT_RETURN_STACK_START);
+    assert_eq!(one_vm.call_depth(), 0);
+    assert_eq!(one_vm.peek_data_cell(0).unwrap(), Cell::new(0x5555));
+    assert!(!one_vm.is_dirty_execution_state());
+}
+
+#[test]
+fn exit_one_rejects_missing_callee_return_value_without_stealing_caller_value() {
+    let mut vm = Tbx16Vm::default();
+    let mut image = ImageBuilder::new(CODE_START);
+    let exit_xt = image.primitive(PrimitiveId::Exit);
+    let callee_xt = image.colon_word(0, 0);
+    image.emit_xt(exit_xt);
+    image.emit_cell(Cell::new(1));
+    let entry_xt = image.colon_word(0, 0);
+    image.emit_xt(callee_xt);
+    image.emit_xt(exit_xt);
+    image.emit_cell(Cell::new(0));
+    image.load_into(&mut vm);
+    vm.push_data_cell(Cell::new(0xaaaa)).unwrap();
+    let before = snapshot(&vm);
+
+    assert_eq!(
+        vm.run(entry_xt),
+        ExecutionOutcome::Trapped(Tbx16Error::DataStackUnderflow)
+    );
+    let after = snapshot(&vm);
+    assert_eq!(after.ip, Some(Address::new(CODE_START + 10)));
+    assert_eq!(after.dsp, Address::new(0x0082));
+    assert_eq!(after.rsp, Address::new(0x0204));
+    assert_eq!(after.bp, Address::new(0x0082));
+    assert_eq!(
+        vm.memory().read_cell(Address::new(0x0080)).unwrap(),
+        Cell::new(0xaaaa)
+    );
+    assert_ne!(after.memory, before.memory);
+    assert_eq!(after.call_depth, 1);
+    assert_eq!(after.step_counter, 3);
+    assert!(vm.is_dirty_execution_state());
+}
+
+#[test]
+fn exit_traps_on_invalid_return_count_and_invalid_frame_metadata() {
+    let mut invalid_count_vm = Tbx16Vm::default();
+    let mut invalid_count = ImageBuilder::new(CODE_START);
+    let exit_xt = invalid_count.primitive(PrimitiveId::Exit);
+    let entry_xt = invalid_count.colon_word(0, 0);
+    invalid_count.emit_xt(exit_xt);
+    invalid_count.emit_cell(Cell::new(2));
+    invalid_count.load_into(&mut invalid_count_vm);
+    let before = snapshot(&invalid_count_vm);
+    assert_eq!(
+        invalid_count_vm.run(entry_xt),
+        ExecutionOutcome::Trapped(Tbx16Error::InvalidReturnCount {
+            count: Cell::new(2),
+        })
+    );
+    let after = snapshot(&invalid_count_vm);
+    assert_eq!(after.ip, Some(Address::new(CODE_START + 10)));
+    assert_eq!(after.dsp, before.dsp);
+    assert_eq!(after.rsp, before.rsp);
+    assert_eq!(after.bp, before.bp);
+    assert_eq!(after.memory, before.memory);
+    assert_eq!(after.call_depth, before.call_depth);
+    assert_eq!(after.step_counter, 2);
+
+    let mut invalid_return_ip_vm = Tbx16Vm::default();
+    let mut invalid_return_ip = ImageBuilder::new(CODE_START);
+    let halt_xt = invalid_return_ip.primitive(PrimitiveId::Halt);
+    let exit_xt = invalid_return_ip.primitive(PrimitiveId::Exit);
+    let callee_xt = invalid_return_ip.colon_word(0, 0);
+    invalid_return_ip.emit_xt(halt_xt);
+    invalid_return_ip.emit_xt(exit_xt);
+    invalid_return_ip.emit_cell(Cell::new(0));
+    let entry_xt = invalid_return_ip.colon_word(0, 0);
+    invalid_return_ip.emit_xt(callee_xt);
+    invalid_return_ip.emit_xt(exit_xt);
+    invalid_return_ip.emit_cell(Cell::new(0));
+    invalid_return_ip.load_into(&mut invalid_return_ip_vm);
+    assert_eq!(invalid_return_ip_vm.run(entry_xt), ExecutionOutcome::Halted);
+    invalid_return_ip_vm
+        .memory_mut()
+        .write_cell(DEFAULT_RETURN_STACK_START, Cell::new(0x1235))
+        .unwrap();
+
+    assert_eq!(
+        invalid_return_ip_vm.run_threaded(Address::new(CODE_START + 16)),
+        ExecutionOutcome::Trapped(Tbx16Error::InstructionPointerOutOfRange {
+            ip: Address::new(0x1235),
+        })
+    );
+    assert_eq!(invalid_return_ip_vm.step_counter(), 1);
+
+    let mut invalid_caller_bp_vm = Tbx16Vm::default();
+    let mut invalid_caller_bp = ImageBuilder::new(CODE_START);
+    let halt_xt = invalid_caller_bp.primitive(PrimitiveId::Halt);
+    let exit_xt = invalid_caller_bp.primitive(PrimitiveId::Exit);
+    let callee_xt = invalid_caller_bp.colon_word(0, 0);
+    invalid_caller_bp.emit_xt(halt_xt);
+    invalid_caller_bp.emit_xt(exit_xt);
+    invalid_caller_bp.emit_cell(Cell::new(0));
+    let entry_xt = invalid_caller_bp.colon_word(0, 0);
+    invalid_caller_bp.emit_xt(callee_xt);
+    invalid_caller_bp.emit_xt(exit_xt);
+    invalid_caller_bp.emit_cell(Cell::new(0));
+    invalid_caller_bp.load_into(&mut invalid_caller_bp_vm);
+    assert_eq!(invalid_caller_bp_vm.run(entry_xt), ExecutionOutcome::Halted);
+    invalid_caller_bp_vm
+        .memory_mut()
+        .write_cell(Address::new(0x0202), Cell::new(0x0081))
+        .unwrap();
+
+    assert_eq!(
+        invalid_caller_bp_vm.run_threaded(Address::new(CODE_START + 16)),
+        ExecutionOutcome::Trapped(Tbx16Error::InvalidExecutionState)
+    );
+    assert_eq!(invalid_caller_bp_vm.step_counter(), 1);
+}
+
+#[test]
+fn entry_primitive_exit_is_invalid_and_state_preserving() {
+    let mut vm = Tbx16Vm::default();
+    let mut image = ImageBuilder::new(CODE_START);
+    let exit_xt = image.primitive(PrimitiveId::Exit);
+    image.emit_cell(Cell::new(1));
+    image.load_into(&mut vm);
+    vm.set_instruction_pointer(Address::new(CODE_START + 4))
+        .unwrap();
+    vm.push_data_cell(Cell::new(0x1111)).unwrap();
+    let before = snapshot(&vm);
+
+    assert_eq!(
+        vm.run(exit_xt),
+        ExecutionOutcome::Trapped(Tbx16Error::InvalidExecutionState)
+    );
+    let after = snapshot(&vm);
+    assert_eq!(after.ip, before.ip);
+    assert_eq!(after.dsp, before.dsp);
+    assert_eq!(after.rsp, before.rsp);
+    assert_eq!(after.bp, before.bp);
+    assert_eq!(after.memory, before.memory);
+    assert_eq!(after.call_depth, before.call_depth);
+    assert_eq!(after.step_counter, 1);
+}
+
+#[test]
+fn halt_and_trap_leave_dirty_state_until_reset() {
+    let mut halt_vm = Tbx16Vm::default();
+    let mut halt_image = ImageBuilder::new(CODE_START);
+    let halt_xt = halt_image.primitive(PrimitiveId::Halt);
+    let entry_xt = halt_image.colon_word(0, 0);
+    halt_image.emit_xt(halt_xt);
+    halt_image.load_into(&mut halt_vm);
+
+    assert_eq!(halt_vm.run(entry_xt), ExecutionOutcome::Halted);
+    assert!(halt_vm.is_dirty_execution_state());
+    let halt_snapshot = snapshot(&halt_vm);
+    assert_eq!(
+        halt_vm.run(entry_xt),
+        ExecutionOutcome::Trapped(Tbx16Error::DirtyExecutionState)
+    );
+    assert_eq!(snapshot(&halt_vm), halt_snapshot);
+
+    let mut trap_vm = Tbx16Vm::default();
+    let mut trap_image = ImageBuilder::new(CODE_START);
+    let exit_xt = trap_image.primitive(PrimitiveId::Exit);
+    let entry_xt = trap_image.colon_word(0, 0);
+    trap_image.emit_xt(exit_xt);
+    trap_image.emit_cell(Cell::new(2));
+    trap_image.load_into(&mut trap_vm);
+
+    assert_eq!(
+        trap_vm.run(entry_xt),
+        ExecutionOutcome::Trapped(Tbx16Error::InvalidReturnCount {
+            count: Cell::new(2),
+        })
+    );
+    assert!(trap_vm.is_dirty_execution_state());
+    let trap_snapshot = snapshot(&trap_vm);
+    assert_eq!(
+        trap_vm.run(entry_xt),
+        ExecutionOutcome::Trapped(Tbx16Error::DirtyExecutionState)
+    );
+    assert_eq!(snapshot(&trap_vm), trap_snapshot);
+
+    halt_vm.push_data_cell(Cell::new(0x9999)).unwrap();
+    halt_vm.set_step_limit(Some(7));
+    halt_vm.reset_execution_state();
+    assert_eq!(halt_vm.registers().ip, None);
+    assert_eq!(halt_vm.registers().bp, DATA_STACK_START);
+    assert_eq!(halt_vm.registers().rsp, DEFAULT_RETURN_STACK_START);
+    assert_eq!(halt_vm.call_depth(), 0);
+    assert_eq!(halt_vm.step_counter(), 0);
+    assert_eq!(halt_vm.registers().dsp, Address::new(0x0082));
+    assert_eq!(halt_vm.peek_data_cell(0).unwrap(), Cell::new(0x9999));
+    assert!(!halt_vm.is_dirty_execution_state());
+    assert_eq!(halt_vm.run(entry_xt), ExecutionOutcome::Halted);
+}
+
+#[test]
+fn primitive_entry_halt_remains_rerunnable_without_reset() {
+    let mut vm = Tbx16Vm::default();
+    let mut image = ImageBuilder::new(CODE_START);
+    let halt_xt = image.primitive(PrimitiveId::Halt);
+    image.load_into(&mut vm);
+
+    assert_eq!(vm.run(halt_xt), ExecutionOutcome::Halted);
+    assert!(!vm.is_dirty_execution_state());
+    assert_eq!(vm.run(halt_xt), ExecutionOutcome::Halted);
+    assert_eq!(vm.step_counter(), 1);
+}

--- a/tests/tbx16.rs
+++ b/tests/tbx16.rs
@@ -1210,6 +1210,52 @@ fn nested_exit_zero_and_one_restore_caller_frame() {
 }
 
 #[test]
+fn three_nested_exit_one_returns_restore_full_state() {
+    let mut vm = Tbx16Vm::default();
+    let mut image = ImageBuilder::new(CODE_START);
+    let lit_xt = image.primitive(PrimitiveId::Lit);
+    let exit_xt = image.primitive(PrimitiveId::Exit);
+
+    let level3_xt = image.colon_word(0, 0);
+    image.emit_xt(lit_xt);
+    image.emit_cell(Cell::new(0x3333));
+    image.emit_xt(exit_xt);
+    image.emit_cell(Cell::new(1));
+
+    let level2_xt = image.colon_word(0, 0);
+    image.emit_xt(level3_xt);
+    image.emit_xt(exit_xt);
+    image.emit_cell(Cell::new(1));
+
+    let level1_xt = image.colon_word(0, 0);
+    image.emit_xt(level2_xt);
+    image.emit_xt(exit_xt);
+    image.emit_cell(Cell::new(1));
+
+    let entry_xt = image.colon_word(1, 0);
+    image.emit_xt(level1_xt);
+    image.emit_xt(exit_xt);
+    image.emit_cell(Cell::new(1));
+    image.load_into(&mut vm);
+
+    vm.push_data_cell(Cell::new(0x1111)).unwrap();
+    vm.push_data_cell(Cell::new(0x2222)).unwrap();
+
+    assert_eq!(vm.run(entry_xt), ExecutionOutcome::Returned);
+    assert_eq!(vm.registers().ip, None);
+    assert_eq!(vm.registers().bp, DATA_STACK_START);
+    assert_eq!(vm.registers().dsp, Address::new(0x0084));
+    assert_eq!(vm.registers().rsp, DEFAULT_RETURN_STACK_START);
+    assert_eq!(vm.call_depth(), 0);
+    assert_eq!(
+        vm.memory().read_cell(Address::new(0x0080)).unwrap(),
+        Cell::new(0x1111)
+    );
+    assert_eq!(vm.peek_data_cell(0).unwrap(), Cell::new(0x3333));
+    assert!(!vm.is_dirty_execution_state());
+}
+
+#[test]
 fn exit_one_rejects_missing_callee_return_value_without_stealing_caller_value() {
     let mut vm = Tbx16Vm::default();
     let mut image = ImageBuilder::new(CODE_START);
@@ -1388,6 +1434,29 @@ fn halt_and_trap_leave_dirty_state_until_reset() {
     );
     assert_eq!(snapshot(&trap_vm), trap_snapshot);
 
+    let mut nested_halt_vm = Tbx16Vm::default();
+    let mut nested_halt_image = ImageBuilder::new(CODE_START);
+    let halt_xt = nested_halt_image.primitive(PrimitiveId::Halt);
+    let callee_xt = nested_halt_image.colon_word(0, 0);
+    nested_halt_image.emit_xt(halt_xt);
+    let nested_entry_xt = nested_halt_image.colon_word(0, 0);
+    nested_halt_image.emit_xt(callee_xt);
+    nested_halt_image.load_into(&mut nested_halt_vm);
+
+    assert_eq!(
+        nested_halt_vm.run(nested_entry_xt),
+        ExecutionOutcome::Halted
+    );
+    assert_eq!(nested_halt_vm.call_depth(), 1);
+    assert_eq!(nested_halt_vm.registers().rsp, Address::new(0x0204));
+    assert!(nested_halt_vm.is_dirty_execution_state());
+    let nested_halt_snapshot = snapshot(&nested_halt_vm);
+    assert_eq!(
+        nested_halt_vm.run(nested_entry_xt),
+        ExecutionOutcome::Trapped(Tbx16Error::DirtyExecutionState)
+    );
+    assert_eq!(snapshot(&nested_halt_vm), nested_halt_snapshot);
+
     halt_vm.push_data_cell(Cell::new(0x9999)).unwrap();
     halt_vm.set_step_limit(Some(7));
     halt_vm.reset_execution_state();
@@ -1400,6 +1469,31 @@ fn halt_and_trap_leave_dirty_state_until_reset() {
     assert_eq!(halt_vm.peek_data_cell(0).unwrap(), Cell::new(0x9999));
     assert!(!halt_vm.is_dirty_execution_state());
     assert_eq!(halt_vm.run(entry_xt), ExecutionOutcome::Halted);
+}
+
+#[test]
+fn reset_execution_state_preserves_step_limit() {
+    let mut vm = Tbx16Vm::default();
+    let mut image = ImageBuilder::new(CODE_START);
+    let lit_xt = image.primitive(PrimitiveId::Lit);
+    let halt_xt = image.primitive(PrimitiveId::Halt);
+    let entry_xt = image.colon_word(0, 0);
+    image.emit_xt(lit_xt);
+    image.emit_cell(Cell::new(0x1111));
+    image.emit_xt(halt_xt);
+    image.load_into(&mut vm);
+
+    vm.set_step_limit(Some(1));
+    vm.push_data_cell(Cell::new(0x9999)).unwrap();
+    vm.reset_execution_state();
+
+    assert_eq!(
+        vm.run(entry_xt),
+        ExecutionOutcome::Trapped(Tbx16Error::StepLimitExceeded)
+    );
+    assert_eq!(vm.step_counter(), 1);
+    assert_eq!(vm.registers().ip, Some(Address::new(CODE_START + 14)));
+    assert_eq!(vm.peek_data_cell(0).unwrap(), Cell::new(0x9999));
 }
 
 #[test]


### PR DESCRIPTION
## 概要

Closes #1006

tbx16 に `EXIT` primitive と entry context ベースの return 処理を追加し、top-level return / nested return / dirty execution state / reset API の仕様を実装しました。

## 変更内容

- `PrimitiveId::Exit` を追加し、operand 付き `EXIT` dispatch を実装
- `InvalidReturnCount` / `InvalidExecutionState` / `DirtyExecutionState` を追加
- entry colon 実行時に top-level return 復元専用の `EntryContext` を保持
- nested return と top-level return を分離し、return count・戻り値境界・return frame・caller BP を検証してから commit するように変更
- dirty execution state 判定と `reset_execution_state()` を追加
- `tests/tbx16.rs` に top-level / nested return、entry primitive `EXIT`、dirty state、reset、atomicity の回帰テストを追加

## 確認

- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
