### PR TITLE
分析レポートに base_is_mandatory を明示

### DIFF
--- a/experiments/galactic_exodus/README.md
+++ b/experiments/galactic_exodus/README.md
@@ -65,6 +65,7 @@ The `COSTS` section includes the shortest-path metrics used by the verdict class
 - `S_to_H_via_B_cost`
 - `S_to_H_without_B_cost`
 - `base_route_advantage_raw`
+- `base_is_mandatory` (`yes` / `no`)
 
 Unavailable metrics are rendered as `N/A`.
 

--- a/experiments/galactic_exodus/simulate.py
+++ b/experiments/galactic_exodus/simulate.py
@@ -299,6 +299,10 @@ def format_optional_metric(value: int | None) -> str:
     return "N/A" if value is None else str(value)
 
 
+def format_yes_no(value: bool) -> str:
+    return "yes" if value else "no"
+
+
 def build_map_id(galactic_map: GalacticMap) -> str:
     return (
         f"seed-{galactic_map.seed}"
@@ -348,6 +352,7 @@ def format_output(galactic_map: GalacticMap) -> str:
         f"  S_to_H_via_B_cost: {format_optional_metric(analysis.best_cost_via_base)}",
         f"  S_to_H_without_B_cost: {format_optional_metric(analysis.best_cost_without_base)}",
         f"  base_route_advantage_raw: {format_optional_metric(analysis.base_route_advantage_raw)}",
+        f"  base_is_mandatory: {format_yes_no(analysis.base_is_mandatory)}",
         "",
         "VERDICT",
         f"  verdict: {verdict}",

--- a/experiments/galactic_exodus/test_simulate.py
+++ b/experiments/galactic_exodus/test_simulate.py
@@ -256,11 +256,38 @@ class AnalysisAndOutputTests(unittest.TestCase):
         self.assertIn("  B_to_H_cost: 9", output)
         self.assertIn("  S_to_H_via_B_cost: 17", output)
         self.assertIn("  S_to_H_without_B_cost: 17", output)
+        self.assertIn("  base_is_mandatory: no", output)
         self.assertIn("  verdict: ACCEPT", output)
         self.assertIn("  priority_1: REJECT_TOO_HARD", output)
         self.assertIn("  priority_2: REJECT_BASE_MANDATORY", output)
         self.assertIn("  priority_3: ACCEPT", output)
         self.assertIn("  note: ACCEPT is a minimal candidate verdict, not a final fun/balance judgment.", output)
+
+    def test_format_output_marks_mandatory_base_with_yes(self) -> None:
+        cells = filled_cells(".")
+        b_position = (2, 1)
+        blocked_edges = (
+            simulate.normalize_edge(simulate.SPECIAL_S, (1, 2)),
+            simulate.normalize_edge((2, 2), (3, 2)),
+            simulate.normalize_edge((3, 1), (3, 2)),
+        )
+        cells[simulate.SPECIAL_S] = "S"
+        cells[simulate.SPECIAL_H] = "H"
+        cells[b_position] = "B"
+        galactic_map = simulate.GalacticMap(
+            seed=9,
+            resource_count=0,
+            rift_density=0.03,
+            b_position=b_position,
+            r_positions=[],
+            rift_edges=blocked_edges,
+            cells=cells,
+        )
+
+        output = simulate.format_output(galactic_map)
+
+        self.assertIn("  base_is_mandatory: yes", output)
+        self.assertIn("  verdict: REJECT_BASE_MANDATORY", output)
 
     def test_format_output_uses_na_for_unreachable_segments(self) -> None:
         cells = filled_cells(".")
@@ -291,6 +318,7 @@ class AnalysisAndOutputTests(unittest.TestCase):
         self.assertIn("  S_to_H_via_B_cost: N/A", output)
         self.assertIn("  S_to_H_without_B_cost: N/A", output)
         self.assertIn("  base_route_advantage_raw: N/A", output)
+        self.assertIn("  base_is_mandatory: no", output)
         self.assertIn("  verdict: REJECT_TOO_HARD", output)
 
 


### PR DESCRIPTION
## 概要

Closes #1030

Galactic Exodus Phase 0 の分析レポート `COSTS` セクションに `base_is_mandatory: yes/no` を追加し、README とテストの出力契約を更新しました。

## 変更内容

- `simulate.py` の `COSTS` 出力に `base_is_mandatory` を追加
- `yes/no` 表記の helper を追加して出力形式を固定
- B 必須ケースと非必須ケースの出力テストを追加・更新
- `experiments/galactic_exodus/README.md` の出力指標一覧に `base_is_mandatory` を追記

## 確認

- `python -m unittest experiments.galactic_exodus.test_simulate`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo fmt --check`
