### PR TITLE
Phase 0 subtask: Python実験環境に中央ベース経由/非経由の評価指標を追加する

### DIFF
--- a/experiments/galactic_exodus/README.md
+++ b/experiments/galactic_exodus/README.md
@@ -43,6 +43,7 @@ Selected rift edges are impassable in both directions and are excluded from all 
 - `S -> H`
 - `S -> B`
 - `B -> H`
+- `S -> H` while forbidding `B`
 
 ## COSTS Output
 
@@ -56,8 +57,11 @@ Selected rift edges are impassable in both directions and are excluded from all 
 - `cost_to_base`: minimum terrain cost from `S` to `B`
 - `cost_base_to_goal`: minimum terrain cost from `B` to `H`
 - `best_cost_via_base`: `cost_to_base + cost_base_to_goal`
+- `best_cost_without_base`: minimum terrain cost from `S` to `H` while forbidding `B`
+- `base_route_advantage_raw`: `best_cost_without_base - best_cost_via_base`
+- `base_is_mandatory`: whether `H` is reachable only via `B`
 
-Internally these values stay numeric or `None`. The output layer converts them to `yes` / `no` and `N/A`.
+Internally numeric values stay as `int | None`. The output layer converts unavailable costs to `N/A` and booleans to `yes` / `no`.
 
 ## Tests
 

--- a/experiments/galactic_exodus/simulate.py
+++ b/experiments/galactic_exodus/simulate.py
@@ -63,6 +63,9 @@ class PathAnalysis:
     cost_to_base: int | None
     cost_base_to_goal: int | None
     best_cost_via_base: int | None
+    best_cost_without_base: int | None
+    base_route_advantage_raw: int | None
+    base_is_mandatory: bool
 
 
 def parse_args() -> argparse.Namespace:
@@ -195,12 +198,16 @@ def shortest_path(
     start: Position,
     goal: Position,
     blocked_edges: set[Edge] | None = None,
+    forbidden_nodes: set[Position] | None = None,
 ) -> PathResult | None:
     if start not in cells:
         raise ValueError(f"start position is outside map cells: {start}")
     if goal not in cells:
         raise ValueError(f"goal position is outside map cells: {goal}")
     blocked = blocked_edges or set()
+    forbidden = forbidden_nodes or set()
+    if start in forbidden or goal in forbidden:
+        return None
 
     queue: list[tuple[int, int, Position]] = [(0, 0, start)]
     best: dict[Position, tuple[int, int]] = {start: (0, 0)}
@@ -213,6 +220,8 @@ def shortest_path(
             return PathResult(cost=cost, steps=steps)
 
         for neighbor in neighbors(position):
+            if neighbor in forbidden:
+                continue
             if normalize_edge(position, neighbor) in blocked:
                 continue
             candidate = (cost + terrain_cost(cells[neighbor]), steps + 1)
@@ -229,9 +238,20 @@ def analyze_paths(galactic_map: GalacticMap) -> PathAnalysis:
     best_route = shortest_path(galactic_map.cells, SPECIAL_S, SPECIAL_H, blocked_edges)
     to_base = shortest_path(galactic_map.cells, SPECIAL_S, galactic_map.b_position, blocked_edges)
     base_to_goal = shortest_path(galactic_map.cells, galactic_map.b_position, SPECIAL_H, blocked_edges)
+    without_base = shortest_path(
+        galactic_map.cells,
+        SPECIAL_S,
+        SPECIAL_H,
+        blocked_edges,
+        forbidden_nodes={galactic_map.b_position},
+    )
     via_base = None
     if to_base is not None and base_to_goal is not None:
         via_base = to_base.cost + base_to_goal.cost
+    advantage = None
+    if via_base is not None and without_base is not None:
+        advantage = without_base.cost - via_base
+    base_is_mandatory = without_base is None and via_base is not None
 
     return PathAnalysis(
         reachable=best_route is not None,
@@ -240,6 +260,9 @@ def analyze_paths(galactic_map: GalacticMap) -> PathAnalysis:
         cost_to_base=None if to_base is None else to_base.cost,
         cost_base_to_goal=None if base_to_goal is None else base_to_goal.cost,
         best_cost_via_base=via_base,
+        best_cost_without_base=None if without_base is None else without_base.cost,
+        base_route_advantage_raw=advantage,
+        base_is_mandatory=base_is_mandatory,
     )
 
 
@@ -288,6 +311,9 @@ def format_output(galactic_map: GalacticMap) -> str:
         f"  cost_to_base: {format_optional_metric(analysis.cost_to_base)}",
         f"  cost_base_to_goal: {format_optional_metric(analysis.cost_base_to_goal)}",
         f"  best_cost_via_base: {format_optional_metric(analysis.best_cost_via_base)}",
+        f"  best_cost_without_base: {format_optional_metric(analysis.best_cost_without_base)}",
+        f"  base_route_advantage_raw: {format_optional_metric(analysis.base_route_advantage_raw)}",
+        f"  base_is_mandatory: {'yes' if analysis.base_is_mandatory else 'no'}",
     ]
     return "\n".join(lines)
 

--- a/experiments/galactic_exodus/test_simulate.py
+++ b/experiments/galactic_exodus/test_simulate.py
@@ -108,6 +108,15 @@ class ShortestPathTests(unittest.TestCase):
 
         self.assertIsNone(result)
 
+    def test_shortest_path_can_forbid_intermediate_nodes(self) -> None:
+        cells = filled_cells(".")
+        cells[(2, 1)] = "B"
+        cells[(3, 1)] = "H"
+
+        result = simulate.shortest_path(cells, (1, 1), (3, 1), forbidden_nodes={(2, 1)})
+
+        self.assertEqual(result, simulate.PathResult(cost=4, steps=4))
+
 
 class RiftGenerationTests(unittest.TestCase):
     def test_rift_count_uses_total_undirected_edges(self) -> None:
@@ -167,6 +176,38 @@ class AnalysisAndOutputTests(unittest.TestCase):
         self.assertEqual(analysis.cost_base_to_goal, 9)
         self.assertEqual(analysis.best_cost_via_base, 17)
         self.assertEqual(analysis.best_cost_via_base, analysis.cost_to_base + analysis.cost_base_to_goal)
+        self.assertEqual(analysis.best_cost_without_base, 17)
+        self.assertEqual(analysis.base_route_advantage_raw, 0)
+        self.assertFalse(analysis.base_is_mandatory)
+
+    def test_analyze_paths_marks_base_as_mandatory_when_home_is_only_reachable_via_base(self) -> None:
+        cells = filled_cells(".")
+        b_position = (2, 1)
+        blocked_edges = (
+            simulate.normalize_edge(simulate.SPECIAL_S, (1, 2)),
+            simulate.normalize_edge((2, 2), (3, 2)),
+            simulate.normalize_edge((3, 1), (3, 2)),
+        )
+        cells[simulate.SPECIAL_S] = "S"
+        cells[simulate.SPECIAL_H] = "H"
+        cells[b_position] = "B"
+        galactic_map = simulate.GalacticMap(
+            seed=9,
+            resource_count=0,
+            rift_density=0.03,
+            b_position=b_position,
+            r_positions=[],
+            rift_edges=blocked_edges,
+            cells=cells,
+        )
+
+        analysis = simulate.analyze_paths(galactic_map)
+
+        self.assertTrue(analysis.reachable)
+        self.assertEqual(analysis.best_cost_via_base, analysis.cost_to_base + analysis.cost_base_to_goal)
+        self.assertIsNone(analysis.best_cost_without_base)
+        self.assertIsNone(analysis.base_route_advantage_raw)
+        self.assertTrue(analysis.base_is_mandatory)
 
     def test_format_output_includes_costs_section(self) -> None:
         output = simulate.format_output(simulate.generate_map(42, 3))
@@ -180,6 +221,9 @@ class AnalysisAndOutputTests(unittest.TestCase):
         self.assertIn("  cost_to_base: 8", output)
         self.assertIn("  cost_base_to_goal: 9", output)
         self.assertIn("  best_cost_via_base: 17", output)
+        self.assertIn("  best_cost_without_base: 17", output)
+        self.assertIn("  base_route_advantage_raw: 0", output)
+        self.assertIn("  base_is_mandatory: no", output)
 
     def test_format_output_uses_na_for_unreachable_segments(self) -> None:
         cells = filled_cells(".")
@@ -205,6 +249,9 @@ class AnalysisAndOutputTests(unittest.TestCase):
         self.assertIn("  cost_to_base: N/A", output)
         self.assertIn("  cost_base_to_goal: N/A", output)
         self.assertIn("  best_cost_via_base: N/A", output)
+        self.assertIn("  best_cost_without_base: N/A", output)
+        self.assertIn("  base_route_advantage_raw: N/A", output)
+        self.assertIn("  base_is_mandatory: no", output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 概要

Closes #908

Python 実験環境の `Galactic Exodus` 評価指標に、中央基地 `B` を経由する場合と経由しない場合の比較を追加しました。

## 変更内容

- `shortest_path` に `forbidden_nodes` を追加し、`B` を通らない `S -> H` 最短路を計算可能にした
- `best_cost_without_base`、`base_route_advantage_raw`、`base_is_mandatory` を `PathAnalysis` と出力へ追加した
- `B` 非経由経路、`B` 強制経由ケース、`N/A` 表示を Python テストでカバーした
- README の `COSTS` セクションを新指標に合わせて更新した

## 確認

- `python -m unittest experiments.galactic_exodus.test_simulate`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo fmt --check`
