### PR TITLE
Python実験環境に断層航路を追加

### DIFF
--- a/experiments/galactic_exodus/README.md
+++ b/experiments/galactic_exodus/README.md
@@ -7,7 +7,7 @@ It is not the formal TBX application implementation. The future TBX-side impleme
 ## Run
 
 ```bash
-python experiments/galactic_exodus/simulate.py --seed 42
+python experiments/galactic_exodus/simulate.py --seed 42 --rift-density 0.10
 ```
 
 ## Terrain Costs
@@ -26,12 +26,30 @@ Each move adds the cost of the destination cell. The starting cell does not add 
 | `S` | start | 0 |
 | `H` | home | 1 |
 
-This experiment computes a baseline with full map information and no fault-line restrictions.
+This experiment computes a full-information baseline with optional fault-line restrictions on movement edges.
+
+## Fault-Line Rifts
+
+The grid has 112 undirected adjacent edges in total. Rift edges are chosen deterministically from the seed:
+
+```text
+rift_count = round(112 * rift_density)
+```
+
+Use `--rift-density FLOAT` to control the density. The default is `0.10`.
+
+Selected rift edges are impassable in both directions and are excluded from all shortest-path calculations:
+
+- `S -> H`
+- `S -> B`
+- `B -> H`
 
 ## COSTS Output
 
 `simulate.py` now prints a `COSTS` section after the map:
 
+- `rift_density`: configured density used for fault-line generation
+- `rift_count`: number of blocked undirected edges
 - `reachable`: whether `S -> H` is reachable
 - `best_cost`: minimum terrain cost from `S` to `H`
 - `best_path_length`: minimum number of moves among paths with `best_cost`

--- a/experiments/galactic_exodus/simulate.py
+++ b/experiments/galactic_exodus/simulate.py
@@ -14,6 +14,8 @@ WIDTH = 8
 HEIGHT = 8
 DEFAULT_SEED = 42
 DEFAULT_RESOURCE_COUNT = 3
+DEFAULT_RIFT_DENSITY = 0.10
+TOTAL_UNDIRECTED_EDGES = WIDTH * (HEIGHT - 1) + HEIGHT * (WIDTH - 1)
 
 SPECIAL_S = (1, 1)
 SPECIAL_H = (8, 8)
@@ -33,14 +35,17 @@ TERRAIN_COSTS = {
 
 Position: TypeAlias = tuple[int, int]
 Cells: TypeAlias = dict[Position, str]
+Edge: TypeAlias = tuple[Position, Position]
 
 
 @dataclass(frozen=True)
 class GalacticMap:
     seed: int
     resource_count: int
+    rift_density: float
     b_position: Position
     r_positions: list[Position]
+    rift_edges: tuple[Edge, ...]
     cells: Cells
 
 
@@ -69,6 +74,12 @@ def parse_args() -> argparse.Namespace:
         default=DEFAULT_RESOURCE_COUNT,
         help="Number of resource objects to place (default: 3).",
     )
+    parser.add_argument(
+        "--rift-density",
+        type=float,
+        default=DEFAULT_RIFT_DENSITY,
+        help="Density of impassable fault-line edges (default: 0.10).",
+    )
     return parser.parse_args()
 
 
@@ -80,8 +91,14 @@ def validate_resource_count(resource_count: int) -> None:
         raise ValueError(f"resource-count must be at most {available_cells}")
 
 
-def generate_map(seed: int, resource_count: int) -> GalacticMap:
+def validate_rift_density(rift_density: float) -> None:
+    if not 0.0 <= rift_density <= 1.0:
+        raise ValueError("rift-density must be between 0.0 and 1.0")
+
+
+def generate_map(seed: int, resource_count: int, rift_density: float = DEFAULT_RIFT_DENSITY) -> GalacticMap:
     validate_resource_count(resource_count)
+    validate_rift_density(rift_density)
 
     rng = random.Random(seed)
     b_position = rng.choice(CENTRAL_B_CANDIDATES)
@@ -106,11 +123,15 @@ def generate_map(seed: int, resource_count: int) -> GalacticMap:
     for position in r_positions:
         cells[position] = "R"
 
+    rift_edges = sample_rift_edges(seed, rift_density)
+
     return GalacticMap(
         seed=seed,
         resource_count=resource_count,
+        rift_density=rift_density,
         b_position=b_position,
         r_positions=sorted(r_positions, key=lambda pos: (-pos[1], pos[0])),
+        rift_edges=rift_edges,
         cells=cells,
     )
 
@@ -141,11 +162,45 @@ def neighbors(position: Position) -> list[Position]:
     return adjacent
 
 
-def shortest_path(cells: Cells, start: Position, goal: Position) -> PathResult | None:
+def normalize_edge(start: Position, goal: Position) -> Edge:
+    return (start, goal) if start <= goal else (goal, start)
+
+
+def undirected_adjacent_edges() -> list[Edge]:
+    edges: list[Edge] = []
+    for y in range(1, HEIGHT + 1):
+        for x in range(1, WIDTH + 1):
+            position = (x, y)
+            for neighbor in ((x + 1, y), (x, y + 1)):
+                if 1 <= neighbor[0] <= WIDTH and 1 <= neighbor[1] <= HEIGHT:
+                    edges.append((position, neighbor))
+    return edges
+
+
+def rift_count_for_density(rift_density: float) -> int:
+    validate_rift_density(rift_density)
+    return round(TOTAL_UNDIRECTED_EDGES * rift_density)
+
+
+def sample_rift_edges(seed: int, rift_density: float) -> tuple[Edge, ...]:
+    rift_count = rift_count_for_density(rift_density)
+    edges = undirected_adjacent_edges()
+    rng = random.Random(f"{seed}:rift")
+    selected = rng.sample(edges, rift_count)
+    return tuple(sorted(selected))
+
+
+def shortest_path(
+    cells: Cells,
+    start: Position,
+    goal: Position,
+    blocked_edges: set[Edge] | None = None,
+) -> PathResult | None:
     if start not in cells:
         raise ValueError(f"start position is outside map cells: {start}")
     if goal not in cells:
         raise ValueError(f"goal position is outside map cells: {goal}")
+    blocked = blocked_edges or set()
 
     queue: list[tuple[int, int, Position]] = [(0, 0, start)]
     best: dict[Position, tuple[int, int]] = {start: (0, 0)}
@@ -158,6 +213,8 @@ def shortest_path(cells: Cells, start: Position, goal: Position) -> PathResult |
             return PathResult(cost=cost, steps=steps)
 
         for neighbor in neighbors(position):
+            if normalize_edge(position, neighbor) in blocked:
+                continue
             candidate = (cost + terrain_cost(cells[neighbor]), steps + 1)
             previous = best.get(neighbor)
             if previous is None or candidate < previous:
@@ -168,9 +225,10 @@ def shortest_path(cells: Cells, start: Position, goal: Position) -> PathResult |
 
 
 def analyze_paths(galactic_map: GalacticMap) -> PathAnalysis:
-    best_route = shortest_path(galactic_map.cells, SPECIAL_S, SPECIAL_H)
-    to_base = shortest_path(galactic_map.cells, SPECIAL_S, galactic_map.b_position)
-    base_to_goal = shortest_path(galactic_map.cells, galactic_map.b_position, SPECIAL_H)
+    blocked_edges = set(galactic_map.rift_edges)
+    best_route = shortest_path(galactic_map.cells, SPECIAL_S, SPECIAL_H, blocked_edges)
+    to_base = shortest_path(galactic_map.cells, SPECIAL_S, galactic_map.b_position, blocked_edges)
+    base_to_goal = shortest_path(galactic_map.cells, galactic_map.b_position, SPECIAL_H, blocked_edges)
     via_base = None
     if to_base is not None and base_to_goal is not None:
         via_base = to_base.cost + base_to_goal.cost
@@ -222,6 +280,8 @@ def format_output(galactic_map: GalacticMap) -> str:
         render_map(galactic_map.cells),
         "",
         "COSTS:",
+        f"  rift_density: {galactic_map.rift_density:.2f}",
+        f"  rift_count: {len(galactic_map.rift_edges)}",
         f"  reachable: {'yes' if analysis.reachable else 'no'}",
         f"  best_cost: {format_optional_metric(analysis.best_cost)}",
         f"  best_path_length: {format_optional_metric(analysis.best_path_length)}",
@@ -235,7 +295,7 @@ def format_output(galactic_map: GalacticMap) -> str:
 def main() -> int:
     args = parse_args()
     try:
-        galactic_map = generate_map(args.seed, args.resource_count)
+        galactic_map = generate_map(args.seed, args.resource_count, args.rift_density)
     except ValueError as exc:
         raise SystemExit(f"error: {exc}") from exc
     print(format_output(galactic_map))

--- a/experiments/galactic_exodus/test_simulate.py
+++ b/experiments/galactic_exodus/test_simulate.py
@@ -35,6 +35,14 @@ class NeighborTests(unittest.TestCase):
             [(4, 5), (5, 4), (4, 3), (3, 4)],
         )
 
+    def test_undirected_adjacent_edges_cover_full_grid_without_duplicates(self) -> None:
+        edges = simulate.undirected_adjacent_edges()
+
+        self.assertEqual(len(edges), simulate.TOTAL_UNDIRECTED_EDGES)
+        self.assertEqual(len(set(edges)), simulate.TOTAL_UNDIRECTED_EDGES)
+        self.assertEqual(edges[0], ((1, 1), (2, 1)))
+        self.assertEqual(edges[1], ((1, 1), (1, 2)))
+
 
 class ShortestPathTests(unittest.TestCase):
     def test_shortest_path_on_plain_grid_is_fourteen_cost_and_steps(self) -> None:
@@ -53,6 +61,19 @@ class ShortestPathTests(unittest.TestCase):
         cells[(4, 1)] = "H"
 
         result = simulate.shortest_path(cells, (1, 1), (4, 1))
+
+        self.assertEqual(result, simulate.PathResult(cost=5, steps=5))
+
+    def test_shortest_path_excludes_blocked_rift_edges(self) -> None:
+        cells = filled_cells(".")
+        cells[(4, 1)] = "H"
+        blocked_edges = {
+            simulate.normalize_edge((1, 1), (2, 1)),
+            simulate.normalize_edge((2, 1), (3, 1)),
+            simulate.normalize_edge((3, 1), (4, 1)),
+        }
+
+        result = simulate.shortest_path(cells, (1, 1), (4, 1), blocked_edges)
 
         self.assertEqual(result, simulate.PathResult(cost=5, steps=5))
 
@@ -76,6 +97,39 @@ class ShortestPathTests(unittest.TestCase):
 
         self.assertEqual(result, simulate.PathResult(cost=2, steps=2))
 
+    def test_shortest_path_returns_none_when_rifts_cut_off_start(self) -> None:
+        cells = filled_cells(".")
+        blocked_edges = {
+            simulate.normalize_edge((1, 1), (2, 1)),
+            simulate.normalize_edge((1, 1), (1, 2)),
+        }
+
+        result = simulate.shortest_path(cells, (1, 1), (3, 1), blocked_edges)
+
+        self.assertIsNone(result)
+
+
+class RiftGenerationTests(unittest.TestCase):
+    def test_rift_count_uses_total_undirected_edges(self) -> None:
+        self.assertEqual(simulate.rift_count_for_density(0.0), 0)
+        self.assertEqual(simulate.rift_count_for_density(0.10), 11)
+        self.assertEqual(simulate.rift_count_for_density(0.50), 56)
+        self.assertEqual(simulate.rift_count_for_density(1.0), simulate.TOTAL_UNDIRECTED_EDGES)
+
+    def test_rift_density_validation_rejects_out_of_range_values(self) -> None:
+        with self.assertRaisesRegex(ValueError, "rift-density"):
+            simulate.rift_count_for_density(-0.01)
+        with self.assertRaisesRegex(ValueError, "rift-density"):
+            simulate.rift_count_for_density(1.01)
+
+    def test_sample_rift_edges_is_deterministic_and_unique(self) -> None:
+        first = simulate.sample_rift_edges(42, 0.10)
+        second = simulate.sample_rift_edges(42, 0.10)
+
+        self.assertEqual(first, second)
+        self.assertEqual(len(first), 11)
+        self.assertEqual(len(set(first)), 11)
+
 
 class AnalysisAndOutputTests(unittest.TestCase):
     def test_seed_42_map_generation_is_unchanged(self) -> None:
@@ -83,6 +137,8 @@ class AnalysisAndOutputTests(unittest.TestCase):
 
         self.assertEqual(galactic_map.b_position, (4, 4))
         self.assertEqual(galactic_map.r_positions, [(5, 7), (3, 3), (3, 1)])
+        self.assertEqual(galactic_map.rift_density, 0.10)
+        self.assertEqual(len(galactic_map.rift_edges), 11)
         self.assertEqual(
             simulate.render_map(galactic_map.cells),
             "\n".join(
@@ -105,23 +161,50 @@ class AnalysisAndOutputTests(unittest.TestCase):
         analysis = simulate.analyze_paths(galactic_map)
 
         self.assertTrue(analysis.reachable)
-        self.assertEqual(analysis.best_cost, 15)
+        self.assertEqual(analysis.best_cost, 17)
         self.assertEqual(analysis.best_path_length, 14)
-        self.assertEqual(analysis.cost_to_base, 6)
+        self.assertEqual(analysis.cost_to_base, 8)
         self.assertEqual(analysis.cost_base_to_goal, 9)
-        self.assertEqual(analysis.best_cost_via_base, 15)
+        self.assertEqual(analysis.best_cost_via_base, 17)
         self.assertEqual(analysis.best_cost_via_base, analysis.cost_to_base + analysis.cost_base_to_goal)
 
     def test_format_output_includes_costs_section(self) -> None:
         output = simulate.format_output(simulate.generate_map(42, 3))
 
         self.assertIn("COSTS:", output)
+        self.assertIn("  rift_density: 0.10", output)
+        self.assertIn("  rift_count: 11", output)
         self.assertIn("  reachable: yes", output)
-        self.assertIn("  best_cost: 15", output)
+        self.assertIn("  best_cost: 17", output)
         self.assertIn("  best_path_length: 14", output)
-        self.assertIn("  cost_to_base: 6", output)
+        self.assertIn("  cost_to_base: 8", output)
         self.assertIn("  cost_base_to_goal: 9", output)
-        self.assertIn("  best_cost_via_base: 15", output)
+        self.assertIn("  best_cost_via_base: 17", output)
+
+    def test_format_output_uses_na_for_unreachable_segments(self) -> None:
+        cells = filled_cells(".")
+        galactic_map = simulate.GalacticMap(
+            seed=7,
+            resource_count=0,
+            rift_density=0.10,
+            b_position=(2, 1),
+            r_positions=[],
+            rift_edges=(
+                simulate.normalize_edge(simulate.SPECIAL_S, (2, 1)),
+                simulate.normalize_edge(simulate.SPECIAL_S, (1, 2)),
+                simulate.normalize_edge((2, 1), (3, 1)),
+                simulate.normalize_edge((2, 1), (2, 2)),
+            ),
+            cells=cells,
+        )
+
+        output = simulate.format_output(galactic_map)
+
+        self.assertIn("  reachable: no", output)
+        self.assertIn("  best_cost: N/A", output)
+        self.assertIn("  cost_to_base: N/A", output)
+        self.assertIn("  cost_base_to_goal: N/A", output)
+        self.assertIn("  best_cost_via_base: N/A", output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 概要

Closes #907

Python 実験環境 `experiments/galactic_exodus/` に断層航路を追加し、断層辺を全経路評価から除外するようにしました。

## 変更内容

- `--rift-density` CLI オプションを追加し、`round(112 * rift_density)` で断層本数を決定
- 8x8 グリッドの無向隣接辺を列挙し、seed から決定的かつ重複なしで断層辺をサンプリング
- `shortest_path` に通行不可辺を渡せるようにし、`S -> H` / `S -> B` / `B -> H` の全計算で断層辺を除外
- 到達不能時は `reachable: no` と各コストの `N/A` 表示を維持
- Python テストと README を更新

## 確認

- `python -m unittest experiments.galactic_exodus.test_simulate`
- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
