### PR TITLE
Phase 1A2 prototype: Python対話CLIとASCII表示を実装する

### DIFF
--- a/experiments/galactic_exodus/README.md
+++ b/experiments/galactic_exodus/README.md
@@ -150,6 +150,124 @@ generation_error
 
 `GameLog.to_dict()` と `GameLog.to_json()` は key 順と配列順を固定し、同一 seed・同一 command 列から同一 JSON を生成します。
 
+## Phase 1A2 interactive CLI prototype
+
+`play.py` は Phase 1A2 用の対話 CLI です。盤面生成、移動、燃料、補給、勝敗判定は `engine.py` に委譲し、CLI 側は入力・ASCII 表示・JSON ログ出力だけを担当します。
+
+起動:
+
+```bash
+python experiments/galactic_exodus/play.py --seed 42
+python experiments/galactic_exodus/play.py --seed 42 --json-log .tmp/galactic-exodus-log.json
+```
+
+- `--seed <int>`
+  - 必須。requested seed を指定します。
+- `--json-log <path>`
+  - 任意。終了時に `GameLog schema_version=1` を JSON で書き出します。
+
+コマンド:
+
+```text
+N
+E
+S
+W
+Q
+```
+
+- 大文字小文字を区別しません
+- 前後空白を無視します
+- `Q` と EOF は状態を変えずに正常終了します
+
+盤面記号:
+
+```text
+?  未知セル
+.  既知 plain
+N  既知 nebula
+A  既知 asteroid
+@  既知 anomaly
+S  start
+H  goal
+B  既知 base
+R  既知 resource
+P  現在地
+```
+
+- `H` は開始時から表示されます
+- 未知の地形・B・R は表示しません
+- 表示優先順位は `P > S/H > B/R > terrain > ?` です
+
+状態表示:
+
+```text
+SEED: requested=<n> effective=<n> rerolls=<n>
+POSITION: (<x>,<y>)
+FUEL: <remaining>
+SUPPLY: unused | B | R(<x>,<y>)
+TURN: <n>
+STATUS: IN PROGRESS | WON | LOST FUEL
+BLOCKED: <known-rift-directions or ->
+```
+
+ターン結果文言:
+
+```text
+MOVED TO (x,y), COST n
+RIFT BLOCKED <direction>, COST 1
+KNOWN RIFT <direction>
+OUT OF BOUNDS
+INVALID COMMAND
+INSUFFICIENT FUEL: NEED n, HAVE m
+SUPPLIED AT B: +8
+SUPPLIED AT R(x,y): +5
+YOU REACHED H
+NO FURTHER MOVE IS POSSIBLE
+```
+
+fuel / 断層 / 補給 / 勝敗:
+
+- 各移動コストと断層判定は `engine.apply_command()` の結果をそのまま表示します
+- `B` 補給は 1 回だけ `+8`、`R` 補給も 1 回だけ `+5` です
+- `STATUS: WON` で勝利、`STATUS: LOST FUEL` で行動不能です
+
+requested / effective seed の再現:
+
+- playable map が見つからなかった候補は `requested_seed + attempt` で deterministic に再抽選されます
+- 画面の `requested=<n> effective=<n> rerolls=<n>` を記録すれば同じ map を再現できます
+
+JSON ログの用途:
+
+- `--json-log` は CLI セッションを `GameLog schema_version=1` として保存します
+- `Q` / EOF で終了したセッションは `final_summary.outcome = ABORTED_NO_POLICY_ACTION` になります
+
+これは Phase 1A のプロトタイプであり、完成ゲーム UI ではありません。
+
+固定 seed のサンプル操作:
+
+```text
+$ python experiments/galactic_exodus/play.py --seed 42
+MAP:
+y=8 ? ? ? ? ? ? ? H
+y=7 ? ? ? ? ? ? ? ?
+y=6 ? ? ? ? ? ? ? ?
+y=5 ? ? ? ? ? ? ? ?
+y=4 ? ? ? ? ? ? ? ?
+y=3 ? ? ? ? ? ? ? ?
+y=2 ? ? ? ? ? ? ? ?
+y=1 P ? ? ? ? ? ? ?
+     x=1 2 3 4 5 6 7 8
+SEED: requested=42 effective=42 rerolls=0
+POSITION: (1,1)
+FUEL: 16
+SUPPLY: unused
+TURN: 0
+STATUS: IN PROGRESS
+BLOCKED: -
+COMMAND> q
+```
+
 ## 実行方法
 
 ```bash

--- a/experiments/galactic_exodus/README.md
+++ b/experiments/galactic_exodus/README.md
@@ -241,6 +241,7 @@ JSON ログの用途:
 
 - `--json-log` は CLI セッションを `GameLog schema_version=1` として保存します
 - `Q` / EOF で終了したセッションは `final_summary.outcome = ABORTED_NO_POLICY_ACTION` になります
+- generation error は通常敗北と分離し、`requested / attempts / last_candidate_seed / reason / message` を表示します
 
 これは Phase 1A のプロトタイプであり、完成ゲーム UI ではありません。
 

--- a/experiments/galactic_exodus/engine.py
+++ b/experiments/galactic_exodus/engine.py
@@ -146,6 +146,7 @@ class TurnEvent:
     fuel_before: int
     fuel_spent: int
     fuel_after: int
+    required_fuel: int | None
     discovered_cell: str | None
     discovered_rift: bool
     supply_applied: bool
@@ -163,6 +164,7 @@ class TurnEvent:
             "fuel_before": self.fuel_before,
             "fuel_spent": self.fuel_spent,
             "fuel_after": self.fuel_after,
+            "required_fuel": self.required_fuel,
             "discovered_cell": self.discovered_cell,
             "discovered_rift": self.discovered_rift,
             "supply_applied": self.supply_applied,
@@ -365,6 +367,7 @@ def apply_command(state: GameState, command: str) -> TurnEvent:
             fuel_before=state.remaining_fuel,
             fuel_spent=0,
             fuel_after=state.remaining_fuel,
+            required_fuel=None,
             discovered_cell=None,
             discovered_rift=False,
             supply_applied=False,
@@ -388,6 +391,7 @@ def apply_command(state: GameState, command: str) -> TurnEvent:
             fuel_before=fuel_before,
             fuel_spent=0,
             fuel_after=state.remaining_fuel,
+            required_fuel=None,
             discovered_cell=None,
             discovered_rift=False,
             supply_applied=False,
@@ -409,6 +413,7 @@ def apply_command(state: GameState, command: str) -> TurnEvent:
             fuel_before=fuel_before,
             fuel_spent=0,
             fuel_after=state.remaining_fuel,
+            required_fuel=None,
             discovered_cell=None,
             discovered_rift=False,
             supply_applied=False,
@@ -429,6 +434,7 @@ def apply_command(state: GameState, command: str) -> TurnEvent:
                 fuel_before=fuel_before,
                 fuel_spent=0,
                 fuel_after=state.remaining_fuel,
+                required_fuel=1,
                 discovered_cell=None,
                 discovered_rift=False,
                 supply_applied=False,
@@ -451,6 +457,7 @@ def apply_command(state: GameState, command: str) -> TurnEvent:
             fuel_before=fuel_before,
             fuel_spent=1,
             fuel_after=state.remaining_fuel,
+            required_fuel=None,
             discovered_cell=None,
             discovered_rift=True,
             supply_applied=False,
@@ -472,6 +479,7 @@ def apply_command(state: GameState, command: str) -> TurnEvent:
             fuel_before=fuel_before,
             fuel_spent=0,
             fuel_after=state.remaining_fuel,
+            required_fuel=fuel_cost,
             discovered_cell=None,
             discovered_rift=False,
             supply_applied=False,
@@ -511,6 +519,7 @@ def apply_command(state: GameState, command: str) -> TurnEvent:
         fuel_before=fuel_before,
         fuel_spent=fuel_cost,
         fuel_after=state.remaining_fuel,
+        required_fuel=None,
         discovered_cell=discovered_cell,
         discovered_rift=False,
         supply_applied=supply_applied,

--- a/experiments/galactic_exodus/play.py
+++ b/experiments/galactic_exodus/play.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+from typing import Sequence, TextIO
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from experiments.galactic_exodus import engine
+from experiments.galactic_exodus import simulate
+
+
+ABORTED_BY_USER = engine.FINAL_OUTCOME_ABORTED_NO_POLICY_ACTION
+KNOWN_TERRAIN_SYMBOLS = {".", "N", "A", "@", "B", "R"}
+DIRECTION_ORDER = ("N", "E", "S", "W")
+
+
+class CliArgumentParser(argparse.ArgumentParser):
+    def __init__(self, *, stderr: TextIO, **kwargs: object) -> None:
+        super().__init__(**kwargs)
+        self.stderr = stderr
+
+    def _print_message(self, message: str | None, file: TextIO | None = None) -> None:
+        super()._print_message(message, self.stderr)
+
+
+def build_parser(stderr: TextIO) -> argparse.ArgumentParser:
+    parser = CliArgumentParser(
+        stderr=stderr,
+        description="Play the Galactic Exodus Phase 1A2 prototype.",
+    )
+    parser.add_argument("--seed", type=int, help="Requested seed.")
+    parser.add_argument(
+        "--json-log",
+        type=Path,
+        help="Write the final GameLog schema_version=1 JSON to this path.",
+    )
+    return parser
+
+
+def parse_args(argv: Sequence[str], stderr: TextIO) -> argparse.Namespace:
+    parser = build_parser(stderr)
+    if not any(argument == "--seed" or argument.startswith("--seed=") for argument in argv):
+        parser.print_help(stderr)
+        raise SystemExit(0)
+    return parser.parse_args(argv)
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    stdin: TextIO | None = None,
+    stdout: TextIO | None = None,
+    stderr: TextIO | None = None,
+) -> int:
+    effective_argv = list(sys.argv[1:] if argv is None else argv)
+    effective_stdin = sys.stdin if stdin is None else stdin
+    effective_stdout = sys.stdout if stdout is None else stdout
+    effective_stderr = sys.stderr if stderr is None else stderr
+    try:
+        args = parse_args(effective_argv, effective_stderr)
+    except SystemExit as exc:
+        return int(exc.code) if isinstance(exc.code, int) else 1
+
+    try:
+        state = engine.create_game(args.seed)
+    except engine.GenerationError as exc:
+        print_generation_error(exc, effective_stdout)
+        if args.json_log is not None:
+            write_json_log(args.json_log, build_generation_error_log(args.seed, exc))
+        return 1
+
+    initial_state = engine.snapshot_state(state)
+    events: list[engine.TurnEvent] = []
+
+    render_state(state, effective_stdout)
+    while state.game_status == engine.GAME_STATUS_IN_PROGRESS:
+        effective_stdout.write("COMMAND> ")
+        effective_stdout.flush()
+        line = effective_stdin.readline()
+        if line == "":
+            break
+        if line.strip().upper() == "Q":
+            break
+        event = engine.apply_command(state, line)
+        events.append(event)
+        render_event(state, event, effective_stdout)
+        render_state(state, effective_stdout)
+
+    if args.json_log is not None:
+        write_json_log(args.json_log, build_session_log(args.seed, state, initial_state, events))
+    return 0
+
+
+def render_state(state: engine.GameState, output: TextIO) -> None:
+    output.write("MAP:\n")
+    for row in board_lines(state):
+        output.write(f"{row}\n")
+    output.write("     x=1 2 3 4 5 6 7 8\n")
+    output.write(
+        f"SEED: requested={state.requested_seed} effective={state.effective_seed} rerolls={state.reroll_count}\n"
+    )
+    output.write(f"POSITION: {format_position(state.player_position)}\n")
+    output.write(f"FUEL: {state.remaining_fuel}\n")
+    output.write(f"SUPPLY: {format_supply_status(state)}\n")
+    output.write(f"TURN: {state.turn_count}\n")
+    output.write(f"STATUS: {format_status(state.game_status)}\n")
+    output.write(f"BLOCKED: {format_blocked_directions(state)}\n")
+
+
+def board_lines(state: engine.GameState) -> list[str]:
+    rows: list[str] = []
+    for y in range(simulate.HEIGHT, 0, -1):
+        symbols = [display_symbol(state, (x, y)) for x in range(1, simulate.WIDTH + 1)]
+        rows.append(f"y={y} {' '.join(symbols)}")
+    return rows
+
+
+def display_symbol(state: engine.GameState, position: simulate.Position) -> str:
+    if position == state.player_position:
+        return "P"
+    if position == state.settings.start_position:
+        return "S"
+    if position == state.settings.goal_position:
+        return "H"
+    symbol = state.known_cells.get(position)
+    if symbol in KNOWN_TERRAIN_SYMBOLS:
+        return symbol
+    return "?"
+
+
+def render_event(state: engine.GameState, event: engine.TurnEvent, output: TextIO) -> None:
+    for line in format_event_messages(state, event):
+        output.write(f"{line}\n")
+
+
+def format_event_messages(state: engine.GameState, event: engine.TurnEvent) -> list[str]:
+    if event.outcome == engine.OUTCOME_MOVED:
+        messages = [f"MOVED TO {format_position(event.to_position)}, COST {event.fuel_spent}"]
+        if event.supply_applied and event.supply_source is not None:
+            messages.append(format_supply_message(state, event.supply_source))
+        if event.status_after == engine.GAME_STATUS_WON:
+            messages.append("YOU REACHED H")
+        elif event.status_after == engine.GAME_STATUS_LOST_FUEL:
+            messages.append("NO FURTHER MOVE IS POSSIBLE")
+        return messages
+    if event.outcome == engine.OUTCOME_BLOCKED_UNKNOWN_RIFT:
+        messages = [f"RIFT BLOCKED {direction_for_event(event)}, COST 1"]
+        if event.status_after == engine.GAME_STATUS_LOST_FUEL:
+            messages.append("NO FURTHER MOVE IS POSSIBLE")
+        return messages
+    if event.outcome == engine.OUTCOME_REJECTED_KNOWN_RIFT:
+        return [f"KNOWN RIFT {direction_for_event(event)}"]
+    if event.outcome == engine.OUTCOME_OUT_OF_BOUNDS:
+        return ["OUT OF BOUNDS"]
+    if event.outcome == engine.OUTCOME_REJECTED_INSUFFICIENT_FUEL:
+        needed = required_fuel_for_event(state, event)
+        return [f"INSUFFICIENT FUEL: NEED {needed}, HAVE {event.fuel_before}"]
+    if event.outcome == engine.OUTCOME_INVALID_COMMAND:
+        return ["INVALID COMMAND"]
+    raise ValueError(f"unexpected outcome: {event.outcome}")
+
+
+def format_supply_message(state: engine.GameState, source: engine.SupplySource) -> str:
+    if source.kind == engine.BASE_CELL:
+        return f"SUPPLIED AT B: +{state.settings.base_supply}"
+    if source.kind == engine.RESOURCE_CELL:
+        return f"SUPPLIED AT R{format_position(source.position)}: +{state.settings.resource_supply}"
+    raise ValueError(f"unexpected supply source kind: {source.kind}")
+
+
+def direction_for_event(event: engine.TurnEvent) -> str:
+    if event.attempted_position is None:
+        raise ValueError("event does not have an attempted position")
+    dx = event.attempted_position[0] - event.from_position[0]
+    dy = event.attempted_position[1] - event.from_position[1]
+    delta_map = {
+        (0, 1): "N",
+        (1, 0): "E",
+        (0, -1): "S",
+        (-1, 0): "W",
+    }
+    try:
+        return delta_map[(dx, dy)]
+    except KeyError as exc:
+        raise ValueError(f"unexpected move delta: {(dx, dy)!r}") from exc
+
+
+def required_fuel_for_event(state: engine.GameState, event: engine.TurnEvent) -> int:
+    if event.attempted_position is None:
+        raise ValueError("insufficient-fuel event does not have an attempted position")
+    edge = simulate.normalize_edge(event.from_position, event.attempted_position)
+    if engine.is_rift_edge(state, edge):
+        return 1
+    symbol = state.actual_map.cells[event.attempted_position]
+    return simulate.terrain_cost(symbol)
+
+
+def format_position(position: simulate.Position) -> str:
+    return f"({position[0]},{position[1]})"
+
+
+def format_status(status: str) -> str:
+    if status == engine.GAME_STATUS_IN_PROGRESS:
+        return "IN PROGRESS"
+    if status == engine.GAME_STATUS_WON:
+        return "WON"
+    if status == engine.GAME_STATUS_LOST_FUEL:
+        return "LOST FUEL"
+    raise ValueError(f"unexpected game status: {status}")
+
+
+def format_supply_status(state: engine.GameState) -> str:
+    if not state.supply_used or state.supply_source is None:
+        return "unused"
+    if state.supply_source.kind == engine.BASE_CELL:
+        return "B"
+    if state.supply_source.kind == engine.RESOURCE_CELL:
+        return f"R{format_position(state.supply_source.position)}"
+    raise ValueError(f"unexpected supply source kind: {state.supply_source.kind}")
+
+
+def format_blocked_directions(state: engine.GameState) -> str:
+    blocked: list[str] = []
+    for direction in DIRECTION_ORDER:
+        delta = engine.COMMAND_DELTAS[direction]
+        neighbor = engine.move_position(state.player_position, delta)
+        if not engine.is_inside_board(neighbor):
+            continue
+        edge = simulate.normalize_edge(state.player_position, neighbor)
+        if state.known_routes.get(edge) == engine.ROUTE_RIFT:
+            blocked.append(direction)
+    return "-" if not blocked else ",".join(blocked)
+
+
+def build_generation_error_log(requested_seed: int, exc: engine.GenerationError) -> engine.GameLog:
+    return engine.GameLog(
+        schema_version=engine.SCHEMA_VERSION,
+        settings=engine.DEFAULT_SETTINGS,
+        requested_seed=requested_seed,
+        effective_seed=None,
+        reroll_count=None,
+        initial_state=None,
+        events=(),
+        final_summary=None,
+        generation_error=exc.to_info(),
+    )
+
+
+def build_session_log(
+    requested_seed: int,
+    state: engine.GameState,
+    initial_state: dict[str, object],
+    events: list[engine.TurnEvent],
+) -> engine.GameLog:
+    if state.game_status == engine.GAME_STATUS_IN_PROGRESS:
+        final_outcome = ABORTED_BY_USER
+    else:
+        final_outcome = engine.final_outcome_for_status(state.game_status)
+    return engine.build_game_log(
+        settings=state.settings,
+        requested_seed=requested_seed,
+        state=state,
+        initial_state=initial_state,
+        events=events,
+        final_outcome=final_outcome,
+    )
+
+
+def print_generation_error(exc: engine.GenerationError, output: TextIO) -> None:
+    output.write(
+        "GENERATION ERROR: "
+        f"requested={exc.requested_seed} attempts={exc.attempts} "
+        f"reason={exc.reason} message={exc}\n"
+    )
+
+
+def write_json_log(path: Path, log: engine.GameLog) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(log.to_json() + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/galactic_exodus/play.py
+++ b/experiments/galactic_exodus/play.py
@@ -12,8 +12,6 @@ if __package__ in (None, ""):
 
 from experiments.galactic_exodus import engine
 from experiments.galactic_exodus import simulate
-
-
 ABORTED_BY_USER = engine.FINAL_OUTCOME_ABORTED_NO_POLICY_ACTION
 KNOWN_TERRAIN_SYMBOLS = {".", "N", "A", "@", "B", "R"}
 DIRECTION_ORDER = ("N", "E", "S", "W")
@@ -158,8 +156,9 @@ def format_event_messages(state: engine.GameState, event: engine.TurnEvent) -> l
     if event.outcome == engine.OUTCOME_OUT_OF_BOUNDS:
         return ["OUT OF BOUNDS"]
     if event.outcome == engine.OUTCOME_REJECTED_INSUFFICIENT_FUEL:
-        needed = required_fuel_for_event(state, event)
-        return [f"INSUFFICIENT FUEL: NEED {needed}, HAVE {event.fuel_before}"]
+        if event.required_fuel is None:
+            raise ValueError("insufficient-fuel event must include required_fuel")
+        return [f"INSUFFICIENT FUEL: NEED {event.required_fuel}, HAVE {event.fuel_before}"]
     if event.outcome == engine.OUTCOME_INVALID_COMMAND:
         return ["INVALID COMMAND"]
     raise ValueError(f"unexpected outcome: {event.outcome}")
@@ -188,16 +187,6 @@ def direction_for_event(event: engine.TurnEvent) -> str:
         return delta_map[(dx, dy)]
     except KeyError as exc:
         raise ValueError(f"unexpected move delta: {(dx, dy)!r}") from exc
-
-
-def required_fuel_for_event(state: engine.GameState, event: engine.TurnEvent) -> int:
-    if event.attempted_position is None:
-        raise ValueError("insufficient-fuel event does not have an attempted position")
-    edge = simulate.normalize_edge(event.from_position, event.attempted_position)
-    if engine.is_rift_edge(state, edge):
-        return 1
-    symbol = state.actual_map.cells[event.attempted_position]
-    return simulate.terrain_cost(symbol)
 
 
 def format_position(position: simulate.Position) -> str:
@@ -272,9 +261,11 @@ def build_session_log(
 
 
 def print_generation_error(exc: engine.GenerationError, output: TextIO) -> None:
+    last_candidate_seed = "none" if exc.last_candidate_seed is None else str(exc.last_candidate_seed)
     output.write(
         "GENERATION ERROR: "
         f"requested={exc.requested_seed} attempts={exc.attempts} "
+        f"last_candidate_seed={last_candidate_seed} "
         f"reason={exc.reason} message={exc}\n"
     )
 

--- a/experiments/galactic_exodus/test_engine.py
+++ b/experiments/galactic_exodus/test_engine.py
@@ -177,9 +177,11 @@ class ApplyCommandTests(unittest.TestCase):
         self.assertEqual(first.outcome, engine.OUTCOME_BLOCKED_UNKNOWN_RIFT)
         self.assertTrue(first.discovered_rift)
         self.assertEqual(first.fuel_after, 2)
+        self.assertIsNone(first.required_fuel)
         self.assertEqual(first.turn, 1)
         self.assertEqual(second.outcome, engine.OUTCOME_REJECTED_KNOWN_RIFT)
         self.assertEqual(second.fuel_after, 2)
+        self.assertIsNone(second.required_fuel)
         self.assertEqual(second.turn, 1)
         self.assertEqual(state.rift_attempt_count, 1)
 
@@ -262,6 +264,9 @@ class ApplyCommandTests(unittest.TestCase):
         self.assertEqual(invalid.outcome, engine.OUTCOME_INVALID_COMMAND)
         self.assertEqual(out_of_bounds.outcome, engine.OUTCOME_OUT_OF_BOUNDS)
         self.assertEqual(insufficient.outcome, engine.OUTCOME_REJECTED_INSUFFICIENT_FUEL)
+        self.assertIsNone(invalid.required_fuel)
+        self.assertIsNone(out_of_bounds.required_fuel)
+        self.assertEqual(insufficient.required_fuel, 3)
         self.assertEqual(
             snapshot,
             (
@@ -354,6 +359,7 @@ class RunCommandsTests(unittest.TestCase):
         self.assertIn("supply_source", payload["final_summary"])
         if payload["events"]:
             self.assertIn("supply_source", payload["events"][0])
+            self.assertIn("required_fuel", payload["events"][0])
         json.loads(log.to_json())
 
     def test_game_log_serializes_structured_supply_source(self) -> None:

--- a/experiments/galactic_exodus/test_play.py
+++ b/experiments/galactic_exodus/test_play.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from experiments.galactic_exodus import engine
+from experiments.galactic_exodus import play
+from experiments.galactic_exodus import simulate
+from experiments.galactic_exodus.test_engine import filled_cells
+from experiments.galactic_exodus.test_engine import make_actual_map
+from experiments.galactic_exodus.test_engine import make_state
+
+
+class PlayCliTests(unittest.TestCase):
+    def test_script_entrypoint_starts_with_seed_42(self) -> None:
+        result = subprocess.run(
+            ["python", "experiments/galactic_exodus/play.py", "--seed", "42"],
+            cwd=Path(__file__).resolve().parents[2],
+            input="Q\n",
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("SEED: requested=42 effective=42 rerolls=0", result.stdout)
+        self.assertEqual(result.stderr, "")
+
+    def run_cli(
+        self,
+        argv: list[str],
+        stdin_text: str,
+    ) -> tuple[int, str, str]:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        exit_code = play.main(
+            argv,
+            stdin=io.StringIO(stdin_text),
+            stdout=stdout,
+            stderr=stderr,
+        )
+        return exit_code, stdout.getvalue(), stderr.getvalue()
+
+    def test_missing_seed_prints_help_without_starting_game(self) -> None:
+        with patch.object(engine, "create_game") as create_game:
+            exit_code, stdout, stderr = self.run_cli([], "")
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(stdout, "")
+        self.assertIn("--seed", stderr)
+        create_game.assert_not_called()
+
+    def test_invalid_seed_does_not_start_game(self) -> None:
+        with patch.object(engine, "create_game") as create_game:
+            exit_code, stdout, stderr = self.run_cli(["--seed", "oops"], "")
+
+        self.assertEqual(exit_code, 2)
+        self.assertEqual(stdout, "")
+        self.assertIn("invalid int value", stderr)
+        create_game.assert_not_called()
+
+    def test_seed_equals_syntax_is_accepted(self) -> None:
+        exit_code, stdout, stderr = self.run_cli(["--seed=42"], "Q\n")
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn("SEED: requested=42 effective=42 rerolls=0", stdout)
+        self.assertEqual(stderr, "")
+
+    def test_quit_command_exits_without_changing_state(self) -> None:
+        exit_code, stdout, _ = self.run_cli(["--seed", "42"], "Q\n")
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(stdout.count("MAP:\n"), 1)
+        self.assertIn("TURN: 0\n", stdout)
+        self.assertTrue(stdout.endswith("COMMAND> "))
+
+    def test_eof_exits_without_changing_state(self) -> None:
+        exit_code, stdout, _ = self.run_cli(["--seed", "42"], "")
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(stdout.count("MAP:\n"), 1)
+        self.assertIn("STATUS: IN PROGRESS\n", stdout)
+        self.assertTrue(stdout.endswith("COMMAND> "))
+
+    def test_lowercase_and_surrounding_whitespace_are_accepted(self) -> None:
+        exit_code, stdout, _ = self.run_cli(["--seed", "42"], "  e  \nQ\n")
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn("MOVED TO (2,1), COST ", stdout)
+        self.assertIn("TURN: 1\n", stdout)
+
+    def test_invalid_input_leaves_state_unchanged(self) -> None:
+        exit_code, stdout, _ = self.run_cli(["--seed", "42"], "X\nQ\n")
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn("INVALID COMMAND\n", stdout)
+        self.assertIn("POSITION: (1,1)\n", stdout)
+        self.assertIn("TURN: 0\n", stdout)
+
+    def test_renderer_hides_unknown_cells_bases_resources_and_terrain(self) -> None:
+        cells = filled_cells(".")
+        cells[(2, 1)] = "N"
+        actual_map = make_actual_map(cells=cells, base_position=(3, 1), resource_positions=((4, 1),))
+        state = make_state(actual_map=actual_map)
+
+        rendered = play.board_lines(state)
+
+        self.assertEqual(rendered[-1], "y=1 P ? ? ? ? ? ? ?")
+        self.assertIn("y=8 ? ? ? ? ? ? ? H", rendered)
+
+    def test_goal_is_visible_from_start_and_player_has_priority(self) -> None:
+        cells = filled_cells(".")
+        actual_map = make_actual_map(cells=cells)
+        start_state = make_state(actual_map=actual_map)
+        goal_state = make_state(
+            actual_map=actual_map,
+            player_position=simulate.SPECIAL_H,
+            visited_cells={simulate.SPECIAL_H},
+            path=[simulate.SPECIAL_H],
+        )
+
+        self.assertEqual(play.board_lines(start_state)[0], "y=8 ? ? ? ? ? ? ? H")
+        self.assertEqual(play.board_lines(goal_state)[0], "y=8 ? ? ? ? ? ? ? P")
+
+    def test_blocked_line_uses_known_adjacent_rifts(self) -> None:
+        blocked_edge = simulate.normalize_edge((1, 1), (1, 2))
+        state = make_state(
+            actual_map=make_actual_map(cells=filled_cells("."), rift_edges=(blocked_edge,)),
+            known_routes={blocked_edge: engine.ROUTE_RIFT},
+        )
+
+        self.assertEqual(play.format_blocked_directions(state), "N")
+
+    def test_turn_messages_cover_outcomes(self) -> None:
+        blocked_edge = simulate.normalize_edge((1, 1), (1, 2))
+        rift_state = make_state(
+            actual_map=make_actual_map(cells=filled_cells("."), rift_edges=(blocked_edge,)),
+            remaining_fuel=2,
+        )
+        blocked_event = engine.apply_command(rift_state, "N")
+        known_event = engine.apply_command(rift_state, "N")
+
+        cells = filled_cells(".")
+        cells[(2, 1)] = "A"
+        insufficient_state = make_state(actual_map=make_actual_map(cells=cells), remaining_fuel=2)
+        insufficient_event = engine.apply_command(insufficient_state, "E")
+
+        self.assertEqual(play.format_event_messages(rift_state, blocked_event), ["RIFT BLOCKED N, COST 1"])
+        self.assertEqual(play.format_event_messages(rift_state, known_event), ["KNOWN RIFT N"])
+        self.assertEqual(
+            play.format_event_messages(insufficient_state, insufficient_event),
+            ["INSUFFICIENT FUEL: NEED 3, HAVE 2"],
+        )
+
+    def test_generation_error_is_reported_separately(self) -> None:
+        with patch.object(
+            engine,
+            "create_game",
+            side_effect=engine.GenerationError(
+                requested_seed=99,
+                attempts=100,
+                last_candidate_seed=198,
+                reason="NO_REACHABLE_MAP",
+                message="no map",
+            ),
+        ):
+            exit_code, stdout, stderr = self.run_cli(["--seed", "99"], "")
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(stderr, "")
+        self.assertIn("GENERATION ERROR: requested=99 attempts=100 reason=NO_REACHABLE_MAP message=no map", stdout)
+
+    def test_same_seed_and_input_produce_same_output(self) -> None:
+        first = self.run_cli(["--seed", "42"], "E\nN\nQ\n")
+        second = self.run_cli(["--seed", "42"], "E\nN\nQ\n")
+
+        self.assertEqual(first, second)
+
+    def test_json_log_writes_schema_version_1(self) -> None:
+        with tempfile.TemporaryDirectory(dir=".tmp") as tmp_dir:
+            log_path = Path(tmp_dir) / "play-log.json"
+
+            exit_code, stdout, stderr = self.run_cli(
+                ["--seed", "42", "--json-log", str(log_path)],
+                "Q\n",
+            )
+
+            payload = json.loads(log_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(stderr, "")
+        self.assertTrue(stdout.endswith("COMMAND> "))
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertEqual(payload["final_summary"]["outcome"], engine.FINAL_OUTCOME_ABORTED_NO_POLICY_ACTION)
+        self.assertIsNone(payload["generation_error"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experiments/galactic_exodus/test_play.py
+++ b/experiments/galactic_exodus/test_play.py
@@ -173,7 +173,10 @@ class PlayCliTests(unittest.TestCase):
 
         self.assertEqual(exit_code, 1)
         self.assertEqual(stderr, "")
-        self.assertIn("GENERATION ERROR: requested=99 attempts=100 reason=NO_REACHABLE_MAP message=no map", stdout)
+        self.assertIn(
+            "GENERATION ERROR: requested=99 attempts=100 last_candidate_seed=198 reason=NO_REACHABLE_MAP message=no map",
+            stdout,
+        )
 
     def test_same_seed_and_input_produce_same_output(self) -> None:
         first = self.run_cli(["--seed", "42"], "E\nN\nQ\n")


### PR DESCRIPTION
## 概要

Closes #1060

Phase 1A2 prototype として、`experiments/galactic_exodus/play.py` に対話 CLI を追加しました。
ゲーム進行は `engine.create_game()` / `engine.apply_command()` に委譲し、CLI 側は入力正規化、既知情報だけを使う ASCII 表示、固定文言のターン結果表示、JSON ログ出力を担当します。

## 変更内容

- `play.py` を追加し、`python experiments/galactic_exodus/play.py --seed 42` で起動できる対話ループを実装
- known cells / known routes / 現在地だけを使う 8x8 ASCII renderer を実装
- outcome ごとの固定メッセージ、Q/EOF 終了、`--json-log` 出力を実装
- `test_play.py` を追加し、seed 入力、無効入力、Q/EOF、表示優先順位、generation error、再現性、JSON ログを書き出す統合テストを追加
- `experiments/galactic_exodus/README.md` に起動方法、コマンド、盤面記号、状態表示、固定文言、再現方法、JSON ログ、サンプル操作を追記

## 確認

- `python -m unittest experiments.galactic_exodus.test_engine experiments.galactic_exodus.test_play experiments.galactic_exodus.test_simulate experiments.galactic_exodus.test_metrics experiments.galactic_exodus.test_fuel_metrics`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo fmt --check`
