### PR TITLE
draft: tbx16 M2.3 primitive一括実装の分割元

### DIFF
--- a/src/tbx16/error.rs
+++ b/src/tbx16/error.rs
@@ -28,6 +28,10 @@ pub enum Tbx16Error {
         addr: Address,
     },
     DivisionByZero,
+    InvalidFrameSlot {
+        slot_index: u16,
+        slot_count: u16,
+    },
     InvalidExecutionToken {
         xt: Cell,
     },
@@ -62,6 +66,15 @@ impl fmt::Display for Tbx16Error {
                 write!(f, "misaligned {stack} stack pointer at {addr}")
             }
             Tbx16Error::DivisionByZero => write!(f, "division by zero"),
+            Tbx16Error::InvalidFrameSlot {
+                slot_index,
+                slot_count,
+            } => {
+                write!(
+                    f,
+                    "invalid frame slot {slot_index} for frame with {slot_count} slots"
+                )
+            }
             Tbx16Error::InvalidExecutionToken { xt } => {
                 write!(f, "invalid execution token ${:04x}", xt.raw())
             }

--- a/src/tbx16/mod.rs
+++ b/src/tbx16/mod.rs
@@ -346,15 +346,12 @@ pub struct Tbx16Vm {
     step_counter: usize,
     call_depth: u16,
     entry_context: Option<EntryContext>,
-    current_frame_slot_count: Option<u16>,
-    caller_frame_slot_counts: Vec<Option<u16>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct EntryContext {
     initial_bp: Address,
     frame_base: Address,
-    frame_slot_count: u16,
 }
 
 impl Default for Tbx16Vm {
@@ -400,8 +397,6 @@ impl Tbx16Vm {
             step_counter: 0,
             call_depth: 0,
             entry_context: None,
-            current_frame_slot_count: None,
-            caller_frame_slot_counts: Vec::new(),
         };
         vm.validate_invariants()?;
         Ok(vm)
@@ -461,8 +456,6 @@ impl Tbx16Vm {
         self.entry_context.is_some()
             || self.call_depth != 0
             || self.registers.rsp != self.return_stack_region.start()
-            || self.current_frame_slot_count.is_some()
-            || !self.caller_frame_slot_counts.is_empty()
     }
 
     pub fn reset_execution_state(&mut self) {
@@ -471,8 +464,6 @@ impl Tbx16Vm {
         self.registers.rsp = self.return_stack_region.start();
         self.call_depth = 0;
         self.entry_context = None;
-        self.current_frame_slot_count = None;
-        self.caller_frame_slot_counts.clear();
         self.step_counter = 0;
         self.debug_validate_state();
     }
@@ -727,12 +718,6 @@ impl Tbx16Vm {
                 reason: "return stack usage does not match call depth",
             });
         }
-        if self.caller_frame_slot_counts.len() != usize::from(self.call_depth) {
-            return Err(Tbx16Error::InvalidExecutionState);
-        }
-        if self.entry_context.is_none() && self.current_frame_slot_count.is_some() {
-            return Err(Tbx16Error::InvalidExecutionState);
-        }
         validate_return_stack_region(self.return_stack_region)?;
         if self.data_stack_region.overlaps(self.return_stack_region) {
             return Err(Tbx16Error::InvalidStackRegion {
@@ -784,9 +769,6 @@ impl Tbx16Vm {
             } => {
                 let initial_bp = self.registers.bp;
                 let frame_base = self.compute_frame_base(arity)?;
-                let frame_slot_count = arity
-                    .checked_add(local_count)
-                    .ok_or(Tbx16Error::InvalidExecutionState)?;
                 let locals_start = self.registers.dsp;
                 let new_dsp = self.checked_extend_data_stack(locals_start, local_count)?;
 
@@ -797,9 +779,7 @@ impl Tbx16Vm {
                 self.entry_context = Some(EntryContext {
                     initial_bp,
                     frame_base,
-                    frame_slot_count,
                 });
-                self.current_frame_slot_count = Some(frame_slot_count);
                 self.registers.bp = frame_base;
                 self.registers.dsp = new_dsp;
                 self.registers.ip = Some(parameter_ip);
@@ -1079,13 +1059,6 @@ impl Tbx16Vm {
             .call_depth
             .checked_add(1)
             .expect("call depth fits in configured return stack space");
-        self.caller_frame_slot_counts
-            .push(self.current_frame_slot_count);
-        self.current_frame_slot_count = Some(
-            arity
-                .checked_add(local_count)
-                .ok_or(Tbx16Error::InvalidExecutionState)?,
-        );
         Ok(())
     }
 
@@ -1152,10 +1125,6 @@ impl Tbx16Vm {
             .call_depth
             .checked_sub(1)
             .expect("call depth is positive for nested exit");
-        self.current_frame_slot_count = self
-            .caller_frame_slot_counts
-            .pop()
-            .ok_or(Tbx16Error::InvalidExecutionState)?;
         Ok(())
     }
 
@@ -1189,7 +1158,6 @@ impl Tbx16Vm {
         self.registers.ip = None;
         self.call_depth = 0;
         self.entry_context = None;
-        self.current_frame_slot_count = None;
         Ok(ExecutionOutcome::Returned)
     }
 
@@ -1366,22 +1334,22 @@ impl Tbx16Vm {
     }
 
     fn execute_load_slot_from_operand(&mut self, operand_ip: Address) -> Result<(), Tbx16Error> {
-        let slot_index = self.read_ip_cell(operand_ip)?.raw();
-        let addr = self.frame_slot_address(slot_index)?;
+        let slot_operand = self.read_slot_operand(operand_ip)?;
+        let addr = self.frame_slot_address(slot_operand)?;
         self.ensure_data_stack_pushable(self.registers.dsp)?;
         let value = self.memory.read_cell(addr)?;
         self.push_data_cell(value)?;
-        self.registers.ip = Some(validated_successor_ip(operand_ip)?);
+        self.registers.ip = Some(slot_operand.successor_ip);
         Ok(())
     }
 
     fn execute_store_slot_from_operand(&mut self, operand_ip: Address) -> Result<(), Tbx16Error> {
-        let slot_index = self.read_ip_cell(operand_ip)?.raw();
-        let addr = self.frame_slot_address(slot_index)?;
+        let slot_operand = self.read_slot_operand(operand_ip)?;
         let value = self.peek_data_cell(0)?;
+        let addr = self.frame_slot_address(slot_operand)?;
         self.memory.write_cell(addr, value)?;
         self.pop_data_cell()?;
-        self.registers.ip = Some(validated_successor_ip(operand_ip)?);
+        self.registers.ip = Some(slot_operand.successor_ip);
         Ok(())
     }
 
@@ -1508,17 +1476,29 @@ impl Tbx16Vm {
         ))
     }
 
-    fn frame_slot_address(&self, slot_index: u16) -> Result<Address, Tbx16Error> {
-        let slot_count = self
-            .current_frame_slot_count
-            .ok_or(Tbx16Error::InvalidExecutionState)?;
-        if slot_index >= slot_count {
+    fn frame_slot_address(&self, slot_operand: SlotOperand) -> Result<Address, Tbx16Error> {
+        if self.entry_context.is_none() {
+            return Err(Tbx16Error::InvalidExecutionState);
+        }
+        if slot_operand.slot_index >= slot_operand.slot_count {
             return Err(Tbx16Error::InvalidFrameSlot {
-                slot_index,
-                slot_count,
+                slot_index: slot_operand.slot_index,
+                slot_count: slot_operand.slot_count,
             });
         }
-        self.data_slot_address(slot_index)
+        self.data_slot_address(slot_operand.slot_index)
+    }
+
+    fn read_slot_operand(&self, operand_ip: Address) -> Result<SlotOperand, Tbx16Error> {
+        let slot_count_ip = validated_successor_ip(operand_ip)?;
+        let successor_ip = validated_ip_offset(operand_ip, 4)?;
+        let slot_index = self.read_ip_cell(operand_ip)?.raw();
+        let slot_count = self.read_ip_cell(slot_count_ip)?.raw();
+        Ok(SlotOperand {
+            slot_index,
+            slot_count,
+            successor_ip,
+        })
     }
 
     fn read_length_prefixed_bytes(&self, addr: Address) -> Result<Vec<u8>, Tbx16Error> {
@@ -1545,6 +1525,13 @@ impl Tbx16Vm {
 enum ExecutionState {
     Running,
     Finished(ExecutionOutcome),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SlotOperand {
+    slot_index: u16,
+    slot_count: u16,
+    successor_ip: Address,
 }
 
 fn validate_return_stack_region(region: StackRegion) -> Result<(), Tbx16Error> {
@@ -1581,8 +1568,12 @@ fn validate_instruction_pointer_target(ip: Address) -> Result<Address, Tbx16Erro
 }
 
 fn validated_successor_ip(ip: Address) -> Result<Address, Tbx16Error> {
+    validated_ip_offset(ip, 2)
+}
+
+fn validated_ip_offset(ip: Address, byte_offset: u16) -> Result<Address, Tbx16Error> {
     let next_ip = ip
-        .checked_add(2)
+        .checked_add(byte_offset)
         .ok_or(Tbx16Error::InstructionPointerOutOfRange { ip })?;
     validate_instruction_pointer_target(next_ip)
 }

--- a/src/tbx16/mod.rs
+++ b/src/tbx16/mod.rs
@@ -30,6 +30,13 @@ const RETURN_FRAME_BYTES: u16 = 4;
 pub const CODE_TOKEN_PRIMITIVE: Cell = Cell::new(0x0001);
 pub const CODE_TOKEN_DOCOL: Cell = Cell::new(0x0002);
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PrimitiveDescriptor {
+    pub id: PrimitiveId,
+    pub name: &'static str,
+    pub has_operand: bool,
+}
+
 /// Result of one `tbx16` execution entry.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ExecutionOutcome {
@@ -47,11 +54,55 @@ pub enum PrimitiveId {
     ZBranch = 3,
     Halt = 4,
     Exit = 5,
+    Dup = 6,
+    Drop = 7,
+    Swap = 8,
+    Over = 9,
+    Add = 10,
+    Sub = 11,
+    Mul = 12,
+    Div = 13,
+    Mod = 14,
+    Negate = 15,
+    Eq = 16,
+    Ne = 17,
+    Lt = 18,
+    Le = 19,
+    Gt = 20,
+    Ge = 21,
+    ToBool = 22,
+    Not = 23,
+    And = 24,
+    Or = 25,
+    Band = 26,
+    Bor = 27,
+    Fetch = 28,
+    Store = 29,
+    LoadSlot = 30,
+    StoreSlot = 31,
+    PutChr = 32,
+    PutDec = 33,
+    PutStr = 34,
 }
 
 impl PrimitiveId {
     pub const fn as_cell(self) -> Cell {
         Cell::new(self as u16)
+    }
+
+    pub const fn name(self) -> &'static str {
+        descriptor_for(self).name
+    }
+
+    pub const fn has_operand(self) -> bool {
+        descriptor_for(self).has_operand
+    }
+
+    pub fn from_name(name: &str) -> Option<Self> {
+        PRIMITIVE_REGISTRY
+            .iter()
+            .find(|descriptor| descriptor.name == name)
+            .map(|descriptor| descriptor.id)
     }
 }
 
@@ -65,10 +116,212 @@ impl TryFrom<Cell> for PrimitiveId {
             3 => Ok(Self::ZBranch),
             4 => Ok(Self::Halt),
             5 => Ok(Self::Exit),
+            6 => Ok(Self::Dup),
+            7 => Ok(Self::Drop),
+            8 => Ok(Self::Swap),
+            9 => Ok(Self::Over),
+            10 => Ok(Self::Add),
+            11 => Ok(Self::Sub),
+            12 => Ok(Self::Mul),
+            13 => Ok(Self::Div),
+            14 => Ok(Self::Mod),
+            15 => Ok(Self::Negate),
+            16 => Ok(Self::Eq),
+            17 => Ok(Self::Ne),
+            18 => Ok(Self::Lt),
+            19 => Ok(Self::Le),
+            20 => Ok(Self::Gt),
+            21 => Ok(Self::Ge),
+            22 => Ok(Self::ToBool),
+            23 => Ok(Self::Not),
+            24 => Ok(Self::And),
+            25 => Ok(Self::Or),
+            26 => Ok(Self::Band),
+            27 => Ok(Self::Bor),
+            28 => Ok(Self::Fetch),
+            29 => Ok(Self::Store),
+            30 => Ok(Self::LoadSlot),
+            31 => Ok(Self::StoreSlot),
+            32 => Ok(Self::PutChr),
+            33 => Ok(Self::PutDec),
+            34 => Ok(Self::PutStr),
             _ => Err(()),
         }
     }
 }
+
+pub const PRIMITIVE_REGISTRY: &[PrimitiveDescriptor] = &[
+    PrimitiveDescriptor {
+        id: PrimitiveId::Lit,
+        name: "LIT",
+        has_operand: true,
+    },
+    PrimitiveDescriptor {
+        id: PrimitiveId::Branch,
+        name: "BRANCH",
+        has_operand: true,
+    },
+    PrimitiveDescriptor {
+        id: PrimitiveId::ZBranch,
+        name: "ZBRANCH",
+        has_operand: true,
+    },
+    PrimitiveDescriptor {
+        id: PrimitiveId::Halt,
+        name: "HALT",
+        has_operand: false,
+    },
+    PrimitiveDescriptor {
+        id: PrimitiveId::Exit,
+        name: "EXIT",
+        has_operand: true,
+    },
+    PrimitiveDescriptor {
+        id: PrimitiveId::Dup,
+        name: "DUP",
+        has_operand: false,
+    },
+    PrimitiveDescriptor {
+        id: PrimitiveId::Drop,
+        name: "DROP",
+        has_operand: false,
+    },
+    PrimitiveDescriptor {
+        id: PrimitiveId::Swap,
+        name: "SWAP",
+        has_operand: false,
+    },
+    PrimitiveDescriptor {
+        id: PrimitiveId::Over,
+        name: "OVER",
+        has_operand: false,
+    },
+    PrimitiveDescriptor {
+        id: PrimitiveId::Add,
+        name: "ADD",
+        has_operand: false,
+    },
+    PrimitiveDescriptor {
+        id: PrimitiveId::Sub,
+        name: "SUB",
+        has_operand: false,
+    },
+    PrimitiveDescriptor {
+        id: PrimitiveId::Mul,
+        name: "MUL",
+        has_operand: false,
+    },
+    PrimitiveDescriptor {
+        id: PrimitiveId::Div,
+        name: "DIV",
+        has_operand: false,
+    },
+    PrimitiveDescriptor {
+        id: PrimitiveId::Mod,
+        name: "MOD",
+        has_operand: false,
+    },
+    PrimitiveDescriptor {
+        id: PrimitiveId::Negate,
+        name: "NEGATE",
+        has_operand: false,
+    },
+    PrimitiveDescriptor {
+        id: PrimitiveId::Eq,
+        name: "EQ",
+        has_operand: false,
+    },
+    PrimitiveDescriptor {
+        id: PrimitiveId::Ne,
+        name: "NE",
+        has_operand: false,
+    },
+    PrimitiveDescriptor {
+        id: PrimitiveId::Lt,
+        name: "LT",
+        has_operand: false,
+    },
+    PrimitiveDescriptor {
+        id: PrimitiveId::Le,
+        name: "LE",
+        has_operand: false,
+    },
+    PrimitiveDescriptor {
+        id: PrimitiveId::Gt,
+        name: "GT",
+        has_operand: false,
+    },
+    PrimitiveDescriptor {
+        id: PrimitiveId::Ge,
+        name: "GE",
+        has_operand: false,
+    },
+    PrimitiveDescriptor {
+        id: PrimitiveId::ToBool,
+        name: "TO_BOOL",
+        has_operand: false,
+    },
+    PrimitiveDescriptor {
+        id: PrimitiveId::Not,
+        name: "NOT",
+        has_operand: false,
+    },
+    PrimitiveDescriptor {
+        id: PrimitiveId::And,
+        name: "AND",
+        has_operand: false,
+    },
+    PrimitiveDescriptor {
+        id: PrimitiveId::Or,
+        name: "OR",
+        has_operand: false,
+    },
+    PrimitiveDescriptor {
+        id: PrimitiveId::Band,
+        name: "BAND",
+        has_operand: false,
+    },
+    PrimitiveDescriptor {
+        id: PrimitiveId::Bor,
+        name: "BOR",
+        has_operand: false,
+    },
+    PrimitiveDescriptor {
+        id: PrimitiveId::Fetch,
+        name: "FETCH",
+        has_operand: false,
+    },
+    PrimitiveDescriptor {
+        id: PrimitiveId::Store,
+        name: "STORE",
+        has_operand: false,
+    },
+    PrimitiveDescriptor {
+        id: PrimitiveId::LoadSlot,
+        name: "LOAD_SLOT",
+        has_operand: true,
+    },
+    PrimitiveDescriptor {
+        id: PrimitiveId::StoreSlot,
+        name: "STORE_SLOT",
+        has_operand: true,
+    },
+    PrimitiveDescriptor {
+        id: PrimitiveId::PutChr,
+        name: "PUTCHR",
+        has_operand: false,
+    },
+    PrimitiveDescriptor {
+        id: PrimitiveId::PutDec,
+        name: "PUTDEC",
+        has_operand: false,
+    },
+    PrimitiveDescriptor {
+        id: PrimitiveId::PutStr,
+        name: "PUTSTR",
+        has_operand: false,
+    },
+];
 
 /// Resolved word metadata for the shared XT namespace.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -88,16 +341,20 @@ pub struct Tbx16Vm {
     registers: Registers,
     data_stack_region: StackRegion,
     return_stack_region: StackRegion,
+    output: Vec<u8>,
     step_limit: Option<usize>,
     step_counter: usize,
     call_depth: u16,
     entry_context: Option<EntryContext>,
+    current_frame_slot_count: Option<u16>,
+    caller_frame_slot_counts: Vec<Option<u16>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct EntryContext {
     initial_bp: Address,
     frame_base: Address,
+    frame_slot_count: u16,
 }
 
 impl Default for Tbx16Vm {
@@ -138,10 +395,13 @@ impl Tbx16Vm {
             registers,
             data_stack_region,
             return_stack_region,
+            output: Vec::new(),
             step_limit: None,
             step_counter: 0,
             call_depth: 0,
             entry_context: None,
+            current_frame_slot_count: None,
+            caller_frame_slot_counts: Vec::new(),
         };
         vm.validate_invariants()?;
         Ok(vm)
@@ -177,6 +437,18 @@ impl Tbx16Vm {
         self.step_limit = step_limit;
     }
 
+    pub fn output(&self) -> &[u8] {
+        &self.output
+    }
+
+    pub fn take_output(&mut self) -> Vec<u8> {
+        std::mem::take(&mut self.output)
+    }
+
+    pub fn clear_output(&mut self) {
+        self.output.clear();
+    }
+
     pub fn step_counter(&self) -> usize {
         self.step_counter
     }
@@ -189,6 +461,8 @@ impl Tbx16Vm {
         self.entry_context.is_some()
             || self.call_depth != 0
             || self.registers.rsp != self.return_stack_region.start()
+            || self.current_frame_slot_count.is_some()
+            || !self.caller_frame_slot_counts.is_empty()
     }
 
     pub fn reset_execution_state(&mut self) {
@@ -197,6 +471,8 @@ impl Tbx16Vm {
         self.registers.rsp = self.return_stack_region.start();
         self.call_depth = 0;
         self.entry_context = None;
+        self.current_frame_slot_count = None;
+        self.caller_frame_slot_counts.clear();
         self.step_counter = 0;
         self.debug_validate_state();
     }
@@ -451,6 +727,12 @@ impl Tbx16Vm {
                 reason: "return stack usage does not match call depth",
             });
         }
+        if self.caller_frame_slot_counts.len() != usize::from(self.call_depth) {
+            return Err(Tbx16Error::InvalidExecutionState);
+        }
+        if self.entry_context.is_none() && self.current_frame_slot_count.is_some() {
+            return Err(Tbx16Error::InvalidExecutionState);
+        }
         validate_return_stack_region(self.return_stack_region)?;
         if self.data_stack_region.overlaps(self.return_stack_region) {
             return Err(Tbx16Error::InvalidStackRegion {
@@ -468,11 +750,19 @@ impl Tbx16Vm {
     ) -> Result<ExecutionOutcome, Tbx16Error> {
         match primitive {
             PrimitiveId::Halt => Ok(ExecutionOutcome::Halted),
-            PrimitiveId::Lit | PrimitiveId::Branch | PrimitiveId::ZBranch => {
+            PrimitiveId::Lit
+            | PrimitiveId::Branch
+            | PrimitiveId::ZBranch
+            | PrimitiveId::Exit
+            | PrimitiveId::LoadSlot
+            | PrimitiveId::StoreSlot => {
                 self.execute_primitive(primitive)?;
                 Ok(ExecutionOutcome::Returned)
             }
-            PrimitiveId::Exit => Err(Tbx16Error::InvalidExecutionState),
+            _ => {
+                self.execute_primitive_no_operand(primitive)?;
+                Ok(ExecutionOutcome::Returned)
+            }
         }
     }
 
@@ -494,6 +784,9 @@ impl Tbx16Vm {
             } => {
                 let initial_bp = self.registers.bp;
                 let frame_base = self.compute_frame_base(arity)?;
+                let frame_slot_count = arity
+                    .checked_add(local_count)
+                    .ok_or(Tbx16Error::InvalidExecutionState)?;
                 let locals_start = self.registers.dsp;
                 let new_dsp = self.checked_extend_data_stack(locals_start, local_count)?;
 
@@ -504,7 +797,9 @@ impl Tbx16Vm {
                 self.entry_context = Some(EntryContext {
                     initial_bp,
                     frame_base,
+                    frame_slot_count,
                 });
+                self.current_frame_slot_count = Some(frame_slot_count);
                 self.registers.bp = frame_base;
                 self.registers.dsp = new_dsp;
                 self.registers.ip = Some(parameter_ip);
@@ -566,6 +861,29 @@ impl Tbx16Vm {
                 Ok(None)
             }
             PrimitiveId::Exit => self.execute_exit_from_operand(continuation_ip),
+            PrimitiveId::LoadSlot => {
+                self.execute_load_slot_from_operand(continuation_ip)?;
+                Ok(None)
+            }
+            PrimitiveId::StoreSlot => {
+                self.execute_store_slot_from_operand(continuation_ip)?;
+                Ok(None)
+            }
+            _ => {
+                self.execute_primitive_no_operand(primitive)?;
+                let next_ip = if primitive.has_operand() {
+                    continuation_ip
+                        .checked_add(2)
+                        .ok_or(Tbx16Error::InstructionPointerOutOfRange {
+                            ip: continuation_ip,
+                        })
+                        .and_then(validate_instruction_pointer_target)?
+                } else {
+                    continuation_ip
+                };
+                self.registers.ip = Some(next_ip);
+                Ok(None)
+            }
         }
     }
 
@@ -574,8 +892,52 @@ impl Tbx16Vm {
             PrimitiveId::Lit => self.execute_lit_from_operand(self.current_ip()?),
             PrimitiveId::Branch => self.execute_branch_from_operand(self.current_ip()?),
             PrimitiveId::ZBranch => self.execute_zbranch_from_operand(self.current_ip()?),
+            PrimitiveId::Exit => {
+                self.execute_exit_from_operand(self.current_ip()?)?;
+                Ok(())
+            }
+            PrimitiveId::LoadSlot => self.execute_load_slot_from_operand(self.current_ip()?),
+            PrimitiveId::StoreSlot => self.execute_store_slot_from_operand(self.current_ip()?),
+            _ => self.execute_primitive_no_operand(primitive),
+        }
+    }
+
+    fn execute_primitive_no_operand(&mut self, primitive: PrimitiveId) -> Result<(), Tbx16Error> {
+        match primitive {
             PrimitiveId::Halt => Ok(()),
-            PrimitiveId::Exit => Err(Tbx16Error::InvalidExecutionState),
+            PrimitiveId::Dup => self.execute_dup(),
+            PrimitiveId::Drop => self.execute_drop(),
+            PrimitiveId::Swap => self.execute_swap(),
+            PrimitiveId::Over => self.execute_over(),
+            PrimitiveId::Add => self.execute_add(),
+            PrimitiveId::Sub => self.execute_sub(),
+            PrimitiveId::Mul => self.execute_mul(),
+            PrimitiveId::Div => self.execute_div(),
+            PrimitiveId::Mod => self.execute_mod(),
+            PrimitiveId::Negate => self.execute_negate(),
+            PrimitiveId::Eq => self.execute_eq(),
+            PrimitiveId::Ne => self.execute_ne(),
+            PrimitiveId::Lt => self.execute_lt(),
+            PrimitiveId::Le => self.execute_le(),
+            PrimitiveId::Gt => self.execute_gt(),
+            PrimitiveId::Ge => self.execute_ge(),
+            PrimitiveId::ToBool => self.execute_to_bool(),
+            PrimitiveId::Not => self.execute_not(),
+            PrimitiveId::And => self.execute_and(),
+            PrimitiveId::Or => self.execute_or(),
+            PrimitiveId::Band => self.execute_band(),
+            PrimitiveId::Bor => self.execute_bor(),
+            PrimitiveId::Fetch => self.execute_fetch(),
+            PrimitiveId::Store => self.execute_store(),
+            PrimitiveId::PutChr => self.execute_putchr(),
+            PrimitiveId::PutDec => self.execute_putdec(),
+            PrimitiveId::PutStr => self.execute_putstr(),
+            PrimitiveId::Lit
+            | PrimitiveId::Branch
+            | PrimitiveId::ZBranch
+            | PrimitiveId::Exit
+            | PrimitiveId::LoadSlot
+            | PrimitiveId::StoreSlot => Err(Tbx16Error::InvalidExecutionState),
         }
     }
 
@@ -717,6 +1079,13 @@ impl Tbx16Vm {
             .call_depth
             .checked_add(1)
             .expect("call depth fits in configured return stack space");
+        self.caller_frame_slot_counts
+            .push(self.current_frame_slot_count);
+        self.current_frame_slot_count = Some(
+            arity
+                .checked_add(local_count)
+                .ok_or(Tbx16Error::InvalidExecutionState)?,
+        );
         Ok(())
     }
 
@@ -783,6 +1152,10 @@ impl Tbx16Vm {
             .call_depth
             .checked_sub(1)
             .expect("call depth is positive for nested exit");
+        self.current_frame_slot_count = self
+            .caller_frame_slot_counts
+            .pop()
+            .ok_or(Tbx16Error::InvalidExecutionState)?;
         Ok(())
     }
 
@@ -816,6 +1189,7 @@ impl Tbx16Vm {
         self.registers.ip = None;
         self.call_depth = 0;
         self.entry_context = None;
+        self.current_frame_slot_count = None;
         Ok(ExecutionOutcome::Returned)
     }
 
@@ -854,6 +1228,317 @@ impl Tbx16Vm {
         #[cfg(debug_assertions)]
         self.validate_invariants()
             .expect("tbx16 invariants must hold after successful state transitions");
+    }
+
+    fn execute_dup(&mut self) -> Result<(), Tbx16Error> {
+        self.ensure_data_stack_pushable(self.registers.dsp)?;
+        let value = self.peek_data_cell(0)?;
+        self.push_data_cell(value)
+    }
+
+    fn execute_drop(&mut self) -> Result<(), Tbx16Error> {
+        self.pop_data_cell()?;
+        Ok(())
+    }
+
+    fn execute_swap(&mut self) -> Result<(), Tbx16Error> {
+        let top = self.peek_data_cell(0)?;
+        let below = self.peek_data_cell(1)?;
+        let top_addr = self
+            .registers
+            .dsp
+            .checked_sub(2)
+            .ok_or(Tbx16Error::DataStackUnderflow)?;
+        let below_addr = self
+            .registers
+            .dsp
+            .checked_sub(4)
+            .ok_or(Tbx16Error::DataStackUnderflow)?;
+        self.memory.write_cell(top_addr, below)?;
+        self.memory.write_cell(below_addr, top)?;
+        Ok(())
+    }
+
+    fn execute_over(&mut self) -> Result<(), Tbx16Error> {
+        self.ensure_data_stack_pushable(self.registers.dsp)?;
+        let value = self.peek_data_cell(1)?;
+        self.push_data_cell(value)
+    }
+
+    fn execute_add(&mut self) -> Result<(), Tbx16Error> {
+        self.execute_binary_arithmetic(|lhs, rhs| lhs.wrapping_add(rhs))
+    }
+
+    fn execute_sub(&mut self) -> Result<(), Tbx16Error> {
+        self.execute_binary_arithmetic(|lhs, rhs| lhs.wrapping_sub(rhs))
+    }
+
+    fn execute_mul(&mut self) -> Result<(), Tbx16Error> {
+        self.execute_binary_arithmetic(|lhs, rhs| lhs.wrapping_mul(rhs))
+    }
+
+    fn execute_div(&mut self) -> Result<(), Tbx16Error> {
+        self.execute_binary_result(Self::checked_div)
+    }
+
+    fn execute_mod(&mut self) -> Result<(), Tbx16Error> {
+        self.execute_binary_result(Self::checked_mod)
+    }
+
+    fn execute_negate(&mut self) -> Result<(), Tbx16Error> {
+        self.execute_unary_transform(|value| Cell::from_i16(value.as_i16().wrapping_neg()))
+    }
+
+    fn execute_eq(&mut self) -> Result<(), Tbx16Error> {
+        self.execute_binary_compare(|lhs, rhs| lhs.raw() == rhs.raw())
+    }
+
+    fn execute_ne(&mut self) -> Result<(), Tbx16Error> {
+        self.execute_binary_compare(|lhs, rhs| lhs.raw() != rhs.raw())
+    }
+
+    fn execute_lt(&mut self) -> Result<(), Tbx16Error> {
+        self.execute_binary_compare(|lhs, rhs| lhs.as_i16() < rhs.as_i16())
+    }
+
+    fn execute_le(&mut self) -> Result<(), Tbx16Error> {
+        self.execute_binary_compare(|lhs, rhs| lhs.as_i16() <= rhs.as_i16())
+    }
+
+    fn execute_gt(&mut self) -> Result<(), Tbx16Error> {
+        self.execute_binary_compare(|lhs, rhs| lhs.as_i16() > rhs.as_i16())
+    }
+
+    fn execute_ge(&mut self) -> Result<(), Tbx16Error> {
+        self.execute_binary_compare(|lhs, rhs| lhs.as_i16() >= rhs.as_i16())
+    }
+
+    fn execute_to_bool(&mut self) -> Result<(), Tbx16Error> {
+        self.execute_unary_transform(Cell::to_canonical_bool)
+    }
+
+    fn execute_not(&mut self) -> Result<(), Tbx16Error> {
+        self.execute_unary_transform(|value| Cell::from_bool(!value.is_truthy()))
+    }
+
+    fn execute_and(&mut self) -> Result<(), Tbx16Error> {
+        self.execute_binary_transform(|lhs, rhs| {
+            Cell::from_bool(lhs.is_truthy() && rhs.is_truthy())
+        })
+    }
+
+    fn execute_or(&mut self) -> Result<(), Tbx16Error> {
+        self.execute_binary_transform(|lhs, rhs| {
+            Cell::from_bool(lhs.is_truthy() || rhs.is_truthy())
+        })
+    }
+
+    fn execute_band(&mut self) -> Result<(), Tbx16Error> {
+        self.execute_binary_transform(|lhs, rhs| Cell::new(lhs.raw() & rhs.raw()))
+    }
+
+    fn execute_bor(&mut self) -> Result<(), Tbx16Error> {
+        self.execute_binary_transform(|lhs, rhs| Cell::new(lhs.raw() | rhs.raw()))
+    }
+
+    fn execute_fetch(&mut self) -> Result<(), Tbx16Error> {
+        let addr = Address::new(self.peek_data_cell(0)?.raw());
+        let value = self.memory.read_cell(addr)?;
+        let stack_addr = self
+            .registers
+            .dsp
+            .checked_sub(2)
+            .ok_or(Tbx16Error::DataStackUnderflow)?;
+        self.memory.write_cell(stack_addr, value)?;
+        Ok(())
+    }
+
+    fn execute_store(&mut self) -> Result<(), Tbx16Error> {
+        let value = self.peek_data_cell(0)?;
+        let addr = self.peek_data_cell(1)?;
+        self.memory.write_cell(Address::new(addr.raw()), value)?;
+        self.registers.dsp = self
+            .registers
+            .dsp
+            .checked_sub(4)
+            .ok_or(Tbx16Error::DataStackUnderflow)?;
+        Ok(())
+    }
+
+    fn execute_load_slot_from_operand(&mut self, operand_ip: Address) -> Result<(), Tbx16Error> {
+        let slot_index = self.read_ip_cell(operand_ip)?.raw();
+        let addr = self.frame_slot_address(slot_index)?;
+        self.ensure_data_stack_pushable(self.registers.dsp)?;
+        let value = self.memory.read_cell(addr)?;
+        self.push_data_cell(value)?;
+        self.registers.ip = Some(validated_successor_ip(operand_ip)?);
+        Ok(())
+    }
+
+    fn execute_store_slot_from_operand(&mut self, operand_ip: Address) -> Result<(), Tbx16Error> {
+        let slot_index = self.read_ip_cell(operand_ip)?.raw();
+        let addr = self.frame_slot_address(slot_index)?;
+        let value = self.peek_data_cell(0)?;
+        self.memory.write_cell(addr, value)?;
+        self.pop_data_cell()?;
+        self.registers.ip = Some(validated_successor_ip(operand_ip)?);
+        Ok(())
+    }
+
+    fn execute_putchr(&mut self) -> Result<(), Tbx16Error> {
+        let value = self.peek_data_cell(0)?;
+        self.output.push(value.raw() as u8);
+        self.pop_data_cell()?;
+        Ok(())
+    }
+
+    fn execute_putdec(&mut self) -> Result<(), Tbx16Error> {
+        let value = self.peek_data_cell(0)?;
+        let rendered = value.as_i16().to_string();
+        self.output.extend_from_slice(rendered.as_bytes());
+        self.pop_data_cell()?;
+        Ok(())
+    }
+
+    fn execute_putstr(&mut self) -> Result<(), Tbx16Error> {
+        let addr = Address::new(self.peek_data_cell(0)?.raw());
+        let bytes = self.read_length_prefixed_bytes(addr)?;
+        self.output.extend_from_slice(&bytes);
+        self.pop_data_cell()?;
+        Ok(())
+    }
+
+    fn execute_unary_transform(
+        &mut self,
+        transform: impl FnOnce(Cell) -> Cell,
+    ) -> Result<(), Tbx16Error> {
+        let value = self.peek_data_cell(0)?;
+        let addr = self
+            .registers
+            .dsp
+            .checked_sub(2)
+            .ok_or(Tbx16Error::DataStackUnderflow)?;
+        self.memory.write_cell(addr, transform(value))?;
+        Ok(())
+    }
+
+    fn execute_binary_transform(
+        &mut self,
+        transform: impl FnOnce(Cell, Cell) -> Cell,
+    ) -> Result<(), Tbx16Error> {
+        let rhs = self.peek_data_cell(0)?;
+        let lhs = self.peek_data_cell(1)?;
+        let result = transform(lhs, rhs);
+        let addr = self
+            .registers
+            .dsp
+            .checked_sub(4)
+            .ok_or(Tbx16Error::DataStackUnderflow)?;
+        self.memory.write_cell(addr, result)?;
+        self.registers.dsp = self
+            .registers
+            .dsp
+            .checked_sub(2)
+            .ok_or(Tbx16Error::DataStackUnderflow)?;
+        Ok(())
+    }
+
+    fn execute_binary_result(
+        &mut self,
+        transform: impl FnOnce(Cell, Cell) -> Result<Cell, Tbx16Error>,
+    ) -> Result<(), Tbx16Error> {
+        let rhs = self.peek_data_cell(0)?;
+        let lhs = self.peek_data_cell(1)?;
+        let result = transform(lhs, rhs)?;
+        let addr = self
+            .registers
+            .dsp
+            .checked_sub(4)
+            .ok_or(Tbx16Error::DataStackUnderflow)?;
+        self.memory.write_cell(addr, result)?;
+        self.registers.dsp = self
+            .registers
+            .dsp
+            .checked_sub(2)
+            .ok_or(Tbx16Error::DataStackUnderflow)?;
+        Ok(())
+    }
+
+    fn execute_binary_arithmetic(
+        &mut self,
+        transform: impl FnOnce(i16, i16) -> i16,
+    ) -> Result<(), Tbx16Error> {
+        self.execute_binary_transform(|lhs, rhs| {
+            Cell::from_i16(transform(lhs.as_i16(), rhs.as_i16()))
+        })
+    }
+
+    fn execute_binary_compare(
+        &mut self,
+        compare: impl FnOnce(Cell, Cell) -> bool,
+    ) -> Result<(), Tbx16Error> {
+        self.execute_binary_transform(|lhs, rhs| Cell::from_bool(compare(lhs, rhs)))
+    }
+
+    fn checked_div(lhs: Cell, rhs: Cell) -> Result<Cell, Tbx16Error> {
+        let divisor = rhs.as_i16();
+        if divisor == 0 {
+            return Err(Tbx16Error::DivisionByZero);
+        }
+        let dividend = lhs.as_i16();
+        if dividend == i16::MIN && divisor == -1 {
+            return Ok(Cell::from_i16(i16::MIN));
+        }
+        Ok(Cell::from_i16(
+            (i32::from(dividend) / i32::from(divisor)) as i16,
+        ))
+    }
+
+    fn checked_mod(lhs: Cell, rhs: Cell) -> Result<Cell, Tbx16Error> {
+        let divisor = rhs.as_i16();
+        if divisor == 0 {
+            return Err(Tbx16Error::DivisionByZero);
+        }
+        let dividend = lhs.as_i16();
+        if dividend == i16::MIN && divisor == -1 {
+            return Ok(Cell::from_i16(0));
+        }
+        Ok(Cell::from_i16(
+            (i32::from(dividend) % i32::from(divisor)) as i16,
+        ))
+    }
+
+    fn frame_slot_address(&self, slot_index: u16) -> Result<Address, Tbx16Error> {
+        let slot_count = self
+            .current_frame_slot_count
+            .ok_or(Tbx16Error::InvalidExecutionState)?;
+        if slot_index >= slot_count {
+            return Err(Tbx16Error::InvalidFrameSlot {
+                slot_index,
+                slot_count,
+            });
+        }
+        self.data_slot_address(slot_index)
+    }
+
+    fn read_length_prefixed_bytes(&self, addr: Address) -> Result<Vec<u8>, Tbx16Error> {
+        let len = usize::from(self.memory.read_cell(addr)?.raw());
+        let bytes_start = addr.checked_add(2).ok_or(Tbx16Error::InvalidMemoryAccess {
+            addr,
+            operation: "string read",
+        })?;
+        let mut bytes = Vec::with_capacity(len);
+        for offset in 0..len {
+            let byte_addr =
+                bytes_start
+                    .checked_add_usize(offset)
+                    .ok_or(Tbx16Error::InvalidMemoryAccess {
+                        addr,
+                        operation: "string read",
+                    })?;
+            bytes.push(self.memory.read_byte(byte_addr)?);
+        }
+        Ok(bytes)
     }
 }
 
@@ -904,4 +1589,43 @@ fn validated_successor_ip(ip: Address) -> Result<Address, Tbx16Error> {
 
 fn invalid_execution_token(xt: Cell) -> Tbx16Error {
     Tbx16Error::InvalidExecutionToken { xt }
+}
+
+const fn descriptor_for(id: PrimitiveId) -> PrimitiveDescriptor {
+    match id {
+        PrimitiveId::Lit => PRIMITIVE_REGISTRY[0],
+        PrimitiveId::Branch => PRIMITIVE_REGISTRY[1],
+        PrimitiveId::ZBranch => PRIMITIVE_REGISTRY[2],
+        PrimitiveId::Halt => PRIMITIVE_REGISTRY[3],
+        PrimitiveId::Exit => PRIMITIVE_REGISTRY[4],
+        PrimitiveId::Dup => PRIMITIVE_REGISTRY[5],
+        PrimitiveId::Drop => PRIMITIVE_REGISTRY[6],
+        PrimitiveId::Swap => PRIMITIVE_REGISTRY[7],
+        PrimitiveId::Over => PRIMITIVE_REGISTRY[8],
+        PrimitiveId::Add => PRIMITIVE_REGISTRY[9],
+        PrimitiveId::Sub => PRIMITIVE_REGISTRY[10],
+        PrimitiveId::Mul => PRIMITIVE_REGISTRY[11],
+        PrimitiveId::Div => PRIMITIVE_REGISTRY[12],
+        PrimitiveId::Mod => PRIMITIVE_REGISTRY[13],
+        PrimitiveId::Negate => PRIMITIVE_REGISTRY[14],
+        PrimitiveId::Eq => PRIMITIVE_REGISTRY[15],
+        PrimitiveId::Ne => PRIMITIVE_REGISTRY[16],
+        PrimitiveId::Lt => PRIMITIVE_REGISTRY[17],
+        PrimitiveId::Le => PRIMITIVE_REGISTRY[18],
+        PrimitiveId::Gt => PRIMITIVE_REGISTRY[19],
+        PrimitiveId::Ge => PRIMITIVE_REGISTRY[20],
+        PrimitiveId::ToBool => PRIMITIVE_REGISTRY[21],
+        PrimitiveId::Not => PRIMITIVE_REGISTRY[22],
+        PrimitiveId::And => PRIMITIVE_REGISTRY[23],
+        PrimitiveId::Or => PRIMITIVE_REGISTRY[24],
+        PrimitiveId::Band => PRIMITIVE_REGISTRY[25],
+        PrimitiveId::Bor => PRIMITIVE_REGISTRY[26],
+        PrimitiveId::Fetch => PRIMITIVE_REGISTRY[27],
+        PrimitiveId::Store => PRIMITIVE_REGISTRY[28],
+        PrimitiveId::LoadSlot => PRIMITIVE_REGISTRY[29],
+        PrimitiveId::StoreSlot => PRIMITIVE_REGISTRY[30],
+        PrimitiveId::PutChr => PRIMITIVE_REGISTRY[31],
+        PrimitiveId::PutDec => PRIMITIVE_REGISTRY[32],
+        PrimitiveId::PutStr => PRIMITIVE_REGISTRY[33],
+    }
 }

--- a/tests/tbx16.rs
+++ b/tests/tbx16.rs
@@ -97,6 +97,11 @@ impl ImageBuilder {
         self.labels.insert(label, self.cursor);
     }
 
+    fn emit_slot_operand(&mut self, slot_index: u16, slot_count: u16) {
+        self.emit_cell(Cell::new(slot_index));
+        self.emit_cell(Cell::new(slot_count));
+    }
+
     fn load_into(self, vm: &mut Tbx16Vm) {
         for (addr, pending) in self.cells {
             let cell = match pending {
@@ -1938,11 +1943,11 @@ fn frame_slot_primitives_read_and_write_arguments_and_locals() {
     let exit_xt = local_image.primitive(PrimitiveId::Exit);
     let entry_xt = local_image.colon_word(1, 1);
     local_image.emit_xt(load_slot_xt);
-    local_image.emit_cell(Cell::new(0));
+    local_image.emit_slot_operand(0, 2);
     local_image.emit_xt(store_slot_xt);
-    local_image.emit_cell(Cell::new(1));
+    local_image.emit_slot_operand(1, 2);
     local_image.emit_xt(load_slot_xt);
-    local_image.emit_cell(Cell::new(1));
+    local_image.emit_slot_operand(1, 2);
     local_image.emit_xt(exit_xt);
     local_image.emit_cell(Cell::new(1));
     local_image.load_into(&mut local_vm);
@@ -1960,9 +1965,9 @@ fn frame_slot_primitives_read_and_write_arguments_and_locals() {
     arg_image.emit_xt(lit_xt);
     arg_image.emit_cell(Cell::new(0x4321));
     arg_image.emit_xt(store_slot_xt);
-    arg_image.emit_cell(Cell::new(0));
+    arg_image.emit_slot_operand(0, 1);
     arg_image.emit_xt(load_slot_xt);
-    arg_image.emit_cell(Cell::new(0));
+    arg_image.emit_slot_operand(0, 1);
     arg_image.emit_xt(exit_xt);
     arg_image.emit_cell(Cell::new(1));
     arg_image.load_into(&mut arg_vm);
@@ -1978,7 +1983,7 @@ fn frame_slot_primitives_trap_on_out_of_range_indices() {
     let load_slot_xt = load_image.primitive(PrimitiveId::LoadSlot);
     let entry_xt = load_image.colon_word(1, 1);
     load_image.emit_xt(load_slot_xt);
-    load_image.emit_cell(Cell::new(2));
+    load_image.emit_slot_operand(2, 2);
     load_image.load_into(&mut load_vm);
     load_vm.push_data_cell(Cell::new(0x1111)).unwrap();
     assert_eq!(
@@ -1997,7 +2002,7 @@ fn frame_slot_primitives_trap_on_out_of_range_indices() {
     store_image.emit_xt(lit_xt);
     store_image.emit_cell(Cell::new(0x9999));
     store_image.emit_xt(store_slot_xt);
-    store_image.emit_cell(Cell::new(0));
+    store_image.emit_slot_operand(0, 0);
     store_image.load_into(&mut store_vm);
     assert_eq!(
         store_vm.run(entry_xt),
@@ -2006,6 +2011,92 @@ fn frame_slot_primitives_trap_on_out_of_range_indices() {
             slot_count: 0,
         })
     );
+}
+
+#[test]
+fn frame_slot_primitives_are_atomic_when_successor_ip_is_invalid() {
+    let mut load_vm = Tbx16Vm::default();
+    let mut primitive_image = ImageBuilder::new(CODE_START);
+    let load_slot_xt = primitive_image.primitive(PrimitiveId::LoadSlot);
+    primitive_image.load_into(&mut load_vm);
+    let entry_xt = Cell::new(0xfff4);
+    load_vm
+        .memory_mut()
+        .write_cell(Address::new(0xfff4), CODE_TOKEN_DOCOL)
+        .unwrap();
+    load_vm
+        .memory_mut()
+        .write_cell(Address::new(0xfff6), Cell::new(0))
+        .unwrap();
+    load_vm
+        .memory_mut()
+        .write_cell(Address::new(0xfff8), Cell::new(1))
+        .unwrap();
+    load_vm
+        .memory_mut()
+        .write_cell(Address::new(0xfffa), load_slot_xt)
+        .unwrap();
+    load_vm
+        .memory_mut()
+        .write_cell(Address::new(0xfffc), Cell::new(0))
+        .unwrap();
+    load_vm
+        .memory_mut()
+        .write_cell(Address::new(0xfffe), Cell::new(1))
+        .unwrap();
+    let before = snapshot(&load_vm);
+    assert_eq!(
+        load_vm.run(entry_xt),
+        ExecutionOutcome::Trapped(Tbx16Error::InstructionPointerOutOfRange {
+            ip: Address::new(0xfffc),
+        })
+    );
+    let after = snapshot(&load_vm);
+    assert_eq!(after.ip, Some(Address::new(0xfffa)));
+    assert_eq!(after.dsp, Address::new(0x0082));
+    assert_eq!(after.memory, before.memory);
+
+    let mut store_vm = Tbx16Vm::default();
+    let mut primitive_image = ImageBuilder::new(CODE_START);
+    let store_slot_xt = primitive_image.primitive(PrimitiveId::StoreSlot);
+    primitive_image.load_into(&mut store_vm);
+    let entry_xt = Cell::new(0xfff4);
+    store_vm
+        .memory_mut()
+        .write_cell(Address::new(0xfff4), CODE_TOKEN_DOCOL)
+        .unwrap();
+    store_vm
+        .memory_mut()
+        .write_cell(Address::new(0xfff6), Cell::new(0))
+        .unwrap();
+    store_vm
+        .memory_mut()
+        .write_cell(Address::new(0xfff8), Cell::new(1))
+        .unwrap();
+    store_vm
+        .memory_mut()
+        .write_cell(Address::new(0xfffa), store_slot_xt)
+        .unwrap();
+    store_vm
+        .memory_mut()
+        .write_cell(Address::new(0xfffc), Cell::new(0))
+        .unwrap();
+    store_vm
+        .memory_mut()
+        .write_cell(Address::new(0xfffe), Cell::new(1))
+        .unwrap();
+    store_vm.push_data_cell(Cell::new(0x9999)).unwrap();
+    let before = snapshot(&store_vm);
+    assert_eq!(
+        store_vm.run(entry_xt),
+        ExecutionOutcome::Trapped(Tbx16Error::InstructionPointerOutOfRange {
+            ip: Address::new(0xfffc),
+        })
+    );
+    let after = snapshot(&store_vm);
+    assert_eq!(after.ip, Some(Address::new(0xfffa)));
+    assert_eq!(after.dsp, Address::new(0x0084));
+    assert_eq!(after.memory, before.memory);
 }
 
 #[test]

--- a/tests/tbx16.rs
+++ b/tests/tbx16.rs
@@ -8,6 +8,7 @@ use tbx::tbx16::stack::{ReturnFrame, StackRegion};
 use tbx::tbx16::{
     ExecutionOutcome, PrimitiveId, ResolvedWord, Tbx16Vm, CODE_TOKEN_DOCOL, CODE_TOKEN_PRIMITIVE,
     DATA_STACK_END, DATA_STACK_START, DEFAULT_RETURN_STACK_END, DEFAULT_RETURN_STACK_START,
+    PRIMITIVE_REGISTRY,
 };
 
 const CODE_START: u16 = 0x0400;
@@ -108,6 +109,27 @@ impl ImageBuilder {
             vm.memory_mut().write_cell(addr, cell).unwrap();
         }
     }
+}
+
+fn write_length_prefixed_bytes(vm: &mut Tbx16Vm, addr: u16, bytes: &[u8]) {
+    let addr = Address::new(addr);
+    vm.memory_mut()
+        .write_cell(addr, Cell::new(bytes.len() as u16))
+        .unwrap();
+    for (offset, byte) in bytes.iter().copied().enumerate() {
+        vm.memory_mut()
+            .write_byte(
+                addr.checked_add(2)
+                    .and_then(|start| start.checked_add_usize(offset))
+                    .unwrap(),
+                byte,
+            )
+            .unwrap();
+    }
+}
+
+fn output_bytes(vm: &mut Tbx16Vm) -> Vec<u8> {
+    vm.take_output()
 }
 
 #[test]
@@ -1507,4 +1529,511 @@ fn primitive_entry_halt_remains_rerunnable_without_reset() {
     assert!(!vm.is_dirty_execution_state());
     assert_eq!(vm.run(halt_xt), ExecutionOutcome::Halted);
     assert_eq!(vm.step_counter(), 1);
+}
+
+#[test]
+fn primitive_registry_round_trips_names_and_ids() {
+    assert_eq!(PrimitiveId::from_name("ADD"), Some(PrimitiveId::Add));
+    assert_eq!(PrimitiveId::Add.name(), "ADD");
+    assert_eq!(PrimitiveId::LoadSlot.name(), "LOAD_SLOT");
+    assert!(PrimitiveId::LoadSlot.has_operand());
+    assert!(!PrimitiveId::PutDec.has_operand());
+
+    for descriptor in PRIMITIVE_REGISTRY {
+        assert_eq!(PrimitiveId::from_name(descriptor.name), Some(descriptor.id));
+        assert_eq!(descriptor.id.name(), descriptor.name);
+    }
+}
+
+#[test]
+fn stack_primitives_apply_expected_stack_effects() {
+    let mut vm = Tbx16Vm::default();
+    let mut image = ImageBuilder::new(CODE_START);
+    let lit_xt = image.primitive(PrimitiveId::Lit);
+    let dup_xt = image.primitive(PrimitiveId::Dup);
+    let over_xt = image.primitive(PrimitiveId::Over);
+    let swap_xt = image.primitive(PrimitiveId::Swap);
+    let drop_xt = image.primitive(PrimitiveId::Drop);
+    let halt_xt = image.primitive(PrimitiveId::Halt);
+
+    image.mark_label("start");
+    image.emit_xt(lit_xt);
+    image.emit_cell(Cell::new(0x1111));
+    image.emit_xt(lit_xt);
+    image.emit_cell(Cell::new(0x2222));
+    image.emit_xt(dup_xt);
+    image.emit_xt(over_xt);
+    image.emit_xt(swap_xt);
+    image.emit_xt(drop_xt);
+    image.emit_xt(halt_xt);
+    let start_ip = image.labels["start"];
+    image.load_into(&mut vm);
+
+    assert_eq!(vm.run_threaded(start_ip), ExecutionOutcome::Halted);
+    assert_eq!(vm.registers().dsp, Address::new(0x0086));
+    assert_eq!(vm.peek_data_cell(0).unwrap(), Cell::new(0x2222));
+    assert_eq!(vm.peek_data_cell(1).unwrap(), Cell::new(0x2222));
+    assert_eq!(vm.peek_data_cell(2).unwrap(), Cell::new(0x1111));
+}
+
+#[test]
+fn stack_primitives_report_underflow_and_overflow_traps() {
+    let mut empty_vm = Tbx16Vm::default();
+    let mut image = ImageBuilder::new(CODE_START);
+    let dup_xt = image.primitive(PrimitiveId::Dup);
+    let drop_xt = image.primitive(PrimitiveId::Drop);
+    let swap_xt = image.primitive(PrimitiveId::Swap);
+    let over_xt = image.primitive(PrimitiveId::Over);
+    image.load_into(&mut empty_vm);
+
+    assert_eq!(
+        empty_vm.run(dup_xt),
+        ExecutionOutcome::Trapped(Tbx16Error::DataStackUnderflow)
+    );
+    assert_eq!(
+        empty_vm.run(drop_xt),
+        ExecutionOutcome::Trapped(Tbx16Error::DataStackUnderflow)
+    );
+    assert_eq!(
+        empty_vm.run(swap_xt),
+        ExecutionOutcome::Trapped(Tbx16Error::DataStackUnderflow)
+    );
+    assert_eq!(
+        empty_vm.run(over_xt),
+        ExecutionOutcome::Trapped(Tbx16Error::DataStackUnderflow)
+    );
+
+    let mut single_vm = Tbx16Vm::default();
+    let mut single_image = ImageBuilder::new(CODE_START);
+    single_image.primitive(PrimitiveId::Dup);
+    single_image.primitive(PrimitiveId::Drop);
+    let swap_xt = single_image.primitive(PrimitiveId::Swap);
+    let over_xt = single_image.primitive(PrimitiveId::Over);
+    single_image.load_into(&mut single_vm);
+    single_vm.push_data_cell(Cell::new(1)).unwrap();
+    assert_eq!(
+        single_vm.run(swap_xt),
+        ExecutionOutcome::Trapped(Tbx16Error::DataStackUnderflow)
+    );
+    assert_eq!(
+        single_vm.run(over_xt),
+        ExecutionOutcome::Trapped(Tbx16Error::DataStackUnderflow)
+    );
+
+    let mut full_vm = Tbx16Vm::default();
+    let mut full_image = ImageBuilder::new(CODE_START);
+    let dup_xt = full_image.primitive(PrimitiveId::Dup);
+    full_image.primitive(PrimitiveId::Drop);
+    full_image.primitive(PrimitiveId::Swap);
+    let over_xt = full_image.primitive(PrimitiveId::Over);
+    full_image.load_into(&mut full_vm);
+    for i in 0..64u16 {
+        full_vm.push_data_cell(Cell::new(i)).unwrap();
+    }
+    assert_eq!(
+        full_vm.run(dup_xt),
+        ExecutionOutcome::Trapped(Tbx16Error::DataStackOverflow)
+    );
+    assert_eq!(
+        full_vm.run(over_xt),
+        ExecutionOutcome::Trapped(Tbx16Error::DataStackOverflow)
+    );
+}
+
+#[test]
+fn arithmetic_primitives_wrap_and_divide_with_signed_i16_rules() {
+    let cases = [
+        (
+            PrimitiveId::Add,
+            Cell::from_i16(32767),
+            Cell::from_i16(1),
+            Cell::from_i16(-32768),
+        ),
+        (
+            PrimitiveId::Sub,
+            Cell::from_i16(-32768),
+            Cell::from_i16(1),
+            Cell::from_i16(32767),
+        ),
+        (
+            PrimitiveId::Mul,
+            Cell::from_i16(300),
+            Cell::from_i16(300),
+            Cell::new(0x5f90),
+        ),
+        (
+            PrimitiveId::Div,
+            Cell::from_i16(7),
+            Cell::from_i16(3),
+            Cell::from_i16(2),
+        ),
+        (
+            PrimitiveId::Div,
+            Cell::from_i16(-7),
+            Cell::from_i16(3),
+            Cell::from_i16(-2),
+        ),
+        (
+            PrimitiveId::Div,
+            Cell::from_i16(7),
+            Cell::from_i16(-3),
+            Cell::from_i16(-2),
+        ),
+        (
+            PrimitiveId::Div,
+            Cell::from_i16(-7),
+            Cell::from_i16(-3),
+            Cell::from_i16(2),
+        ),
+        (
+            PrimitiveId::Mod,
+            Cell::from_i16(7),
+            Cell::from_i16(3),
+            Cell::from_i16(1),
+        ),
+        (
+            PrimitiveId::Mod,
+            Cell::from_i16(-7),
+            Cell::from_i16(3),
+            Cell::from_i16(-1),
+        ),
+        (
+            PrimitiveId::Mod,
+            Cell::from_i16(7),
+            Cell::from_i16(-3),
+            Cell::from_i16(1),
+        ),
+        (
+            PrimitiveId::Mod,
+            Cell::from_i16(-7),
+            Cell::from_i16(-3),
+            Cell::from_i16(-1),
+        ),
+    ];
+
+    for (primitive, lhs, rhs, expected) in cases {
+        let mut vm = Tbx16Vm::default();
+        let mut image = ImageBuilder::new(CODE_START);
+        let primitive_xt = image.primitive(primitive);
+        image.load_into(&mut vm);
+        vm.push_data_cell(lhs).unwrap();
+        vm.push_data_cell(rhs).unwrap();
+        assert_eq!(vm.run(primitive_xt), ExecutionOutcome::Returned);
+        assert_eq!(vm.peek_data_cell(0).unwrap(), expected, "{primitive:?}");
+    }
+
+    let mut negate_vm = Tbx16Vm::default();
+    let mut negate_image = ImageBuilder::new(CODE_START);
+    let negate_xt = negate_image.primitive(PrimitiveId::Negate);
+    negate_image.load_into(&mut negate_vm);
+    negate_vm.push_data_cell(Cell::from_i16(-32768)).unwrap();
+    assert_eq!(negate_vm.run(negate_xt), ExecutionOutcome::Returned);
+    assert_eq!(negate_vm.peek_data_cell(0).unwrap(), Cell::from_i16(-32768));
+
+    let mut zero_div_vm = Tbx16Vm::default();
+    let mut zero_div_image = ImageBuilder::new(CODE_START);
+    let div_xt = zero_div_image.primitive(PrimitiveId::Div);
+    zero_div_image.load_into(&mut zero_div_vm);
+    zero_div_vm.push_data_cell(Cell::from_i16(1)).unwrap();
+    zero_div_vm.push_data_cell(Cell::from_i16(0)).unwrap();
+    assert_eq!(
+        zero_div_vm.run(div_xt),
+        ExecutionOutcome::Trapped(Tbx16Error::DivisionByZero)
+    );
+
+    let mut min_overflow_vm = Tbx16Vm::default();
+    let mut min_overflow_image = ImageBuilder::new(CODE_START);
+    let div_xt = min_overflow_image.primitive(PrimitiveId::Div);
+    let mod_xt = min_overflow_image.primitive(PrimitiveId::Mod);
+    min_overflow_image.load_into(&mut min_overflow_vm);
+    min_overflow_vm
+        .push_data_cell(Cell::from_i16(-32768))
+        .unwrap();
+    min_overflow_vm.push_data_cell(Cell::from_i16(-1)).unwrap();
+    assert_eq!(min_overflow_vm.run(div_xt), ExecutionOutcome::Returned);
+    assert_eq!(
+        min_overflow_vm.peek_data_cell(0).unwrap(),
+        Cell::from_i16(-32768)
+    );
+    min_overflow_vm.push_data_cell(Cell::from_i16(-1)).unwrap();
+    assert_eq!(min_overflow_vm.run(mod_xt), ExecutionOutcome::Returned);
+    assert_eq!(
+        min_overflow_vm.peek_data_cell(0).unwrap(),
+        Cell::from_i16(0)
+    );
+}
+
+#[test]
+fn comparison_and_boolean_primitives_produce_canonical_results() {
+    let compare_cases = [
+        (
+            PrimitiveId::Eq,
+            Cell::new(0x8000),
+            Cell::new(0x8000),
+            Cell::TRUE,
+        ),
+        (
+            PrimitiveId::Ne,
+            Cell::new(0x8000),
+            Cell::new(0x7fff),
+            Cell::TRUE,
+        ),
+        (
+            PrimitiveId::Lt,
+            Cell::from_i16(-1),
+            Cell::from_i16(1),
+            Cell::TRUE,
+        ),
+        (
+            PrimitiveId::Le,
+            Cell::from_i16(-1),
+            Cell::from_i16(-1),
+            Cell::TRUE,
+        ),
+        (
+            PrimitiveId::Gt,
+            Cell::from_i16(1),
+            Cell::from_i16(-1),
+            Cell::TRUE,
+        ),
+        (
+            PrimitiveId::Ge,
+            Cell::from_i16(-1),
+            Cell::from_i16(-1),
+            Cell::TRUE,
+        ),
+    ];
+
+    for (primitive, lhs, rhs, expected) in compare_cases {
+        let mut vm = Tbx16Vm::default();
+        let mut image = ImageBuilder::new(CODE_START);
+        let primitive_xt = image.primitive(primitive);
+        image.load_into(&mut vm);
+        vm.push_data_cell(lhs).unwrap();
+        vm.push_data_cell(rhs).unwrap();
+        assert_eq!(vm.run(primitive_xt), ExecutionOutcome::Returned);
+        assert_eq!(vm.peek_data_cell(0).unwrap(), expected, "{primitive:?}");
+    }
+
+    let truthy_values = [
+        (Cell::new(0x0000), Cell::FALSE, Cell::TRUE),
+        (Cell::new(0x0001), Cell::TRUE, Cell::FALSE),
+        (Cell::new(0x8000), Cell::TRUE, Cell::FALSE),
+        (Cell::new(0xffff), Cell::TRUE, Cell::FALSE),
+    ];
+
+    for (value, to_bool_expected, not_expected) in truthy_values {
+        let mut to_bool_vm = Tbx16Vm::default();
+        let mut image = ImageBuilder::new(CODE_START);
+        let to_bool_xt = image.primitive(PrimitiveId::ToBool);
+        image.load_into(&mut to_bool_vm);
+        to_bool_vm.push_data_cell(value).unwrap();
+        assert_eq!(to_bool_vm.run(to_bool_xt), ExecutionOutcome::Returned);
+        assert_eq!(to_bool_vm.peek_data_cell(0).unwrap(), to_bool_expected);
+
+        let mut not_vm = Tbx16Vm::default();
+        let mut image = ImageBuilder::new(CODE_START);
+        let not_xt = image.primitive(PrimitiveId::Not);
+        image.load_into(&mut not_vm);
+        not_vm.push_data_cell(value).unwrap();
+        assert_eq!(not_vm.run(not_xt), ExecutionOutcome::Returned);
+        assert_eq!(not_vm.peek_data_cell(0).unwrap(), not_expected);
+    }
+}
+
+#[test]
+fn logical_and_bitwise_primitives_differ_as_profiled() {
+    let mut and_vm = Tbx16Vm::default();
+    let mut and_image = ImageBuilder::new(CODE_START);
+    let and_xt = and_image.primitive(PrimitiveId::And);
+    and_image.load_into(&mut and_vm);
+    and_vm.push_data_cell(Cell::new(0x8000)).unwrap();
+    and_vm.push_data_cell(Cell::new(0x0001)).unwrap();
+    assert_eq!(and_vm.run(and_xt), ExecutionOutcome::Returned);
+    assert_eq!(and_vm.peek_data_cell(0).unwrap(), Cell::TRUE);
+
+    let mut or_vm = Tbx16Vm::default();
+    let mut or_image = ImageBuilder::new(CODE_START);
+    let or_xt = or_image.primitive(PrimitiveId::Or);
+    or_image.load_into(&mut or_vm);
+    or_vm.push_data_cell(Cell::new(0x0000)).unwrap();
+    or_vm.push_data_cell(Cell::new(0x8000)).unwrap();
+    assert_eq!(or_vm.run(or_xt), ExecutionOutcome::Returned);
+    assert_eq!(or_vm.peek_data_cell(0).unwrap(), Cell::TRUE);
+
+    let mut band_vm = Tbx16Vm::default();
+    let mut band_image = ImageBuilder::new(CODE_START);
+    let band_xt = band_image.primitive(PrimitiveId::Band);
+    band_image.load_into(&mut band_vm);
+    band_vm.push_data_cell(Cell::new(0x8000)).unwrap();
+    band_vm.push_data_cell(Cell::new(0x0001)).unwrap();
+    assert_eq!(band_vm.run(band_xt), ExecutionOutcome::Returned);
+    assert_eq!(band_vm.peek_data_cell(0).unwrap(), Cell::FALSE);
+
+    let mut bor_vm = Tbx16Vm::default();
+    let mut bor_image = ImageBuilder::new(CODE_START);
+    let bor_xt = bor_image.primitive(PrimitiveId::Bor);
+    bor_image.load_into(&mut bor_vm);
+    bor_vm.push_data_cell(Cell::new(0x8000)).unwrap();
+    bor_vm.push_data_cell(Cell::new(0x0001)).unwrap();
+    assert_eq!(bor_vm.run(bor_xt), ExecutionOutcome::Returned);
+    assert_eq!(bor_vm.peek_data_cell(0).unwrap(), Cell::new(0x8001));
+}
+
+#[test]
+fn fetch_and_store_use_byte_addresses_and_little_endian_cells() {
+    let mut vm = Tbx16Vm::default();
+    let mut image = ImageBuilder::new(CODE_START);
+    let store_xt = image.primitive(PrimitiveId::Store);
+    let fetch_xt = image.primitive(PrimitiveId::Fetch);
+    image.load_into(&mut vm);
+
+    vm.push_data_cell(Cell::new(0x3001)).unwrap();
+    vm.push_data_cell(Cell::new(0xabcd)).unwrap();
+    assert_eq!(vm.run(store_xt), ExecutionOutcome::Returned);
+    assert_eq!(vm.memory().read_byte(Address::new(0x3001)).unwrap(), 0xcd);
+    assert_eq!(vm.memory().read_byte(Address::new(0x3002)).unwrap(), 0xab);
+
+    vm.push_data_cell(Cell::new(0x3001)).unwrap();
+    assert_eq!(vm.run(fetch_xt), ExecutionOutcome::Returned);
+    assert_eq!(vm.peek_data_cell(0).unwrap(), Cell::new(0xabcd));
+}
+
+#[test]
+fn fetch_and_store_trap_on_end_crossing() {
+    let mut fetch_vm = Tbx16Vm::default();
+    let mut fetch_image = ImageBuilder::new(CODE_START);
+    let fetch_xt = fetch_image.primitive(PrimitiveId::Fetch);
+    fetch_image.load_into(&mut fetch_vm);
+    fetch_vm.push_data_cell(Cell::new(0xffff)).unwrap();
+    assert_eq!(
+        fetch_vm.run(fetch_xt),
+        ExecutionOutcome::Trapped(Tbx16Error::InvalidMemoryAccess {
+            addr: Address::new(0xffff),
+            operation: "cell read",
+        })
+    );
+
+    let mut store_vm = Tbx16Vm::default();
+    let mut store_image = ImageBuilder::new(CODE_START);
+    let store_xt = store_image.primitive(PrimitiveId::Store);
+    store_image.load_into(&mut store_vm);
+    store_vm.push_data_cell(Cell::new(0xffff)).unwrap();
+    store_vm.push_data_cell(Cell::new(0x1234)).unwrap();
+    assert_eq!(
+        store_vm.run(store_xt),
+        ExecutionOutcome::Trapped(Tbx16Error::InvalidMemoryAccess {
+            addr: Address::new(0xffff),
+            operation: "cell write",
+        })
+    );
+}
+
+#[test]
+fn frame_slot_primitives_read_and_write_arguments_and_locals() {
+    let mut local_vm = Tbx16Vm::default();
+    let mut local_image = ImageBuilder::new(CODE_START);
+    let load_slot_xt = local_image.primitive(PrimitiveId::LoadSlot);
+    let store_slot_xt = local_image.primitive(PrimitiveId::StoreSlot);
+    let exit_xt = local_image.primitive(PrimitiveId::Exit);
+    let entry_xt = local_image.colon_word(1, 1);
+    local_image.emit_xt(load_slot_xt);
+    local_image.emit_cell(Cell::new(0));
+    local_image.emit_xt(store_slot_xt);
+    local_image.emit_cell(Cell::new(1));
+    local_image.emit_xt(load_slot_xt);
+    local_image.emit_cell(Cell::new(1));
+    local_image.emit_xt(exit_xt);
+    local_image.emit_cell(Cell::new(1));
+    local_image.load_into(&mut local_vm);
+    local_vm.push_data_cell(Cell::new(0x1234)).unwrap();
+    assert_eq!(local_vm.run(entry_xt), ExecutionOutcome::Returned);
+    assert_eq!(local_vm.peek_data_cell(0).unwrap(), Cell::new(0x1234));
+
+    let mut arg_vm = Tbx16Vm::default();
+    let mut arg_image = ImageBuilder::new(CODE_START);
+    let lit_xt = arg_image.primitive(PrimitiveId::Lit);
+    let store_slot_xt = arg_image.primitive(PrimitiveId::StoreSlot);
+    let load_slot_xt = arg_image.primitive(PrimitiveId::LoadSlot);
+    let exit_xt = arg_image.primitive(PrimitiveId::Exit);
+    let entry_xt = arg_image.colon_word(1, 0);
+    arg_image.emit_xt(lit_xt);
+    arg_image.emit_cell(Cell::new(0x4321));
+    arg_image.emit_xt(store_slot_xt);
+    arg_image.emit_cell(Cell::new(0));
+    arg_image.emit_xt(load_slot_xt);
+    arg_image.emit_cell(Cell::new(0));
+    arg_image.emit_xt(exit_xt);
+    arg_image.emit_cell(Cell::new(1));
+    arg_image.load_into(&mut arg_vm);
+    arg_vm.push_data_cell(Cell::new(0x1111)).unwrap();
+    assert_eq!(arg_vm.run(entry_xt), ExecutionOutcome::Returned);
+    assert_eq!(arg_vm.peek_data_cell(0).unwrap(), Cell::new(0x4321));
+}
+
+#[test]
+fn frame_slot_primitives_trap_on_out_of_range_indices() {
+    let mut load_vm = Tbx16Vm::default();
+    let mut load_image = ImageBuilder::new(CODE_START);
+    let load_slot_xt = load_image.primitive(PrimitiveId::LoadSlot);
+    let entry_xt = load_image.colon_word(1, 1);
+    load_image.emit_xt(load_slot_xt);
+    load_image.emit_cell(Cell::new(2));
+    load_image.load_into(&mut load_vm);
+    load_vm.push_data_cell(Cell::new(0x1111)).unwrap();
+    assert_eq!(
+        load_vm.run(entry_xt),
+        ExecutionOutcome::Trapped(Tbx16Error::InvalidFrameSlot {
+            slot_index: 2,
+            slot_count: 2,
+        })
+    );
+
+    let mut store_vm = Tbx16Vm::default();
+    let mut store_image = ImageBuilder::new(CODE_START);
+    let lit_xt = store_image.primitive(PrimitiveId::Lit);
+    let store_slot_xt = store_image.primitive(PrimitiveId::StoreSlot);
+    let entry_xt = store_image.colon_word(0, 0);
+    store_image.emit_xt(lit_xt);
+    store_image.emit_cell(Cell::new(0x9999));
+    store_image.emit_xt(store_slot_xt);
+    store_image.emit_cell(Cell::new(0));
+    store_image.load_into(&mut store_vm);
+    assert_eq!(
+        store_vm.run(entry_xt),
+        ExecutionOutcome::Trapped(Tbx16Error::InvalidFrameSlot {
+            slot_index: 0,
+            slot_count: 0,
+        })
+    );
+}
+
+#[test]
+fn output_primitives_write_to_the_vm_sink() {
+    let mut chr_vm = Tbx16Vm::default();
+    let mut chr_image = ImageBuilder::new(CODE_START);
+    let putchr_xt = chr_image.primitive(PrimitiveId::PutChr);
+    chr_image.load_into(&mut chr_vm);
+    chr_vm.push_data_cell(Cell::new(0x0141)).unwrap();
+    assert_eq!(chr_vm.run(putchr_xt), ExecutionOutcome::Returned);
+    assert_eq!(output_bytes(&mut chr_vm), b"A");
+
+    let mut dec_vm = Tbx16Vm::default();
+    let mut dec_image = ImageBuilder::new(CODE_START);
+    let putdec_xt = dec_image.primitive(PrimitiveId::PutDec);
+    dec_image.load_into(&mut dec_vm);
+    for value in [0, 1234, -45, -32768] {
+        dec_vm.push_data_cell(Cell::from_i16(value)).unwrap();
+        assert_eq!(dec_vm.run(putdec_xt), ExecutionOutcome::Returned);
+    }
+    assert_eq!(output_bytes(&mut dec_vm), b"01234-45-32768");
+
+    let mut str_vm = Tbx16Vm::default();
+    let mut str_image = ImageBuilder::new(CODE_START);
+    let putstr_xt = str_image.primitive(PrimitiveId::PutStr);
+    str_image.load_into(&mut str_vm);
+    write_length_prefixed_bytes(&mut str_vm, 0x3000, b"hi\0there");
+    str_vm.push_data_cell(Cell::new(0x3000)).unwrap();
+    assert_eq!(str_vm.run(putstr_xt), ExecutionOutcome::Returned);
+    assert_eq!(output_bytes(&mut str_vm), b"hi\0there");
 }


### PR DESCRIPTION
## 状態

このPRは #999 のM2.3 primitiveを一括実装した分割元です。レビューの結果、frame slotのruntime metadata取得方法とreturn frame契約が未確定だったため、ドラフトへ戻し、次の3チケットへ分割しました。

- #1011 — stack・算術・比較・論理・memory primitive
- #1012 — output primitiveと決定的な出力sink
- #1013 — Wレジスタと検証可能なframe slotアクセス

## 取り扱い

- このPRはそのままマージしません。
- `Closes #999` は外しています。
- 各サブチケットの独立PRで、必要な実装・テストを切り出して再利用してください。
- 各PRのbaseは `integration/961-tbx-6502` とします。
- `LOAD_SLOT` / `STORE_SLOT` の `slot_index + slot_count` 2 Cell operand方式は採用しません。

## 分割後の設計

- #1011でprimitive registryと基本primitiveを確立
- #1012でVM所有の決定的なbyte output sinkと出力primitiveを追加
- #1013でcurrent colon wordを指すWレジスタを追加し、return frameを3 Cellへ正式改訂
- frame slot boundsはoperandの自己申告ではなく、Wが指すactual colon metadataからruntime検証

分割後の確定仕様は #1011、#1012、#1013 を正としてください。