### PR TITLE
Phase 1A1 の非対話ゲームエンジンを実装

### DIFF
--- a/experiments/galactic_exodus/README.md
+++ b/experiments/galactic_exodus/README.md
@@ -87,6 +87,8 @@ log = engine.run_commands(42, ["E", "N", "E"])
 - `ABORTED_NO_POLICY_ACTION`
 
 generation error は通常敗北と分離し、`GameLog.generation_error` に記録します。
+`supply_source` は `{"kind": "B"|"R", "position": {"x": ..., "y": ...}}` の構造で保持し、
+補給後に別セルへ移動したあとも補給元座標を参照できます。
 
 ### deterministic log schema
 
@@ -134,6 +136,16 @@ final_summary
   rift_attempts
   invalid_or_rejected_actions
   path
+```
+
+```text
+generation_error
+  kind
+  requested_seed
+  attempts
+  last_candidate_seed
+  reason
+  message
 ```
 
 `GameLog.to_dict()` と `GameLog.to_json()` は key 順と配列順を固定し、同一 seed・同一 command 列から同一 JSON を生成します。

--- a/experiments/galactic_exodus/README.md
+++ b/experiments/galactic_exodus/README.md
@@ -4,6 +4,140 @@
 
 これは正式な TBX アプリ実装ではありません。将来の TBX 側の実装は、`examples/galactic_exodus/` など別の場所に置く想定です。
 
+## Phase 1A1 engine
+
+`engine.py` は、標準入力や画面表示に依存しない Phase 1A1 用の非対話ゲームエンジンです。
+マップ生成は既存の `simulate.generate_map()` をそのまま利用し、到達不能マップだけを deterministic に再抽選します。
+
+公開 API:
+
+```python
+from experiments.galactic_exodus import engine
+
+state = engine.create_game(42)
+event = engine.apply_command(state, "E")
+log = engine.run_commands(42, ["E", "N", "E"])
+```
+
+- `create_game(requested_seed, settings=DEFAULT_SETTINGS) -> GameState`
+  - 到達可能な `S -> H` 経路を持つ候補が見つかるまで `requested_seed + attempt` を試す
+  - `attempt` は `0..99`
+  - `effective_seed` と `reroll_count` を state に保持する
+- `apply_command(state, command) -> TurnEvent`
+  - `state` をその場で更新する
+  - `command` は `N / E / S / W`
+  - 標準入力・標準出力は使わない
+- `run_commands(requested_seed, commands, settings=DEFAULT_SETTINGS, max_turns=256) -> GameLog`
+  - 非対話でコマンド列を最後まで実行する
+  - 勝敗、turn limit、コマンド枯渇、generation error をログ化する
+
+### state fields
+
+`GameState` は次の状態を保持します。
+
+- `actual_map`
+- `known_cells`
+- `visited_cells`
+- `known_routes`
+- `player_position`
+- `remaining_fuel`
+- `supply_used`
+- `supply_source`
+- `turn_count`
+- `game_status`
+- `requested_seed`
+- `effective_seed`
+- `reroll_count`
+
+開始時は `known_cells = {S, H}`、`visited_cells = {S}`、`known_routes = {}` です。
+
+### movement contract
+
+- 成功移動: 移動先地形コストを消費し、`known_routes` に `OPEN` を記録する
+- 未知断層への試行: 位置不変、`fuel -1`、`turn +1`、`known_routes` に `RIFT` を記録する
+- 既知断層への再試行: 行動拒否、fuel/turn 不変
+- 盤面外・無効コマンド・燃料不足: 状態不変
+- `H` / `B` / `R` へ残量 0 ちょうどで到着してよい
+- 補給は `B` または `R` の最初の 1 回だけで、到着後に加算する
+
+### turn outcomes
+
+`TurnEvent.outcome` は次の固定値を使います。
+
+- `MOVED`
+- `BLOCKED_UNKNOWN_RIFT`
+- `REJECTED_KNOWN_RIFT`
+- `REJECTED_INSUFFICIENT_FUEL`
+- `INVALID_COMMAND`
+- `OUT_OF_BOUNDS`
+
+### game status and final outcomes
+
+`GameState.game_status`:
+
+- `IN_PROGRESS`
+- `WON`
+- `LOST_FUEL`
+
+`GameLog.final_summary.outcome`:
+
+- `WON`
+- `LOST_FUEL`
+- `ABORTED_TURN_LIMIT`
+- `ABORTED_NO_POLICY_ACTION`
+
+generation error は通常敗北と分離し、`GameLog.generation_error` に記録します。
+
+### deterministic log schema
+
+`GameLog.schema_version` は `1` 固定です。
+
+```text
+GameLog
+  schema_version
+  settings
+  requested_seed
+  effective_seed
+  reroll_count
+  initial_state
+  events
+  final_summary
+  generation_error
+```
+
+```text
+TurnEvent
+  turn
+  command
+  outcome
+  from_position
+  attempted_position
+  to_position
+  fuel_before
+  fuel_spent
+  fuel_after
+  discovered_cell
+  discovered_rift
+  supply_applied
+  supply_source
+  status_after
+```
+
+```text
+final_summary
+  outcome
+  turn_count
+  remaining_fuel
+  supply_source
+  base_visited
+  resource_visits
+  rift_attempts
+  invalid_or_rejected_actions
+  path
+```
+
+`GameLog.to_dict()` と `GameLog.to_json()` は key 順と配列順を固定し、同一 seed・同一 command 列から同一 JSON を生成します。
+
 ## 実行方法
 
 ```bash

--- a/experiments/galactic_exodus/engine.py
+++ b/experiments/galactic_exodus/engine.py
@@ -80,6 +80,18 @@ class ActualMap:
     resource_positions: tuple[simulate.Position, ...]
 
 
+@dataclass(frozen=True)
+class SupplySource:
+    kind: str
+    position: simulate.Position
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "kind": self.kind,
+            "position": position_to_dict(self.position),
+        }
+
+
 @dataclass
 class GameState:
     settings: GameSettings
@@ -90,7 +102,7 @@ class GameState:
     player_position: simulate.Position
     remaining_fuel: int
     supply_used: bool
-    supply_source: str | None
+    supply_source: SupplySource | None
     turn_count: int
     game_status: str
     requested_seed: int
@@ -106,11 +118,19 @@ class GameState:
 @dataclass(frozen=True)
 class GenerationErrorInfo:
     kind: str
+    requested_seed: int
+    attempts: int
+    last_candidate_seed: int | None
+    reason: str
     message: str
 
     def to_dict(self) -> dict[str, object]:
         return {
             "kind": self.kind,
+            "requested_seed": self.requested_seed,
+            "attempts": self.attempts,
+            "last_candidate_seed": self.last_candidate_seed,
+            "reason": self.reason,
             "message": self.message,
         }
 
@@ -129,7 +149,7 @@ class TurnEvent:
     discovered_cell: str | None
     discovered_rift: bool
     supply_applied: bool
-    supply_source: str | None
+    supply_source: SupplySource | None
     status_after: str
 
     def to_dict(self) -> dict[str, object]:
@@ -146,7 +166,7 @@ class TurnEvent:
             "discovered_cell": self.discovered_cell,
             "discovered_rift": self.discovered_rift,
             "supply_applied": self.supply_applied,
-            "supply_source": self.supply_source,
+            "supply_source": optional_supply_source_to_dict(self.supply_source),
             "status_after": self.status_after,
         }
 
@@ -156,7 +176,7 @@ class FinalSummary:
     outcome: str
     turn_count: int
     remaining_fuel: int
-    supply_source: str | None
+    supply_source: SupplySource | None
     base_visited: bool
     resource_visits: int
     rift_attempts: int
@@ -168,7 +188,7 @@ class FinalSummary:
             "outcome": self.outcome,
             "turn_count": self.turn_count,
             "remaining_fuel": self.remaining_fuel,
-            "supply_source": self.supply_source,
+            "supply_source": optional_supply_source_to_dict(self.supply_source),
             "base_visited": self.base_visited,
             "resource_visits": self.resource_visits,
             "rift_attempts": self.rift_attempts,
@@ -207,12 +227,30 @@ class GameLog:
 
 
 class GenerationError(ValueError):
-    def __init__(self, kind: str, message: str):
+    def __init__(
+        self,
+        *,
+        requested_seed: int,
+        attempts: int,
+        last_candidate_seed: int | None,
+        reason: str,
+        message: str,
+    ):
         super().__init__(message)
-        self.kind = kind
+        self.requested_seed = requested_seed
+        self.attempts = attempts
+        self.last_candidate_seed = last_candidate_seed
+        self.reason = reason
 
     def to_info(self) -> GenerationErrorInfo:
-        return GenerationErrorInfo(kind=self.kind, message=str(self))
+        return GenerationErrorInfo(
+            kind="GENERATION_ERROR",
+            requested_seed=self.requested_seed,
+            attempts=self.attempts,
+            last_candidate_seed=self.last_candidate_seed,
+            reason=self.reason,
+            message=str(self),
+        )
 
 
 def create_game(requested_seed: int, settings: GameSettings = DEFAULT_SETTINGS) -> GameState:
@@ -452,7 +490,11 @@ def apply_command(state: GameState, command: str) -> TurnEvent:
         state.known_cells[attempted_position] = destination_symbol
         discovered_cell = destination_symbol
 
-    supply_applied, supply_source = maybe_apply_supply(state, destination_symbol)
+    supply_applied, supply_source = maybe_apply_supply(
+        state,
+        destination_symbol,
+        attempted_position,
+    )
     if destination_symbol == BASE_CELL:
         state.base_visited = True
     if destination_symbol == RESOURCE_CELL:
@@ -481,8 +523,10 @@ def create_playable_map(
     requested_seed: int,
     settings: GameSettings,
 ) -> tuple[simulate.GalacticMap, int, int]:
+    last_candidate_seed: int | None = None
     for attempt in range(MAX_GENERATION_ATTEMPTS):
         candidate_seed = add_seed_offset(requested_seed, attempt)
+        last_candidate_seed = candidate_seed
         galactic_map = simulate.generate_map(
             candidate_seed,
             settings.resource_count,
@@ -491,17 +535,24 @@ def create_playable_map(
         if is_goal_reachable(galactic_map):
             return galactic_map, candidate_seed, attempt
     raise GenerationError(
-        "NO_REACHABLE_MAP",
-        f"failed to generate a reachable map after {MAX_GENERATION_ATTEMPTS} attempts",
+        requested_seed=requested_seed,
+        attempts=MAX_GENERATION_ATTEMPTS,
+        last_candidate_seed=last_candidate_seed,
+        reason="NO_REACHABLE_MAP",
+        message=f"failed to generate a reachable map after {MAX_GENERATION_ATTEMPTS} attempts",
     )
 
 
 def add_seed_offset(seed: int, offset: int) -> int:
     candidate = seed + offset
     if not MIN_INT64 <= candidate <= MAX_INT64:
+        last_candidate_seed = None if offset == 0 else seed + offset - 1
         raise GenerationError(
-            "SEED_OVERFLOW",
-            f"seed overflow while adding attempt {offset} to requested_seed={seed}",
+            requested_seed=seed,
+            attempts=offset + 1,
+            last_candidate_seed=last_candidate_seed,
+            reason="SEED_OVERFLOW",
+            message=f"seed overflow while adding attempt {offset} to requested_seed={seed}",
         )
     return candidate
 
@@ -518,7 +569,11 @@ def is_goal_reachable(galactic_map: simulate.GalacticMap) -> bool:
     )
 
 
-def maybe_apply_supply(state: GameState, destination_symbol: str) -> tuple[bool, str | None]:
+def maybe_apply_supply(
+    state: GameState,
+    destination_symbol: str,
+    position: simulate.Position,
+) -> tuple[bool, SupplySource | None]:
     if state.supply_used:
         return False, None
     if destination_symbol == BASE_CELL:
@@ -528,9 +583,9 @@ def maybe_apply_supply(state: GameState, destination_symbol: str) -> tuple[bool,
     else:
         return False, None
     state.supply_used = True
-    state.supply_source = destination_symbol
+    state.supply_source = SupplySource(kind=destination_symbol, position=position)
     state.remaining_fuel += supply_amount
-    return True, destination_symbol
+    return True, state.supply_source
 
 
 def determine_game_status(state: GameState) -> str:
@@ -614,7 +669,7 @@ def snapshot_state(state: GameState) -> dict[str, object]:
         "player_position": position_to_dict(state.player_position),
         "remaining_fuel": state.remaining_fuel,
         "supply_used": state.supply_used,
-        "supply_source": state.supply_source,
+        "supply_source": optional_supply_source_to_dict(state.supply_source),
         "turn_count": state.turn_count,
         "game_status": state.game_status,
         "requested_seed": state.requested_seed,
@@ -694,6 +749,12 @@ def optional_position_to_dict(position: simulate.Position | None) -> dict[str, i
     if position is None:
         return None
     return position_to_dict(position)
+
+
+def optional_supply_source_to_dict(source: SupplySource | None) -> dict[str, object] | None:
+    if source is None:
+        return None
+    return source.to_dict()
 
 
 def edge_to_dict(edge: simulate.Edge) -> dict[str, object]:

--- a/experiments/galactic_exodus/engine.py
+++ b/experiments/galactic_exodus/engine.py
@@ -1,0 +1,703 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+from typing import Iterable
+
+from experiments.galactic_exodus import simulate
+
+
+SCHEMA_VERSION = 1
+MAX_GENERATION_ATTEMPTS = 100
+MIN_INT64 = -(2**63)
+MAX_INT64 = 2**63 - 1
+
+GAME_STATUS_IN_PROGRESS = "IN_PROGRESS"
+GAME_STATUS_WON = "WON"
+GAME_STATUS_LOST_FUEL = "LOST_FUEL"
+
+OUTCOME_MOVED = "MOVED"
+OUTCOME_BLOCKED_UNKNOWN_RIFT = "BLOCKED_UNKNOWN_RIFT"
+OUTCOME_REJECTED_KNOWN_RIFT = "REJECTED_KNOWN_RIFT"
+OUTCOME_REJECTED_INSUFFICIENT_FUEL = "REJECTED_INSUFFICIENT_FUEL"
+OUTCOME_INVALID_COMMAND = "INVALID_COMMAND"
+OUTCOME_OUT_OF_BOUNDS = "OUT_OF_BOUNDS"
+
+FINAL_OUTCOME_WON = "WON"
+FINAL_OUTCOME_LOST_FUEL = "LOST_FUEL"
+FINAL_OUTCOME_ABORTED_TURN_LIMIT = "ABORTED_TURN_LIMIT"
+FINAL_OUTCOME_ABORTED_NO_POLICY_ACTION = "ABORTED_NO_POLICY_ACTION"
+
+ROUTE_OPEN = "OPEN"
+ROUTE_RIFT = "RIFT"
+
+RESOURCE_CELL = "R"
+BASE_CELL = "B"
+HOME_CELL = "H"
+
+COMMAND_DELTAS: dict[str, tuple[int, int]] = {
+    "N": (0, 1),
+    "E": (1, 0),
+    "S": (0, -1),
+    "W": (-1, 0),
+}
+
+
+@dataclass(frozen=True)
+class GameSettings:
+    width: int = simulate.WIDTH
+    height: int = simulate.HEIGHT
+    start_position: simulate.Position = simulate.SPECIAL_S
+    goal_position: simulate.Position = simulate.SPECIAL_H
+    rift_density: float = simulate.DEFAULT_RIFT_DENSITY
+    initial_fuel: int = simulate.DEFAULT_INITIAL_FUEL
+    base_supply: int = simulate.DEFAULT_BASE_SUPPLY
+    resource_count: int = simulate.DEFAULT_RESOURCE_COUNT
+    resource_supply: int = simulate.DEFAULT_RESOURCE_SUPPLY
+
+    def validate(self) -> None:
+        if self.width != simulate.WIDTH or self.height != simulate.HEIGHT:
+            raise ValueError("only the fixed 8x8 board is supported")
+        if self.start_position != simulate.SPECIAL_S:
+            raise ValueError("start_position must be (1, 1)")
+        if self.goal_position != simulate.SPECIAL_H:
+            raise ValueError("goal_position must be (8, 8)")
+        simulate.validate_rift_density(self.rift_density)
+        simulate.validate_non_negative("initial-fuel", self.initial_fuel)
+        simulate.validate_non_negative("base-supply", self.base_supply)
+        simulate.validate_non_negative("resource-supply", self.resource_supply)
+        simulate.validate_resource_count(self.resource_count)
+
+
+DEFAULT_SETTINGS = GameSettings()
+
+
+@dataclass(frozen=True)
+class ActualMap:
+    cells: simulate.Cells
+    rift_edges: tuple[simulate.Edge, ...]
+    base_position: simulate.Position
+    resource_positions: tuple[simulate.Position, ...]
+
+
+@dataclass
+class GameState:
+    settings: GameSettings
+    actual_map: ActualMap
+    known_cells: dict[simulate.Position, str]
+    visited_cells: set[simulate.Position]
+    known_routes: dict[simulate.Edge, str]
+    player_position: simulate.Position
+    remaining_fuel: int
+    supply_used: bool
+    supply_source: str | None
+    turn_count: int
+    game_status: str
+    requested_seed: int
+    effective_seed: int
+    reroll_count: int
+    resource_visit_count: int = 0
+    rift_attempt_count: int = 0
+    invalid_or_rejected_action_count: int = 0
+    path: list[simulate.Position] = field(default_factory=list)
+    base_visited: bool = False
+
+
+@dataclass(frozen=True)
+class GenerationErrorInfo:
+    kind: str
+    message: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "kind": self.kind,
+            "message": self.message,
+        }
+
+
+@dataclass(frozen=True)
+class TurnEvent:
+    turn: int
+    command: str
+    outcome: str
+    from_position: simulate.Position
+    attempted_position: simulate.Position | None
+    to_position: simulate.Position
+    fuel_before: int
+    fuel_spent: int
+    fuel_after: int
+    discovered_cell: str | None
+    discovered_rift: bool
+    supply_applied: bool
+    supply_source: str | None
+    status_after: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "turn": self.turn,
+            "command": self.command,
+            "outcome": self.outcome,
+            "from_position": position_to_dict(self.from_position),
+            "attempted_position": optional_position_to_dict(self.attempted_position),
+            "to_position": position_to_dict(self.to_position),
+            "fuel_before": self.fuel_before,
+            "fuel_spent": self.fuel_spent,
+            "fuel_after": self.fuel_after,
+            "discovered_cell": self.discovered_cell,
+            "discovered_rift": self.discovered_rift,
+            "supply_applied": self.supply_applied,
+            "supply_source": self.supply_source,
+            "status_after": self.status_after,
+        }
+
+
+@dataclass(frozen=True)
+class FinalSummary:
+    outcome: str
+    turn_count: int
+    remaining_fuel: int
+    supply_source: str | None
+    base_visited: bool
+    resource_visits: int
+    rift_attempts: int
+    invalid_or_rejected_actions: int
+    path: tuple[simulate.Position, ...]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "outcome": self.outcome,
+            "turn_count": self.turn_count,
+            "remaining_fuel": self.remaining_fuel,
+            "supply_source": self.supply_source,
+            "base_visited": self.base_visited,
+            "resource_visits": self.resource_visits,
+            "rift_attempts": self.rift_attempts,
+            "invalid_or_rejected_actions": self.invalid_or_rejected_actions,
+            "path": [position_to_dict(position) for position in self.path],
+        }
+
+
+@dataclass(frozen=True)
+class GameLog:
+    schema_version: int
+    settings: GameSettings
+    requested_seed: int
+    effective_seed: int | None
+    reroll_count: int | None
+    initial_state: dict[str, object] | None
+    events: tuple[TurnEvent, ...]
+    final_summary: FinalSummary | None
+    generation_error: GenerationErrorInfo | None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "settings": settings_to_dict(self.settings),
+            "requested_seed": self.requested_seed,
+            "effective_seed": self.effective_seed,
+            "reroll_count": self.reroll_count,
+            "initial_state": self.initial_state,
+            "events": [event.to_dict() for event in self.events],
+            "final_summary": None if self.final_summary is None else self.final_summary.to_dict(),
+            "generation_error": None if self.generation_error is None else self.generation_error.to_dict(),
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), ensure_ascii=True, separators=(",", ":"))
+
+
+class GenerationError(ValueError):
+    def __init__(self, kind: str, message: str):
+        super().__init__(message)
+        self.kind = kind
+
+    def to_info(self) -> GenerationErrorInfo:
+        return GenerationErrorInfo(kind=self.kind, message=str(self))
+
+
+def create_game(requested_seed: int, settings: GameSettings = DEFAULT_SETTINGS) -> GameState:
+    settings.validate()
+    galactic_map, effective_seed, reroll_count = create_playable_map(requested_seed, settings)
+    actual_map = ActualMap(
+        cells=dict(galactic_map.cells),
+        rift_edges=tuple(galactic_map.rift_edges),
+        base_position=galactic_map.b_position,
+        resource_positions=tuple(galactic_map.r_positions),
+    )
+    known_cells = {
+        settings.start_position: actual_map.cells[settings.start_position],
+        settings.goal_position: actual_map.cells[settings.goal_position],
+    }
+    state = GameState(
+        settings=settings,
+        actual_map=actual_map,
+        known_cells=known_cells,
+        visited_cells={settings.start_position},
+        known_routes={},
+        player_position=settings.start_position,
+        remaining_fuel=settings.initial_fuel,
+        supply_used=False,
+        supply_source=None,
+        turn_count=0,
+        game_status=GAME_STATUS_IN_PROGRESS,
+        requested_seed=requested_seed,
+        effective_seed=effective_seed,
+        reroll_count=reroll_count,
+        path=[settings.start_position],
+    )
+    state.game_status = determine_game_status(state)
+    return state
+
+
+def run_commands(
+    requested_seed: int,
+    commands: Iterable[str],
+    settings: GameSettings = DEFAULT_SETTINGS,
+    max_turns: int = 256,
+) -> GameLog:
+    simulate.validate_non_negative("max-turns", max_turns)
+    try:
+        state = create_game(requested_seed, settings)
+    except GenerationError as exc:
+        return GameLog(
+            schema_version=SCHEMA_VERSION,
+            settings=settings,
+            requested_seed=requested_seed,
+            effective_seed=None,
+            reroll_count=None,
+            initial_state=None,
+            events=(),
+            final_summary=None,
+            generation_error=exc.to_info(),
+        )
+
+    initial_state = snapshot_state(state)
+    events: list[TurnEvent] = []
+    command_iter = iter(commands)
+
+    while state.game_status == GAME_STATUS_IN_PROGRESS:
+        if state.turn_count >= max_turns:
+            return build_game_log(
+                settings=settings,
+                requested_seed=requested_seed,
+                state=state,
+                initial_state=initial_state,
+                events=events,
+                final_outcome=FINAL_OUTCOME_ABORTED_TURN_LIMIT,
+            )
+
+        try:
+            command = next(command_iter)
+        except StopIteration:
+            return build_game_log(
+                settings=settings,
+                requested_seed=requested_seed,
+                state=state,
+                initial_state=initial_state,
+                events=events,
+                final_outcome=FINAL_OUTCOME_ABORTED_NO_POLICY_ACTION,
+            )
+
+        events.append(apply_command(state, command))
+
+    return build_game_log(
+        settings=settings,
+        requested_seed=requested_seed,
+        state=state,
+        initial_state=initial_state,
+        events=events,
+        final_outcome=final_outcome_for_status(state.game_status),
+    )
+
+
+def apply_command(state: GameState, command: str) -> TurnEvent:
+    if state.game_status != GAME_STATUS_IN_PROGRESS:
+        raise ValueError("game is already finished")
+
+    normalized_command = command.strip().upper()
+    if normalized_command not in COMMAND_DELTAS:
+        state.invalid_or_rejected_action_count += 1
+        return TurnEvent(
+            turn=state.turn_count,
+            command=normalized_command,
+            outcome=OUTCOME_INVALID_COMMAND,
+            from_position=state.player_position,
+            attempted_position=None,
+            to_position=state.player_position,
+            fuel_before=state.remaining_fuel,
+            fuel_spent=0,
+            fuel_after=state.remaining_fuel,
+            discovered_cell=None,
+            discovered_rift=False,
+            supply_applied=False,
+            supply_source=None,
+            status_after=state.game_status,
+        )
+
+    from_position = state.player_position
+    attempted_position = move_position(from_position, COMMAND_DELTAS[normalized_command])
+    fuel_before = state.remaining_fuel
+
+    if not is_inside_board(attempted_position):
+        state.invalid_or_rejected_action_count += 1
+        return TurnEvent(
+            turn=state.turn_count,
+            command=normalized_command,
+            outcome=OUTCOME_OUT_OF_BOUNDS,
+            from_position=from_position,
+            attempted_position=attempted_position,
+            to_position=from_position,
+            fuel_before=fuel_before,
+            fuel_spent=0,
+            fuel_after=state.remaining_fuel,
+            discovered_cell=None,
+            discovered_rift=False,
+            supply_applied=False,
+            supply_source=None,
+            status_after=state.game_status,
+        )
+
+    edge = simulate.normalize_edge(from_position, attempted_position)
+    route_state = state.known_routes.get(edge)
+    if route_state == ROUTE_RIFT:
+        state.invalid_or_rejected_action_count += 1
+        return TurnEvent(
+            turn=state.turn_count,
+            command=normalized_command,
+            outcome=OUTCOME_REJECTED_KNOWN_RIFT,
+            from_position=from_position,
+            attempted_position=attempted_position,
+            to_position=from_position,
+            fuel_before=fuel_before,
+            fuel_spent=0,
+            fuel_after=state.remaining_fuel,
+            discovered_cell=None,
+            discovered_rift=False,
+            supply_applied=False,
+            supply_source=None,
+            status_after=state.game_status,
+        )
+
+    if is_rift_edge(state, edge):
+        if fuel_before < 1:
+            state.invalid_or_rejected_action_count += 1
+            return TurnEvent(
+                turn=state.turn_count,
+                command=normalized_command,
+                outcome=OUTCOME_REJECTED_INSUFFICIENT_FUEL,
+                from_position=from_position,
+                attempted_position=attempted_position,
+                to_position=from_position,
+                fuel_before=fuel_before,
+                fuel_spent=0,
+                fuel_after=state.remaining_fuel,
+                discovered_cell=None,
+                discovered_rift=False,
+                supply_applied=False,
+                supply_source=None,
+                status_after=state.game_status,
+            )
+
+        state.remaining_fuel -= 1
+        state.turn_count += 1
+        state.known_routes[edge] = ROUTE_RIFT
+        state.rift_attempt_count += 1
+        state.game_status = determine_game_status(state)
+        return TurnEvent(
+            turn=state.turn_count,
+            command=normalized_command,
+            outcome=OUTCOME_BLOCKED_UNKNOWN_RIFT,
+            from_position=from_position,
+            attempted_position=attempted_position,
+            to_position=from_position,
+            fuel_before=fuel_before,
+            fuel_spent=1,
+            fuel_after=state.remaining_fuel,
+            discovered_cell=None,
+            discovered_rift=True,
+            supply_applied=False,
+            supply_source=None,
+            status_after=state.game_status,
+        )
+
+    destination_symbol = state.actual_map.cells[attempted_position]
+    fuel_cost = simulate.terrain_cost(destination_symbol)
+    if fuel_before < fuel_cost:
+        state.invalid_or_rejected_action_count += 1
+        return TurnEvent(
+            turn=state.turn_count,
+            command=normalized_command,
+            outcome=OUTCOME_REJECTED_INSUFFICIENT_FUEL,
+            from_position=from_position,
+            attempted_position=attempted_position,
+            to_position=from_position,
+            fuel_before=fuel_before,
+            fuel_spent=0,
+            fuel_after=state.remaining_fuel,
+            discovered_cell=None,
+            discovered_rift=False,
+            supply_applied=False,
+            supply_source=None,
+            status_after=state.game_status,
+        )
+
+    state.remaining_fuel -= fuel_cost
+    state.turn_count += 1
+    state.player_position = attempted_position
+    state.known_routes[edge] = ROUTE_OPEN
+    state.visited_cells.add(attempted_position)
+    state.path.append(attempted_position)
+    discovered_cell = None
+    if attempted_position not in state.known_cells:
+        state.known_cells[attempted_position] = destination_symbol
+        discovered_cell = destination_symbol
+
+    supply_applied, supply_source = maybe_apply_supply(state, destination_symbol)
+    if destination_symbol == BASE_CELL:
+        state.base_visited = True
+    if destination_symbol == RESOURCE_CELL:
+        state.resource_visit_count += 1
+
+    state.game_status = determine_game_status(state)
+    return TurnEvent(
+        turn=state.turn_count,
+        command=normalized_command,
+        outcome=OUTCOME_MOVED,
+        from_position=from_position,
+        attempted_position=attempted_position,
+        to_position=attempted_position,
+        fuel_before=fuel_before,
+        fuel_spent=fuel_cost,
+        fuel_after=state.remaining_fuel,
+        discovered_cell=discovered_cell,
+        discovered_rift=False,
+        supply_applied=supply_applied,
+        supply_source=supply_source,
+        status_after=state.game_status,
+    )
+
+
+def create_playable_map(
+    requested_seed: int,
+    settings: GameSettings,
+) -> tuple[simulate.GalacticMap, int, int]:
+    for attempt in range(MAX_GENERATION_ATTEMPTS):
+        candidate_seed = add_seed_offset(requested_seed, attempt)
+        galactic_map = simulate.generate_map(
+            candidate_seed,
+            settings.resource_count,
+            settings.rift_density,
+        )
+        if is_goal_reachable(galactic_map):
+            return galactic_map, candidate_seed, attempt
+    raise GenerationError(
+        "NO_REACHABLE_MAP",
+        f"failed to generate a reachable map after {MAX_GENERATION_ATTEMPTS} attempts",
+    )
+
+
+def add_seed_offset(seed: int, offset: int) -> int:
+    candidate = seed + offset
+    if not MIN_INT64 <= candidate <= MAX_INT64:
+        raise GenerationError(
+            "SEED_OVERFLOW",
+            f"seed overflow while adding attempt {offset} to requested_seed={seed}",
+        )
+    return candidate
+
+
+def is_goal_reachable(galactic_map: simulate.GalacticMap) -> bool:
+    return (
+        simulate.shortest_path(
+            galactic_map.cells,
+            simulate.SPECIAL_S,
+            simulate.SPECIAL_H,
+            set(galactic_map.rift_edges),
+        )
+        is not None
+    )
+
+
+def maybe_apply_supply(state: GameState, destination_symbol: str) -> tuple[bool, str | None]:
+    if state.supply_used:
+        return False, None
+    if destination_symbol == BASE_CELL:
+        supply_amount = state.settings.base_supply
+    elif destination_symbol == RESOURCE_CELL:
+        supply_amount = state.settings.resource_supply
+    else:
+        return False, None
+    state.supply_used = True
+    state.supply_source = destination_symbol
+    state.remaining_fuel += supply_amount
+    return True, destination_symbol
+
+
+def determine_game_status(state: GameState) -> str:
+    if state.player_position == simulate.SPECIAL_H:
+        return GAME_STATUS_WON
+    if can_continue(state):
+        return GAME_STATUS_IN_PROGRESS
+    return GAME_STATUS_LOST_FUEL
+
+
+def can_continue(state: GameState) -> bool:
+    for neighbor in simulate.neighbors(state.player_position):
+        edge = simulate.normalize_edge(state.player_position, neighbor)
+        if is_rift_edge(state, edge):
+            continue
+        terrain_symbol = state.actual_map.cells[neighbor]
+        if simulate.terrain_cost(terrain_symbol) <= state.remaining_fuel:
+            return True
+    return False
+
+
+def is_rift_edge(state: GameState, edge: simulate.Edge) -> bool:
+    return edge in state.actual_map.rift_edges
+
+
+def move_position(position: simulate.Position, delta: tuple[int, int]) -> simulate.Position:
+    return (position[0] + delta[0], position[1] + delta[1])
+
+
+def is_inside_board(position: simulate.Position) -> bool:
+    x, y = position
+    return 1 <= x <= simulate.WIDTH and 1 <= y <= simulate.HEIGHT
+
+
+def final_outcome_for_status(status: str) -> str:
+    if status == GAME_STATUS_WON:
+        return FINAL_OUTCOME_WON
+    if status == GAME_STATUS_LOST_FUEL:
+        return FINAL_OUTCOME_LOST_FUEL
+    raise ValueError(f"unexpected terminal status: {status}")
+
+
+def build_game_log(
+    *,
+    settings: GameSettings,
+    requested_seed: int,
+    state: GameState,
+    initial_state: dict[str, object],
+    events: list[TurnEvent],
+    final_outcome: str,
+) -> GameLog:
+    return GameLog(
+        schema_version=SCHEMA_VERSION,
+        settings=settings,
+        requested_seed=requested_seed,
+        effective_seed=state.effective_seed,
+        reroll_count=state.reroll_count,
+        initial_state=initial_state,
+        events=tuple(events),
+        final_summary=FinalSummary(
+            outcome=final_outcome,
+            turn_count=state.turn_count,
+            remaining_fuel=state.remaining_fuel,
+            supply_source=state.supply_source,
+            base_visited=state.base_visited,
+            resource_visits=state.resource_visit_count,
+            rift_attempts=state.rift_attempt_count,
+            invalid_or_rejected_actions=state.invalid_or_rejected_action_count,
+            path=tuple(state.path),
+        ),
+        generation_error=None,
+    )
+
+
+def snapshot_state(state: GameState) -> dict[str, object]:
+    return {
+        "actual_map": actual_map_to_dict(state.actual_map),
+        "known_cells": known_cells_to_dict(state.known_cells),
+        "visited_cells": positions_to_sorted_dicts(state.visited_cells),
+        "known_routes": known_routes_to_dict(state.known_routes),
+        "player_position": position_to_dict(state.player_position),
+        "remaining_fuel": state.remaining_fuel,
+        "supply_used": state.supply_used,
+        "supply_source": state.supply_source,
+        "turn_count": state.turn_count,
+        "game_status": state.game_status,
+        "requested_seed": state.requested_seed,
+        "effective_seed": state.effective_seed,
+        "reroll_count": state.reroll_count,
+    }
+
+
+def settings_to_dict(settings: GameSettings) -> dict[str, object]:
+    return {
+        "width": settings.width,
+        "height": settings.height,
+        "start_position": position_to_dict(settings.start_position),
+        "goal_position": position_to_dict(settings.goal_position),
+        "rift_density": settings.rift_density,
+        "initial_fuel": settings.initial_fuel,
+        "base_supply": settings.base_supply,
+        "resource_count": settings.resource_count,
+        "resource_supply": settings.resource_supply,
+    }
+
+
+def actual_map_to_dict(actual_map: ActualMap) -> dict[str, object]:
+    return {
+        "cells": cells_to_sorted_rows(actual_map.cells),
+        "rift_edges": [
+            edge_to_dict(edge)
+            for edge in sorted(actual_map.rift_edges)
+        ],
+        "base_position": position_to_dict(actual_map.base_position),
+        "resource_positions": [position_to_dict(position) for position in actual_map.resource_positions],
+    }
+
+
+def known_cells_to_dict(known_cells: dict[simulate.Position, str]) -> list[dict[str, object]]:
+    return [
+        {
+            "position": position_to_dict(position),
+            "symbol": known_cells[position],
+        }
+        for position in sorted(known_cells)
+    ]
+
+
+def known_routes_to_dict(known_routes: dict[simulate.Edge, str]) -> list[dict[str, object]]:
+    return [
+        {
+            "edge": edge_to_dict(edge),
+            "state": known_routes[edge],
+        }
+        for edge in sorted(known_routes)
+    ]
+
+
+def cells_to_sorted_rows(cells: simulate.Cells) -> list[dict[str, object]]:
+    return [
+        {
+            "position": position_to_dict(position),
+            "symbol": cells[position],
+        }
+        for position in sorted(cells)
+    ]
+
+
+def positions_to_sorted_dicts(positions: set[simulate.Position]) -> list[dict[str, int]]:
+    return [position_to_dict(position) for position in sorted(positions)]
+
+
+def position_to_dict(position: simulate.Position) -> dict[str, int]:
+    return {
+        "x": position[0],
+        "y": position[1],
+    }
+
+
+def optional_position_to_dict(position: simulate.Position | None) -> dict[str, int] | None:
+    if position is None:
+        return None
+    return position_to_dict(position)
+
+
+def edge_to_dict(edge: simulate.Edge) -> dict[str, object]:
+    return {
+        "from": position_to_dict(edge[0]),
+        "to": position_to_dict(edge[1]),
+    }

--- a/experiments/galactic_exodus/test_engine.py
+++ b/experiments/galactic_exodus/test_engine.py
@@ -1,0 +1,326 @@
+import json
+import unittest
+from unittest.mock import patch
+
+from experiments.galactic_exodus import engine
+from experiments.galactic_exodus import simulate
+
+
+def filled_cells(symbol: str = ".") -> simulate.Cells:
+    return {
+        (x, y): symbol
+        for y in range(1, simulate.HEIGHT + 1)
+        for x in range(1, simulate.WIDTH + 1)
+    }
+
+
+def make_actual_map(
+    *,
+    cells: simulate.Cells,
+    base_position: simulate.Position = (4, 4),
+    resource_positions: tuple[simulate.Position, ...] = (),
+    rift_edges: tuple[simulate.Edge, ...] = (),
+) -> engine.ActualMap:
+    map_cells = dict(cells)
+    map_cells[simulate.SPECIAL_S] = "S"
+    map_cells[simulate.SPECIAL_H] = "H"
+    map_cells[base_position] = "B"
+    for position in resource_positions:
+        map_cells[position] = "R"
+    return engine.ActualMap(
+        cells=map_cells,
+        rift_edges=rift_edges,
+        base_position=base_position,
+        resource_positions=resource_positions,
+    )
+
+
+def make_state(
+    *,
+    actual_map: engine.ActualMap,
+    settings: engine.GameSettings | None = None,
+    player_position: simulate.Position = simulate.SPECIAL_S,
+    remaining_fuel: int = 16,
+    known_cells: dict[simulate.Position, str] | None = None,
+    visited_cells: set[simulate.Position] | None = None,
+    known_routes: dict[simulate.Edge, str] | None = None,
+    supply_used: bool = False,
+    supply_source: str | None = None,
+    turn_count: int = 0,
+    requested_seed: int = 1,
+    effective_seed: int = 1,
+    reroll_count: int = 0,
+    path: list[simulate.Position] | None = None,
+) -> engine.GameState:
+    effective_settings = settings or engine.DEFAULT_SETTINGS
+    state = engine.GameState(
+        settings=effective_settings,
+        actual_map=actual_map,
+        known_cells=(
+            {
+                simulate.SPECIAL_S: actual_map.cells[simulate.SPECIAL_S],
+                simulate.SPECIAL_H: actual_map.cells[simulate.SPECIAL_H],
+            }
+            if known_cells is None
+            else dict(known_cells)
+        ),
+        visited_cells={player_position} if visited_cells is None else set(visited_cells),
+        known_routes={} if known_routes is None else dict(known_routes),
+        player_position=player_position,
+        remaining_fuel=remaining_fuel,
+        supply_used=supply_used,
+        supply_source=supply_source,
+        turn_count=turn_count,
+        game_status=engine.GAME_STATUS_IN_PROGRESS,
+        requested_seed=requested_seed,
+        effective_seed=effective_seed,
+        reroll_count=reroll_count,
+        path=[player_position] if path is None else list(path),
+    )
+    state.game_status = engine.determine_game_status(state)
+    return state
+
+
+class CreateGameTests(unittest.TestCase):
+    def test_create_game_starts_with_only_s_and_h_known(self) -> None:
+        state = engine.create_game(42)
+
+        self.assertEqual(state.player_position, simulate.SPECIAL_S)
+        self.assertEqual(state.known_cells, {simulate.SPECIAL_S: "S", simulate.SPECIAL_H: "H"})
+        self.assertEqual(state.visited_cells, {simulate.SPECIAL_S})
+        self.assertEqual(state.known_routes, {})
+        self.assertEqual(state.turn_count, 0)
+        self.assertEqual(state.remaining_fuel, engine.DEFAULT_SETTINGS.initial_fuel)
+        self.assertEqual(state.path, [simulate.SPECIAL_S])
+
+    def test_create_game_preserves_seed_compatibility_for_first_reachable_candidate(self) -> None:
+        for seed in range(1, 1001):
+            state = engine.create_game(seed)
+            self.assertEqual(state.actual_map.cells, simulate.generate_map(state.effective_seed, 3, 0.10).cells)
+            self.assertEqual(state.actual_map.rift_edges, simulate.generate_map(state.effective_seed, 3, 0.10).rift_edges)
+            self.assertEqual(state.effective_seed, seed + state.reroll_count)
+            self.assertGreaterEqual(state.reroll_count, 0)
+            self.assertLess(state.reroll_count, engine.MAX_GENERATION_ATTEMPTS)
+
+    def test_create_playable_map_rerolls_until_reachable_candidate(self) -> None:
+        unreachable = simulate.GalacticMap(
+            seed=10,
+            resource_count=0,
+            rift_density=0.10,
+            b_position=(4, 4),
+            r_positions=[],
+            rift_edges=(),
+            cells=filled_cells("."),
+        )
+        reachable = simulate.generate_map(12, 3, 0.10)
+        generated = {
+            10: unreachable,
+            11: unreachable,
+            12: reachable,
+        }
+        with (
+            patch.object(engine.simulate, "generate_map", side_effect=lambda seed, *_: generated[seed]),
+            patch.object(engine, "is_goal_reachable", side_effect=lambda galactic_map: galactic_map.seed == 12),
+        ):
+            galactic_map, effective_seed, reroll_count = engine.create_playable_map(10, engine.DEFAULT_SETTINGS)
+
+        self.assertEqual(galactic_map.seed, 12)
+        self.assertEqual(effective_seed, 12)
+        self.assertEqual(reroll_count, 2)
+
+    def test_seed_overflow_raises_explicit_generation_error(self) -> None:
+        with self.assertRaises(engine.GenerationError) as ctx:
+            engine.add_seed_offset(engine.MAX_INT64, 1)
+
+        self.assertEqual(ctx.exception.kind, "SEED_OVERFLOW")
+
+    def test_exhausted_generation_attempts_raise_generation_error(self) -> None:
+        reachable = simulate.generate_map(1, 3, 0.10)
+        with (
+            patch.object(engine.simulate, "generate_map", return_value=reachable),
+            patch.object(engine, "is_goal_reachable", return_value=False),
+        ):
+            with self.assertRaises(engine.GenerationError) as ctx:
+                engine.create_playable_map(1, engine.DEFAULT_SETTINGS)
+
+        self.assertEqual(ctx.exception.kind, "NO_REACHABLE_MAP")
+
+
+class ApplyCommandTests(unittest.TestCase):
+    def test_move_consumes_destination_terrain_cost_and_discovers_cell(self) -> None:
+        cells = filled_cells(".")
+        cells[(2, 1)] = "A"
+        state = make_state(actual_map=make_actual_map(cells=cells), remaining_fuel=10)
+
+        event = engine.apply_command(state, "E")
+
+        self.assertEqual(event.outcome, engine.OUTCOME_MOVED)
+        self.assertEqual(event.fuel_spent, 3)
+        self.assertEqual(event.discovered_cell, "A")
+        self.assertEqual(state.player_position, (2, 1))
+        self.assertEqual(state.remaining_fuel, 7)
+        self.assertEqual(state.turn_count, 1)
+        self.assertEqual(state.known_routes[simulate.normalize_edge((1, 1), (2, 1))], engine.ROUTE_OPEN)
+
+    def test_unknown_rift_consumes_one_fuel_and_known_rift_retry_is_rejected(self) -> None:
+        rift_edge = (simulate.normalize_edge((1, 1), (1, 2)),)
+        state = make_state(actual_map=make_actual_map(cells=filled_cells("."), rift_edges=rift_edge), remaining_fuel=3)
+
+        first = engine.apply_command(state, "N")
+        second = engine.apply_command(state, "N")
+
+        self.assertEqual(first.outcome, engine.OUTCOME_BLOCKED_UNKNOWN_RIFT)
+        self.assertTrue(first.discovered_rift)
+        self.assertEqual(first.fuel_after, 2)
+        self.assertEqual(first.turn, 1)
+        self.assertEqual(second.outcome, engine.OUTCOME_REJECTED_KNOWN_RIFT)
+        self.assertEqual(second.fuel_after, 2)
+        self.assertEqual(second.turn, 1)
+        self.assertEqual(state.rift_attempt_count, 1)
+
+    def test_base_supply_applies_once_even_on_revisit(self) -> None:
+        settings = engine.GameSettings(initial_fuel=3, base_supply=2)
+        state = make_state(
+            actual_map=make_actual_map(cells=filled_cells("."), base_position=(2, 1)),
+            settings=settings,
+            remaining_fuel=3,
+        )
+
+        first = engine.apply_command(state, "E")
+        engine.apply_command(state, "W")
+        second = engine.apply_command(state, "E")
+
+        self.assertTrue(first.supply_applied)
+        self.assertEqual(first.supply_source, "B")
+        self.assertEqual(second.supply_applied, False)
+        self.assertEqual(state.remaining_fuel, 3)
+        self.assertEqual(state.supply_source, "B")
+
+    def test_resource_supply_can_apply_after_arriving_with_zero_fuel(self) -> None:
+        settings = engine.GameSettings(initial_fuel=1, resource_supply=5)
+        state = make_state(
+            actual_map=make_actual_map(cells=filled_cells("."), resource_positions=((2, 1),)),
+            settings=settings,
+            remaining_fuel=1,
+        )
+
+        event = engine.apply_command(state, "E")
+
+        self.assertTrue(event.supply_applied)
+        self.assertEqual(event.supply_source, "R")
+        self.assertEqual(state.remaining_fuel, 5)
+
+    def test_arriving_at_home_with_zero_fuel_is_a_win(self) -> None:
+        state = make_state(
+            actual_map=make_actual_map(cells=filled_cells(".")),
+            player_position=(7, 8),
+            remaining_fuel=1,
+            visited_cells={(7, 8)},
+            path=[(7, 8)],
+        )
+
+        event = engine.apply_command(state, "E")
+
+        self.assertEqual(event.status_after, engine.GAME_STATUS_WON)
+        self.assertEqual(state.player_position, simulate.SPECIAL_H)
+        self.assertEqual(state.remaining_fuel, 0)
+
+    def test_invalid_out_of_bounds_and_insufficient_fuel_leave_state_unchanged(self) -> None:
+        cells = filled_cells(".")
+        cells[(2, 1)] = "A"
+        state = make_state(actual_map=make_actual_map(cells=cells), remaining_fuel=2)
+        snapshot = (
+            state.player_position,
+            state.remaining_fuel,
+            state.turn_count,
+            dict(state.known_cells),
+            dict(state.known_routes),
+        )
+
+        invalid = engine.apply_command(state, "X")
+        out_of_bounds = engine.apply_command(state, "W")
+        insufficient = engine.apply_command(state, "E")
+
+        self.assertEqual(invalid.outcome, engine.OUTCOME_INVALID_COMMAND)
+        self.assertEqual(out_of_bounds.outcome, engine.OUTCOME_OUT_OF_BOUNDS)
+        self.assertEqual(insufficient.outcome, engine.OUTCOME_REJECTED_INSUFFICIENT_FUEL)
+        self.assertEqual(
+            snapshot,
+            (
+                state.player_position,
+                state.remaining_fuel,
+                state.turn_count,
+                state.known_cells,
+                state.known_routes,
+            ),
+        )
+
+    def test_actual_map_controls_lost_fuel_detection(self) -> None:
+        cells = filled_cells(".")
+        cells[(2, 1)] = "A"
+        blocked = (simulate.normalize_edge((1, 1), (1, 2)),)
+        state = make_state(
+            actual_map=make_actual_map(cells=cells, rift_edges=blocked),
+            remaining_fuel=1,
+        )
+
+        self.assertEqual(state.game_status, engine.GAME_STATUS_LOST_FUEL)
+
+
+class RunCommandsTests(unittest.TestCase):
+    def test_run_commands_is_deterministic_for_same_seed_and_commands(self) -> None:
+        commands = ["E", "N", "N", "W", "S"]
+
+        first = engine.run_commands(42, commands)
+        second = engine.run_commands(42, commands)
+
+        self.assertEqual(first.to_dict(), second.to_dict())
+        self.assertEqual(first.to_json(), second.to_json())
+
+    def test_run_commands_aborts_when_commands_run_out(self) -> None:
+        log = engine.run_commands(42, [])
+
+        self.assertEqual(log.final_summary.outcome, engine.FINAL_OUTCOME_ABORTED_NO_POLICY_ACTION)
+        self.assertEqual(log.events, ())
+        self.assertIsNone(log.generation_error)
+
+    def test_run_commands_aborts_on_turn_limit(self) -> None:
+        settings = engine.GameSettings(initial_fuel=100)
+        log = engine.run_commands(42, ["E"] * 100, settings=settings, max_turns=1)
+
+        self.assertEqual(log.final_summary.outcome, engine.FINAL_OUTCOME_ABORTED_TURN_LIMIT)
+        self.assertEqual(log.final_summary.turn_count, 1)
+
+    def test_run_commands_reports_generation_error_separately(self) -> None:
+        with patch.object(engine, "create_game", side_effect=engine.GenerationError("NO_REACHABLE_MAP", "no map")):
+            log = engine.run_commands(99, ["E"])
+
+        self.assertIsNone(log.final_summary)
+        self.assertEqual(log.generation_error.kind, "NO_REACHABLE_MAP")
+
+    def test_game_log_schema_and_summary_are_stable(self) -> None:
+        log = engine.run_commands(42, ["E", "N"])
+        payload = log.to_dict()
+
+        self.assertEqual(
+            list(payload.keys()),
+            [
+                "schema_version",
+                "settings",
+                "requested_seed",
+                "effective_seed",
+                "reroll_count",
+                "initial_state",
+                "events",
+                "final_summary",
+                "generation_error",
+            ],
+        )
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertIn("outcome", payload["final_summary"])
+        self.assertIn("path", payload["final_summary"])
+        json.loads(log.to_json())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experiments/galactic_exodus/test_engine.py
+++ b/experiments/galactic_exodus/test_engine.py
@@ -45,7 +45,7 @@ def make_state(
     visited_cells: set[simulate.Position] | None = None,
     known_routes: dict[simulate.Edge, str] | None = None,
     supply_used: bool = False,
-    supply_source: str | None = None,
+    supply_source: engine.SupplySource | None = None,
     turn_count: int = 0,
     requested_seed: int = 1,
     effective_seed: int = 1,
@@ -132,7 +132,10 @@ class CreateGameTests(unittest.TestCase):
         with self.assertRaises(engine.GenerationError) as ctx:
             engine.add_seed_offset(engine.MAX_INT64, 1)
 
-        self.assertEqual(ctx.exception.kind, "SEED_OVERFLOW")
+        self.assertEqual(ctx.exception.reason, "SEED_OVERFLOW")
+        self.assertEqual(ctx.exception.requested_seed, engine.MAX_INT64)
+        self.assertEqual(ctx.exception.attempts, 2)
+        self.assertEqual(ctx.exception.last_candidate_seed, engine.MAX_INT64)
 
     def test_exhausted_generation_attempts_raise_generation_error(self) -> None:
         reachable = simulate.generate_map(1, 3, 0.10)
@@ -143,7 +146,9 @@ class CreateGameTests(unittest.TestCase):
             with self.assertRaises(engine.GenerationError) as ctx:
                 engine.create_playable_map(1, engine.DEFAULT_SETTINGS)
 
-        self.assertEqual(ctx.exception.kind, "NO_REACHABLE_MAP")
+        self.assertEqual(ctx.exception.reason, "NO_REACHABLE_MAP")
+        self.assertEqual(ctx.exception.attempts, engine.MAX_GENERATION_ATTEMPTS)
+        self.assertEqual(ctx.exception.last_candidate_seed, 100)
 
 
 class ApplyCommandTests(unittest.TestCase):
@@ -191,10 +196,10 @@ class ApplyCommandTests(unittest.TestCase):
         second = engine.apply_command(state, "E")
 
         self.assertTrue(first.supply_applied)
-        self.assertEqual(first.supply_source, "B")
+        self.assertEqual(first.supply_source, engine.SupplySource(kind="B", position=(2, 1)))
         self.assertEqual(second.supply_applied, False)
         self.assertEqual(state.remaining_fuel, 3)
-        self.assertEqual(state.supply_source, "B")
+        self.assertEqual(state.supply_source, engine.SupplySource(kind="B", position=(2, 1)))
 
     def test_resource_supply_can_apply_after_arriving_with_zero_fuel(self) -> None:
         settings = engine.GameSettings(initial_fuel=1, resource_supply=5)
@@ -207,8 +212,21 @@ class ApplyCommandTests(unittest.TestCase):
         event = engine.apply_command(state, "E")
 
         self.assertTrue(event.supply_applied)
-        self.assertEqual(event.supply_source, "R")
+        self.assertEqual(event.supply_source, engine.SupplySource(kind="R", position=(2, 1)))
         self.assertEqual(state.remaining_fuel, 5)
+
+    def test_supply_source_position_survives_later_movement(self) -> None:
+        settings = engine.GameSettings(initial_fuel=4, resource_supply=5)
+        state = make_state(
+            actual_map=make_actual_map(cells=filled_cells("."), resource_positions=((2, 1),)),
+            settings=settings,
+            remaining_fuel=4,
+        )
+
+        engine.apply_command(state, "E")
+        engine.apply_command(state, "W")
+
+        self.assertEqual(state.supply_source, engine.SupplySource(kind="R", position=(2, 1)))
 
     def test_arriving_at_home_with_zero_fuel_is_a_win(self) -> None:
         state = make_state(
@@ -292,11 +310,25 @@ class RunCommandsTests(unittest.TestCase):
         self.assertEqual(log.final_summary.turn_count, 1)
 
     def test_run_commands_reports_generation_error_separately(self) -> None:
-        with patch.object(engine, "create_game", side_effect=engine.GenerationError("NO_REACHABLE_MAP", "no map")):
+        with patch.object(
+            engine,
+            "create_game",
+            side_effect=engine.GenerationError(
+                requested_seed=99,
+                attempts=100,
+                last_candidate_seed=198,
+                reason="NO_REACHABLE_MAP",
+                message="no map",
+            ),
+        ):
             log = engine.run_commands(99, ["E"])
 
         self.assertIsNone(log.final_summary)
-        self.assertEqual(log.generation_error.kind, "NO_REACHABLE_MAP")
+        self.assertEqual(log.generation_error.kind, "GENERATION_ERROR")
+        self.assertEqual(log.generation_error.reason, "NO_REACHABLE_MAP")
+        self.assertEqual(log.generation_error.requested_seed, 99)
+        self.assertEqual(log.generation_error.attempts, 100)
+        self.assertEqual(log.generation_error.last_candidate_seed, 198)
 
     def test_game_log_schema_and_summary_are_stable(self) -> None:
         log = engine.run_commands(42, ["E", "N"])
@@ -319,7 +351,62 @@ class RunCommandsTests(unittest.TestCase):
         self.assertEqual(payload["schema_version"], 1)
         self.assertIn("outcome", payload["final_summary"])
         self.assertIn("path", payload["final_summary"])
+        self.assertIn("supply_source", payload["final_summary"])
+        if payload["events"]:
+            self.assertIn("supply_source", payload["events"][0])
         json.loads(log.to_json())
+
+    def test_game_log_serializes_structured_supply_source(self) -> None:
+        state = make_state(
+            actual_map=make_actual_map(cells=filled_cells("."), base_position=(2, 1)),
+            settings=engine.GameSettings(initial_fuel=1, base_supply=3, resource_count=0),
+            remaining_fuel=1,
+            requested_seed=1,
+            effective_seed=1,
+        )
+        with patch.object(engine, "create_game", return_value=state):
+            payload = engine.run_commands(1, ["E"], settings=state.settings).to_dict()
+
+        self.assertEqual(
+            payload["events"][0]["supply_source"],
+            {
+                "kind": "B",
+                "position": {"x": 2, "y": 1},
+            },
+        )
+        self.assertEqual(
+            payload["final_summary"]["supply_source"],
+            {
+                "kind": "B",
+                "position": {"x": 2, "y": 1},
+            },
+        )
+
+    def test_game_log_serializes_structured_generation_error(self) -> None:
+        with patch.object(
+            engine,
+            "create_game",
+            side_effect=engine.GenerationError(
+                requested_seed=7,
+                attempts=2,
+                last_candidate_seed=7,
+                reason="SEED_OVERFLOW",
+                message="overflow",
+            ),
+        ):
+            payload = engine.run_commands(7, ["E"]).to_dict()
+
+        self.assertEqual(
+            payload["generation_error"],
+            {
+                "kind": "GENERATION_ERROR",
+                "requested_seed": 7,
+                "attempts": 2,
+                "last_candidate_seed": 7,
+                "reason": "SEED_OVERFLOW",
+                "message": "overflow",
+            },
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 概要

Closes #1057

Galactic Exodus Phase 1A1 向けに、標準入力や画面表示に依存しない Python ゲームエンジンを追加しました。
既存の `simulate.generate_map()` をそのまま利用しつつ、到達不能マップのみ deterministic に再抽選します。

## 変更内容

- `experiments/galactic_exodus/engine.py` を追加
- `create_game` / `apply_command` / `run_commands` の非対話 API を実装
- `requested_seed` / `effective_seed` / `reroll_count` を保持し、最大 100 回の再抽選と overflow / generation error を分離
- 未知断層・既知断層・燃料不足・補給・勝敗判定を issue 契約どおりに実装
- `GameLog` / `TurnEvent` / `FinalSummary` と deterministic JSON 変換を追加
- `experiments/galactic_exodus/test_engine.py` を追加し、状態遷移・再抽選・ログ schema を回帰テスト化
- `experiments/galactic_exodus/README.md` に Phase 1A1 engine API とログ契約を追記

## 確認

- `python -m unittest discover -s experiments/galactic_exodus -p 'test_*.py' -q`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo fmt --check`
