### PR TITLE
Galactic Exodus実験レポートのverdict分類を追加

### DIFF
--- a/experiments/galactic_exodus/README.md
+++ b/experiments/galactic_exodus/README.md
@@ -45,23 +45,44 @@ Selected rift edges are impassable in both directions and are excluded from all 
 - `B -> H`
 - `S -> H` while forbidding `B`
 
-## COSTS Output
+## Report Output
 
-`simulate.py` now prints a `COSTS` section after the map:
+`simulate.py` prints the following sections in order:
 
-- `rift_density`: configured density used for fault-line generation
-- `rift_count`: number of blocked undirected edges
-- `reachable`: whether `S -> H` is reachable
-- `best_cost`: minimum terrain cost from `S` to `H`
-- `best_path_length`: minimum number of moves among paths with `best_cost`
-- `cost_to_base`: minimum terrain cost from `S` to `B`
-- `cost_base_to_goal`: minimum terrain cost from `B` to `H`
-- `best_cost_via_base`: `cost_to_base + cost_base_to_goal`
-- `best_cost_without_base`: minimum terrain cost from `S` to `H` while forbidding `B`
-- `base_route_advantage_raw`: `best_cost_without_base - best_cost_via_base`
-- `base_is_mandatory`: whether `H` is reachable only via `B`
+- `MAP ID`
+- `OBJECTS`
+- `PARAMETERS`
+- `MAP`
+- `COSTS`
+- `VERDICT`
 
-Internally numeric values stay as `int | None`. The output layer converts unavailable costs to `N/A` and booleans to `yes` / `no`.
+The `COSTS` section includes the shortest-path metrics used by the verdict classifier:
+
+- `S_to_H_cost`
+- `S_to_H_steps`
+- `S_to_B_cost`
+- `B_to_H_cost`
+- `S_to_H_via_B_cost`
+- `S_to_H_without_B_cost`
+- `base_route_advantage_raw`
+
+Unavailable metrics are rendered as `N/A`.
+
+## Verdict Rules
+
+The verdict priority order is:
+
+1. `REJECT_TOO_HARD`
+2. `REJECT_BASE_MANDATORY`
+3. `ACCEPT`
+
+Classification rules:
+
+- `REJECT_TOO_HARD`: at least one of `S -> H`, `S -> B`, or `B -> H` is unreachable
+- `REJECT_BASE_MANDATORY`: all required segments are reachable, but `S -> H` has no route that avoids `B`
+- `ACCEPT`: any map not rejected by the higher-priority rules
+
+`ACCEPT` is only a minimal candidate verdict. It does not mean the map is already proven fun, balanced, or final-quality.
 
 ## Tests
 

--- a/experiments/galactic_exodus/simulate.py
+++ b/experiments/galactic_exodus/simulate.py
@@ -68,6 +68,17 @@ class PathAnalysis:
     base_is_mandatory: bool
 
 
+VERDICT_REJECT_TOO_HARD = "REJECT_TOO_HARD"
+VERDICT_REJECT_BASE_MANDATORY = "REJECT_BASE_MANDATORY"
+VERDICT_ACCEPT = "ACCEPT"
+VERDICT_PRIORITY_ORDER = (
+    VERDICT_REJECT_TOO_HARD,
+    VERDICT_REJECT_BASE_MANDATORY,
+    VERDICT_ACCEPT,
+)
+ACCEPT_NOTE = "ACCEPT is a minimal candidate verdict, not a final fun/balance judgment."
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Generate a deterministic 8x8 Galactic Exodus map.")
     parser.add_argument("--seed", type=int, default=DEFAULT_SEED, help="Random seed (default: 42).")
@@ -288,32 +299,62 @@ def format_optional_metric(value: int | None) -> str:
     return "N/A" if value is None else str(value)
 
 
+def build_map_id(galactic_map: GalacticMap) -> str:
+    return (
+        f"seed-{galactic_map.seed}"
+        f"-rift-{galactic_map.rift_density:.2f}"
+        f"-res-{galactic_map.resource_count}"
+    )
+
+
+def classify_verdict(analysis: PathAnalysis) -> str:
+    if analysis.best_cost is None or analysis.cost_to_base is None or analysis.cost_base_to_goal is None:
+        return VERDICT_REJECT_TOO_HARD
+    if analysis.base_is_mandatory:
+        return VERDICT_REJECT_BASE_MANDATORY
+    return VERDICT_ACCEPT
+
+
 def format_output(galactic_map: GalacticMap) -> str:
     analysis = analyze_paths(galactic_map)
+    verdict = classify_verdict(analysis)
+    resource_positions = ", ".join(format_position(position) for position in galactic_map.r_positions) or "(none)"
     lines = [
-        f"SEED: {galactic_map.seed}",
-        f"SIZE: {WIDTH}x{HEIGHT}",
-        f"S POSITION: {format_position(SPECIAL_S)}",
-        f"H POSITION: {format_position(SPECIAL_H)}",
-        f"B POSITION: {format_position(galactic_map.b_position)}",
-        "R POSITIONS: " + ", ".join(format_position(position) for position in galactic_map.r_positions),
-        f"TERRAIN DISTRIBUTION: {terrain_distribution(galactic_map.cells)}",
+        "MAP ID",
+        f"  map_id: {build_map_id(galactic_map)}",
         "",
-        "MAP:",
-        render_map(galactic_map.cells),
+        "OBJECTS",
+        f"  S: {format_position(SPECIAL_S)}",
+        f"  H: {format_position(SPECIAL_H)}",
+        f"  B: {format_position(galactic_map.b_position)}",
+        f"  R: {resource_positions}",
         "",
-        "COSTS:",
+        "PARAMETERS",
+        f"  seed: {galactic_map.seed}",
+        f"  size: {WIDTH}x{HEIGHT}",
+        f"  resource_count: {galactic_map.resource_count}",
         f"  rift_density: {galactic_map.rift_density:.2f}",
         f"  rift_count: {len(galactic_map.rift_edges)}",
-        f"  reachable: {'yes' if analysis.reachable else 'no'}",
-        f"  best_cost: {format_optional_metric(analysis.best_cost)}",
-        f"  best_path_length: {format_optional_metric(analysis.best_path_length)}",
-        f"  cost_to_base: {format_optional_metric(analysis.cost_to_base)}",
-        f"  cost_base_to_goal: {format_optional_metric(analysis.cost_base_to_goal)}",
-        f"  best_cost_via_base: {format_optional_metric(analysis.best_cost_via_base)}",
-        f"  best_cost_without_base: {format_optional_metric(analysis.best_cost_without_base)}",
+        f"  terrain_distribution: {terrain_distribution(galactic_map.cells)}",
+        "",
+        "MAP",
+        render_map(galactic_map.cells),
+        "",
+        "COSTS",
+        f"  S_to_H_cost: {format_optional_metric(analysis.best_cost)}",
+        f"  S_to_H_steps: {format_optional_metric(analysis.best_path_length)}",
+        f"  S_to_B_cost: {format_optional_metric(analysis.cost_to_base)}",
+        f"  B_to_H_cost: {format_optional_metric(analysis.cost_base_to_goal)}",
+        f"  S_to_H_via_B_cost: {format_optional_metric(analysis.best_cost_via_base)}",
+        f"  S_to_H_without_B_cost: {format_optional_metric(analysis.best_cost_without_base)}",
         f"  base_route_advantage_raw: {format_optional_metric(analysis.base_route_advantage_raw)}",
-        f"  base_is_mandatory: {'yes' if analysis.base_is_mandatory else 'no'}",
+        "",
+        "VERDICT",
+        f"  verdict: {verdict}",
+        f"  priority_1: {VERDICT_PRIORITY_ORDER[0]}",
+        f"  priority_2: {VERDICT_PRIORITY_ORDER[1]}",
+        f"  priority_3: {VERDICT_PRIORITY_ORDER[2]}",
+        f"  note: {ACCEPT_NOTE}",
     ]
     return "\n".join(lines)
 

--- a/experiments/galactic_exodus/test_simulate.py
+++ b/experiments/galactic_exodus/test_simulate.py
@@ -179,6 +179,7 @@ class AnalysisAndOutputTests(unittest.TestCase):
         self.assertEqual(analysis.best_cost_without_base, 17)
         self.assertEqual(analysis.base_route_advantage_raw, 0)
         self.assertFalse(analysis.base_is_mandatory)
+        self.assertEqual(simulate.classify_verdict(analysis), "ACCEPT")
 
     def test_analyze_paths_marks_base_as_mandatory_when_home_is_only_reachable_via_base(self) -> None:
         cells = filled_cells(".")
@@ -208,25 +209,64 @@ class AnalysisAndOutputTests(unittest.TestCase):
         self.assertIsNone(analysis.best_cost_without_base)
         self.assertIsNone(analysis.base_route_advantage_raw)
         self.assertTrue(analysis.base_is_mandatory)
+        self.assertEqual(simulate.classify_verdict(analysis), "REJECT_BASE_MANDATORY")
 
-    def test_format_output_includes_costs_section(self) -> None:
+    def test_analyze_paths_rejects_too_hard_when_any_required_route_is_unreachable(self) -> None:
+        cells = filled_cells(".")
+        b_position = (2, 1)
+        cells[simulate.SPECIAL_S] = "S"
+        cells[simulate.SPECIAL_H] = "H"
+        cells[b_position] = "B"
+        galactic_map = simulate.GalacticMap(
+            seed=11,
+            resource_count=0,
+            rift_density=0.04,
+            b_position=b_position,
+            r_positions=[],
+            rift_edges=(
+                simulate.normalize_edge(simulate.SPECIAL_S, (2, 1)),
+                simulate.normalize_edge(simulate.SPECIAL_S, (1, 2)),
+            ),
+            cells=cells,
+        )
+
+        analysis = simulate.analyze_paths(galactic_map)
+
+        self.assertFalse(analysis.reachable)
+        self.assertIsNone(analysis.best_cost)
+        self.assertIsNone(analysis.cost_to_base)
+        self.assertEqual(analysis.cost_base_to_goal, 13)
+        self.assertEqual(simulate.classify_verdict(analysis), "REJECT_TOO_HARD")
+
+    def test_format_output_uses_required_sections_and_accept_verdict(self) -> None:
         output = simulate.format_output(simulate.generate_map(42, 3))
 
-        self.assertIn("COSTS:", output)
+        self.assertIn("MAP ID\n", output)
+        self.assertIn("\nOBJECTS\n", output)
+        self.assertIn("\nPARAMETERS\n", output)
+        self.assertIn("\nMAP\n", output)
+        self.assertIn("\nCOSTS\n", output)
+        self.assertIn("\nVERDICT\n", output)
+        self.assertIn("  map_id: seed-42-rift-0.10-res-3", output)
+        self.assertIn("  B: (4,4)", output)
         self.assertIn("  rift_density: 0.10", output)
-        self.assertIn("  rift_count: 11", output)
-        self.assertIn("  reachable: yes", output)
-        self.assertIn("  best_cost: 17", output)
-        self.assertIn("  best_path_length: 14", output)
-        self.assertIn("  cost_to_base: 8", output)
-        self.assertIn("  cost_base_to_goal: 9", output)
-        self.assertIn("  best_cost_via_base: 17", output)
-        self.assertIn("  best_cost_without_base: 17", output)
-        self.assertIn("  base_route_advantage_raw: 0", output)
-        self.assertIn("  base_is_mandatory: no", output)
+        self.assertIn("  S_to_H_cost: 17", output)
+        self.assertIn("  S_to_H_steps: 14", output)
+        self.assertIn("  S_to_B_cost: 8", output)
+        self.assertIn("  B_to_H_cost: 9", output)
+        self.assertIn("  S_to_H_via_B_cost: 17", output)
+        self.assertIn("  S_to_H_without_B_cost: 17", output)
+        self.assertIn("  verdict: ACCEPT", output)
+        self.assertIn("  priority_1: REJECT_TOO_HARD", output)
+        self.assertIn("  priority_2: REJECT_BASE_MANDATORY", output)
+        self.assertIn("  priority_3: ACCEPT", output)
+        self.assertIn("  note: ACCEPT is a minimal candidate verdict, not a final fun/balance judgment.", output)
 
     def test_format_output_uses_na_for_unreachable_segments(self) -> None:
         cells = filled_cells(".")
+        cells[simulate.SPECIAL_S] = "S"
+        cells[simulate.SPECIAL_H] = "H"
+        cells[(2, 1)] = "B"
         galactic_map = simulate.GalacticMap(
             seed=7,
             resource_count=0,
@@ -244,14 +284,14 @@ class AnalysisAndOutputTests(unittest.TestCase):
 
         output = simulate.format_output(galactic_map)
 
-        self.assertIn("  reachable: no", output)
-        self.assertIn("  best_cost: N/A", output)
-        self.assertIn("  cost_to_base: N/A", output)
-        self.assertIn("  cost_base_to_goal: N/A", output)
-        self.assertIn("  best_cost_via_base: N/A", output)
-        self.assertIn("  best_cost_without_base: N/A", output)
+        self.assertIn("  S_to_H_cost: N/A", output)
+        self.assertIn("  S_to_H_steps: N/A", output)
+        self.assertIn("  S_to_B_cost: N/A", output)
+        self.assertIn("  B_to_H_cost: N/A", output)
+        self.assertIn("  S_to_H_via_B_cost: N/A", output)
+        self.assertIn("  S_to_H_without_B_cost: N/A", output)
         self.assertIn("  base_route_advantage_raw: N/A", output)
-        self.assertIn("  base_is_mandatory: no", output)
+        self.assertIn("  verdict: REJECT_TOO_HARD", output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 概要

Closes #909

Galactic Exodus の Phase 0 実験環境に、1 seed 分析レポートの標準出力整形と最小 verdict 分類を追加しました。

## 変更内容

- `MAP ID / OBJECTS / PARAMETERS / MAP / COSTS / VERDICT` の順でレポートを出力
- 到達不能なコスト指標を `N/A` で安全に表示
- `REJECT_TOO_HARD` / `REJECT_BASE_MANDATORY` / `ACCEPT` の優先順つき verdict 判定を追加
- `ACCEPT` は面白さ確定ではなく最小候補分類であることを README と出力に明記
- Python テストを更新し、3種類の verdict と新しいレポート構成を固定

## 確認

- `python -m unittest experiments.galactic_exodus.test_simulate`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo fmt --check`
