### PR TITLE
Phase 0 metrics: 地形なし・断層なし基準との差分指標を追加

### DIFF
--- a/experiments/galactic_exodus/README.md
+++ b/experiments/galactic_exodus/README.md
@@ -75,6 +75,37 @@ rift_count = round(112 * rift_density)
 
 利用できない指標は `N/A` と表示されます。
 
+続いて `COST CONTRIBUTIONS` セクションで、同じ `GalacticMap` に対する全情報あり基準分析を出力します。ここでは地形配置と `S/H/B/R` 配置を固定したまま、経路計算条件だけを切り替えます。
+
+- A: `plain`
+  - 断層なし
+  - 移動先記号に関係なく、1 移動ごとにコスト 1
+- B: `terrain_only`
+  - 断層なし
+  - 現行の地形コスト表を使用
+- C: `full`
+  - 生成済み断層あり
+  - 現行の地形コスト表を使用
+
+開始地点 `S` のコストは、A/B/C のどれでも加算しません。
+
+`COST CONTRIBUTIONS` セクションには次の 5 指標が含まれます。
+
+- `plain_cost`
+  - A の `S -> H` 最小コスト
+- `terrain_only_cost`
+  - B の `S -> H` 最小コスト
+- `full_cost`
+  - C の `S -> H` 最小コスト
+- `terrain_extra_cost`
+  - `terrain_only_cost - plain_cost`
+  - 地形コスト差だけで基準経路にどれだけ追加消費が生じるか
+- `rift_detour_cost`
+  - `full_cost - terrain_only_cost`
+  - 現行地形上で断層を加えたことでどれだけ追加消費が生じるか
+
+`full` 条件だけは断層により到達不能になり得ます。その場合は `full_cost` と `rift_detour_cost` を内部では `None` とし、レポートでは `N/A` と表示します。`plain_cost`、`terrain_only_cost`、`terrain_extra_cost` は、その場合でも数値のまま保持されます。
+
 ## verdict の判定規則
 
 verdict の優先順位は次のとおりです。

--- a/experiments/galactic_exodus/simulate.py
+++ b/experiments/galactic_exodus/simulate.py
@@ -7,7 +7,7 @@ from collections import Counter
 from dataclasses import dataclass
 import heapq
 import random
-from typing import TypeAlias
+from typing import Callable, TypeAlias
 
 
 WIDTH = 8
@@ -36,6 +36,7 @@ TERRAIN_COSTS = {
 Position: TypeAlias = tuple[int, int]
 Cells: TypeAlias = dict[Position, str]
 Edge: TypeAlias = tuple[Position, Position]
+CostFunction: TypeAlias = Callable[[str], int]
 
 
 @dataclass(frozen=True)
@@ -66,6 +67,15 @@ class PathAnalysis:
     best_cost_without_base: int | None
     base_route_advantage_raw: int | None
     base_is_mandatory: bool
+
+
+@dataclass(frozen=True)
+class CostContributionAnalysis:
+    plain_cost: int | None
+    terrain_only_cost: int | None
+    full_cost: int | None
+    terrain_extra_cost: int | None
+    rift_detour_cost: int | None
 
 
 VERDICT_REJECT_TOO_HARD = "REJECT_TOO_HARD"
@@ -167,6 +177,11 @@ def terrain_cost(symbol: str) -> int:
         raise ValueError(f"unknown terrain symbol: {symbol!r}") from exc
 
 
+def plain_movement_cost(symbol: str) -> int:
+    terrain_cost(symbol)
+    return 1
+
+
 def neighbors(position: Position) -> list[Position]:
     x, y = position
     adjacent: list[Position] = []
@@ -210,6 +225,7 @@ def shortest_path(
     goal: Position,
     blocked_edges: set[Edge] | None = None,
     forbidden_nodes: set[Position] | None = None,
+    cost_function: CostFunction = terrain_cost,
 ) -> PathResult | None:
     if start not in cells:
         raise ValueError(f"start position is outside map cells: {start}")
@@ -235,7 +251,7 @@ def shortest_path(
                 continue
             if normalize_edge(position, neighbor) in blocked:
                 continue
-            candidate = (cost + terrain_cost(cells[neighbor]), steps + 1)
+            candidate = (cost + cost_function(cells[neighbor]), steps + 1)
             previous = best.get(neighbor)
             if previous is None or candidate < previous:
                 best[neighbor] = candidate
@@ -274,6 +290,42 @@ def analyze_paths(galactic_map: GalacticMap) -> PathAnalysis:
         best_cost_without_base=None if without_base is None else without_base.cost,
         base_route_advantage_raw=advantage,
         base_is_mandatory=base_is_mandatory,
+    )
+
+
+def analyze_cost_contributions(galactic_map: GalacticMap) -> CostContributionAnalysis:
+    plain_route = shortest_path(
+        galactic_map.cells,
+        SPECIAL_S,
+        SPECIAL_H,
+        cost_function=plain_movement_cost,
+    )
+    terrain_only_route = shortest_path(galactic_map.cells, SPECIAL_S, SPECIAL_H)
+    full_route = shortest_path(
+        galactic_map.cells,
+        SPECIAL_S,
+        SPECIAL_H,
+        blocked_edges=set(galactic_map.rift_edges),
+    )
+
+    plain_cost = None if plain_route is None else plain_route.cost
+    terrain_only_cost = None if terrain_only_route is None else terrain_only_route.cost
+    full_cost = None if full_route is None else full_route.cost
+
+    terrain_extra_cost = None
+    if plain_cost is not None and terrain_only_cost is not None:
+        terrain_extra_cost = terrain_only_cost - plain_cost
+
+    rift_detour_cost = None
+    if terrain_only_cost is not None and full_cost is not None:
+        rift_detour_cost = full_cost - terrain_only_cost
+
+    return CostContributionAnalysis(
+        plain_cost=plain_cost,
+        terrain_only_cost=terrain_only_cost,
+        full_cost=full_cost,
+        terrain_extra_cost=terrain_extra_cost,
+        rift_detour_cost=rift_detour_cost,
     )
 
 
@@ -321,6 +373,7 @@ def classify_verdict(analysis: PathAnalysis) -> str:
 
 def format_output(galactic_map: GalacticMap) -> str:
     analysis = analyze_paths(galactic_map)
+    cost_contributions = analyze_cost_contributions(galactic_map)
     verdict = classify_verdict(analysis)
     resource_positions = ", ".join(format_position(position) for position in galactic_map.r_positions) or "(none)"
     lines = [
@@ -353,6 +406,13 @@ def format_output(galactic_map: GalacticMap) -> str:
         f"  S_to_H_without_B_cost: {format_optional_metric(analysis.best_cost_without_base)}",
         f"  base_route_advantage_raw: {format_optional_metric(analysis.base_route_advantage_raw)}",
         f"  base_is_mandatory: {format_yes_no(analysis.base_is_mandatory)}",
+        "",
+        "COST CONTRIBUTIONS",
+        f"  plain_cost: {format_optional_metric(cost_contributions.plain_cost)}",
+        f"  terrain_only_cost: {format_optional_metric(cost_contributions.terrain_only_cost)}",
+        f"  full_cost: {format_optional_metric(cost_contributions.full_cost)}",
+        f"  terrain_extra_cost: {format_optional_metric(cost_contributions.terrain_extra_cost)}",
+        f"  rift_detour_cost: {format_optional_metric(cost_contributions.rift_detour_cost)}",
         "",
         "VERDICT",
         f"  verdict: {verdict}",

--- a/experiments/galactic_exodus/test_simulate.py
+++ b/experiments/galactic_exodus/test_simulate.py
@@ -11,6 +11,27 @@ def filled_cells(symbol: str = ".") -> simulate.Cells:
     }
 
 
+def make_map(
+    *,
+    cells: simulate.Cells,
+    b_position: simulate.Position = (4, 4),
+    rift_edges: tuple[simulate.Edge, ...] = (),
+) -> simulate.GalacticMap:
+    map_cells = dict(cells)
+    map_cells[simulate.SPECIAL_S] = "S"
+    map_cells[simulate.SPECIAL_H] = "H"
+    map_cells[b_position] = "B"
+    return simulate.GalacticMap(
+        seed=0,
+        resource_count=0,
+        rift_density=0.0,
+        b_position=b_position,
+        r_positions=[],
+        rift_edges=rift_edges,
+        cells=map_cells,
+    )
+
+
 class TerrainCostTests(unittest.TestCase):
     def test_terrain_cost_table_and_unknown_symbol(self) -> None:
         self.assertEqual(simulate.terrain_cost("."), 1)
@@ -24,6 +45,19 @@ class TerrainCostTests(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "unknown terrain symbol"):
             simulate.terrain_cost("?")
+
+    def test_plain_movement_cost_is_one_for_all_known_symbols_and_rejects_unknown(self) -> None:
+        self.assertEqual(simulate.plain_movement_cost("."), 1)
+        self.assertEqual(simulate.plain_movement_cost("N"), 1)
+        self.assertEqual(simulate.plain_movement_cost("A"), 1)
+        self.assertEqual(simulate.plain_movement_cost("@"), 1)
+        self.assertEqual(simulate.plain_movement_cost("B"), 1)
+        self.assertEqual(simulate.plain_movement_cost("R"), 1)
+        self.assertEqual(simulate.plain_movement_cost("S"), 1)
+        self.assertEqual(simulate.plain_movement_cost("H"), 1)
+
+        with self.assertRaisesRegex(ValueError, "unknown terrain symbol"):
+            simulate.plain_movement_cost("?")
 
 
 class NeighborTests(unittest.TestCase):
@@ -117,6 +151,21 @@ class ShortestPathTests(unittest.TestCase):
 
         self.assertEqual(result, simulate.PathResult(cost=4, steps=4))
 
+    def test_shortest_path_can_use_plain_cost_function(self) -> None:
+        cells = filled_cells(".")
+        cells[(2, 1)] = "A"
+        cells[(3, 1)] = "A"
+        cells[(4, 1)] = "H"
+
+        result = simulate.shortest_path(
+            cells,
+            (1, 1),
+            (4, 1),
+            cost_function=simulate.plain_movement_cost,
+        )
+
+        self.assertEqual(result, simulate.PathResult(cost=3, steps=3))
+
 
 class RiftGenerationTests(unittest.TestCase):
     def test_rift_count_uses_total_undirected_edges(self) -> None:
@@ -180,6 +229,100 @@ class AnalysisAndOutputTests(unittest.TestCase):
         self.assertEqual(analysis.base_route_advantage_raw, 0)
         self.assertFalse(analysis.base_is_mandatory)
         self.assertEqual(simulate.classify_verdict(analysis), "ACCEPT")
+
+    def test_cost_contributions_are_zero_on_plain_map_without_rifts(self) -> None:
+        galactic_map = make_map(cells=filled_cells("."))
+
+        analysis = simulate.analyze_cost_contributions(galactic_map)
+
+        self.assertEqual(
+            analysis,
+            simulate.CostContributionAnalysis(
+                plain_cost=14,
+                terrain_only_cost=14,
+                full_cost=14,
+                terrain_extra_cost=0,
+                rift_detour_cost=0,
+            ),
+        )
+
+    def test_cost_contributions_report_positive_terrain_extra_cost(self) -> None:
+        cells = filled_cells(".")
+        for y in range(1, simulate.HEIGHT + 1):
+            cells[(4, y)] = "A"
+        galactic_map = make_map(cells=cells, b_position=(5, 4))
+
+        analysis = simulate.analyze_cost_contributions(galactic_map)
+
+        self.assertEqual(analysis.plain_cost, 14)
+        self.assertEqual(analysis.terrain_only_cost, 16)
+        self.assertEqual(analysis.full_cost, 16)
+        self.assertEqual(analysis.terrain_extra_cost, 2)
+        self.assertEqual(analysis.rift_detour_cost, 0)
+
+    def test_cost_contributions_report_positive_rift_detour_cost(self) -> None:
+        blocked_edges = (
+            simulate.normalize_edge((1, 4), (2, 4)),
+            simulate.normalize_edge((3, 4), (4, 4)),
+            simulate.normalize_edge((3, 6), (3, 7)),
+            simulate.normalize_edge((6, 6), (7, 6)),
+            simulate.normalize_edge((6, 7), (7, 7)),
+            simulate.normalize_edge((7, 1), (7, 2)),
+            simulate.normalize_edge((7, 6), (7, 7)),
+            simulate.normalize_edge((7, 8), (8, 8)),
+            simulate.normalize_edge((8, 6), (8, 7)),
+        )
+        galactic_map = make_map(cells=filled_cells("."), rift_edges=blocked_edges)
+
+        analysis = simulate.analyze_cost_contributions(galactic_map)
+
+        self.assertEqual(analysis.plain_cost, 14)
+        self.assertEqual(analysis.terrain_only_cost, 14)
+        self.assertEqual(analysis.full_cost, 16)
+        self.assertEqual(analysis.terrain_extra_cost, 0)
+        self.assertEqual(analysis.rift_detour_cost, 2)
+
+    def test_cost_contributions_report_zero_rift_detour_when_rifts_do_not_change_best_cost(self) -> None:
+        blocked_edges = (
+            simulate.normalize_edge((8, 1), (8, 2)),
+        )
+        galactic_map = make_map(cells=filled_cells("."), rift_edges=blocked_edges)
+
+        analysis = simulate.analyze_cost_contributions(galactic_map)
+
+        self.assertEqual(analysis.full_cost, 14)
+        self.assertEqual(analysis.rift_detour_cost, 0)
+
+    def test_cost_contributions_keep_plain_and_terrain_costs_when_full_route_is_unreachable(self) -> None:
+        blocked_edges = (
+            simulate.normalize_edge(simulate.SPECIAL_S, (2, 1)),
+            simulate.normalize_edge(simulate.SPECIAL_S, (1, 2)),
+        )
+        galactic_map = make_map(cells=filled_cells("."), rift_edges=blocked_edges)
+
+        analysis = simulate.analyze_cost_contributions(galactic_map)
+
+        self.assertEqual(analysis.plain_cost, 14)
+        self.assertEqual(analysis.terrain_only_cost, 14)
+        self.assertIsNone(analysis.full_cost)
+        self.assertEqual(analysis.terrain_extra_cost, 0)
+        self.assertIsNone(analysis.rift_detour_cost)
+
+    def test_seed_42_cost_contributions_are_stable(self) -> None:
+        galactic_map = simulate.generate_map(42, 3)
+
+        analysis = simulate.analyze_cost_contributions(galactic_map)
+
+        self.assertEqual(
+            analysis,
+            simulate.CostContributionAnalysis(
+                plain_cost=14,
+                terrain_only_cost=15,
+                full_cost=17,
+                terrain_extra_cost=1,
+                rift_detour_cost=2,
+            ),
+        )
 
     def test_analyze_paths_marks_base_as_mandatory_when_home_is_only_reachable_via_base(self) -> None:
         cells = filled_cells(".")
@@ -246,6 +389,7 @@ class AnalysisAndOutputTests(unittest.TestCase):
         self.assertIn("\nPARAMETERS\n", output)
         self.assertIn("\nMAP\n", output)
         self.assertIn("\nCOSTS\n", output)
+        self.assertIn("\nCOST CONTRIBUTIONS\n", output)
         self.assertIn("\nVERDICT\n", output)
         self.assertIn("  map_id: seed-42-rift-0.10-res-3", output)
         self.assertIn("  B: (4,4)", output)
@@ -257,6 +401,11 @@ class AnalysisAndOutputTests(unittest.TestCase):
         self.assertIn("  S_to_H_via_B_cost: 17", output)
         self.assertIn("  S_to_H_without_B_cost: 17", output)
         self.assertIn("  base_is_mandatory: no", output)
+        self.assertIn("  plain_cost: 14", output)
+        self.assertIn("  terrain_only_cost: 15", output)
+        self.assertIn("  full_cost: 17", output)
+        self.assertIn("  terrain_extra_cost: 1", output)
+        self.assertIn("  rift_detour_cost: 2", output)
         self.assertIn("  verdict: ACCEPT", output)
         self.assertIn("  priority_1: REJECT_TOO_HARD", output)
         self.assertIn("  priority_2: REJECT_BASE_MANDATORY", output)
@@ -319,6 +468,11 @@ class AnalysisAndOutputTests(unittest.TestCase):
         self.assertIn("  S_to_H_without_B_cost: N/A", output)
         self.assertIn("  base_route_advantage_raw: N/A", output)
         self.assertIn("  base_is_mandatory: no", output)
+        self.assertIn("  plain_cost: 14", output)
+        self.assertIn("  terrain_only_cost: 14", output)
+        self.assertIn("  full_cost: N/A", output)
+        self.assertIn("  terrain_extra_cost: 0", output)
+        self.assertIn("  rift_detour_cost: N/A", output)
         self.assertIn("  verdict: REJECT_TOO_HARD", output)
 
 


### PR DESCRIPTION
## 概要

Closes #1034

同一 `GalacticMap` を再利用しながら、地形コスト差と断層迂回差を分離して計測できるようにしました。
既存の `analyze_paths` / verdict 判定は変えず、1 seed レポートに比較指標を追加しています。

## 変更内容

- `shortest_path` にコスト関数注入を追加し、既定値は現行の `terrain_cost` を維持
- `plain_movement_cost` と `CostContributionAnalysis` / `analyze_cost_contributions` を追加
- `format_output` に `COST CONTRIBUTIONS` セクションを追加し、到達不能時は `N/A` を表示
- 地形寄与、断層寄与、到達不能時、seed 42 安定値、出力表示の unit test を追加
- README に A/B/C 比較条件と 5 指標の意味を追記

## 確認

- `python -m unittest experiments.galactic_exodus.test_simulate experiments.galactic_exodus.test_metrics`
- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
