### PR TITLE
Galactic Exodusに周囲観測を追加

### DIFF
--- a/experiments/galactic_exodus/README.md
+++ b/experiments/galactic_exodus/README.md
@@ -4,9 +4,9 @@
 
 これは正式な TBX アプリ実装ではありません。将来の TBX 側の実装は、`examples/galactic_exodus/` など別の場所に置く想定です。
 
-## Phase 1A1 engine
+## Phase 1A prototype engine
 
-`engine.py` は、標準入力や画面表示に依存しない Phase 1A1 用の非対話ゲームエンジンです。
+`engine.py` は、標準入力や画面表示に依存しない Phase 1A 用の非対話ゲームエンジンです。
 マップ生成は既存の `simulate.generate_map()` をそのまま利用し、到達不能マップだけを deterministic に再抽選します。
 
 公開 API:
@@ -49,11 +49,19 @@ log = engine.run_commands(42, ["E", "N", "E"])
 - `effective_seed`
 - `reroll_count`
 
-開始時は `known_cells = {S, H}`、`visited_cells = {S}`、`known_routes = {}` です。
+開始時は `visited_cells = {S}`、`known_routes = {}` です。`known_cells` は `H` に加えて `S` を中心とした 3x3 範囲の盤面内セルで始まります。
+
+観測ルール:
+
+- 開始時に `S` を中心とした 3x3 範囲の盤面内セルを `known_cells` に追加します
+- 成功移動後に、新しい現在地を中心とした 3x3 範囲の盤面内セルを `known_cells` に追加します
+- 既知情報は累積し、離れても失われません
+- 断層は周囲観測では開示されず、移動失敗時にだけ `known_routes` へ記録されます
 
 ### movement contract
 
 - 成功移動: 移動先地形コストを消費し、`known_routes` に `OPEN` を記録する
+- 成功移動: 移動後の現在地を中心とした周囲 8 マスの地形と `B` / `R` を開示する
 - 未知断層への試行: 位置不変、`fuel -1`、`turn +1`、`known_routes` に `RIFT` を記録する
 - 既知断層への再試行: 行動拒否、fuel/turn 不変
 - 盤面外・無効コマンド・燃料不足: 状態不変
@@ -92,7 +100,7 @@ generation error は通常敗北と分離し、`GameLog.generation_error` に記
 
 ### deterministic log schema
 
-`GameLog.schema_version` は `1` 固定です。
+`GameLog.schema_version` は `2` 固定です。
 
 ```text
 GameLog
@@ -118,7 +126,7 @@ TurnEvent
   fuel_before
   fuel_spent
   fuel_after
-  discovered_cell
+  discovered_cells
   discovered_rift
   supply_applied
   supply_source
@@ -164,7 +172,7 @@ python experiments/galactic_exodus/play.py --seed 42 --json-log .tmp/galactic-ex
 - `--seed <int>`
   - 必須。requested seed を指定します。
 - `--json-log <path>`
-  - 任意。終了時に `GameLog schema_version=1` を JSON で書き出します。
+  - 任意。終了時に `GameLog schema_version=2` を JSON で書き出します。
 
 コマンド:
 
@@ -196,6 +204,7 @@ P  現在地
 ```
 
 - `H` は開始時から表示されます
+- `S` 周囲 8 マスの地形と `B` / `R` は開始時から表示されます
 - 未知の地形・B・R は表示しません
 - 表示優先順位は `P > S/H > B/R > terrain > ?` です
 
@@ -239,7 +248,7 @@ requested / effective seed の再現:
 
 JSON ログの用途:
 
-- `--json-log` は CLI セッションを `GameLog schema_version=1` として保存します
+- `--json-log` は CLI セッションを `GameLog schema_version=2` として保存します
 - `Q` / EOF で終了したセッションは `final_summary.outcome = ABORTED_NO_POLICY_ACTION` になります
 - generation error は通常敗北と分離し、`requested / attempts / last_candidate_seed / reason / message` を表示します
 

--- a/experiments/galactic_exodus/engine.py
+++ b/experiments/galactic_exodus/engine.py
@@ -7,7 +7,7 @@ from typing import Iterable
 from experiments.galactic_exodus import simulate
 
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 MAX_GENERATION_ATTEMPTS = 100
 MIN_INT64 = -(2**63)
 MAX_INT64 = 2**63 - 1
@@ -92,6 +92,18 @@ class SupplySource:
         }
 
 
+@dataclass(frozen=True)
+class DiscoveredCell:
+    position: simulate.Position
+    symbol: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "position": position_to_dict(self.position),
+            "symbol": self.symbol,
+        }
+
+
 @dataclass
 class GameState:
     settings: GameSettings
@@ -147,7 +159,7 @@ class TurnEvent:
     fuel_spent: int
     fuel_after: int
     required_fuel: int | None
-    discovered_cell: str | None
+    discovered_cells: tuple[DiscoveredCell, ...]
     discovered_rift: bool
     supply_applied: bool
     supply_source: SupplySource | None
@@ -165,7 +177,7 @@ class TurnEvent:
             "fuel_spent": self.fuel_spent,
             "fuel_after": self.fuel_after,
             "required_fuel": self.required_fuel,
-            "discovered_cell": self.discovered_cell,
+            "discovered_cells": [cell.to_dict() for cell in self.discovered_cells],
             "discovered_rift": self.discovered_rift,
             "supply_applied": self.supply_applied,
             "supply_source": optional_supply_source_to_dict(self.supply_source),
@@ -264,10 +276,7 @@ def create_game(requested_seed: int, settings: GameSettings = DEFAULT_SETTINGS) 
         base_position=galactic_map.b_position,
         resource_positions=tuple(galactic_map.r_positions),
     )
-    known_cells = {
-        settings.start_position: actual_map.cells[settings.start_position],
-        settings.goal_position: actual_map.cells[settings.goal_position],
-    }
+    known_cells = {settings.goal_position: actual_map.cells[settings.goal_position]}
     state = GameState(
         settings=settings,
         actual_map=actual_map,
@@ -285,6 +294,7 @@ def create_game(requested_seed: int, settings: GameSettings = DEFAULT_SETTINGS) 
         reroll_count=reroll_count,
         path=[settings.start_position],
     )
+    reveal_neighborhood(state, settings.start_position)
     state.game_status = determine_game_status(state)
     return state
 
@@ -368,7 +378,7 @@ def apply_command(state: GameState, command: str) -> TurnEvent:
             fuel_spent=0,
             fuel_after=state.remaining_fuel,
             required_fuel=None,
-            discovered_cell=None,
+            discovered_cells=(),
             discovered_rift=False,
             supply_applied=False,
             supply_source=None,
@@ -392,7 +402,7 @@ def apply_command(state: GameState, command: str) -> TurnEvent:
             fuel_spent=0,
             fuel_after=state.remaining_fuel,
             required_fuel=None,
-            discovered_cell=None,
+            discovered_cells=(),
             discovered_rift=False,
             supply_applied=False,
             supply_source=None,
@@ -414,7 +424,7 @@ def apply_command(state: GameState, command: str) -> TurnEvent:
             fuel_spent=0,
             fuel_after=state.remaining_fuel,
             required_fuel=None,
-            discovered_cell=None,
+            discovered_cells=(),
             discovered_rift=False,
             supply_applied=False,
             supply_source=None,
@@ -435,7 +445,7 @@ def apply_command(state: GameState, command: str) -> TurnEvent:
                 fuel_spent=0,
                 fuel_after=state.remaining_fuel,
                 required_fuel=1,
-                discovered_cell=None,
+                discovered_cells=(),
                 discovered_rift=False,
                 supply_applied=False,
                 supply_source=None,
@@ -458,7 +468,7 @@ def apply_command(state: GameState, command: str) -> TurnEvent:
             fuel_spent=1,
             fuel_after=state.remaining_fuel,
             required_fuel=None,
-            discovered_cell=None,
+            discovered_cells=(),
             discovered_rift=True,
             supply_applied=False,
             supply_source=None,
@@ -480,7 +490,7 @@ def apply_command(state: GameState, command: str) -> TurnEvent:
             fuel_spent=0,
             fuel_after=state.remaining_fuel,
             required_fuel=fuel_cost,
-            discovered_cell=None,
+            discovered_cells=(),
             discovered_rift=False,
             supply_applied=False,
             supply_source=None,
@@ -493,10 +503,7 @@ def apply_command(state: GameState, command: str) -> TurnEvent:
     state.known_routes[edge] = ROUTE_OPEN
     state.visited_cells.add(attempted_position)
     state.path.append(attempted_position)
-    discovered_cell = None
-    if attempted_position not in state.known_cells:
-        state.known_cells[attempted_position] = destination_symbol
-        discovered_cell = destination_symbol
+    discovered_cells = reveal_neighborhood(state, attempted_position)
 
     supply_applied, supply_source = maybe_apply_supply(
         state,
@@ -520,7 +527,7 @@ def apply_command(state: GameState, command: str) -> TurnEvent:
         fuel_spent=fuel_cost,
         fuel_after=state.remaining_fuel,
         required_fuel=None,
-        discovered_cell=discovered_cell,
+        discovered_cells=discovered_cells,
         discovered_rift=False,
         supply_applied=supply_applied,
         supply_source=supply_source,
@@ -595,6 +602,25 @@ def maybe_apply_supply(
     state.supply_source = SupplySource(kind=destination_symbol, position=position)
     state.remaining_fuel += supply_amount
     return True, state.supply_source
+
+
+def reveal_neighborhood(
+    state: GameState,
+    center: simulate.Position,
+    radius: int = 1,
+) -> tuple[DiscoveredCell, ...]:
+    discovered: list[DiscoveredCell] = []
+    for y in range(center[1] - radius, center[1] + radius + 1):
+        for x in range(center[0] - radius, center[0] + radius + 1):
+            position = (x, y)
+            if not is_inside_board(position):
+                continue
+            if position in state.known_cells:
+                continue
+            symbol = state.actual_map.cells[position]
+            state.known_cells[position] = symbol
+            discovered.append(DiscoveredCell(position=position, symbol=symbol))
+    return tuple(sorted(discovered, key=lambda cell: cell.position))
 
 
 def determine_game_status(state: GameState) -> str:

--- a/experiments/galactic_exodus/play.py
+++ b/experiments/galactic_exodus/play.py
@@ -35,7 +35,7 @@ def build_parser(stderr: TextIO) -> argparse.ArgumentParser:
     parser.add_argument(
         "--json-log",
         type=Path,
-        help="Write the final GameLog schema_version=1 JSON to this path.",
+        help="Write the final GameLog schema_version=2 JSON to this path.",
     )
     return parser
 
@@ -118,7 +118,7 @@ def board_lines(state: engine.GameState) -> list[str]:
     rows: list[str] = []
     for y in range(simulate.HEIGHT, 0, -1):
         symbols = [display_symbol(state, (x, y)) for x in range(1, simulate.WIDTH + 1)]
-        rows.append(f"{y} {' '.join(symbols)}")
+        rows.append(f"y={y} {' '.join(symbols)}")
     return rows
 
 

--- a/experiments/galactic_exodus/test_engine.py
+++ b/experiments/galactic_exodus/test_engine.py
@@ -81,12 +81,51 @@ def make_state(
     return state
 
 
+def start_neighborhood_known_cells(
+    actual_map: engine.ActualMap,
+) -> dict[simulate.Position, str]:
+    return {
+        (1, 1): actual_map.cells[(1, 1)],
+        (1, 2): actual_map.cells[(1, 2)],
+        (2, 1): actual_map.cells[(2, 1)],
+        (2, 2): actual_map.cells[(2, 2)],
+        simulate.SPECIAL_H: actual_map.cells[simulate.SPECIAL_H],
+    }
+
+
 class CreateGameTests(unittest.TestCase):
-    def test_create_game_starts_with_only_s_and_h_known(self) -> None:
-        state = engine.create_game(42)
+    def test_create_game_reveals_start_neighborhood_and_home(self) -> None:
+        custom_map = simulate.GalacticMap(
+            seed=42,
+            resource_count=1,
+            rift_density=0.10,
+            b_position=(4, 4),
+            r_positions=[(5, 5)],
+            rift_edges=(),
+            cells=make_actual_map(
+                cells=filled_cells("."),
+                base_position=(4, 4),
+                resource_positions=((5, 5),),
+            ).cells,
+        )
+        with patch.object(
+            engine,
+            "create_playable_map",
+            return_value=(custom_map, 42, 0),
+        ):
+            state = engine.create_game(42)
 
         self.assertEqual(state.player_position, simulate.SPECIAL_S)
-        self.assertEqual(state.known_cells, {simulate.SPECIAL_S: "S", simulate.SPECIAL_H: "H"})
+        self.assertEqual(
+            state.known_cells,
+            {
+                (1, 1): "S",
+                (1, 2): ".",
+                (2, 1): ".",
+                (2, 2): ".",
+                simulate.SPECIAL_H: "H",
+            },
+        )
         self.assertEqual(state.visited_cells, {simulate.SPECIAL_S})
         self.assertEqual(state.known_routes, {})
         self.assertEqual(state.turn_count, 0)
@@ -155,17 +194,66 @@ class ApplyCommandTests(unittest.TestCase):
     def test_move_consumes_destination_terrain_cost_and_discovers_cell(self) -> None:
         cells = filled_cells(".")
         cells[(2, 1)] = "A"
-        state = make_state(actual_map=make_actual_map(cells=cells), remaining_fuel=10)
+        actual_map = make_actual_map(cells=cells)
+        state = make_state(
+            actual_map=actual_map,
+            remaining_fuel=10,
+            known_cells=start_neighborhood_known_cells(actual_map),
+        )
 
         event = engine.apply_command(state, "E")
 
         self.assertEqual(event.outcome, engine.OUTCOME_MOVED)
         self.assertEqual(event.fuel_spent, 3)
-        self.assertEqual(event.discovered_cell, "A")
+        self.assertEqual(
+            event.discovered_cells,
+            (
+                engine.DiscoveredCell(position=(3, 1), symbol="."),
+                engine.DiscoveredCell(position=(3, 2), symbol="."),
+            ),
+        )
         self.assertEqual(state.player_position, (2, 1))
         self.assertEqual(state.remaining_fuel, 7)
         self.assertEqual(state.turn_count, 1)
         self.assertEqual(state.known_routes[simulate.normalize_edge((1, 1), (2, 1))], engine.ROUTE_OPEN)
+        self.assertEqual(state.known_cells[(2, 1)], "A")
+
+    def test_move_reveals_centered_three_by_three_without_losing_known_cells(self) -> None:
+        cells = filled_cells(".")
+        cells[(2, 2)] = "B"
+        cells[(3, 2)] = "R"
+        cells[(3, 1)] = "A"
+        state = make_state(
+            actual_map=make_actual_map(cells=cells, base_position=(2, 2), resource_positions=((3, 2),)),
+            player_position=(2, 1),
+            known_cells={
+                (1, 1): "S",
+                (1, 2): ".",
+                (2, 1): ".",
+                (2, 2): "B",
+                simulate.SPECIAL_H: "H",
+            },
+            visited_cells={(1, 1), (2, 1)},
+            path=[(1, 1), (2, 1)],
+            remaining_fuel=10,
+        )
+
+        event = engine.apply_command(state, "N")
+
+        self.assertEqual(event.outcome, engine.OUTCOME_MOVED)
+        self.assertEqual(
+            event.discovered_cells,
+            (
+                engine.DiscoveredCell(position=(1, 3), symbol="."),
+                engine.DiscoveredCell(position=(2, 3), symbol="."),
+                engine.DiscoveredCell(position=(3, 1), symbol="A"),
+                engine.DiscoveredCell(position=(3, 2), symbol="R"),
+                engine.DiscoveredCell(position=(3, 3), symbol="."),
+            ),
+        )
+        self.assertEqual(state.known_cells[(1, 1)], "S")
+        self.assertEqual(state.known_cells[(3, 2)], "R")
+        self.assertEqual(state.known_cells[(3, 1)], "A")
 
     def test_unknown_rift_consumes_one_fuel_and_known_rift_retry_is_rejected(self) -> None:
         rift_edge = (simulate.normalize_edge((1, 1), (1, 2)),)
@@ -179,10 +267,12 @@ class ApplyCommandTests(unittest.TestCase):
         self.assertEqual(first.fuel_after, 2)
         self.assertIsNone(first.required_fuel)
         self.assertEqual(first.turn, 1)
+        self.assertEqual(first.discovered_cells, ())
         self.assertEqual(second.outcome, engine.OUTCOME_REJECTED_KNOWN_RIFT)
         self.assertEqual(second.fuel_after, 2)
         self.assertIsNone(second.required_fuel)
         self.assertEqual(second.turn, 1)
+        self.assertEqual(second.discovered_cells, ())
         self.assertEqual(state.rift_attempt_count, 1)
 
     def test_base_supply_applies_once_even_on_revisit(self) -> None:
@@ -267,6 +357,9 @@ class ApplyCommandTests(unittest.TestCase):
         self.assertIsNone(invalid.required_fuel)
         self.assertIsNone(out_of_bounds.required_fuel)
         self.assertEqual(insufficient.required_fuel, 3)
+        self.assertEqual(invalid.discovered_cells, ())
+        self.assertEqual(out_of_bounds.discovered_cells, ())
+        self.assertEqual(insufficient.discovered_cells, ())
         self.assertEqual(
             snapshot,
             (
@@ -353,13 +446,14 @@ class RunCommandsTests(unittest.TestCase):
                 "generation_error",
             ],
         )
-        self.assertEqual(payload["schema_version"], 1)
+        self.assertEqual(payload["schema_version"], 2)
         self.assertIn("outcome", payload["final_summary"])
         self.assertIn("path", payload["final_summary"])
         self.assertIn("supply_source", payload["final_summary"])
         if payload["events"]:
             self.assertIn("supply_source", payload["events"][0])
             self.assertIn("required_fuel", payload["events"][0])
+            self.assertIn("discovered_cells", payload["events"][0])
         json.loads(log.to_json())
 
     def test_game_log_serializes_structured_supply_source(self) -> None:
@@ -412,6 +506,26 @@ class RunCommandsTests(unittest.TestCase):
                 "reason": "SEED_OVERFLOW",
                 "message": "overflow",
             },
+        )
+
+    def test_game_log_serializes_all_discovered_cells_in_deterministic_order(self) -> None:
+        cells = filled_cells(".")
+        cells[(2, 1)] = "A"
+        actual_map = make_actual_map(cells=cells)
+        state = make_state(
+            actual_map=actual_map,
+            remaining_fuel=10,
+            known_cells=start_neighborhood_known_cells(actual_map),
+        )
+        with patch.object(engine, "create_game", return_value=state):
+            payload = engine.run_commands(1, ["E"]).to_dict()
+
+        self.assertEqual(
+            payload["events"][0]["discovered_cells"],
+            [
+                {"position": {"x": 3, "y": 1}, "symbol": "."},
+                {"position": {"x": 3, "y": 2}, "symbol": "."},
+            ],
         )
 
 

--- a/experiments/galactic_exodus/test_play.py
+++ b/experiments/galactic_exodus/test_play.py
@@ -184,7 +184,7 @@ class PlayCliTests(unittest.TestCase):
 
         self.assertEqual(first, second)
 
-    def test_json_log_writes_schema_version_1(self) -> None:
+    def test_json_log_writes_schema_version_2(self) -> None:
         with tempfile.TemporaryDirectory(dir=".tmp") as tmp_dir:
             log_path = Path(tmp_dir) / "play-log.json"
 
@@ -198,7 +198,7 @@ class PlayCliTests(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         self.assertEqual(stderr, "")
         self.assertTrue(stdout.endswith("COMMAND> "))
-        self.assertEqual(payload["schema_version"], 1)
+        self.assertEqual(payload["schema_version"], 2)
         self.assertEqual(payload["final_summary"]["outcome"], engine.FINAL_OUTCOME_ABORTED_NO_POLICY_ACTION)
         self.assertIsNone(payload["generation_error"])
 


### PR DESCRIPTION
## 概要

Closes #1064

Galactic Exodus Phase 1A prototype に、現在地を中心とした 3x3 の局所観測を追加しました。
開始時と成功移動後に盤面内セルを `known_cells` へ累積開示し、断層は従来どおり移動失敗時だけ `known_routes` で判明します。

## 変更内容

- `engine.py` に `reveal_neighborhood()` を追加し、開始時と成功移動後の開示処理を集約
- `TurnEvent.discovered_cell` を `discovered_cells` へ置き換え、座標順で決定的に記録
- `GameLog.schema_version` を `2` に更新
- CLI/README を新しい観測仕様とログ契約に合わせて更新
- 初期開示、移動後開示、非開示、ログ順序のテストを追加

## 確認

- `python -m unittest discover -s experiments/galactic_exodus -p 'test_*.py'`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo fmt --check`
