### PR TITLE
Galactic Exodus実験READMEを日本語化

### DIFF
--- a/experiments/galactic_exodus/README.md
+++ b/experiments/galactic_exodus/README.md
@@ -1,53 +1,53 @@
-# Galactic Exodus Phase 0 Experiments
+# Galactic Exodus Phase 0 実験環境
 
-This directory contains a small Python experiment harness for the Phase 0 mathematical and game-design validation work for `Galactic Exodus`.
+このディレクトリには、`Galactic Exodus` の Phase 0 における数理・ゲームデザイン検証用の小規模な Python 実験環境が含まれています。
 
-It is not the formal TBX application implementation. The future TBX-side implementation is expected to live elsewhere, such as `examples/galactic_exodus/`.
+これは正式な TBX アプリ実装ではありません。将来の TBX 側の実装は、`examples/galactic_exodus/` など別の場所に置く想定です。
 
-## Run
+## 実行方法
 
 ```bash
 python experiments/galactic_exodus/simulate.py --seed 42 --rift-density 0.10
 ```
 
-## Terrain Costs
+## 地形コスト
 
-The baseline path analysis treats movement as four-directional (`N/E/S/W`) on the 8x8 grid.
-Each move adds the cost of the destination cell. The starting cell does not add cost.
+基準となる経路分析では、8x8 グリッド上を4方向（`N/E/S/W`）に移動します。
+各移動では、移動先マスのコストを加算します。開始地点のコストは加算しません。
 
-| Symbol | Meaning | Cost |
+| 記号 | 意味 | コスト |
 | --- | --- | --- |
-| `.` | normal sector | 1 |
-| `N` | nebula | 2 |
-| `A` | asteroid field | 3 |
-| `@` | gravity well / gravity anomaly | 2 |
-| `B` | base | 1 |
-| `R` | resource | 1 |
-| `S` | start | 0 |
-| `H` | home | 1 |
+| `.` | 安定宙域 | 1 |
+| `N` | 星雲 | 2 |
+| `A` | 小惑星帯 | 3 |
+| `@` | 重力井戸 / 重力異常 | 2 |
+| `B` | 辺境基地 | 1 |
+| `R` | 資源天体 | 1 |
+| `S` | 出発星系 | 0 |
+| `H` | 故郷星系 | 1 |
 
-This experiment computes a full-information baseline with optional fault-line restrictions on movement edges.
+この実験では、マップ全体の情報が既知であることを前提に、移動辺へ任意の断層制約を加えた基準計算を行います。
 
-## Fault-Line Rifts
+## 断層航路
 
-The grid has 112 undirected adjacent edges in total. Rift edges are chosen deterministically from the seed:
+グリッドには、無向の隣接辺が合計112本あります。断層辺は seed に基づいて決定的に選ばれます。
 
 ```text
 rift_count = round(112 * rift_density)
 ```
 
-Use `--rift-density FLOAT` to control the density. The default is `0.10`.
+密度は `--rift-density FLOAT` で指定します。既定値は `0.10` です。
 
-Selected rift edges are impassable in both directions and are excluded from all shortest-path calculations:
+選択された断層辺は双方向に通行不能となり、次のすべての最短路計算から除外されます。
 
 - `S -> H`
 - `S -> B`
 - `B -> H`
-- `S -> H` while forbidding `B`
+- `B` を通行禁止にした `S -> H`
 
-## Report Output
+## レポート出力
 
-`simulate.py` prints the following sections in order:
+`simulate.py` は、次のセクションをこの順序で出力します。
 
 - `MAP ID`
 - `OBJECTS`
@@ -56,7 +56,7 @@ Selected rift edges are impassable in both directions and are excluded from all 
 - `COSTS`
 - `VERDICT`
 
-The `COSTS` section includes the shortest-path metrics used by the verdict classifier:
+`COSTS` セクションには、verdict 分類に使う次の最短路指標が含まれます。
 
 - `S_to_H_cost`
 - `S_to_H_steps`
@@ -65,29 +65,29 @@ The `COSTS` section includes the shortest-path metrics used by the verdict class
 - `S_to_H_via_B_cost`
 - `S_to_H_without_B_cost`
 - `base_route_advantage_raw`
-- `base_is_mandatory` (`yes` / `no`)
+- `base_is_mandatory`（`yes` / `no`）
 
-Unavailable metrics are rendered as `N/A`.
+利用できない指標は `N/A` と表示されます。
 
-## Verdict Rules
+## verdict の判定規則
 
-The verdict priority order is:
+verdict の優先順位は次のとおりです。
 
 1. `REJECT_TOO_HARD`
 2. `REJECT_BASE_MANDATORY`
 3. `ACCEPT`
 
-Classification rules:
+分類規則:
 
-- `REJECT_TOO_HARD`: at least one of `S -> H`, `S -> B`, or `B -> H` is unreachable
-- `REJECT_BASE_MANDATORY`: all required segments are reachable, but `S -> H` has no route that avoids `B`
-- `ACCEPT`: any map not rejected by the higher-priority rules
+- `REJECT_TOO_HARD`: `S -> H`、`S -> B`、`B -> H` のいずれかが到達不能
+- `REJECT_BASE_MANDATORY`: 必要な各区間には到達できるが、`B` を回避する `S -> H` 経路が存在しない
+- `ACCEPT`: 上位の棄却条件に該当しないマップ
 
-`ACCEPT` is only a minimal candidate verdict. It does not mean the map is already proven fun, balanced, or final-quality.
+`ACCEPT` は最低限の候補判定にすぎません。そのマップがすでに面白い、バランスが取れている、最終品質に達していることを意味しません。
 
-## Tests
+## テスト
 
-Run the Python experiment tests with the standard library `unittest` runner:
+Python 実験環境のテストは、標準ライブラリの `unittest` で実行します。
 
 ```bash
 python -m unittest experiments.galactic_exodus.test_simulate


### PR DESCRIPTION
## 概要

`experiments/galactic_exodus/README.md` を日本語へ翻訳しました。

## 変更内容

- 見出しと本文を日本語化
- 地形名を現在の仕様に合わせて日本語化
- コマンド、識別子、verdict名はそのまま維持
- 技術的な意味や判定規則は変更していません

## 対象

- `experiments/galactic_exodus/README.md` のみ

## ベースブランチ

`integration/882-galactic-exodus`
