### PR TITLE
Phase 0 metricsに航行力分析を追加

### DIFF
--- a/experiments/galactic_exodus/README.md
+++ b/experiments/galactic_exodus/README.md
@@ -7,7 +7,7 @@
 ## 実行方法
 
 ```bash
-python experiments/galactic_exodus/simulate.py --seed 42 --rift-density 0.10
+python experiments/galactic_exodus/simulate.py --seed 42 --rift-density 0.10 --initial-fuel 27 --base-supply 10 --resource-supply 5
 ```
 
 複数 seed の Phase 0 統計をまとめて出す場合は、次を実行します。
@@ -58,8 +58,11 @@ rift_count = round(112 * rift_density)
 - `MAP ID`
 - `OBJECTS`
 - `PARAMETERS`
+- `FUEL PARAMETERS`
+- `FUEL ANALYSIS`
 - `MAP`
 - `COSTS`
+- `COST CONTRIBUTIONS`
 - `VERDICT`
 
 `COSTS` セクションには、verdict 分類に使う次の最短路指標が含まれます。
@@ -74,6 +77,67 @@ rift_count = round(112 * rift_density)
 - `base_is_mandatory`（`yes` / `no`）
 
 利用できない指標は `N/A` と表示されます。
+
+## 航行力モデル
+
+`simulate.py` には、1 seed レポートと後続比較用に再利用する純粋関数 `analyze_fuel()` があります。
+
+入力パラメータ:
+
+- `initial_fuel`
+- `base_supply`
+- `resource_supply`
+
+暫定 CLI 既定値:
+
+- `initial_fuel = 27`
+- `base_supply = 10`
+- `resource_supply = 5`
+
+いずれも 0 以上の整数で、負数は `ValueError` です。
+
+この分析では、既存の地形コストと断層制約をそのまま使います。
+
+- `S` では消費しない
+- 隣接マスへ移動すると、移動先マスの地形コストを消費する
+- 断層辺は通行不能
+- 燃料が負になる移動はできない
+- `B` / `R` / `H` にちょうど 0 で到着してよい
+- 補給は `B` または 1 つの `R` で最大 1 回だけ行う
+- 補給量は到着後に加算する
+- 燃料容量上限は設けない
+
+評価対象の走行計画は次の 3 種類だけです。
+
+- `direct`: 補給なし
+- `via_base`: `B` で 1 回補給
+- `via_resource`: 選んだ 1 つの `R` で 1 回補給
+
+`FUEL ANALYSIS` セクションには次が含まれます。
+
+- `fuel_feasible_direct`
+- `fuel_feasible_via_base`
+- `fuel_feasible_via_resource`
+- `remaining_fuel_direct`
+- `remaining_fuel_via_base`
+- `remaining_fuel_via_resource`
+- `remaining_fuel_at_goal`
+- `required_supply`
+- `best_cost_via_resource`
+- `best_resource_position`
+
+bool は `yes` / `no`、値なしは `N/A` で表示します。
+
+## この issue で扱わないもの
+
+次はこの燃料分析の対象外です。
+
+- `B` と `R` の両方で補給する経路
+- 複数の `R` で補給する経路
+- 同じ地点で複数回補給する経路
+- 補給地点の巡回順最適化
+- 正式な燃料容量
+- プローブ、敵、故障などの追加要素
 
 続いて `COST CONTRIBUTIONS` セクションで、同じ `GalacticMap` に対する全情報あり基準分析を出力します。ここでは地形配置と `S/H/B/R` 配置を固定したまま、経路計算条件だけを切り替えます。
 

--- a/experiments/galactic_exodus/simulate.py
+++ b/experiments/galactic_exodus/simulate.py
@@ -15,6 +15,9 @@ HEIGHT = 8
 DEFAULT_SEED = 42
 DEFAULT_RESOURCE_COUNT = 3
 DEFAULT_RIFT_DENSITY = 0.10
+DEFAULT_INITIAL_FUEL = 27
+DEFAULT_BASE_SUPPLY = 10
+DEFAULT_RESOURCE_SUPPLY = 5
 TOTAL_UNDIRECTED_EDGES = WIDTH * (HEIGHT - 1) + HEIGHT * (WIDTH - 1)
 
 SPECIAL_S = (1, 1)
@@ -78,6 +81,31 @@ class CostContributionAnalysis:
     rift_detour_cost: int | None
 
 
+@dataclass(frozen=True)
+class FuelAnalysis:
+    fuel_feasible_direct: bool
+    fuel_feasible_via_base: bool
+    fuel_feasible_via_resource: bool
+    remaining_fuel_direct: int | None
+    remaining_fuel_via_base: int | None
+    remaining_fuel_via_resource: int | None
+    remaining_fuel_at_goal: int | None
+    required_supply: int | None
+    best_cost_via_resource: int | None
+    best_resource_position: Position | None
+
+
+@dataclass(frozen=True)
+class LegCost:
+    position: Position
+    cost_to_stop: int
+    cost_to_goal: int
+
+    @property
+    def total_cost(self) -> int:
+        return self.cost_to_stop + self.cost_to_goal
+
+
 VERDICT_REJECT_TOO_HARD = "REJECT_TOO_HARD"
 VERDICT_REJECT_BASE_MANDATORY = "REJECT_BASE_MANDATORY"
 VERDICT_ACCEPT = "ACCEPT"
@@ -104,6 +132,24 @@ def parse_args() -> argparse.Namespace:
         default=DEFAULT_RIFT_DENSITY,
         help="Density of impassable fault-line edges (default: 0.10).",
     )
+    parser.add_argument(
+        "--initial-fuel",
+        type=int,
+        default=DEFAULT_INITIAL_FUEL,
+        help="Initial fuel before movement (default: 27).",
+    )
+    parser.add_argument(
+        "--base-supply",
+        type=int,
+        default=DEFAULT_BASE_SUPPLY,
+        help="Fuel gained when resupplying once at B (default: 10).",
+    )
+    parser.add_argument(
+        "--resource-supply",
+        type=int,
+        default=DEFAULT_RESOURCE_SUPPLY,
+        help="Fuel gained when resupplying once at R (default: 5).",
+    )
     return parser.parse_args()
 
 
@@ -118,6 +164,11 @@ def validate_resource_count(resource_count: int) -> None:
 def validate_rift_density(rift_density: float) -> None:
     if not 0.0 <= rift_density <= 1.0:
         raise ValueError("rift-density must be between 0.0 and 1.0")
+
+
+def validate_non_negative(name: str, value: int) -> None:
+    if value < 0:
+        raise ValueError(f"{name} must be non-negative")
 
 
 def generate_map(seed: int, resource_count: int, rift_density: float = DEFAULT_RIFT_DENSITY) -> GalacticMap:
@@ -260,6 +311,168 @@ def shortest_path(
     return None
 
 
+def shortest_path_cost(
+    cells: Cells,
+    start: Position,
+    goal: Position,
+    blocked_edges: set[Edge],
+    *,
+    forbid_home_on_route: bool = False,
+) -> int | None:
+    forbidden_nodes = {SPECIAL_H} if forbid_home_on_route else None
+    result = shortest_path(
+        cells,
+        start,
+        goal,
+        blocked_edges,
+        forbidden_nodes=forbidden_nodes,
+    )
+    return None if result is None else result.cost
+
+
+def route_remaining_fuel(initial_fuel: int, total_cost: int, supply: int) -> int:
+    return initial_fuel + supply - total_cost
+
+
+def leg_costs_to_resource_positions(galactic_map: GalacticMap, blocked_edges: set[Edge]) -> list[LegCost]:
+    leg_costs: list[LegCost] = []
+    for position in sorted(galactic_map.r_positions):
+        cost_to_stop = shortest_path_cost(
+            galactic_map.cells,
+            SPECIAL_S,
+            position,
+            blocked_edges,
+            forbid_home_on_route=True,
+        )
+        cost_to_goal = shortest_path_cost(
+            galactic_map.cells,
+            position,
+            SPECIAL_H,
+            blocked_edges,
+        )
+        if cost_to_stop is None or cost_to_goal is None:
+            continue
+        leg_costs.append(
+            LegCost(
+                position=position,
+                cost_to_stop=cost_to_stop,
+                cost_to_goal=cost_to_goal,
+            )
+        )
+    return leg_costs
+
+
+def analyze_fuel(
+    galactic_map: GalacticMap,
+    *,
+    initial_fuel: int,
+    base_supply: int,
+    resource_supply: int,
+) -> FuelAnalysis:
+    validate_non_negative("initial-fuel", initial_fuel)
+    validate_non_negative("base-supply", base_supply)
+    validate_non_negative("resource-supply", resource_supply)
+
+    blocked_edges = set(galactic_map.rift_edges)
+
+    direct_cost = shortest_path_cost(galactic_map.cells, SPECIAL_S, SPECIAL_H, blocked_edges)
+    cost_to_base = shortest_path_cost(
+        galactic_map.cells,
+        SPECIAL_S,
+        galactic_map.b_position,
+        blocked_edges,
+        forbid_home_on_route=True,
+    )
+    cost_base_to_goal = shortest_path_cost(
+        galactic_map.cells,
+        galactic_map.b_position,
+        SPECIAL_H,
+        blocked_edges,
+    )
+
+    fuel_feasible_direct = direct_cost is not None and direct_cost <= initial_fuel
+    remaining_fuel_direct = None if not fuel_feasible_direct else initial_fuel - direct_cost
+
+    fuel_feasible_via_base = (
+        cost_to_base is not None
+        and cost_base_to_goal is not None
+        and cost_to_base <= initial_fuel
+        and cost_base_to_goal <= initial_fuel - cost_to_base + base_supply
+    )
+    remaining_fuel_via_base = None
+    if fuel_feasible_via_base:
+        remaining_fuel_via_base = route_remaining_fuel(
+            initial_fuel,
+            cost_to_base + cost_base_to_goal,
+            base_supply,
+        )
+
+    resource_leg_costs = leg_costs_to_resource_positions(galactic_map, blocked_edges)
+    best_resource_leg = min(resource_leg_costs, key=lambda leg: (leg.total_cost, leg.position), default=None)
+
+    feasible_resource_legs = [
+        leg
+        for leg in resource_leg_costs
+        if leg.cost_to_stop <= initial_fuel
+        and leg.cost_to_goal <= initial_fuel - leg.cost_to_stop + resource_supply
+    ]
+    best_remaining_resource_leg = max(
+        feasible_resource_legs,
+        key=lambda leg: (route_remaining_fuel(initial_fuel, leg.total_cost, resource_supply), -leg.position[0], -leg.position[1]),
+        default=None,
+    )
+
+    fuel_feasible_via_resource = best_remaining_resource_leg is not None
+    remaining_fuel_via_resource = None
+    if best_remaining_resource_leg is not None:
+        remaining_fuel_via_resource = route_remaining_fuel(
+            initial_fuel,
+            best_remaining_resource_leg.total_cost,
+            resource_supply,
+        )
+
+    remaining_candidates = [
+        value
+        for value in (
+            remaining_fuel_direct,
+            remaining_fuel_via_base,
+            remaining_fuel_via_resource,
+        )
+        if value is not None
+    ]
+    remaining_fuel_at_goal = max(remaining_candidates, default=None)
+
+    required_supply = None
+    if fuel_feasible_direct:
+        required_supply = 0
+    else:
+        supply_candidates: list[int] = []
+        if (
+            cost_to_base is not None
+            and cost_base_to_goal is not None
+            and cost_to_base <= initial_fuel
+        ):
+            supply_candidates.append(max(0, cost_to_base + cost_base_to_goal - initial_fuel))
+        for leg in resource_leg_costs:
+            if leg.cost_to_stop <= initial_fuel:
+                supply_candidates.append(max(0, leg.total_cost - initial_fuel))
+        if supply_candidates:
+            required_supply = min(supply_candidates)
+
+    return FuelAnalysis(
+        fuel_feasible_direct=fuel_feasible_direct,
+        fuel_feasible_via_base=fuel_feasible_via_base,
+        fuel_feasible_via_resource=fuel_feasible_via_resource,
+        remaining_fuel_direct=remaining_fuel_direct,
+        remaining_fuel_via_base=remaining_fuel_via_base,
+        remaining_fuel_via_resource=remaining_fuel_via_resource,
+        remaining_fuel_at_goal=remaining_fuel_at_goal,
+        required_supply=required_supply,
+        best_cost_via_resource=None if best_resource_leg is None else best_resource_leg.total_cost,
+        best_resource_position=None if best_resource_leg is None else best_resource_leg.position,
+    )
+
+
 def analyze_paths(galactic_map: GalacticMap) -> PathAnalysis:
     blocked_edges = set(galactic_map.rift_edges)
     best_route = shortest_path(galactic_map.cells, SPECIAL_S, SPECIAL_H, blocked_edges)
@@ -355,6 +568,10 @@ def format_yes_no(value: bool) -> str:
     return "yes" if value else "no"
 
 
+def format_optional_position(position: Position | None) -> str:
+    return "N/A" if position is None else format_position(position)
+
+
 def build_map_id(galactic_map: GalacticMap) -> str:
     return (
         f"seed-{galactic_map.seed}"
@@ -371,9 +588,21 @@ def classify_verdict(analysis: PathAnalysis) -> str:
     return VERDICT_ACCEPT
 
 
-def format_output(galactic_map: GalacticMap) -> str:
+def format_output(
+    galactic_map: GalacticMap,
+    *,
+    initial_fuel: int = DEFAULT_INITIAL_FUEL,
+    base_supply: int = DEFAULT_BASE_SUPPLY,
+    resource_supply: int = DEFAULT_RESOURCE_SUPPLY,
+) -> str:
     analysis = analyze_paths(galactic_map)
     cost_contributions = analyze_cost_contributions(galactic_map)
+    fuel_analysis = analyze_fuel(
+        galactic_map,
+        initial_fuel=initial_fuel,
+        base_supply=base_supply,
+        resource_supply=resource_supply,
+    )
     verdict = classify_verdict(analysis)
     resource_positions = ", ".join(format_position(position) for position in galactic_map.r_positions) or "(none)"
     lines = [
@@ -393,6 +622,23 @@ def format_output(galactic_map: GalacticMap) -> str:
         f"  rift_density: {galactic_map.rift_density:.2f}",
         f"  rift_count: {len(galactic_map.rift_edges)}",
         f"  terrain_distribution: {terrain_distribution(galactic_map.cells)}",
+        "",
+        "FUEL PARAMETERS",
+        f"  initial_fuel: {initial_fuel}",
+        f"  base_supply: {base_supply}",
+        f"  resource_supply: {resource_supply}",
+        "",
+        "FUEL ANALYSIS",
+        f"  fuel_feasible_direct: {format_yes_no(fuel_analysis.fuel_feasible_direct)}",
+        f"  fuel_feasible_via_base: {format_yes_no(fuel_analysis.fuel_feasible_via_base)}",
+        f"  fuel_feasible_via_resource: {format_yes_no(fuel_analysis.fuel_feasible_via_resource)}",
+        f"  remaining_fuel_direct: {format_optional_metric(fuel_analysis.remaining_fuel_direct)}",
+        f"  remaining_fuel_via_base: {format_optional_metric(fuel_analysis.remaining_fuel_via_base)}",
+        f"  remaining_fuel_via_resource: {format_optional_metric(fuel_analysis.remaining_fuel_via_resource)}",
+        f"  remaining_fuel_at_goal: {format_optional_metric(fuel_analysis.remaining_fuel_at_goal)}",
+        f"  required_supply: {format_optional_metric(fuel_analysis.required_supply)}",
+        f"  best_cost_via_resource: {format_optional_metric(fuel_analysis.best_cost_via_resource)}",
+        f"  best_resource_position: {format_optional_position(fuel_analysis.best_resource_position)}",
         "",
         "MAP",
         render_map(galactic_map.cells),
@@ -428,9 +674,19 @@ def main() -> int:
     args = parse_args()
     try:
         galactic_map = generate_map(args.seed, args.resource_count, args.rift_density)
+        validate_non_negative("initial-fuel", args.initial_fuel)
+        validate_non_negative("base-supply", args.base_supply)
+        validate_non_negative("resource-supply", args.resource_supply)
     except ValueError as exc:
         raise SystemExit(f"error: {exc}") from exc
-    print(format_output(galactic_map))
+    print(
+        format_output(
+            galactic_map,
+            initial_fuel=args.initial_fuel,
+            base_supply=args.base_supply,
+            resource_supply=args.resource_supply,
+        )
+    )
     return 0
 
 

--- a/experiments/galactic_exodus/test_simulate.py
+++ b/experiments/galactic_exodus/test_simulate.py
@@ -15,18 +15,22 @@ def make_map(
     *,
     cells: simulate.Cells,
     b_position: simulate.Position = (4, 4),
+    r_positions: list[simulate.Position] | None = None,
     rift_edges: tuple[simulate.Edge, ...] = (),
 ) -> simulate.GalacticMap:
     map_cells = dict(cells)
     map_cells[simulate.SPECIAL_S] = "S"
     map_cells[simulate.SPECIAL_H] = "H"
     map_cells[b_position] = "B"
+    resource_positions = [] if r_positions is None else list(r_positions)
+    for position in resource_positions:
+        map_cells[position] = "R"
     return simulate.GalacticMap(
         seed=0,
-        resource_count=0,
+        resource_count=len(resource_positions),
         rift_density=0.0,
         b_position=b_position,
-        r_positions=[],
+        r_positions=resource_positions,
         rift_edges=rift_edges,
         cells=map_cells,
     )
@@ -387,6 +391,8 @@ class AnalysisAndOutputTests(unittest.TestCase):
         self.assertIn("MAP ID\n", output)
         self.assertIn("\nOBJECTS\n", output)
         self.assertIn("\nPARAMETERS\n", output)
+        self.assertIn("\nFUEL PARAMETERS\n", output)
+        self.assertIn("\nFUEL ANALYSIS\n", output)
         self.assertIn("\nMAP\n", output)
         self.assertIn("\nCOSTS\n", output)
         self.assertIn("\nCOST CONTRIBUTIONS\n", output)
@@ -394,6 +400,11 @@ class AnalysisAndOutputTests(unittest.TestCase):
         self.assertIn("  map_id: seed-42-rift-0.10-res-3", output)
         self.assertIn("  B: (4,4)", output)
         self.assertIn("  rift_density: 0.10", output)
+        self.assertIn("  initial_fuel: 27", output)
+        self.assertIn("  base_supply: 10", output)
+        self.assertIn("  resource_supply: 5", output)
+        self.assertIn("  fuel_feasible_direct: yes", output)
+        self.assertIn("  fuel_feasible_via_base: yes", output)
         self.assertIn("  S_to_H_cost: 17", output)
         self.assertIn("  S_to_H_steps: 14", output)
         self.assertIn("  S_to_B_cost: 8", output)
@@ -474,6 +485,219 @@ class AnalysisAndOutputTests(unittest.TestCase):
         self.assertIn("  terrain_extra_cost: 0", output)
         self.assertIn("  rift_detour_cost: N/A", output)
         self.assertIn("  verdict: REJECT_TOO_HARD", output)
+
+    def test_format_output_reports_fuel_sections_for_custom_parameters(self) -> None:
+        galactic_map = make_map(cells=filled_cells("."), b_position=(2, 1))
+
+        output = simulate.format_output(
+            galactic_map,
+            initial_fuel=1,
+            base_supply=13,
+            resource_supply=5,
+        )
+
+        self.assertIn("  initial_fuel: 1", output)
+        self.assertIn("  base_supply: 13", output)
+        self.assertIn("  resource_supply: 5", output)
+        self.assertIn("  fuel_feasible_direct: no", output)
+        self.assertIn("  fuel_feasible_via_base: yes", output)
+        self.assertIn("  fuel_feasible_via_resource: no", output)
+        self.assertIn("  remaining_fuel_direct: N/A", output)
+        self.assertIn("  remaining_fuel_via_base: 0", output)
+        self.assertIn("  remaining_fuel_via_resource: N/A", output)
+        self.assertIn("  remaining_fuel_at_goal: 0", output)
+        self.assertIn("  required_supply: 13", output)
+        self.assertIn("  best_cost_via_resource: N/A", output)
+        self.assertIn("  best_resource_position: N/A", output)
+
+
+class FuelAnalysisTests(unittest.TestCase):
+    def test_direct_route_can_arrive_with_exactly_zero_fuel(self) -> None:
+        analysis = simulate.analyze_fuel(
+            make_map(cells=filled_cells(".")),
+            initial_fuel=14,
+            base_supply=0,
+            resource_supply=0,
+        )
+
+        self.assertTrue(analysis.fuel_feasible_direct)
+        self.assertEqual(analysis.remaining_fuel_direct, 0)
+        self.assertEqual(analysis.remaining_fuel_at_goal, 0)
+        self.assertEqual(analysis.required_supply, 0)
+
+    def test_base_route_can_resupply_after_arriving_with_zero_fuel(self) -> None:
+        analysis = simulate.analyze_fuel(
+            make_map(cells=filled_cells("."), b_position=(2, 1)),
+            initial_fuel=1,
+            base_supply=13,
+            resource_supply=0,
+        )
+
+        self.assertFalse(analysis.fuel_feasible_direct)
+        self.assertTrue(analysis.fuel_feasible_via_base)
+        self.assertEqual(analysis.remaining_fuel_via_base, 0)
+        self.assertEqual(analysis.remaining_fuel_at_goal, 0)
+        self.assertEqual(analysis.required_supply, 13)
+
+    def test_base_route_fails_when_initial_fuel_cannot_reach_base(self) -> None:
+        analysis = simulate.analyze_fuel(
+            make_map(cells=filled_cells("."), b_position=(4, 4)),
+            initial_fuel=5,
+            base_supply=100,
+            resource_supply=0,
+        )
+
+        self.assertFalse(analysis.fuel_feasible_via_base)
+        self.assertIsNone(analysis.remaining_fuel_via_base)
+
+    def test_base_route_fails_when_post_supply_fuel_is_still_insufficient(self) -> None:
+        analysis = simulate.analyze_fuel(
+            make_map(cells=filled_cells("."), b_position=(2, 1)),
+            initial_fuel=1,
+            base_supply=12,
+            resource_supply=0,
+        )
+
+        self.assertFalse(analysis.fuel_feasible_via_base)
+        self.assertIsNone(analysis.remaining_fuel_via_base)
+
+    def test_resource_route_is_feasible_when_any_one_resource_plan_works(self) -> None:
+        analysis = simulate.analyze_fuel(
+            make_map(
+                cells=filled_cells("."),
+                r_positions=[(2, 1), (8, 1)],
+            ),
+            initial_fuel=1,
+            base_supply=0,
+            resource_supply=13,
+        )
+
+        self.assertTrue(analysis.fuel_feasible_via_resource)
+        self.assertEqual(analysis.remaining_fuel_via_resource, 0)
+
+    def test_resource_remaining_fuel_uses_best_feasible_resource(self) -> None:
+        cells = filled_cells(".")
+        cells[(3, 1)] = "A"
+        analysis = simulate.analyze_fuel(
+            make_map(
+                cells=cells,
+                r_positions=[(2, 1), (4, 1)],
+            ),
+            initial_fuel=10,
+            base_supply=0,
+            resource_supply=10,
+        )
+
+        self.assertTrue(analysis.fuel_feasible_via_resource)
+        self.assertEqual(analysis.remaining_fuel_via_resource, 6)
+
+    def test_best_resource_cost_ignores_current_fuel_feasibility(self) -> None:
+        analysis = simulate.analyze_fuel(
+            make_map(
+                cells=filled_cells("."),
+                r_positions=[(2, 1)],
+            ),
+            initial_fuel=0,
+            base_supply=0,
+            resource_supply=0,
+        )
+
+        self.assertFalse(analysis.fuel_feasible_via_resource)
+        self.assertEqual(analysis.best_cost_via_resource, 14)
+        self.assertEqual(analysis.best_resource_position, (2, 1))
+
+    def test_resource_count_zero_returns_stable_empty_resource_values(self) -> None:
+        analysis = simulate.analyze_fuel(
+            make_map(cells=filled_cells(".")),
+            initial_fuel=27,
+            base_supply=10,
+            resource_supply=5,
+        )
+
+        self.assertFalse(analysis.fuel_feasible_via_resource)
+        self.assertIsNone(analysis.remaining_fuel_via_resource)
+        self.assertIsNone(analysis.best_cost_via_resource)
+        self.assertIsNone(analysis.best_resource_position)
+
+    def test_required_supply_is_zero_when_direct_route_is_feasible(self) -> None:
+        analysis = simulate.analyze_fuel(
+            make_map(cells=filled_cells("."), b_position=(2, 1)),
+            initial_fuel=20,
+            base_supply=0,
+            resource_supply=0,
+        )
+
+        self.assertEqual(analysis.required_supply, 0)
+
+    def test_required_supply_uses_reachable_supply_stop_when_direct_route_fails(self) -> None:
+        analysis = simulate.analyze_fuel(
+            make_map(cells=filled_cells("."), b_position=(2, 1)),
+            initial_fuel=10,
+            base_supply=0,
+            resource_supply=0,
+        )
+
+        self.assertEqual(analysis.required_supply, 4)
+
+    def test_required_supply_is_none_when_no_supply_stop_is_reachable_with_initial_fuel(self) -> None:
+        analysis = simulate.analyze_fuel(
+            make_map(
+                cells=filled_cells("."),
+                b_position=(4, 4),
+                r_positions=[(8, 1)],
+            ),
+            initial_fuel=1,
+            base_supply=0,
+            resource_supply=0,
+        )
+
+        self.assertIsNone(analysis.required_supply)
+
+    def test_unreachable_second_leg_is_treated_as_none_safely(self) -> None:
+        blocked_edges = (
+            simulate.normalize_edge(simulate.SPECIAL_S, (1, 2)),
+            simulate.normalize_edge((2, 1), (3, 1)),
+            simulate.normalize_edge((2, 1), (2, 2)),
+        )
+        analysis = simulate.analyze_fuel(
+            make_map(
+                cells=filled_cells("."),
+                r_positions=[(2, 1)],
+                rift_edges=blocked_edges,
+            ),
+            initial_fuel=10,
+            base_supply=0,
+            resource_supply=10,
+        )
+
+        self.assertFalse(analysis.fuel_feasible_via_resource)
+        self.assertIsNone(analysis.remaining_fuel_via_resource)
+        self.assertIsNone(analysis.best_cost_via_resource)
+        self.assertIsNone(analysis.best_resource_position)
+
+    def test_negative_inputs_are_rejected(self) -> None:
+        galactic_map = make_map(cells=filled_cells("."))
+
+        with self.assertRaisesRegex(ValueError, "initial-fuel"):
+            simulate.analyze_fuel(galactic_map, initial_fuel=-1, base_supply=0, resource_supply=0)
+        with self.assertRaisesRegex(ValueError, "base-supply"):
+            simulate.analyze_fuel(galactic_map, initial_fuel=0, base_supply=-1, resource_supply=0)
+        with self.assertRaisesRegex(ValueError, "resource-supply"):
+            simulate.analyze_fuel(galactic_map, initial_fuel=0, base_supply=0, resource_supply=-1)
+
+    def test_equal_cost_resource_choice_is_deterministic(self) -> None:
+        analysis = simulate.analyze_fuel(
+            make_map(
+                cells=filled_cells("."),
+                r_positions=[(2, 1), (1, 2)],
+            ),
+            initial_fuel=0,
+            base_supply=0,
+            resource_supply=0,
+        )
+
+        self.assertEqual(analysis.best_cost_via_resource, 14)
+        self.assertEqual(analysis.best_resource_position, (1, 2))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 概要

Closes #1035

Phase 0 metrics 向けに、1 回補給を考慮した航行力分析を `simulate.py` へ追加しました。  
あわせて 1 seed レポート、CLI オプション、README、unit test を更新しています。

## 変更内容

- `FuelAnalysis` / `analyze_fuel()` を追加
- `direct` / `via_base` / `via_resource` の実行可否、残航行力、必要補給量、最良 R 候補を純粋関数で計算
- `--initial-fuel` / `--base-supply` / `--resource-supply` を 1 seed CLI に追加
- レポートへ `FUEL PARAMETERS` / `FUEL ANALYSIS` を追加
- 燃料モデルの対象範囲と非対象を README に追記
- issue 指定の境界条件を含む unit test を追加

## 確認

- `python -m unittest experiments.galactic_exodus.test_simulate`
- `python -m unittest experiments.galactic_exodus.test_metrics`
- `python experiments/galactic_exodus/simulate.py --seed 42 --resource-count 3 --rift-density 0.10 --initial-fuel 27 --base-supply 10 --resource-supply 5`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo fmt --check`
