### PR TITLE
tbx16にWレジスタとframe slot境界検証を追加

### DIFF
--- a/src/tbx16/error.rs
+++ b/src/tbx16/error.rs
@@ -31,6 +31,10 @@ pub enum Tbx16Error {
     InvalidExecutionToken {
         xt: Cell,
     },
+    InvalidFrameSlot {
+        slot_index: u16,
+        slot_count: u16,
+    },
     InvalidExecutionState,
     DirtyExecutionState,
     InstructionPointerOutOfRange {
@@ -65,6 +69,14 @@ impl fmt::Display for Tbx16Error {
             Tbx16Error::InvalidExecutionToken { xt } => {
                 write!(f, "invalid execution token ${:04x}", xt.raw())
             }
+            Tbx16Error::InvalidFrameSlot {
+                slot_index,
+                slot_count,
+            } => write!(
+                f,
+                "invalid frame slot {} for slot count {}",
+                slot_index, slot_count
+            ),
             Tbx16Error::InvalidExecutionState => write!(f, "invalid execution state"),
             Tbx16Error::DirtyExecutionState => write!(f, "dirty execution state"),
             Tbx16Error::InstructionPointerOutOfRange { ip } => {

--- a/src/tbx16/mod.rs
+++ b/src/tbx16/mod.rs
@@ -25,7 +25,7 @@ pub const DEFAULT_RETURN_STACK_START: Address = Address::new(0x0200);
 pub const DEFAULT_RETURN_STACK_END: Address = Address::new(0x0300);
 const PAGE_ONE_END: Address = Address::new(0x0200);
 const NO_IP: Address = Address::new(0xffff);
-const RETURN_FRAME_BYTES: u16 = 4;
+const RETURN_FRAME_BYTES: u16 = 6;
 
 pub const CODE_TOKEN_PRIMITIVE: Cell = Cell::new(0x0001);
 pub const CODE_TOKEN_DOCOL: Cell = Cell::new(0x0002);
@@ -87,6 +87,8 @@ pub enum PrimitiveId {
     PutChr = 96,
     PutDec = 97,
     PutStr = 98,
+    LoadSlot = 112,
+    StoreSlot = 113,
 }
 
 impl PrimitiveId {
@@ -148,6 +150,8 @@ impl TryFrom<Cell> for PrimitiveId {
             96 => Ok(Self::PutChr),
             97 => Ok(Self::PutDec),
             98 => Ok(Self::PutStr),
+            112 => Ok(Self::LoadSlot),
+            113 => Ok(Self::StoreSlot),
             _ => Err(()),
         }
     }
@@ -314,6 +318,16 @@ pub const PRIMITIVE_REGISTRY: &[PrimitiveDescriptor] = &[
         name: "PUTSTR",
         operand: PrimitiveOperand::None,
     },
+    PrimitiveDescriptor {
+        id: PrimitiveId::LoadSlot,
+        name: "LOAD_SLOT",
+        operand: PrimitiveOperand::Cell,
+    },
+    PrimitiveDescriptor {
+        id: PrimitiveId::StoreSlot,
+        name: "STORE_SLOT",
+        operand: PrimitiveOperand::Cell,
+    },
 ];
 
 pub const fn primitive_descriptor_by_id(id: PrimitiveId) -> &'static PrimitiveDescriptor {
@@ -362,7 +376,14 @@ pub struct Tbx16Vm {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct EntryContext {
     initial_bp: Address,
+    initial_w: Option<Address>,
+    entry_w: Address,
     frame_base: Address,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ActiveColonFrame {
+    slot_count: u16,
 }
 
 impl Default for Tbx16Vm {
@@ -397,6 +418,7 @@ impl Tbx16Vm {
             dsp: DATA_STACK_START,
             rsp: return_stack_region.start(),
             bp: DATA_STACK_START,
+            w: None,
         };
         let vm = Self {
             memory: Memory::default(),
@@ -473,6 +495,7 @@ impl Tbx16Vm {
         self.registers.ip = None;
         self.registers.bp = DATA_STACK_START;
         self.registers.rsp = self.return_stack_region.start();
+        self.registers.w = None;
         self.call_depth = 0;
         self.entry_context = None;
         self.step_counter = 0;
@@ -619,7 +642,7 @@ impl Tbx16Vm {
         let next = self
             .registers
             .rsp
-            .checked_add(4)
+            .checked_add(RETURN_FRAME_BYTES)
             .ok_or(Tbx16Error::ReturnStackOverflow)?;
         ensure_pointer_in_region(self.registers.rsp, self.return_stack_region, "return")?;
         if !self.return_stack_region.contains_pointer(next) {
@@ -633,6 +656,13 @@ impl Tbx16Vm {
                 .checked_add(2)
                 .expect("aligned stack pointer has room for second frame cell"),
             Cell::new(frame.caller_bp.get()),
+        )?;
+        self.memory.write_cell(
+            self.registers
+                .rsp
+                .checked_add(4)
+                .expect("aligned stack pointer has room for third frame cell"),
+            Cell::new(frame.caller_w.get()),
         )?;
         self.registers.rsp = next;
         Ok(())
@@ -714,6 +744,11 @@ impl Tbx16Vm {
                 reason: "base pointer must not exceed the data stack pointer",
             });
         }
+        if self.is_active_colon_context() {
+            self.validate_active_colon_frame()?;
+        } else if self.registers.w.is_some() {
+            return Err(Tbx16Error::InvalidExecutionState);
+        }
         let used_return_bytes = self.registers.rsp.get() - self.return_stack_region.start().get();
         let expected_return_bytes = self.call_depth.checked_mul(RETURN_FRAME_BYTES).ok_or(
             Tbx16Error::InvalidStackRegion {
@@ -750,7 +785,9 @@ impl Tbx16Vm {
                 self.execute_primitive(primitive)?;
                 Ok(ExecutionOutcome::Returned)
             }
-            PrimitiveId::Exit => Err(Tbx16Error::InvalidExecutionState),
+            PrimitiveId::LoadSlot | PrimitiveId::StoreSlot | PrimitiveId::Exit => {
+                Err(Tbx16Error::InvalidExecutionState)
+            }
             _ => {
                 self.execute_primitive_no_operand(primitive)?;
                 Ok(ExecutionOutcome::Returned)
@@ -783,13 +820,17 @@ impl Tbx16Vm {
                     self.memory
                         .zero_range(locals_start, usize::from(local_count) * 2)?;
                 }
+                let entry_w = validate_execution_token_address(entry_xt)?;
                 self.entry_context = Some(EntryContext {
                     initial_bp,
+                    initial_w: self.registers.w,
+                    entry_w,
                     frame_base,
                 });
                 self.registers.bp = frame_base;
                 self.registers.dsp = new_dsp;
                 self.registers.ip = Some(parameter_ip);
+                self.registers.w = Some(entry_w);
                 self.debug_validate_state();
                 Ok(ExecutionState::Running)
             }
@@ -848,6 +889,14 @@ impl Tbx16Vm {
                 Ok(None)
             }
             PrimitiveId::Exit => self.execute_exit_from_operand(continuation_ip),
+            PrimitiveId::LoadSlot => {
+                self.execute_load_slot_from_operand(continuation_ip)?;
+                Ok(None)
+            }
+            PrimitiveId::StoreSlot => {
+                self.execute_store_slot_from_operand(continuation_ip)?;
+                Ok(None)
+            }
             _ => {
                 self.execute_primitive_no_operand(primitive)?;
                 self.registers.ip = Some(continuation_ip);
@@ -862,7 +911,9 @@ impl Tbx16Vm {
             PrimitiveId::Branch => self.execute_branch_from_operand(self.current_ip()?),
             PrimitiveId::ZBranch => self.execute_zbranch_from_operand(self.current_ip()?),
             PrimitiveId::Halt => Ok(()),
-            PrimitiveId::Exit => Err(Tbx16Error::InvalidExecutionState),
+            PrimitiveId::Exit | PrimitiveId::LoadSlot | PrimitiveId::StoreSlot => {
+                Err(Tbx16Error::InvalidExecutionState)
+            }
             _ => self.execute_primitive_no_operand(primitive),
         }
     }
@@ -897,9 +948,12 @@ impl Tbx16Vm {
             PrimitiveId::PutChr => self.execute_putchr(),
             PrimitiveId::PutDec => self.execute_putdec(),
             PrimitiveId::PutStr => self.execute_putstr(),
-            PrimitiveId::Lit | PrimitiveId::Branch | PrimitiveId::ZBranch | PrimitiveId::Exit => {
-                Err(Tbx16Error::InvalidExecutionState)
-            }
+            PrimitiveId::Lit
+            | PrimitiveId::Branch
+            | PrimitiveId::ZBranch
+            | PrimitiveId::Exit
+            | PrimitiveId::LoadSlot
+            | PrimitiveId::StoreSlot => Err(Tbx16Error::InvalidExecutionState),
         }
     }
 
@@ -1005,9 +1059,20 @@ impl Tbx16Vm {
         parameter_ip: Address,
         return_ip: Address,
     ) -> Result<(), Tbx16Error> {
+        let caller_w = self.registers.w.ok_or(Tbx16Error::InvalidExecutionState)?;
+        match self.resolve_word(Cell::new(caller_w.get()))? {
+            ResolvedWord::Colon { .. } => {}
+            ResolvedWord::Primitive(_) => return Err(Tbx16Error::InvalidExecutionState),
+        }
         let new_bp = self.compute_frame_base(arity)?;
         let locals_start = self.registers.dsp;
         let new_dsp = self.checked_extend_data_stack(locals_start, local_count)?;
+        let callee_w = self.read_ip_cell(
+            return_ip
+                .checked_sub(2)
+                .expect("continuation ip always follows a callee XT cell"),
+        )?;
+        let callee_w = validate_execution_token_address(callee_w)?;
         let new_rsp = self
             .registers
             .rsp
@@ -1019,6 +1084,10 @@ impl Tbx16Vm {
         }
 
         let caller_bp = self.registers.bp;
+        if local_count != 0 {
+            self.memory
+                .zero_range(locals_start, usize::from(local_count) * 2)?;
+        }
         self.memory
             .write_cell(self.registers.rsp, Cell::new(return_ip.get()))?;
         self.memory.write_cell(
@@ -1028,15 +1097,19 @@ impl Tbx16Vm {
                 .expect("validated return frame has room for caller bp"),
             Cell::new(caller_bp.get()),
         )?;
-        if local_count != 0 {
-            self.memory
-                .zero_range(locals_start, usize::from(local_count) * 2)?;
-        }
+        self.memory.write_cell(
+            self.registers
+                .rsp
+                .checked_add(4)
+                .expect("validated return frame has room for caller w"),
+            Cell::new(caller_w.get()),
+        )?;
 
         self.registers.rsp = new_rsp;
         self.registers.bp = new_bp;
         self.registers.dsp = new_dsp;
         self.registers.ip = Some(parameter_ip);
+        self.registers.w = Some(callee_w);
         self.call_depth = self
             .call_depth
             .checked_add(1)
@@ -1082,6 +1155,10 @@ impl Tbx16Vm {
         let frame = self.peek_return_frame()?;
         let return_ip = validate_instruction_pointer_target(frame.return_ip)?;
         self.validate_base_pointer(frame.caller_bp)?;
+        match self.resolve_word(Cell::new(frame.caller_w.get()))? {
+            ResolvedWord::Colon { .. } => {}
+            ResolvedWord::Primitive(_) => return Err(Tbx16Error::InvalidExecutionState),
+        }
 
         let new_dsp = if return_count == 0 {
             self.registers.bp
@@ -1103,6 +1180,7 @@ impl Tbx16Vm {
         self.registers.bp = frame.caller_bp;
         self.registers.dsp = new_dsp;
         self.registers.ip = Some(return_ip);
+        self.registers.w = Some(frame.caller_w);
         self.call_depth = self
             .call_depth
             .checked_sub(1)
@@ -1122,6 +1200,9 @@ impl Tbx16Vm {
         if self.registers.bp != context.frame_base {
             return Err(Tbx16Error::InvalidExecutionState);
         }
+        if self.registers.w != Some(context.entry_w) {
+            return Err(Tbx16Error::InvalidExecutionState);
+        }
         if self.registers.rsp != self.return_stack_region.start() {
             return Err(Tbx16Error::InvalidExecutionState);
         }
@@ -1138,6 +1219,7 @@ impl Tbx16Vm {
         self.registers.dsp = new_dsp;
         self.registers.bp = context.initial_bp;
         self.registers.ip = None;
+        self.registers.w = context.initial_w;
         self.call_depth = 0;
         self.entry_context = None;
         Ok(ExecutionOutcome::Returned)
@@ -1168,10 +1250,103 @@ impl Tbx16Vm {
                 .checked_add(2)
                 .expect("validated frame start has room for caller bp"),
         )?;
+        let caller_w = self.memory.read_cell(
+            frame_start
+                .checked_add(4)
+                .expect("validated frame start has room for caller w"),
+        )?;
         Ok(ReturnFrame {
             return_ip: Address::new(return_ip.raw()),
             caller_bp: Address::new(caller_bp.raw()),
+            caller_w: Address::new(caller_w.raw()),
         })
+    }
+
+    fn is_active_colon_context(&self) -> bool {
+        self.entry_context.is_some() || self.call_depth != 0
+    }
+
+    fn validate_active_colon_frame(&self) -> Result<ActiveColonFrame, Tbx16Error> {
+        let w = self.registers.w.ok_or(Tbx16Error::InvalidExecutionState)?;
+        let (arity, local_count) = match self.resolve_word(Cell::new(w.get()))? {
+            ResolvedWord::Colon {
+                arity, local_count, ..
+            } => (arity, local_count),
+            ResolvedWord::Primitive(_) => return Err(Tbx16Error::InvalidExecutionState),
+        };
+        self.validate_base_pointer(self.registers.bp)?;
+        let slot_count = arity
+            .checked_add(local_count)
+            .ok_or(Tbx16Error::InvalidExecutionState)?;
+        let frame_end = self.checked_extend_data_stack(self.registers.bp, slot_count)?;
+        if frame_end > self.registers.dsp {
+            return Err(Tbx16Error::InvalidExecutionState);
+        }
+        Ok(ActiveColonFrame { slot_count })
+    }
+
+    fn validated_frame_slot_address(
+        &self,
+        slot_index: u16,
+    ) -> Result<(ActiveColonFrame, Address), Tbx16Error> {
+        let frame = self.validate_active_colon_frame()?;
+        if slot_index >= frame.slot_count {
+            return Err(Tbx16Error::InvalidFrameSlot {
+                slot_index,
+                slot_count: frame.slot_count,
+            });
+        }
+        let addr = self
+            .registers
+            .bp
+            .checked_add(
+                slot_index
+                    .checked_mul(2)
+                    .ok_or(Tbx16Error::InvalidExecutionState)?,
+            )
+            .ok_or(Tbx16Error::InvalidExecutionState)?;
+        let next_addr = addr
+            .checked_add(2)
+            .ok_or(Tbx16Error::InvalidExecutionState)?;
+        if !self.data_stack_region.contains(addr)
+            || !self.data_stack_region.contains_pointer(next_addr)
+        {
+            return Err(Tbx16Error::InvalidExecutionState);
+        }
+        Ok((frame, addr))
+    }
+
+    fn execute_load_slot_from_operand(&mut self, operand_ip: Address) -> Result<(), Tbx16Error> {
+        let slot_index = self.read_ip_cell(operand_ip)?.raw();
+        let next_ip = validated_successor_ip(operand_ip)?;
+        let _ = self.validated_frame_slot_address(slot_index)?;
+        let slot_addr = self.data_slot_address(slot_index)?;
+        let value = self.memory.read_cell(slot_addr)?;
+        self.ensure_data_stack_pushable(self.registers.dsp)?;
+        self.memory.write_cell(self.registers.dsp, value)?;
+        self.registers.dsp = self
+            .registers
+            .dsp
+            .checked_add(2)
+            .ok_or(Tbx16Error::DataStackOverflow)?;
+        self.registers.ip = Some(next_ip);
+        Ok(())
+    }
+
+    fn execute_store_slot_from_operand(&mut self, operand_ip: Address) -> Result<(), Tbx16Error> {
+        let slot_index = self.read_ip_cell(operand_ip)?.raw();
+        let next_ip = validated_successor_ip(operand_ip)?;
+        let (_, slot_addr) = self.validated_frame_slot_address(slot_index)?;
+        let value = self.peek_data_cell(0)?;
+        let new_dsp = self
+            .registers
+            .dsp
+            .checked_sub(2)
+            .ok_or(Tbx16Error::DataStackUnderflow)?;
+        self.memory.write_cell(slot_addr, value)?;
+        self.registers.dsp = new_dsp;
+        self.registers.ip = Some(next_ip);
+        Ok(())
     }
 
     fn debug_validate_state(&self) {

--- a/src/tbx16/mod.rs
+++ b/src/tbx16/mod.rs
@@ -745,7 +745,9 @@ impl Tbx16Vm {
             });
         }
         if self.is_active_colon_context() {
-            self.validate_active_colon_frame()?;
+            if self.registers.w.is_none() {
+                return Err(Tbx16Error::InvalidExecutionState);
+            }
         } else if self.registers.w.is_some() {
             return Err(Tbx16Error::InvalidExecutionState);
         }
@@ -1060,10 +1062,7 @@ impl Tbx16Vm {
         return_ip: Address,
     ) -> Result<(), Tbx16Error> {
         let caller_w = self.registers.w.ok_or(Tbx16Error::InvalidExecutionState)?;
-        match self.resolve_word(Cell::new(caller_w.get()))? {
-            ResolvedWord::Colon { .. } => {}
-            ResolvedWord::Primitive(_) => return Err(Tbx16Error::InvalidExecutionState),
-        }
+        self.resolve_active_colon_word(caller_w)?;
         let new_bp = self.compute_frame_base(arity)?;
         let locals_start = self.registers.dsp;
         let new_dsp = self.checked_extend_data_stack(locals_start, local_count)?;
@@ -1072,7 +1071,8 @@ impl Tbx16Vm {
                 .checked_sub(2)
                 .expect("continuation ip always follows a callee XT cell"),
         )?;
-        let callee_w = validate_execution_token_address(callee_w)?;
+        let callee_w = validate_execution_token_address(callee_w)
+            .map_err(|_| Tbx16Error::InvalidExecutionState)?;
         let new_rsp = self
             .registers
             .rsp
@@ -1155,10 +1155,7 @@ impl Tbx16Vm {
         let frame = self.peek_return_frame()?;
         let return_ip = validate_instruction_pointer_target(frame.return_ip)?;
         self.validate_base_pointer(frame.caller_bp)?;
-        match self.resolve_word(Cell::new(frame.caller_w.get()))? {
-            ResolvedWord::Colon { .. } => {}
-            ResolvedWord::Primitive(_) => return Err(Tbx16Error::InvalidExecutionState),
-        }
+        self.resolve_active_colon_word(frame.caller_w)?;
 
         let new_dsp = if return_count == 0 {
             self.registers.bp
@@ -1203,6 +1200,7 @@ impl Tbx16Vm {
         if self.registers.w != Some(context.entry_w) {
             return Err(Tbx16Error::InvalidExecutionState);
         }
+        self.resolve_active_colon_word(context.entry_w)?;
         if self.registers.rsp != self.return_stack_region.start() {
             return Err(Tbx16Error::InvalidExecutionState);
         }
@@ -1268,7 +1266,7 @@ impl Tbx16Vm {
 
     fn validate_active_colon_frame(&self) -> Result<ActiveColonFrame, Tbx16Error> {
         let w = self.registers.w.ok_or(Tbx16Error::InvalidExecutionState)?;
-        let (arity, local_count) = match self.resolve_word(Cell::new(w.get()))? {
+        let (arity, local_count) = match self.resolve_active_colon_word(w)? {
             ResolvedWord::Colon {
                 arity, local_count, ..
             } => (arity, local_count),
@@ -1283,6 +1281,24 @@ impl Tbx16Vm {
             return Err(Tbx16Error::InvalidExecutionState);
         }
         Ok(ActiveColonFrame { slot_count })
+    }
+
+    fn resolve_active_colon_word(&self, w: Address) -> Result<ResolvedWord, Tbx16Error> {
+        match self.resolve_word(Cell::new(w.get())) {
+            Ok(ResolvedWord::Colon {
+                arity,
+                local_count,
+                parameter_ip,
+            }) => Ok(ResolvedWord::Colon {
+                arity,
+                local_count,
+                parameter_ip,
+            }),
+            Ok(ResolvedWord::Primitive(_)) | Err(Tbx16Error::InvalidExecutionToken { .. }) => {
+                Err(Tbx16Error::InvalidExecutionState)
+            }
+            Err(err) => Err(err),
+        }
     }
 
     fn validated_frame_slot_address(

--- a/src/tbx16/registers.rs
+++ b/src/tbx16/registers.rs
@@ -7,4 +7,5 @@ pub struct Registers {
     pub dsp: Address,
     pub rsp: Address,
     pub bp: Address,
+    pub w: Option<Address>,
 }

--- a/src/tbx16/stack.rs
+++ b/src/tbx16/stack.rs
@@ -55,11 +55,12 @@ impl StackRegion {
     }
 }
 
-/// A return-stack frame stored as two cells in unified memory.
+/// A return-stack frame stored as three cells in unified memory.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ReturnFrame {
     pub return_ip: Address,
     pub caller_bp: Address,
+    pub caller_w: Address,
 }
 
 pub(crate) fn ensure_pointer_in_region(

--- a/tests/tbx16.rs
+++ b/tests/tbx16.rs
@@ -1776,6 +1776,67 @@ fn nested_exit_traps_when_caller_w_is_corrupted() {
 }
 
 #[test]
+fn corrupting_current_w_metadata_via_store_defers_failure_until_metadata_is_needed() {
+    let mut slot_vm = Tbx16Vm::default();
+    let mut slot_image = ImageBuilder::new(CODE_START);
+    let lit_xt = slot_image.primitive(PrimitiveId::Lit);
+    let store_xt = slot_image.primitive(PrimitiveId::Store);
+    let load_slot_xt = slot_image.primitive(PrimitiveId::LoadSlot);
+    let entry_xt = slot_image.colon_word(0, 0);
+    slot_image.emit_xt(lit_xt);
+    slot_image.emit_cell(entry_xt);
+    slot_image.emit_xt(lit_xt);
+    slot_image.emit_cell(Cell::new(0x9999));
+    slot_image.emit_xt(store_xt);
+    slot_image.emit_xt(load_slot_xt);
+    slot_image.emit_cell(Cell::new(0));
+    slot_image.load_into(&mut slot_vm);
+
+    assert_eq!(
+        slot_vm.run(entry_xt),
+        ExecutionOutcome::Trapped(Tbx16Error::InvalidExecutionState)
+    );
+    assert_eq!(slot_vm.step_counter(), 5);
+    assert_eq!(slot_vm.registers().w, Some(Address::new(CODE_START + 12)));
+    assert_eq!(
+        slot_vm
+            .memory()
+            .read_cell(Address::new(CODE_START + 12))
+            .unwrap(),
+        Cell::new(0x9999)
+    );
+
+    let mut exit_vm = Tbx16Vm::default();
+    let mut exit_image = ImageBuilder::new(CODE_START);
+    let lit_xt = exit_image.primitive(PrimitiveId::Lit);
+    let store_xt = exit_image.primitive(PrimitiveId::Store);
+    let exit_xt = exit_image.primitive(PrimitiveId::Exit);
+    let entry_xt = exit_image.colon_word(0, 0);
+    exit_image.emit_xt(lit_xt);
+    exit_image.emit_cell(entry_xt);
+    exit_image.emit_xt(lit_xt);
+    exit_image.emit_cell(Cell::new(0x9999));
+    exit_image.emit_xt(store_xt);
+    exit_image.emit_xt(exit_xt);
+    exit_image.emit_cell(Cell::new(0));
+    exit_image.load_into(&mut exit_vm);
+
+    assert_eq!(
+        exit_vm.run(entry_xt),
+        ExecutionOutcome::Trapped(Tbx16Error::InvalidExecutionState)
+    );
+    assert_eq!(exit_vm.step_counter(), 5);
+    assert_eq!(exit_vm.registers().w, Some(Address::new(CODE_START + 12)));
+    assert_eq!(
+        exit_vm
+            .memory()
+            .read_cell(Address::new(CODE_START + 12))
+            .unwrap(),
+        Cell::new(0x9999)
+    );
+}
+
+#[test]
 fn threaded_program_executes_m2_3a_primitives() {
     let mut vm = Tbx16Vm::default();
     let mut image = ImageBuilder::new(CODE_START);

--- a/tests/tbx16.rs
+++ b/tests/tbx16.rs
@@ -20,6 +20,7 @@ struct VmSnapshot {
     dsp: Address,
     rsp: Address,
     bp: Address,
+    w: Option<Address>,
     step_counter: usize,
     call_depth: u16,
     output: Vec<u8>,
@@ -32,6 +33,7 @@ fn snapshot(vm: &Tbx16Vm) -> VmSnapshot {
         dsp: vm.registers().dsp,
         rsp: vm.registers().rsp,
         bp: vm.registers().bp,
+        w: vm.registers().w,
         step_counter: vm.step_counter(),
         call_depth: vm.call_depth(),
         output: vm.output().to_vec(),
@@ -325,15 +327,16 @@ fn return_stack_push_and_pop_moves_rsp_by_two_bytes() {
 }
 
 #[test]
-fn return_frame_is_stored_as_two_cells_in_memory() {
+fn return_frame_is_stored_as_three_cells_in_memory() {
     let mut vm = Tbx16Vm::default();
     let frame = ReturnFrame {
         return_ip: Address::new(0x3456),
         caller_bp: Address::new(0x00a0),
+        caller_w: Address::new(0x0444),
     };
 
     vm.push_return_frame(frame).unwrap();
-    assert_eq!(vm.registers().rsp, Address::new(0x0204));
+    assert_eq!(vm.registers().rsp, Address::new(0x0206));
     assert_eq!(
         vm.memory().read_cell(Address::new(0x0200)).unwrap(),
         Cell::new(0x3456)
@@ -342,15 +345,20 @@ fn return_frame_is_stored_as_two_cells_in_memory() {
         vm.memory().read_cell(Address::new(0x0202)).unwrap(),
         Cell::new(0x00a0)
     );
-    assert_eq!(vm.peek_return_cell(0).unwrap(), Cell::new(0x00a0));
+    assert_eq!(
+        vm.memory().read_cell(Address::new(0x0204)).unwrap(),
+        Cell::new(0x0444)
+    );
+    assert_eq!(vm.peek_return_cell(0).unwrap(), Cell::new(0x0444));
 }
 
 #[test]
-fn return_frame_round_trips_return_ip_and_caller_bp() {
+fn return_frame_round_trips_return_ip_caller_bp_and_caller_w() {
     let mut vm = Tbx16Vm::default();
     let frame = ReturnFrame {
         return_ip: Address::new(0x4567),
         caller_bp: Address::new(0x00c0),
+        caller_w: Address::new(0x0554),
     };
 
     vm.push_return_frame(frame).unwrap();
@@ -360,13 +368,14 @@ fn return_frame_round_trips_return_ip_and_caller_bp() {
 
 #[test]
 fn return_stack_reports_overflow_and_underflow() {
-    let region = StackRegion::new(Address::new(0x0200), Address::new(0x0204)).unwrap();
+    let region = StackRegion::new(Address::new(0x0200), Address::new(0x0206)).unwrap();
     let mut vm = Tbx16Vm::new(region).unwrap();
 
     vm.push_return_cell(Cell::new(1)).unwrap();
     vm.push_return_cell(Cell::new(2)).unwrap();
+    vm.push_return_cell(Cell::new(3)).unwrap();
     assert_eq!(
-        vm.push_return_cell(Cell::new(3)).unwrap_err(),
+        vm.push_return_cell(Cell::new(4)).unwrap_err(),
         Tbx16Error::ReturnStackOverflow
     );
 
@@ -394,15 +403,15 @@ fn invalid_return_stack_regions_are_rejected() {
 
 #[test]
 fn return_stack_capacity_matches_pushable_cell_count() {
-    let region = StackRegion::new(Address::new(0x0200), Address::new(0x0208)).unwrap();
+    let region = StackRegion::new(Address::new(0x0200), Address::new(0x020c)).unwrap();
     let vm = Tbx16Vm::new(region).unwrap();
-    assert_eq!(usize::from(region.len_bytes()) / 2, 4);
+    assert_eq!(usize::from(region.len_bytes()) / 2, 6);
     assert_eq!(vm.return_stack_region(), region);
 }
 
 #[test]
 fn return_stack_full_region_ends_with_rsp_at_region_end() {
-    let region = StackRegion::new(Address::new(0x0200), Address::new(0x0208)).unwrap();
+    let region = StackRegion::new(Address::new(0x0200), Address::new(0x020c)).unwrap();
     let mut vm = Tbx16Vm::new(region).unwrap();
 
     for i in 0..(usize::from(region.len_bytes()) / 2) {
@@ -471,10 +480,13 @@ fn primitive_registry_matches_the_m2_3b_abi_contract() {
     assert_eq!(PrimitiveId::PutChr as u16, 96);
     assert_eq!(PrimitiveId::PutDec as u16, 97);
     assert_eq!(PrimitiveId::PutStr as u16, 98);
+    assert_eq!(PrimitiveId::LoadSlot as u16, 112);
+    assert_eq!(PrimitiveId::StoreSlot as u16, 113);
 
     assert_eq!(PrimitiveId::Exit.operand(), PrimitiveOperand::Cell);
     assert_eq!(PrimitiveId::Dup.operand(), PrimitiveOperand::None);
     assert_eq!(PrimitiveId::PutDec.operand(), PrimitiveOperand::None);
+    assert_eq!(PrimitiveId::LoadSlot.operand(), PrimitiveOperand::Cell);
     assert_eq!(PrimitiveId::from_name("add"), None);
     assert_eq!(primitive_descriptor_by_name("add"), None);
     assert_eq!(PrimitiveId::try_from(Cell::new(0xffff)), Err(()));
@@ -578,6 +590,7 @@ fn entry_colon_initializes_frames_for_multiple_arities_and_locals() {
     assert_eq!(zero_vm.registers().bp, DATA_STACK_START);
     assert_eq!(zero_vm.registers().dsp, DATA_STACK_START);
     assert_eq!(zero_vm.call_depth(), 0);
+    assert_eq!(zero_vm.registers().w, Some(Address::new(CODE_START + 4)));
 
     let mut one_vm = Tbx16Vm::default();
     let mut one_image = ImageBuilder::new(CODE_START);
@@ -589,6 +602,7 @@ fn entry_colon_initializes_frames_for_multiple_arities_and_locals() {
     assert_eq!(one_vm.run(entry_xt), ExecutionOutcome::Halted);
     assert_eq!(one_vm.registers().bp, DATA_STACK_START);
     assert_eq!(one_vm.registers().dsp, Address::new(0x0082));
+    assert_eq!(one_vm.registers().w, Some(Address::new(CODE_START + 4)));
 
     let mut multi_vm = Tbx16Vm::default();
     let mut multi_image = ImageBuilder::new(CODE_START);
@@ -601,6 +615,7 @@ fn entry_colon_initializes_frames_for_multiple_arities_and_locals() {
     assert_eq!(multi_vm.run(entry_xt), ExecutionOutcome::Halted);
     assert_eq!(multi_vm.registers().bp, Address::new(0x0080));
     assert_eq!(multi_vm.registers().dsp, Address::new(0x0088));
+    assert_eq!(multi_vm.registers().w, Some(Address::new(CODE_START + 4)));
     assert_eq!(
         multi_vm.memory().read_cell(Address::new(0x0084)).unwrap(),
         Cell::new(0)
@@ -662,7 +677,8 @@ fn nested_colon_calls_build_frames_and_return_stack_layouts() {
     zero_image.load_into(&mut zero_vm);
     assert_eq!(zero_vm.run(entry_xt), ExecutionOutcome::Halted);
     assert_eq!(zero_vm.call_depth(), 1);
-    assert_eq!(zero_vm.registers().rsp, Address::new(0x0204));
+    assert_eq!(zero_vm.registers().rsp, Address::new(0x0206));
+    assert_eq!(zero_vm.registers().w, Some(Address::new(CODE_START + 4)));
     assert_eq!(
         zero_vm.memory().read_cell(Address::new(0x0200)).unwrap(),
         Cell::new(CODE_START + 20)
@@ -670,6 +686,10 @@ fn nested_colon_calls_build_frames_and_return_stack_layouts() {
     assert_eq!(
         zero_vm.memory().read_cell(Address::new(0x0202)).unwrap(),
         Cell::new(DATA_STACK_START.get())
+    );
+    assert_eq!(
+        zero_vm.memory().read_cell(Address::new(0x0204)).unwrap(),
+        Cell::new(entry_xt.raw())
     );
 
     let mut one_vm = Tbx16Vm::default();
@@ -685,6 +705,7 @@ fn nested_colon_calls_build_frames_and_return_stack_layouts() {
     assert_eq!(one_vm.call_depth(), 1);
     assert_eq!(one_vm.registers().bp, DATA_STACK_START);
     assert_eq!(one_vm.registers().dsp, Address::new(0x0086));
+    assert_eq!(one_vm.registers().w, Some(Address::new(CODE_START + 4)));
     assert_eq!(
         one_vm.memory().read_cell(Address::new(0x0082)).unwrap(),
         Cell::new(0)
@@ -708,6 +729,7 @@ fn nested_colon_calls_build_frames_and_return_stack_layouts() {
     assert_eq!(multi_vm.call_depth(), 1);
     assert_eq!(multi_vm.registers().bp, DATA_STACK_START);
     assert_eq!(multi_vm.registers().dsp, Address::new(0x0086));
+    assert_eq!(multi_vm.registers().w, Some(Address::new(CODE_START + 4)));
     assert_eq!(
         multi_vm.memory().read_cell(Address::new(0x0084)).unwrap(),
         Cell::new(0)
@@ -716,7 +738,7 @@ fn nested_colon_calls_build_frames_and_return_stack_layouts() {
 
 #[test]
 fn nested_calls_account_for_return_stack_capacity_and_depth() {
-    let region = StackRegion::new(Address::new(0x0200), Address::new(0x0204)).unwrap();
+    let region = StackRegion::new(Address::new(0x0200), Address::new(0x0206)).unwrap();
     let mut exact_vm = Tbx16Vm::new(region).unwrap();
     let mut exact_image = ImageBuilder::new(CODE_START);
     let halt_xt = exact_image.primitive(PrimitiveId::Halt);
@@ -751,6 +773,10 @@ fn nested_calls_account_for_return_stack_capacity_and_depth() {
     assert_eq!(overflow_vm.registers().bp, DATA_STACK_START);
     assert_eq!(overflow_vm.registers().dsp, DATA_STACK_START);
     assert_eq!(overflow_vm.registers().rsp, region.end());
+    assert_eq!(
+        overflow_vm.registers().w,
+        Some(Address::new(CODE_START + 12))
+    );
     assert_eq!(overflow_vm.call_depth(), 1);
     assert_eq!(
         overflow_vm
@@ -765,6 +791,13 @@ fn nested_calls_account_for_return_stack_capacity_and_depth() {
             .read_cell(Address::new(0x0202))
             .unwrap(),
         Cell::new(DATA_STACK_START.get())
+    );
+    assert_eq!(
+        overflow_vm
+            .memory()
+            .read_cell(Address::new(0x0204))
+            .unwrap(),
+        Cell::new(entry_xt.raw())
     );
     assert_eq!(before.step_counter, 0);
 }
@@ -824,10 +857,10 @@ fn three_nested_calls_match_return_stack_usage_and_call_depth() {
 
     assert_eq!(vm.run(entry_xt), ExecutionOutcome::Halted);
     assert_eq!(vm.call_depth(), 3);
-    assert_eq!(vm.registers().rsp, Address::new(0x020c));
+    assert_eq!(vm.registers().rsp, Address::new(0x0212));
     assert_eq!(
         vm.registers().rsp.get() - DEFAULT_RETURN_STACK_START.get(),
-        vm.call_depth() * 4
+        vm.call_depth() * 6
     );
 }
 
@@ -1575,6 +1608,174 @@ fn putstr_rejects_end_crossing_without_mutation() {
 }
 
 #[test]
+fn load_and_store_slot_access_argument_and_local_cells() {
+    let mut vm = Tbx16Vm::default();
+    let mut image = ImageBuilder::new(CODE_START);
+    let load_slot_xt = image.primitive(PrimitiveId::LoadSlot);
+    let store_slot_xt = image.primitive(PrimitiveId::StoreSlot);
+    let exit_xt = image.primitive(PrimitiveId::Exit);
+    let entry_xt = image.colon_word(1, 2);
+    image.emit_xt(load_slot_xt);
+    image.emit_cell(Cell::new(0));
+    image.emit_xt(store_slot_xt);
+    image.emit_cell(Cell::new(2));
+    image.emit_xt(load_slot_xt);
+    image.emit_cell(Cell::new(2));
+    image.emit_xt(exit_xt);
+    image.emit_cell(Cell::new(1));
+    image.load_into(&mut vm);
+    vm.push_data_cell(Cell::new(0x3344)).unwrap();
+
+    assert_eq!(vm.run(entry_xt), ExecutionOutcome::Returned);
+    assert_eq!(vm.peek_data_cell(0).unwrap(), Cell::new(0x3344));
+    assert_eq!(
+        vm.memory().read_cell(Address::new(0x0084)).unwrap(),
+        Cell::new(0x3344)
+    );
+}
+
+#[test]
+fn load_slot_validates_slot_bounds_from_current_w_metadata() {
+    let mut vm = Tbx16Vm::default();
+    let mut image = ImageBuilder::new(CODE_START);
+    let load_slot_xt = image.primitive(PrimitiveId::LoadSlot);
+    let entry_xt = image.colon_word(1, 0);
+    image.emit_xt(load_slot_xt);
+    image.emit_cell(Cell::new(1));
+    image.load_into(&mut vm);
+    vm.push_data_cell(Cell::new(0x1111)).unwrap();
+
+    assert_eq!(
+        vm.run(entry_xt),
+        ExecutionOutcome::Trapped(Tbx16Error::InvalidFrameSlot {
+            slot_index: 1,
+            slot_count: 1,
+        })
+    );
+    assert_eq!(vm.registers().w, Some(Address::new(CODE_START + 4)));
+    assert_eq!(vm.registers().ip, Some(Address::new(CODE_START + 10)));
+}
+
+#[test]
+fn load_and_store_slot_require_an_active_colon_frame() {
+    for primitive in [PrimitiveId::LoadSlot, PrimitiveId::StoreSlot] {
+        let mut vm = Tbx16Vm::default();
+        let mut image = ImageBuilder::new(CODE_START);
+        let xt = image.primitive(primitive);
+        image.emit_cell(Cell::new(0));
+        image.load_into(&mut vm);
+        vm.set_instruction_pointer(Address::new(CODE_START + 4))
+            .unwrap();
+        let before = snapshot(&vm);
+
+        assert_eq!(
+            vm.run(xt),
+            ExecutionOutcome::Trapped(Tbx16Error::InvalidExecutionState)
+        );
+        let after = snapshot(&vm);
+        assert_eq!(after.ip, before.ip);
+        assert_eq!(after.dsp, before.dsp);
+        assert_eq!(after.rsp, before.rsp);
+        assert_eq!(after.bp, before.bp);
+        assert_eq!(after.w, before.w);
+        assert_eq!(after.call_depth, before.call_depth);
+        assert_eq!(after.memory, before.memory);
+        assert_eq!(after.step_counter, 1);
+    }
+
+    let mut threaded_vm = Tbx16Vm::default();
+    let mut image = ImageBuilder::new(CODE_START);
+    let load_slot_xt = image.primitive(PrimitiveId::LoadSlot);
+    image.emit_xt(load_slot_xt);
+    image.emit_cell(Cell::new(0));
+    image.load_into(&mut threaded_vm);
+    let before = snapshot(&threaded_vm);
+    assert_eq!(
+        threaded_vm.run_threaded(Address::new(CODE_START + 4)),
+        ExecutionOutcome::Trapped(Tbx16Error::InvalidExecutionState)
+    );
+    let after = snapshot(&threaded_vm);
+    assert_eq!(after.dsp, before.dsp);
+    assert_eq!(after.rsp, before.rsp);
+    assert_eq!(after.bp, before.bp);
+    assert_eq!(after.w, before.w);
+    assert_eq!(after.memory, before.memory);
+    assert_eq!(after.step_counter, 1);
+}
+
+#[test]
+fn w_tracks_entry_callee_and_caller_colon_contexts() {
+    let mut callee_halt_vm = Tbx16Vm::default();
+    let mut callee_halt = ImageBuilder::new(CODE_START);
+    let halt_xt = callee_halt.primitive(PrimitiveId::Halt);
+    let callee_xt = callee_halt.colon_word(0, 0);
+    callee_halt.emit_xt(halt_xt);
+    let entry_xt = callee_halt.colon_word(0, 0);
+    callee_halt.emit_xt(callee_xt);
+    callee_halt.load_into(&mut callee_halt_vm);
+
+    assert_eq!(callee_halt_vm.run(entry_xt), ExecutionOutcome::Halted);
+    assert_eq!(
+        callee_halt_vm.registers().w,
+        Some(Address::new(CODE_START + 4))
+    );
+
+    let mut caller_restore_vm = Tbx16Vm::default();
+    let mut caller_restore = ImageBuilder::new(CODE_START);
+    let halt_xt = caller_restore.primitive(PrimitiveId::Halt);
+    let exit_xt = caller_restore.primitive(PrimitiveId::Exit);
+    let callee_xt = caller_restore.colon_word(0, 0);
+    caller_restore.emit_xt(exit_xt);
+    caller_restore.emit_cell(Cell::new(0));
+    let entry_xt = caller_restore.colon_word(0, 0);
+    caller_restore.emit_xt(callee_xt);
+    caller_restore.emit_xt(halt_xt);
+    caller_restore.load_into(&mut caller_restore_vm);
+
+    assert_eq!(caller_restore_vm.run(entry_xt), ExecutionOutcome::Halted);
+    assert_eq!(
+        caller_restore_vm.registers().w,
+        Some(Address::new(CODE_START + 18))
+    );
+}
+
+#[test]
+fn nested_exit_traps_when_caller_w_is_corrupted() {
+    let mut vm = Tbx16Vm::default();
+    let mut image = ImageBuilder::new(CODE_START);
+    let halt_xt = image.primitive(PrimitiveId::Halt);
+    let exit_xt = image.primitive(PrimitiveId::Exit);
+    let callee_xt = image.colon_word(0, 0);
+    image.emit_xt(halt_xt);
+    image.emit_xt(exit_xt);
+    image.emit_cell(Cell::new(0));
+    let entry_xt = image.colon_word(0, 0);
+    image.emit_xt(callee_xt);
+    image.emit_xt(exit_xt);
+    image.emit_cell(Cell::new(0));
+    image.load_into(&mut vm);
+    assert_eq!(vm.run(entry_xt), ExecutionOutcome::Halted);
+    vm.memory_mut()
+        .write_cell(Address::new(0x0204), Cell::new(CODE_START))
+        .unwrap();
+    let before = snapshot(&vm);
+
+    assert_eq!(
+        vm.run_threaded(Address::new(CODE_START + 16)),
+        ExecutionOutcome::Trapped(Tbx16Error::InvalidExecutionState)
+    );
+    let after = snapshot(&vm);
+    assert_eq!(after.ip, before.ip);
+    assert_eq!(after.dsp, before.dsp);
+    assert_eq!(after.rsp, before.rsp);
+    assert_eq!(after.bp, before.bp);
+    assert_eq!(after.w, before.w);
+    assert_eq!(after.call_depth, before.call_depth);
+    assert_eq!(after.memory, before.memory);
+    assert_eq!(after.step_counter, 1);
+}
+
+#[test]
 fn threaded_program_executes_m2_3a_primitives() {
     let mut vm = Tbx16Vm::default();
     let mut image = ImageBuilder::new(CODE_START);
@@ -1969,7 +2170,7 @@ fn exit_one_rejects_missing_callee_return_value_without_stealing_caller_value() 
     let after = snapshot(&vm);
     assert_eq!(after.ip, Some(Address::new(CODE_START + 10)));
     assert_eq!(after.dsp, Address::new(0x0082));
-    assert_eq!(after.rsp, Address::new(0x0204));
+    assert_eq!(after.rsp, Address::new(0x0206));
     assert_eq!(after.bp, Address::new(0x0082));
     assert_eq!(
         vm.memory().read_cell(Address::new(0x0080)).unwrap(),
@@ -2139,7 +2340,7 @@ fn halt_and_trap_leave_dirty_state_until_reset() {
         ExecutionOutcome::Halted
     );
     assert_eq!(nested_halt_vm.call_depth(), 1);
-    assert_eq!(nested_halt_vm.registers().rsp, Address::new(0x0204));
+    assert_eq!(nested_halt_vm.registers().rsp, Address::new(0x0206));
     assert!(nested_halt_vm.is_dirty_execution_state());
     let nested_halt_snapshot = snapshot(&nested_halt_vm);
     assert_eq!(
@@ -2154,6 +2355,7 @@ fn halt_and_trap_leave_dirty_state_until_reset() {
     assert_eq!(halt_vm.registers().ip, None);
     assert_eq!(halt_vm.registers().bp, DATA_STACK_START);
     assert_eq!(halt_vm.registers().rsp, DEFAULT_RETURN_STACK_START);
+    assert_eq!(halt_vm.registers().w, None);
     assert_eq!(halt_vm.call_depth(), 0);
     assert_eq!(halt_vm.step_counter(), 0);
     assert_eq!(halt_vm.registers().dsp, Address::new(0x0082));
@@ -2202,6 +2404,7 @@ fn reset_execution_state_preserves_output_sink() {
 
     assert_eq!(vm.output(), b"Q");
     assert_eq!(vm.peek_data_cell(0).unwrap(), Cell::new(0x9999));
+    assert_eq!(vm.registers().w, None);
 }
 
 #[test]


### PR DESCRIPTION
## 概要

Closes #1013

tbx16 に W レジスタを追加し、colon metadata を実行時に参照して `LOAD_SLOT` / `STORE_SLOT` の frame slot 境界を検証できるようにしました。

## 変更内容

- `Registers` に `w` を追加し、entry colon・nested call・nested/top-level return・reset での遷移を実装
- return frame を `return IP / caller BP / caller W` の 3 Cell に改訂
- `PrimitiveId` / registry に `LOAD_SLOT` と `STORE_SLOT` を追加
- active colon frame の検証を `W` 経由の metadata 読み出しに統一し、slot count overflow や frame 不整合を `InvalidExecutionState` / `InvalidFrameSlot` で trap
- slot primitive の原子性と、caller W 破損・W なし実行・return stack 6byte 契約を固定する回帰テストを追加

## 確認

- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
