### PR TITLE
Python実験環境に地形コストと最短路計算を追加

### DIFF
--- a/experiments/galactic_exodus/README.md
+++ b/experiments/galactic_exodus/README.md
@@ -9,3 +9,42 @@ It is not the formal TBX application implementation. The future TBX-side impleme
 ```bash
 python experiments/galactic_exodus/simulate.py --seed 42
 ```
+
+## Terrain Costs
+
+The baseline path analysis treats movement as four-directional (`N/E/S/W`) on the 8x8 grid.
+Each move adds the cost of the destination cell. The starting cell does not add cost.
+
+| Symbol | Meaning | Cost |
+| --- | --- | --- |
+| `.` | normal sector | 1 |
+| `N` | nebula | 2 |
+| `A` | anomaly | 3 |
+| `@` | asteroid field | 2 |
+| `B` | base | 1 |
+| `R` | resource | 1 |
+| `S` | start | 0 |
+| `H` | home | 1 |
+
+This experiment computes a baseline with full map information and no fault-line restrictions.
+
+## COSTS Output
+
+`simulate.py` now prints a `COSTS` section after the map:
+
+- `reachable`: whether `S -> H` is reachable
+- `best_cost`: minimum terrain cost from `S` to `H`
+- `best_path_length`: minimum number of moves among paths with `best_cost`
+- `cost_to_base`: minimum terrain cost from `S` to `B`
+- `cost_base_to_goal`: minimum terrain cost from `B` to `H`
+- `best_cost_via_base`: `cost_to_base + cost_base_to_goal`
+
+Internally these values stay numeric or `None`. The output layer converts them to `yes` / `no` and `N/A`.
+
+## Tests
+
+Run the Python experiment tests with the standard library `unittest` runner:
+
+```bash
+python -m unittest experiments.galactic_exodus.test_simulate
+```

--- a/experiments/galactic_exodus/README.md
+++ b/experiments/galactic_exodus/README.md
@@ -19,8 +19,8 @@ Each move adds the cost of the destination cell. The starting cell does not add 
 | --- | --- | --- |
 | `.` | normal sector | 1 |
 | `N` | nebula | 2 |
-| `A` | anomaly | 3 |
-| `@` | asteroid field | 2 |
+| `A` | asteroid field | 3 |
+| `@` | gravity well / gravity anomaly | 2 |
 | `B` | base | 1 |
 | `R` | resource | 1 |
 | `S` | start | 0 |

--- a/experiments/galactic_exodus/simulate.py
+++ b/experiments/galactic_exodus/simulate.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import argparse
-from dataclasses import dataclass
-import random
 from collections import Counter
+from dataclasses import dataclass
+import heapq
+import random
+from typing import TypeAlias
 
 
 WIDTH = 8
@@ -18,15 +20,44 @@ SPECIAL_H = (8, 8)
 CENTRAL_B_CANDIDATES = [(4, 4), (5, 4), (4, 5), (5, 5)]
 TERRAIN_SYMBOLS = [".", "N", "A", "@"]
 TERRAIN_WEIGHTS = [0.60, 0.20, 0.12, 0.08]
+TERRAIN_COSTS = {
+    ".": 1,
+    "N": 2,
+    "A": 3,
+    "@": 2,
+    "B": 1,
+    "R": 1,
+    "S": 0,
+    "H": 1,
+}
+
+Position: TypeAlias = tuple[int, int]
+Cells: TypeAlias = dict[Position, str]
 
 
 @dataclass(frozen=True)
 class GalacticMap:
     seed: int
     resource_count: int
-    b_position: tuple[int, int]
-    r_positions: list[tuple[int, int]]
-    cells: dict[tuple[int, int], str]
+    b_position: Position
+    r_positions: list[Position]
+    cells: Cells
+
+
+@dataclass(frozen=True)
+class PathResult:
+    cost: int
+    steps: int
+
+
+@dataclass(frozen=True)
+class PathAnalysis:
+    reachable: bool
+    best_cost: int | None
+    best_path_length: int | None
+    cost_to_base: int | None
+    cost_base_to_goal: int | None
+    best_cost_via_base: int | None
 
 
 def parse_args() -> argparse.Namespace:
@@ -94,11 +125,71 @@ def weighted_terrain(rng: random.Random) -> str:
     return TERRAIN_SYMBOLS[-1]
 
 
-def format_position(position: tuple[int, int]) -> str:
+def terrain_cost(symbol: str) -> int:
+    try:
+        return TERRAIN_COSTS[symbol]
+    except KeyError as exc:
+        raise ValueError(f"unknown terrain symbol: {symbol!r}") from exc
+
+
+def neighbors(position: Position) -> list[Position]:
+    x, y = position
+    adjacent: list[Position] = []
+    for next_x, next_y in ((x, y + 1), (x + 1, y), (x, y - 1), (x - 1, y)):
+        if 1 <= next_x <= WIDTH and 1 <= next_y <= HEIGHT:
+            adjacent.append((next_x, next_y))
+    return adjacent
+
+
+def shortest_path(cells: Cells, start: Position, goal: Position) -> PathResult | None:
+    if start not in cells:
+        raise ValueError(f"start position is outside map cells: {start}")
+    if goal not in cells:
+        raise ValueError(f"goal position is outside map cells: {goal}")
+
+    queue: list[tuple[int, int, Position]] = [(0, 0, start)]
+    best: dict[Position, tuple[int, int]] = {start: (0, 0)}
+
+    while queue:
+        cost, steps, position = heapq.heappop(queue)
+        if (cost, steps) != best.get(position):
+            continue
+        if position == goal:
+            return PathResult(cost=cost, steps=steps)
+
+        for neighbor in neighbors(position):
+            candidate = (cost + terrain_cost(cells[neighbor]), steps + 1)
+            previous = best.get(neighbor)
+            if previous is None or candidate < previous:
+                best[neighbor] = candidate
+                heapq.heappush(queue, (candidate[0], candidate[1], neighbor))
+
+    return None
+
+
+def analyze_paths(galactic_map: GalacticMap) -> PathAnalysis:
+    best_route = shortest_path(galactic_map.cells, SPECIAL_S, SPECIAL_H)
+    to_base = shortest_path(galactic_map.cells, SPECIAL_S, galactic_map.b_position)
+    base_to_goal = shortest_path(galactic_map.cells, galactic_map.b_position, SPECIAL_H)
+    via_base = None
+    if to_base is not None and base_to_goal is not None:
+        via_base = to_base.cost + base_to_goal.cost
+
+    return PathAnalysis(
+        reachable=best_route is not None,
+        best_cost=None if best_route is None else best_route.cost,
+        best_path_length=None if best_route is None else best_route.steps,
+        cost_to_base=None if to_base is None else to_base.cost,
+        cost_base_to_goal=None if base_to_goal is None else base_to_goal.cost,
+        best_cost_via_base=via_base,
+    )
+
+
+def format_position(position: Position) -> str:
     return f"({position[0]},{position[1]})"
 
 
-def render_map(cells: dict[tuple[int, int], str]) -> str:
+def render_map(cells: Cells) -> str:
     rows: list[str] = []
     for y in range(HEIGHT, 0, -1):
         row = " ".join(cells[(x, y)] for x in range(1, WIDTH + 1))
@@ -106,13 +197,18 @@ def render_map(cells: dict[tuple[int, int], str]) -> str:
     return "\n".join(rows)
 
 
-def terrain_distribution(cells: dict[tuple[int, int], str]) -> str:
+def terrain_distribution(cells: Cells) -> str:
     counts = Counter(value for value in cells.values() if value in TERRAIN_SYMBOLS)
     ordered = [f"{symbol}:{counts.get(symbol, 0)}" for symbol in TERRAIN_SYMBOLS]
     return ", ".join(ordered)
 
 
+def format_optional_metric(value: int | None) -> str:
+    return "N/A" if value is None else str(value)
+
+
 def format_output(galactic_map: GalacticMap) -> str:
+    analysis = analyze_paths(galactic_map)
     lines = [
         f"SEED: {galactic_map.seed}",
         f"SIZE: {WIDTH}x{HEIGHT}",
@@ -124,6 +220,14 @@ def format_output(galactic_map: GalacticMap) -> str:
         "",
         "MAP:",
         render_map(galactic_map.cells),
+        "",
+        "COSTS:",
+        f"  reachable: {'yes' if analysis.reachable else 'no'}",
+        f"  best_cost: {format_optional_metric(analysis.best_cost)}",
+        f"  best_path_length: {format_optional_metric(analysis.best_path_length)}",
+        f"  cost_to_base: {format_optional_metric(analysis.cost_to_base)}",
+        f"  cost_base_to_goal: {format_optional_metric(analysis.cost_base_to_goal)}",
+        f"  best_cost_via_base: {format_optional_metric(analysis.best_cost_via_base)}",
     ]
     return "\n".join(lines)
 

--- a/experiments/galactic_exodus/test_simulate.py
+++ b/experiments/galactic_exodus/test_simulate.py
@@ -1,0 +1,128 @@
+import unittest
+
+from experiments.galactic_exodus import simulate
+
+
+def filled_cells(symbol: str = ".") -> simulate.Cells:
+    return {
+        (x, y): symbol
+        for y in range(1, simulate.HEIGHT + 1)
+        for x in range(1, simulate.WIDTH + 1)
+    }
+
+
+class TerrainCostTests(unittest.TestCase):
+    def test_terrain_cost_table_and_unknown_symbol(self) -> None:
+        self.assertEqual(simulate.terrain_cost("."), 1)
+        self.assertEqual(simulate.terrain_cost("N"), 2)
+        self.assertEqual(simulate.terrain_cost("A"), 3)
+        self.assertEqual(simulate.terrain_cost("@"), 2)
+        self.assertEqual(simulate.terrain_cost("B"), 1)
+        self.assertEqual(simulate.terrain_cost("R"), 1)
+        self.assertEqual(simulate.terrain_cost("S"), 0)
+        self.assertEqual(simulate.terrain_cost("H"), 1)
+
+        with self.assertRaisesRegex(ValueError, "unknown terrain symbol"):
+            simulate.terrain_cost("?")
+
+
+class NeighborTests(unittest.TestCase):
+    def test_neighbors_for_corner_edge_and_center(self) -> None:
+        self.assertEqual(simulate.neighbors((1, 1)), [(1, 2), (2, 1)])
+        self.assertEqual(simulate.neighbors((1, 4)), [(1, 5), (2, 4), (1, 3)])
+        self.assertEqual(
+            simulate.neighbors((4, 4)),
+            [(4, 5), (5, 4), (4, 3), (3, 4)],
+        )
+
+
+class ShortestPathTests(unittest.TestCase):
+    def test_shortest_path_on_plain_grid_is_fourteen_cost_and_steps(self) -> None:
+        cells = filled_cells(".")
+        cells[simulate.SPECIAL_S] = "S"
+        cells[simulate.SPECIAL_H] = "H"
+
+        result = simulate.shortest_path(cells, simulate.SPECIAL_S, simulate.SPECIAL_H)
+
+        self.assertEqual(result, simulate.PathResult(cost=14, steps=14))
+
+    def test_shortest_path_avoids_high_cost_route(self) -> None:
+        cells = filled_cells(".")
+        cells[(2, 1)] = "A"
+        cells[(3, 1)] = "A"
+        cells[(4, 1)] = "H"
+
+        result = simulate.shortest_path(cells, (1, 1), (4, 1))
+
+        self.assertEqual(result, simulate.PathResult(cost=5, steps=5))
+
+    def test_shortest_path_prefers_fewer_steps_when_costs_are_equal(self) -> None:
+        cells = filled_cells("A")
+        cells.update(
+            {
+                (1, 1): ".",
+                (2, 1): ".",
+                (3, 1): ".",
+                (1, 2): ".",
+                (2, 2): ".",
+                (3, 2): "S",
+                (1, 3): "S",
+                (2, 3): "S",
+                (3, 3): "S",
+            }
+        )
+
+        result = simulate.shortest_path(cells, (1, 1), (3, 1))
+
+        self.assertEqual(result, simulate.PathResult(cost=2, steps=2))
+
+
+class AnalysisAndOutputTests(unittest.TestCase):
+    def test_seed_42_map_generation_is_unchanged(self) -> None:
+        galactic_map = simulate.generate_map(42, 3)
+
+        self.assertEqual(galactic_map.b_position, (4, 4))
+        self.assertEqual(galactic_map.r_positions, [(5, 7), (3, 3), (3, 1)])
+        self.assertEqual(
+            simulate.render_map(galactic_map.cells),
+            "\n".join(
+                [
+                    ". . @ N . . N H",
+                    ". N N N R N . .",
+                    "N @ A A . . A .",
+                    ". . N A . . . N",
+                    ". . . B . . . @",
+                    "A N R . . . N .",
+                    ". N . N N . . .",
+                    "S . R N . . . .",
+                ]
+            ),
+        )
+
+    def test_analyze_paths_reports_consistent_costs(self) -> None:
+        galactic_map = simulate.generate_map(42, 3)
+
+        analysis = simulate.analyze_paths(galactic_map)
+
+        self.assertTrue(analysis.reachable)
+        self.assertEqual(analysis.best_cost, 15)
+        self.assertEqual(analysis.best_path_length, 14)
+        self.assertEqual(analysis.cost_to_base, 6)
+        self.assertEqual(analysis.cost_base_to_goal, 9)
+        self.assertEqual(analysis.best_cost_via_base, 15)
+        self.assertEqual(analysis.best_cost_via_base, analysis.cost_to_base + analysis.cost_base_to_goal)
+
+    def test_format_output_includes_costs_section(self) -> None:
+        output = simulate.format_output(simulate.generate_map(42, 3))
+
+        self.assertIn("COSTS:", output)
+        self.assertIn("  reachable: yes", output)
+        self.assertIn("  best_cost: 15", output)
+        self.assertIn("  best_path_length: 14", output)
+        self.assertIn("  cost_to_base: 6", output)
+        self.assertIn("  cost_base_to_goal: 9", output)
+        self.assertIn("  best_cost_via_base: 15", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概要

Closes #906

Phase 0 の Python 実験環境に、地形コストと全情報あり・断層なし前提の最短路解析を追加しました。

## 変更内容

- `terrain_cost` と `neighbors` を追加し、移動先地形のコスト加算と 4 方向隣接を純粋関数として分離
- Dijkstra による `shortest_path` と `analyze_paths` を追加し、`S -> H`、`S -> B`、`B -> H` を `(cost, steps)` で評価
- `format_output` に `COSTS` セクションを追加し、内部値の `None` を表示層で `N/A` に変換
- `README` に地形コスト表、基準計算の前提、`COSTS` 指標、Python テスト実行方法を追記
- `unittest` を追加し、地形コスト、隣接列挙、経路選択、seed 42 の既存マップ回帰、出力表示を検証

## 確認

- `python -m unittest experiments.galactic_exodus.test_simulate`
- `python experiments/galactic_exodus/simulate.py --seed 42`
- `cargo fmt --check`
- `cargo test --quiet`
- `cargo clippy --all-targets -- -D warnings`
