### PR TITLE
Phase 0最終判断を実験CLI既定値とREADMEへ反映

### DIFF
--- a/experiments/galactic_exodus/README.md
+++ b/experiments/galactic_exodus/README.md
@@ -7,13 +7,23 @@
 ## 実行方法
 
 ```bash
-python experiments/galactic_exodus/simulate.py --seed 42 --rift-density 0.10 --initial-fuel 27 --base-supply 10 --resource-supply 5
+python experiments/galactic_exodus/simulate.py \
+  --seed 42 \
+  --resource-count 3 \
+  --rift-density 0.10 \
+  --initial-fuel 16 \
+  --base-supply 8 \
+  --resource-supply 5
 ```
 
 複数 seed の Phase 0 統計をまとめて出す場合は、次を実行します。
 
 ```bash
-python experiments/galactic_exodus/metrics.py --seed-start 1 --seed-count 1000 --rift-density 0.10 --resource-count 3
+python experiments/galactic_exodus/metrics.py \
+  --seed-start 1 \
+  --seed-count 10 \
+  --rift-density 0.10 \
+  --resource-count 3
 ```
 
 航行力と B/R 補給候補を比較する場合は、次を実行します。
@@ -21,15 +31,106 @@ python experiments/galactic_exodus/metrics.py --seed-start 1 --seed-count 1000 -
 ```bash
 python experiments/galactic_exodus/fuel_metrics.py \
   --seed-start 1 \
-  --seed-count 1000 \
-  --rift-density 0.10,0.15 \
-  --initial-fuels 24,27,30,33 \
-  --base-supplies 8,10,12 \
+  --seed-count 10 \
+  --rift-density 0.10 \
+  --initial-fuels 14,16,18 \
+  --base-supplies 8,10 \
   --resource-supply 5 \
   --resource-counts 0,1,3 \
-  --csv-output experiments/galactic_exodus/results/fuel_comparison_seed_1_1000.csv \
-  --markdown-output experiments/galactic_exodus/results/fuel_comparison_seed_1_1000.md
+  --csv-output .tmp/readme-fuel-metrics.csv \
+  --markdown-output .tmp/readme-fuel-metrics.md
 ```
+
+上の 3 コマンドは README の標準実行例として、unit test からそのまま実行できる形にしてあります。大規模比較を再現したい場合は、後述の結果ファイル生成コマンドを使ってください。
+
+## Phase 1 初期推奨値
+
+Phase 0 の最終判断として、Phase 1 最小縦断スライスへ渡す初期値は次とします。
+
+```text
+board_width: 8
+board_height: 8
+start_position: (1, 1)
+goal_position: (8, 8)
+
+terrain_weights:
+  plain (.): 0.60
+  nebula (N): 0.20
+  asteroid (A): 0.12
+  anomaly (@): 0.08
+
+terrain_costs:
+  plain (.): 1
+  nebula (N): 2
+  asteroid (A): 3
+  anomaly (@): 2
+  base (B): 1
+  resource (R): 1
+  goal (H): 1
+
+rift_density: 0.10
+
+base_positions:
+  (4,4) / (5,4) / (4,5) / (5,5)
+base_placement:
+  上記4候補から seed により 1 地点をランダム選択
+
+initial_fuel: 16
+base_supply: 8
+resource_count: 3
+resource_supply: 5
+```
+
+採用理由の要約:
+
+- `rift_density=0.10`
+  - 到達不能率 `2.3%`、`S->H cost median=16 / p90=18` で、断層影響を観測しつつ悪化を抑えられた。
+- 地形比率・地形コスト
+  - `terrain_extra_cost median=1 / p90=3`、positive ratio `73.3%` で地形差が十分に効いていたため現行値を維持する。
+- B 配置規則
+  - `B mandatory=0.0%`、`B avoid better=35.2%`、`tie=39.8%`、`B via better=25.0%` で固定解化していないため中央 4 候補ランダムを維持する。
+- `initial_fuel=16`
+  - `rift_density=0.10 / R=3 / B supply=10` で `direct=63.4%`、`any=97.7%`、`base rescue=34.3%`、`resource rescue=34.1%`。`14` は補給依存が強すぎ、`18` 以上は補給の役割が弱すぎた。
+- `base_supply=8`
+  - `8/10/12` の走破率差は小さく、増加分の主効果は残航行力だったため最小値を採用する。
+- `resource_count=3`
+  - 現行生成条件の観測比較で `1` より高い R 救済率を示した。これは同一マップへの追加配置の因果効果ではなく、地形・B/R 配置を含む母集団比較である。
+- `resource_supply=5`
+  - `initial_fuel=16 / resource_count=3` で R 救済が十分に立ち上がったため維持する。追加候補比較は未実施。
+
+暫定許容基準:
+
+```text
+到達不能率
+  0%〜3%: 許容
+  3%超〜5%: 要注意
+  5%超: 見直し対象
+
+B必須率
+  0%〜1%: 許容
+  1%超〜5%: 要注意
+  5%超: 見直し対象
+
+B経由偏重
+  B via better >= 70%: B経由が強すぎる可能性
+  B avoid better >= 70%: Bが価値を持たない可能性
+```
+
+Phase 1 で再検証する項目:
+
+- 到達率
+- 残航行力
+- 燃料切れ率
+- B訪問率
+- R訪問率
+- B/R補給回数
+- 直行率
+- 迂回率
+- R=3 の発見率・訪問率・盤面密度感
+- `resource_supply=5` の強さ
+- B補給による固定解化
+- 到達不能盤面の扱い
+- 単一地点・1回補給モデルで十分か
 
 ## 地形コスト
 
@@ -103,10 +204,10 @@ rift_count = round(112 * rift_density)
 - `base_supply`
 - `resource_supply`
 
-暫定 CLI 既定値:
+CLI 既定値:
 
-- `initial_fuel = 27`
-- `base_supply = 10`
+- `initial_fuel = 16`
+- `base_supply = 8`
 - `resource_supply = 5`
 
 いずれも 0 以上の整数で、負数は `ValueError` です。
@@ -246,7 +347,20 @@ verdict の優先順位は次のとおりです。
 - `--resource-supply`
 - `--resource-counts`
 
-複数値引数はカンマ区切りです。`--rift-density` も `0.10,0.15` のように複数指定できます。
+複数値引数はカンマ区切りです。`--rift-density` も `0.10,0.15` のように複数指定できます。大規模比較を再現する標準コマンドは次です。
+
+```bash
+python experiments/galactic_exodus/fuel_metrics.py \
+  --seed-start 1 \
+  --seed-count 1000 \
+  --rift-density 0.10,0.15 \
+  --initial-fuels 14,16,18,20,22,24 \
+  --base-supplies 8,10,12 \
+  --resource-supply 5 \
+  --resource-counts 0,1,3 \
+  --csv-output experiments/galactic_exodus/results/fuel_comparison_low_initial_seed_1_1000.csv \
+  --markdown-output experiments/galactic_exodus/results/fuel_comparison_low_initial_seed_1_1000.md
+```
 
 configuration の並び順は常に次です。
 

--- a/experiments/galactic_exodus/simulate.py
+++ b/experiments/galactic_exodus/simulate.py
@@ -15,8 +15,8 @@ HEIGHT = 8
 DEFAULT_SEED = 42
 DEFAULT_RESOURCE_COUNT = 3
 DEFAULT_RIFT_DENSITY = 0.10
-DEFAULT_INITIAL_FUEL = 27
-DEFAULT_BASE_SUPPLY = 10
+DEFAULT_INITIAL_FUEL = 16
+DEFAULT_BASE_SUPPLY = 8
 DEFAULT_RESOURCE_SUPPLY = 5
 TOTAL_UNDIRECTED_EDGES = WIDTH * (HEIGHT - 1) + HEIGHT * (WIDTH - 1)
 
@@ -136,13 +136,13 @@ def parse_args() -> argparse.Namespace:
         "--initial-fuel",
         type=int,
         default=DEFAULT_INITIAL_FUEL,
-        help="Initial fuel before movement (default: 27).",
+        help="Initial fuel before movement (default: 16).",
     )
     parser.add_argument(
         "--base-supply",
         type=int,
         default=DEFAULT_BASE_SUPPLY,
-        help="Fuel gained when resupplying once at B (default: 10).",
+        help="Fuel gained when resupplying once at B (default: 8).",
     )
     parser.add_argument(
         "--resource-supply",

--- a/experiments/galactic_exodus/test_simulate.py
+++ b/experiments/galactic_exodus/test_simulate.py
@@ -1,4 +1,8 @@
 import unittest
+from pathlib import Path
+import subprocess
+import sys
+from unittest.mock import patch
 
 from experiments.galactic_exodus import simulate
 
@@ -400,11 +404,12 @@ class AnalysisAndOutputTests(unittest.TestCase):
         self.assertIn("  map_id: seed-42-rift-0.10-res-3", output)
         self.assertIn("  B: (4,4)", output)
         self.assertIn("  rift_density: 0.10", output)
-        self.assertIn("  initial_fuel: 27", output)
-        self.assertIn("  base_supply: 10", output)
+        self.assertIn("  initial_fuel: 16", output)
+        self.assertIn("  base_supply: 8", output)
         self.assertIn("  resource_supply: 5", output)
-        self.assertIn("  fuel_feasible_direct: yes", output)
+        self.assertIn("  fuel_feasible_direct: no", output)
         self.assertIn("  fuel_feasible_via_base: yes", output)
+        self.assertIn("  fuel_feasible_via_resource: yes", output)
         self.assertIn("  S_to_H_cost: 17", output)
         self.assertIn("  S_to_H_steps: 14", output)
         self.assertIn("  S_to_B_cost: 8", output)
@@ -698,6 +703,127 @@ class FuelAnalysisTests(unittest.TestCase):
 
         self.assertEqual(analysis.best_cost_via_resource, 14)
         self.assertEqual(analysis.best_resource_position, (1, 2))
+
+
+class CliDefaultsTests(unittest.TestCase):
+    def test_parse_args_uses_phase1_default_recommendations(self) -> None:
+        with patch.object(sys, "argv", ["simulate.py"]):
+            args = simulate.parse_args()
+
+        self.assertEqual(args.resource_count, 3)
+        self.assertEqual(args.rift_density, 0.10)
+        self.assertEqual(args.initial_fuel, 16)
+        self.assertEqual(args.base_supply, 8)
+        self.assertEqual(args.resource_supply, 5)
+
+    def test_parse_args_preserves_explicit_argument_values(self) -> None:
+        with patch.object(
+            sys,
+            "argv",
+            [
+                "simulate.py",
+                "--seed",
+                "99",
+                "--resource-count",
+                "1",
+                "--rift-density",
+                "0.15",
+                "--initial-fuel",
+                "24",
+                "--base-supply",
+                "10",
+                "--resource-supply",
+                "6",
+            ],
+        ):
+            args = simulate.parse_args()
+
+        self.assertEqual(args.seed, 99)
+        self.assertEqual(args.resource_count, 1)
+        self.assertEqual(args.rift_density, 0.15)
+        self.assertEqual(args.initial_fuel, 24)
+        self.assertEqual(args.base_supply, 10)
+        self.assertEqual(args.resource_supply, 6)
+
+
+class ReadmeCommandTests(unittest.TestCase):
+    def run_command(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, *args],
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd=Path(__file__).resolve().parents[2],
+        )
+
+    def test_readme_standard_simulate_command_runs(self) -> None:
+        result = self.run_command(
+            "experiments/galactic_exodus/simulate.py",
+            "--seed",
+            "42",
+            "--resource-count",
+            "3",
+            "--rift-density",
+            "0.10",
+            "--initial-fuel",
+            "16",
+            "--base-supply",
+            "8",
+            "--resource-supply",
+            "5",
+        )
+
+        self.assertIn("MAP ID", result.stdout)
+        self.assertIn("  initial_fuel: 16", result.stdout)
+        self.assertIn("  base_supply: 8", result.stdout)
+
+    def test_readme_standard_metrics_command_runs(self) -> None:
+        result = self.run_command(
+            "experiments/galactic_exodus/metrics.py",
+            "--seed-start",
+            "1",
+            "--seed-count",
+            "10",
+            "--rift-density",
+            "0.10",
+            "--resource-count",
+            "3",
+        )
+
+        self.assertIn("PHASE 0 METRICS", result.stdout)
+        self.assertIn("rift_density: 0.10", result.stdout)
+
+    def test_readme_standard_fuel_metrics_command_runs(self) -> None:
+        csv_output = Path(".tmp/readme-fuel-metrics.csv")
+        markdown_output = Path(".tmp/readme-fuel-metrics.md")
+        self.addCleanup(csv_output.unlink, missing_ok=True)
+        self.addCleanup(markdown_output.unlink, missing_ok=True)
+
+        result = self.run_command(
+            "experiments/galactic_exodus/fuel_metrics.py",
+            "--seed-start",
+            "1",
+            "--seed-count",
+            "10",
+            "--rift-density",
+            "0.10",
+            "--initial-fuels",
+            "14,16,18",
+            "--base-supplies",
+            "8,10",
+            "--resource-supply",
+            "5",
+            "--resource-counts",
+            "0,1,3",
+            "--csv-output",
+            str(csv_output),
+            "--markdown-output",
+            str(markdown_output),
+        )
+
+        self.assertIn("FUEL COMPARISON", result.stdout)
+        self.assertTrue(csv_output.exists())
+        self.assertTrue(markdown_output.exists())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 概要

Closes #1040

Phase 0 の最終判断を、Galactic Exodus 実験環境の既定値・README・関連 issue へ反映しました。

## 変更内容

- `experiments/galactic_exodus/simulate.py` の既定値を `initial_fuel=16` / `base_supply=8` へ更新
- `experiments/galactic_exodus/README.md` に Phase 1 初期推奨値、採用根拠の要約、暫定許容基準、Phase 1 再検証項目を追加
- README の標準実行例を小規模で実行可能なコマンドへ更新し、大規模比較の再現コマンドも明記
- `experiments/galactic_exodus/test_simulate.py` に CLI 既定値固定、明示引数維持、README コマンド実行テストを追加
- #894 本文に `Phase 0 Final Decision` を追加し、#1039 の `initial_fuel=24` 暫定判断を `16` へ明示的に置換
- 到達不能盤面ポリシーの後続設計 issue #1047 を作成
- Phase 1 最小縦断スライス実装 issue #1049 を作成し、#1040 の推奨値を受け取る実装先を明記

## Phase 1 実装 issue 確認結果

- 既存の open issue 群では、今回の推奨値を受け取る具体的な Phase 1 最小縦断スライス実装 issue を確認できませんでした。
- そのため、新しい実装 issue として #1049 を作成しました。
- #1049 は #1040 の初期推奨値をそのまま受け取り、#1047 の到達不能盤面ポリシー確定を前提に進める想定です。

## 確認

- `python -m unittest experiments.galactic_exodus.test_simulate experiments.galactic_exodus.test_metrics experiments.galactic_exodus.test_fuel_metrics`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
