### PR TITLE
Galactic Exodusの基地再補給と資源個別消費を実装

### DIFF
--- a/experiments/galactic_exodus/README.md
+++ b/experiments/galactic_exodus/README.md
@@ -41,8 +41,12 @@ log = engine.run_commands(42, ["E", "N", "E"])
 - `known_routes`
 - `player_position`
 - `remaining_fuel`
-- `supply_used`
-- `supply_source`
+- `used_resource_positions`
+- `base_visit_count`
+- `base_refuel_count`
+- `resource_visit_count`
+- `resource_refuel_count`
+- `last_supply_source`
 - `turn_count`
 - `game_status`
 - `requested_seed`
@@ -66,7 +70,12 @@ log = engine.run_commands(42, ["E", "N", "E"])
 - 既知断層への再試行: 行動拒否、fuel/turn 不変
 - 盤面外・無効コマンド・燃料不足: 状態不変
 - `H` / `B` / `R` へ残量 0 ちょうどで到着してよい
-- 補給は `B` または `R` の最初の 1 回だけで、到着後に加算する
+- `B` は到着ごとに `max_fuel=16` まで即時補給する
+- `B` は何度でも利用できる
+- `R` は燃料が実際に増加した最初の到着時だけ消費される
+- 満タンで未使用 `R` へ到着しても `R` は残る
+- 使用済み `R` は再利用できない
+- 補給は到着ターン内で即時適用され、追加 turn は発生しない
 
 ### turn outcomes
 
@@ -95,12 +104,12 @@ log = engine.run_commands(42, ["E", "N", "E"])
 - `ABORTED_NO_POLICY_ACTION`
 
 generation error は通常敗北と分離し、`GameLog.generation_error` に記録します。
-`supply_source` は `{"kind": "B"|"R", "position": {"x": ..., "y": ...}}` の構造で保持し、
-補給後に別セルへ移動したあとも補給元座標を参照できます。
+`last_supply_source` は `{"kind": "B"|"R", "position": {"x": ..., "y": ...}}` の構造で保持し、
+直近に実際の燃料増加が起きた補給元座標を参照できます。
 
 ### deterministic log schema
 
-`GameLog.schema_version` は `2` 固定です。
+`GameLog.schema_version` は `3` 固定です。
 
 ```text
 GameLog
@@ -128,8 +137,11 @@ TurnEvent
   fuel_after
   discovered_cells
   discovered_rift
-  supply_applied
+  supply_result
   supply_source
+  fuel_before_supply
+  fuel_after_supply
+  supply_amount
   status_after
 ```
 
@@ -138,9 +150,13 @@ final_summary
   outcome
   turn_count
   remaining_fuel
-  supply_source
-  base_visited
-  resource_visits
+  max_fuel
+  used_resource_positions
+  base_visit_count
+  base_refuel_count
+  resource_visit_count
+  resource_refuel_count
+  last_supply_source
   rift_attempts
   invalid_or_rejected_actions
   path
@@ -172,7 +188,7 @@ python experiments/galactic_exodus/play.py --seed 42 --json-log .tmp/galactic-ex
 - `--seed <int>`
   - 必須。requested seed を指定します。
 - `--json-log <path>`
-  - 任意。終了時に `GameLog schema_version=2` を JSON で書き出します。
+  - 任意。終了時に `GameLog schema_version=3` を JSON で書き出します。
 
 コマンド:
 
@@ -213,8 +229,9 @@ P  現在地
 ```text
 SEED: requested=<n> effective=<n> rerolls=<n>
 POSITION: (<x>,<y>)
-FUEL: <remaining>
-SUPPLY: unused | B | R(<x>,<y>)
+FUEL: <remaining>/<max>
+LAST SUPPLY: none | B(<x>,<y>) | R(<x>,<y>)
+USED R: - | (x1,y1),(x2,y2),...
 TURN: <n>
 STATUS: IN PROGRESS | WON | LOST FUEL
 BLOCKED: <known-rift-directions or ->
@@ -229,8 +246,11 @@ KNOWN RIFT <direction>
 OUT OF BOUNDS
 INVALID COMMAND
 INSUFFICIENT FUEL: NEED n, HAVE m
-SUPPLIED AT B: +8
-SUPPLIED AT R(x,y): +5
+REFUELED AT B(x,y): <before> -> <after>
+BASE ALREADY FULL AT B(x,y)
+REFUELED AT R(x,y): +<amount> (<before> -> <after>)
+RESOURCE ALREADY FULL AT R(x,y)
+RESOURCE ALREADY USED AT R(x,y)
 YOU REACHED H
 NO FURTHER MOVE IS POSSIBLE
 ```
@@ -238,7 +258,9 @@ NO FURTHER MOVE IS POSSIBLE
 fuel / 断層 / 補給 / 勝敗:
 
 - 各移動コストと断層判定は `engine.apply_command()` の結果をそのまま表示します
-- `B` 補給は 1 回だけ `+8`、`R` 補給も 1 回だけ `+5` です
+- `max_fuel=16`
+- `B` は到着ごとに満タンまで回復し、何度でも利用できます
+- `R` は最大 `+5` を供給し、燃料が増えた最初の到着時だけ消費されます
 - `STATUS: WON` で勝利、`STATUS: LOST FUEL` で行動不能です
 
 requested / effective seed の再現:
@@ -248,7 +270,7 @@ requested / effective seed の再現:
 
 JSON ログの用途:
 
-- `--json-log` は CLI セッションを `GameLog schema_version=2` として保存します
+- `--json-log` は CLI セッションを `GameLog schema_version=3` として保存します
 - `Q` / EOF で終了したセッションは `final_summary.outcome = ABORTED_NO_POLICY_ACTION` になります
 - generation error は通常敗北と分離し、`requested / attempts / last_candidate_seed / reason / message` を表示します
 
@@ -267,11 +289,12 @@ y=4 ? ? ? ? ? ? ? ?
 y=3 ? ? ? ? ? ? ? ?
 y=2 ? ? ? ? ? ? ? ?
 y=1 P ? ? ? ? ? ? ?
-     x=1 2 3 4 5 6 7 8
+  1 2 3 4 5 6 7 8
 SEED: requested=42 effective=42 rerolls=0
 POSITION: (1,1)
-FUEL: 16
-SUPPLY: unused
+FUEL: 16/16
+LAST SUPPLY: none
+USED R: -
 TURN: 0
 STATUS: IN PROGRESS
 BLOCKED: -

--- a/experiments/galactic_exodus/engine.py
+++ b/experiments/galactic_exodus/engine.py
@@ -7,7 +7,7 @@ from typing import Iterable
 from experiments.galactic_exodus import simulate
 
 
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 MAX_GENERATION_ATTEMPTS = 100
 MIN_INT64 = -(2**63)
 MAX_INT64 = 2**63 - 1
@@ -35,6 +35,13 @@ RESOURCE_CELL = "R"
 BASE_CELL = "B"
 HOME_CELL = "H"
 
+SUPPLY_RESULT_NONE = "NONE"
+SUPPLY_RESULT_BASE_REFUELED = "BASE_REFUELED"
+SUPPLY_RESULT_BASE_ALREADY_FULL = "BASE_ALREADY_FULL"
+SUPPLY_RESULT_RESOURCE_REFUELED = "RESOURCE_REFUELED"
+SUPPLY_RESULT_RESOURCE_ALREADY_FULL = "RESOURCE_ALREADY_FULL"
+SUPPLY_RESULT_RESOURCE_ALREADY_USED = "RESOURCE_ALREADY_USED"
+
 COMMAND_DELTAS: dict[str, tuple[int, int]] = {
     "N": (0, 1),
     "E": (1, 0),
@@ -51,7 +58,7 @@ class GameSettings:
     goal_position: simulate.Position = simulate.SPECIAL_H
     rift_density: float = simulate.DEFAULT_RIFT_DENSITY
     initial_fuel: int = simulate.DEFAULT_INITIAL_FUEL
-    base_supply: int = simulate.DEFAULT_BASE_SUPPLY
+    max_fuel: int = simulate.DEFAULT_INITIAL_FUEL
     resource_count: int = simulate.DEFAULT_RESOURCE_COUNT
     resource_supply: int = simulate.DEFAULT_RESOURCE_SUPPLY
 
@@ -64,9 +71,11 @@ class GameSettings:
             raise ValueError("goal_position must be (8, 8)")
         simulate.validate_rift_density(self.rift_density)
         simulate.validate_non_negative("initial-fuel", self.initial_fuel)
-        simulate.validate_non_negative("base-supply", self.base_supply)
+        simulate.validate_non_negative("max-fuel", self.max_fuel)
         simulate.validate_non_negative("resource-supply", self.resource_supply)
         simulate.validate_resource_count(self.resource_count)
+        if self.initial_fuel > self.max_fuel:
+            raise ValueError("initial-fuel must be less than or equal to max-fuel")
 
 
 DEFAULT_SETTINGS = GameSettings()
@@ -113,18 +122,20 @@ class GameState:
     known_routes: dict[simulate.Edge, str]
     player_position: simulate.Position
     remaining_fuel: int
-    supply_used: bool
-    supply_source: SupplySource | None
+    used_resource_positions: set[simulate.Position]
+    base_visit_count: int
+    base_refuel_count: int
+    resource_visit_count: int
+    resource_refuel_count: int
+    last_supply_source: SupplySource | None
     turn_count: int
     game_status: str
     requested_seed: int
     effective_seed: int
     reroll_count: int
-    resource_visit_count: int = 0
     rift_attempt_count: int = 0
     invalid_or_rejected_action_count: int = 0
     path: list[simulate.Position] = field(default_factory=list)
-    base_visited: bool = False
 
 
 @dataclass(frozen=True)
@@ -161,8 +172,11 @@ class TurnEvent:
     required_fuel: int | None
     discovered_cells: tuple[DiscoveredCell, ...]
     discovered_rift: bool
-    supply_applied: bool
+    supply_result: str
     supply_source: SupplySource | None
+    fuel_before_supply: int | None
+    fuel_after_supply: int | None
+    supply_amount: int
     status_after: str
 
     def to_dict(self) -> dict[str, object]:
@@ -179,8 +193,11 @@ class TurnEvent:
             "required_fuel": self.required_fuel,
             "discovered_cells": [cell.to_dict() for cell in self.discovered_cells],
             "discovered_rift": self.discovered_rift,
-            "supply_applied": self.supply_applied,
+            "supply_result": self.supply_result,
             "supply_source": optional_supply_source_to_dict(self.supply_source),
+            "fuel_before_supply": self.fuel_before_supply,
+            "fuel_after_supply": self.fuel_after_supply,
+            "supply_amount": self.supply_amount,
             "status_after": self.status_after,
         }
 
@@ -190,9 +207,13 @@ class FinalSummary:
     outcome: str
     turn_count: int
     remaining_fuel: int
-    supply_source: SupplySource | None
-    base_visited: bool
-    resource_visits: int
+    max_fuel: int
+    used_resource_positions: tuple[simulate.Position, ...]
+    base_visit_count: int
+    base_refuel_count: int
+    resource_visit_count: int
+    resource_refuel_count: int
+    last_supply_source: SupplySource | None
     rift_attempts: int
     invalid_or_rejected_actions: int
     path: tuple[simulate.Position, ...]
@@ -202,13 +223,26 @@ class FinalSummary:
             "outcome": self.outcome,
             "turn_count": self.turn_count,
             "remaining_fuel": self.remaining_fuel,
-            "supply_source": optional_supply_source_to_dict(self.supply_source),
-            "base_visited": self.base_visited,
-            "resource_visits": self.resource_visits,
+            "max_fuel": self.max_fuel,
+            "used_resource_positions": positions_to_sorted_dicts(set(self.used_resource_positions)),
+            "base_visit_count": self.base_visit_count,
+            "base_refuel_count": self.base_refuel_count,
+            "resource_visit_count": self.resource_visit_count,
+            "resource_refuel_count": self.resource_refuel_count,
+            "last_supply_source": optional_supply_source_to_dict(self.last_supply_source),
             "rift_attempts": self.rift_attempts,
             "invalid_or_rejected_actions": self.invalid_or_rejected_actions,
             "path": [position_to_dict(position) for position in self.path],
         }
+
+
+@dataclass(frozen=True)
+class SupplyResolution:
+    result: str
+    source: SupplySource | None
+    fuel_before_supply: int | None
+    fuel_after_supply: int | None
+    supply_amount: int
 
 
 @dataclass(frozen=True)
@@ -285,8 +319,12 @@ def create_game(requested_seed: int, settings: GameSettings = DEFAULT_SETTINGS) 
         known_routes={},
         player_position=settings.start_position,
         remaining_fuel=settings.initial_fuel,
-        supply_used=False,
-        supply_source=None,
+        used_resource_positions=set(),
+        base_visit_count=0,
+        base_refuel_count=0,
+        resource_visit_count=0,
+        resource_refuel_count=0,
+        last_supply_source=None,
         turn_count=0,
         game_status=GAME_STATUS_IN_PROGRESS,
         requested_seed=requested_seed,
@@ -380,8 +418,11 @@ def apply_command(state: GameState, command: str) -> TurnEvent:
             required_fuel=None,
             discovered_cells=(),
             discovered_rift=False,
-            supply_applied=False,
+            supply_result=SUPPLY_RESULT_NONE,
             supply_source=None,
+            fuel_before_supply=None,
+            fuel_after_supply=None,
+            supply_amount=0,
             status_after=state.game_status,
         )
 
@@ -404,8 +445,11 @@ def apply_command(state: GameState, command: str) -> TurnEvent:
             required_fuel=None,
             discovered_cells=(),
             discovered_rift=False,
-            supply_applied=False,
+            supply_result=SUPPLY_RESULT_NONE,
             supply_source=None,
+            fuel_before_supply=None,
+            fuel_after_supply=None,
+            supply_amount=0,
             status_after=state.game_status,
         )
 
@@ -426,8 +470,11 @@ def apply_command(state: GameState, command: str) -> TurnEvent:
             required_fuel=None,
             discovered_cells=(),
             discovered_rift=False,
-            supply_applied=False,
+            supply_result=SUPPLY_RESULT_NONE,
             supply_source=None,
+            fuel_before_supply=None,
+            fuel_after_supply=None,
+            supply_amount=0,
             status_after=state.game_status,
         )
 
@@ -447,8 +494,11 @@ def apply_command(state: GameState, command: str) -> TurnEvent:
                 required_fuel=1,
                 discovered_cells=(),
                 discovered_rift=False,
-                supply_applied=False,
+                supply_result=SUPPLY_RESULT_NONE,
                 supply_source=None,
+                fuel_before_supply=None,
+                fuel_after_supply=None,
+                supply_amount=0,
                 status_after=state.game_status,
             )
 
@@ -470,8 +520,11 @@ def apply_command(state: GameState, command: str) -> TurnEvent:
             required_fuel=None,
             discovered_cells=(),
             discovered_rift=True,
-            supply_applied=False,
+            supply_result=SUPPLY_RESULT_NONE,
             supply_source=None,
+            fuel_before_supply=None,
+            fuel_after_supply=None,
+            supply_amount=0,
             status_after=state.game_status,
         )
 
@@ -492,8 +545,11 @@ def apply_command(state: GameState, command: str) -> TurnEvent:
             required_fuel=fuel_cost,
             discovered_cells=(),
             discovered_rift=False,
-            supply_applied=False,
+            supply_result=SUPPLY_RESULT_NONE,
             supply_source=None,
+            fuel_before_supply=None,
+            fuel_after_supply=None,
+            supply_amount=0,
             status_after=state.game_status,
         )
 
@@ -505,15 +561,11 @@ def apply_command(state: GameState, command: str) -> TurnEvent:
     state.path.append(attempted_position)
     discovered_cells = reveal_neighborhood(state, attempted_position)
 
-    supply_applied, supply_source = maybe_apply_supply(
+    supply_resolution = maybe_apply_supply(
         state,
         destination_symbol,
         attempted_position,
     )
-    if destination_symbol == BASE_CELL:
-        state.base_visited = True
-    if destination_symbol == RESOURCE_CELL:
-        state.resource_visit_count += 1
 
     state.game_status = determine_game_status(state)
     return TurnEvent(
@@ -529,8 +581,11 @@ def apply_command(state: GameState, command: str) -> TurnEvent:
         required_fuel=None,
         discovered_cells=discovered_cells,
         discovered_rift=False,
-        supply_applied=supply_applied,
-        supply_source=supply_source,
+        supply_result=supply_resolution.result,
+        supply_source=supply_resolution.source,
+        fuel_before_supply=supply_resolution.fuel_before_supply,
+        fuel_after_supply=supply_resolution.fuel_after_supply,
+        supply_amount=supply_resolution.supply_amount,
         status_after=state.game_status,
     )
 
@@ -589,19 +644,89 @@ def maybe_apply_supply(
     state: GameState,
     destination_symbol: str,
     position: simulate.Position,
-) -> tuple[bool, SupplySource | None]:
-    if state.supply_used:
-        return False, None
+) -> SupplyResolution:
     if destination_symbol == BASE_CELL:
-        supply_amount = state.settings.base_supply
-    elif destination_symbol == RESOURCE_CELL:
-        supply_amount = state.settings.resource_supply
-    else:
-        return False, None
-    state.supply_used = True
-    state.supply_source = SupplySource(kind=destination_symbol, position=position)
+        return apply_base_supply(state, position)
+    if destination_symbol == RESOURCE_CELL:
+        return apply_resource_supply(state, position)
+    return SupplyResolution(
+        result=SUPPLY_RESULT_NONE,
+        source=None,
+        fuel_before_supply=None,
+        fuel_after_supply=None,
+        supply_amount=0,
+    )
+
+
+def apply_base_supply(
+    state: GameState,
+    position: simulate.Position,
+) -> SupplyResolution:
+    state.base_visit_count += 1
+    source = SupplySource(kind=BASE_CELL, position=position)
+    fuel_before_supply = state.remaining_fuel
+    supply_amount = state.settings.max_fuel - fuel_before_supply
+    if supply_amount <= 0:
+        return SupplyResolution(
+            result=SUPPLY_RESULT_BASE_ALREADY_FULL,
+            source=source,
+            fuel_before_supply=fuel_before_supply,
+            fuel_after_supply=fuel_before_supply,
+            supply_amount=0,
+        )
+
+    state.remaining_fuel = state.settings.max_fuel
+    state.base_refuel_count += 1
+    state.last_supply_source = source
+    return SupplyResolution(
+        result=SUPPLY_RESULT_BASE_REFUELED,
+        source=source,
+        fuel_before_supply=fuel_before_supply,
+        fuel_after_supply=state.remaining_fuel,
+        supply_amount=supply_amount,
+    )
+
+
+def apply_resource_supply(
+    state: GameState,
+    position: simulate.Position,
+) -> SupplyResolution:
+    state.resource_visit_count += 1
+    source = SupplySource(kind=RESOURCE_CELL, position=position)
+    fuel_before_supply = state.remaining_fuel
+    if position in state.used_resource_positions:
+        return SupplyResolution(
+            result=SUPPLY_RESULT_RESOURCE_ALREADY_USED,
+            source=source,
+            fuel_before_supply=fuel_before_supply,
+            fuel_after_supply=fuel_before_supply,
+            supply_amount=0,
+        )
+
+    supply_amount = min(
+        state.settings.resource_supply,
+        state.settings.max_fuel - state.remaining_fuel,
+    )
+    if supply_amount <= 0:
+        return SupplyResolution(
+            result=SUPPLY_RESULT_RESOURCE_ALREADY_FULL,
+            source=source,
+            fuel_before_supply=fuel_before_supply,
+            fuel_after_supply=fuel_before_supply,
+            supply_amount=0,
+        )
+
     state.remaining_fuel += supply_amount
-    return True, state.supply_source
+    state.used_resource_positions.add(position)
+    state.resource_refuel_count += 1
+    state.last_supply_source = source
+    return SupplyResolution(
+        result=SUPPLY_RESULT_RESOURCE_REFUELED,
+        source=source,
+        fuel_before_supply=fuel_before_supply,
+        fuel_after_supply=state.remaining_fuel,
+        supply_amount=supply_amount,
+    )
 
 
 def reveal_neighborhood(
@@ -684,9 +809,13 @@ def build_game_log(
             outcome=final_outcome,
             turn_count=state.turn_count,
             remaining_fuel=state.remaining_fuel,
-            supply_source=state.supply_source,
-            base_visited=state.base_visited,
-            resource_visits=state.resource_visit_count,
+            max_fuel=state.settings.max_fuel,
+            used_resource_positions=tuple(sorted(state.used_resource_positions)),
+            base_visit_count=state.base_visit_count,
+            base_refuel_count=state.base_refuel_count,
+            resource_visit_count=state.resource_visit_count,
+            resource_refuel_count=state.resource_refuel_count,
+            last_supply_source=state.last_supply_source,
             rift_attempts=state.rift_attempt_count,
             invalid_or_rejected_actions=state.invalid_or_rejected_action_count,
             path=tuple(state.path),
@@ -703,8 +832,13 @@ def snapshot_state(state: GameState) -> dict[str, object]:
         "known_routes": known_routes_to_dict(state.known_routes),
         "player_position": position_to_dict(state.player_position),
         "remaining_fuel": state.remaining_fuel,
-        "supply_used": state.supply_used,
-        "supply_source": optional_supply_source_to_dict(state.supply_source),
+        "max_fuel": state.settings.max_fuel,
+        "used_resource_positions": positions_to_sorted_dicts(state.used_resource_positions),
+        "base_visit_count": state.base_visit_count,
+        "base_refuel_count": state.base_refuel_count,
+        "resource_visit_count": state.resource_visit_count,
+        "resource_refuel_count": state.resource_refuel_count,
+        "last_supply_source": optional_supply_source_to_dict(state.last_supply_source),
         "turn_count": state.turn_count,
         "game_status": state.game_status,
         "requested_seed": state.requested_seed,
@@ -721,7 +855,7 @@ def settings_to_dict(settings: GameSettings) -> dict[str, object]:
         "goal_position": position_to_dict(settings.goal_position),
         "rift_density": settings.rift_density,
         "initial_fuel": settings.initial_fuel,
-        "base_supply": settings.base_supply,
+        "max_fuel": settings.max_fuel,
         "resource_count": settings.resource_count,
         "resource_supply": settings.resource_supply,
     }

--- a/experiments/galactic_exodus/play.py
+++ b/experiments/galactic_exodus/play.py
@@ -35,7 +35,7 @@ def build_parser(stderr: TextIO) -> argparse.ArgumentParser:
     parser.add_argument(
         "--json-log",
         type=Path,
-        help="Write the final GameLog schema_version=2 JSON to this path.",
+        help="Write the final GameLog schema_version=3 JSON to this path.",
     )
     return parser
 
@@ -107,8 +107,9 @@ def render_state(state: engine.GameState, output: TextIO) -> None:
         f"SEED: requested={state.requested_seed} effective={state.effective_seed} rerolls={state.reroll_count}\n"
     )
     output.write(f"POSITION: {format_position(state.player_position)}\n")
-    output.write(f"FUEL: {state.remaining_fuel}\n")
-    output.write(f"SUPPLY: {format_supply_status(state)}\n")
+    output.write(f"FUEL: {state.remaining_fuel}/{state.settings.max_fuel}\n")
+    output.write(f"LAST SUPPLY: {format_last_supply_status(state)}\n")
+    output.write(f"USED R: {format_used_resources(state)}\n")
     output.write(f"TURN: {state.turn_count}\n")
     output.write(f"STATUS: {format_status(state.game_status)}\n")
     output.write(f"BLOCKED: {format_blocked_directions(state)}\n")
@@ -149,8 +150,9 @@ def format_event_messages(
         messages = [
             f"MOVED TO {format_position(event.to_position)}, COST {event.fuel_spent}"
         ]
-        if event.supply_applied and event.supply_source is not None:
-            messages.append(format_supply_message(state, event.supply_source))
+        supply_message = format_supply_message(event)
+        if supply_message is not None:
+            messages.append(supply_message)
         if event.status_after == engine.GAME_STATUS_WON:
             messages.append("YOU REACHED H")
         elif event.status_after == engine.GAME_STATUS_LOST_FUEL:
@@ -176,12 +178,31 @@ def format_event_messages(
     raise ValueError(f"unexpected outcome: {event.outcome}")
 
 
-def format_supply_message(state: engine.GameState, source: engine.SupplySource) -> str:
-    if source.kind == engine.BASE_CELL:
-        return f"SUPPLIED AT B: +{state.settings.base_supply}"
-    if source.kind == engine.RESOURCE_CELL:
-        return f"SUPPLIED AT R{format_position(source.position)}: +{state.settings.resource_supply}"
-    raise ValueError(f"unexpected supply source kind: {source.kind}")
+def format_supply_message(event: engine.TurnEvent) -> str | None:
+    source = event.supply_source
+    if event.supply_result == engine.SUPPLY_RESULT_NONE:
+        return None
+    if source is None:
+        raise ValueError("supply event must include supply_source")
+    if event.fuel_before_supply is None or event.fuel_after_supply is None:
+        raise ValueError("supply event must include fuel_before_supply and fuel_after_supply")
+    if event.supply_result == engine.SUPPLY_RESULT_BASE_REFUELED:
+        return (
+            f"REFUELED AT B{format_position(source.position)}: "
+            f"{event.fuel_before_supply} -> {event.fuel_after_supply}"
+        )
+    if event.supply_result == engine.SUPPLY_RESULT_BASE_ALREADY_FULL:
+        return f"BASE ALREADY FULL AT B{format_position(source.position)}"
+    if event.supply_result == engine.SUPPLY_RESULT_RESOURCE_REFUELED:
+        return (
+            f"REFUELED AT R{format_position(source.position)}: "
+            f"+{event.supply_amount} ({event.fuel_before_supply} -> {event.fuel_after_supply})"
+        )
+    if event.supply_result == engine.SUPPLY_RESULT_RESOURCE_ALREADY_FULL:
+        return f"RESOURCE ALREADY FULL AT R{format_position(source.position)}"
+    if event.supply_result == engine.SUPPLY_RESULT_RESOURCE_ALREADY_USED:
+        return f"RESOURCE ALREADY USED AT R{format_position(source.position)}"
+    raise ValueError(f"unexpected supply result: {event.supply_result}")
 
 
 def direction_for_event(event: engine.TurnEvent) -> str:
@@ -215,14 +236,20 @@ def format_status(status: str) -> str:
     raise ValueError(f"unexpected game status: {status}")
 
 
-def format_supply_status(state: engine.GameState) -> str:
-    if not state.supply_used or state.supply_source is None:
-        return "unused"
-    if state.supply_source.kind == engine.BASE_CELL:
-        return "B"
-    if state.supply_source.kind == engine.RESOURCE_CELL:
-        return f"R{format_position(state.supply_source.position)}"
-    raise ValueError(f"unexpected supply source kind: {state.supply_source.kind}")
+def format_last_supply_status(state: engine.GameState) -> str:
+    if state.last_supply_source is None:
+        return "none"
+    return format_supply_source(state.last_supply_source)
+
+
+def format_supply_source(source: engine.SupplySource) -> str:
+    return f"{source.kind}{format_position(source.position)}"
+
+
+def format_used_resources(state: engine.GameState) -> str:
+    if not state.used_resource_positions:
+        return "-"
+    return ",".join(format_position(position) for position in sorted(state.used_resource_positions))
 
 
 def format_blocked_directions(state: engine.GameState) -> str:

--- a/experiments/galactic_exodus/test_engine.py
+++ b/experiments/galactic_exodus/test_engine.py
@@ -44,8 +44,12 @@ def make_state(
     known_cells: dict[simulate.Position, str] | None = None,
     visited_cells: set[simulate.Position] | None = None,
     known_routes: dict[simulate.Edge, str] | None = None,
-    supply_used: bool = False,
-    supply_source: engine.SupplySource | None = None,
+    used_resource_positions: set[simulate.Position] | None = None,
+    base_visit_count: int = 0,
+    base_refuel_count: int = 0,
+    resource_visit_count: int = 0,
+    resource_refuel_count: int = 0,
+    last_supply_source: engine.SupplySource | None = None,
     turn_count: int = 0,
     requested_seed: int = 1,
     effective_seed: int = 1,
@@ -68,8 +72,12 @@ def make_state(
         known_routes={} if known_routes is None else dict(known_routes),
         player_position=player_position,
         remaining_fuel=remaining_fuel,
-        supply_used=supply_used,
-        supply_source=supply_source,
+        used_resource_positions=set() if used_resource_positions is None else set(used_resource_positions),
+        base_visit_count=base_visit_count,
+        base_refuel_count=base_refuel_count,
+        resource_visit_count=resource_visit_count,
+        resource_refuel_count=resource_refuel_count,
+        last_supply_source=last_supply_source,
         turn_count=turn_count,
         game_status=engine.GAME_STATUS_IN_PROGRESS,
         requested_seed=requested_seed,
@@ -94,6 +102,10 @@ def start_neighborhood_known_cells(
 
 
 class CreateGameTests(unittest.TestCase):
+    def test_game_settings_rejects_initial_fuel_above_max_fuel(self) -> None:
+        with self.assertRaisesRegex(ValueError, "initial-fuel must be less than or equal to max-fuel"):
+            engine.GameSettings(initial_fuel=17, max_fuel=16).validate()
+
     def test_create_game_reveals_start_neighborhood_and_home(self) -> None:
         custom_map = simulate.GalacticMap(
             seed=42,
@@ -275,8 +287,8 @@ class ApplyCommandTests(unittest.TestCase):
         self.assertEqual(second.discovered_cells, ())
         self.assertEqual(state.rift_attempt_count, 1)
 
-    def test_base_supply_applies_once_even_on_revisit(self) -> None:
-        settings = engine.GameSettings(initial_fuel=3, base_supply=2)
+    def test_base_refuels_to_max_on_first_visit_and_revisit(self) -> None:
+        settings = engine.GameSettings(initial_fuel=3, max_fuel=5)
         state = make_state(
             actual_map=make_actual_map(cells=filled_cells("."), base_position=(2, 1)),
             settings=settings,
@@ -287,14 +299,39 @@ class ApplyCommandTests(unittest.TestCase):
         engine.apply_command(state, "W")
         second = engine.apply_command(state, "E")
 
-        self.assertTrue(first.supply_applied)
+        self.assertEqual(first.supply_result, engine.SUPPLY_RESULT_BASE_REFUELED)
         self.assertEqual(first.supply_source, engine.SupplySource(kind="B", position=(2, 1)))
-        self.assertEqual(second.supply_applied, False)
-        self.assertEqual(state.remaining_fuel, 3)
-        self.assertEqual(state.supply_source, engine.SupplySource(kind="B", position=(2, 1)))
+        self.assertEqual(first.fuel_before_supply, 2)
+        self.assertEqual(first.fuel_after_supply, 5)
+        self.assertEqual(first.supply_amount, 3)
+        self.assertEqual(second.supply_result, engine.SUPPLY_RESULT_BASE_REFUELED)
+        self.assertEqual(second.fuel_before_supply, 4)
+        self.assertEqual(second.fuel_after_supply, 5)
+        self.assertEqual(state.remaining_fuel, 5)
+        self.assertEqual(state.base_visit_count, 2)
+        self.assertEqual(state.base_refuel_count, 2)
+        self.assertEqual(state.last_supply_source, engine.SupplySource(kind="B", position=(2, 1)))
+
+    def test_base_arrival_while_already_full_only_increments_visit_count(self) -> None:
+        settings = engine.GameSettings(initial_fuel=4, max_fuel=4)
+        state = make_state(
+            actual_map=make_actual_map(cells=filled_cells("."), base_position=(2, 1)),
+            settings=settings,
+            remaining_fuel=4,
+            last_supply_source=engine.SupplySource(kind="R", position=(7, 7)),
+        )
+
+        event = engine.apply_base_supply(state, (2, 1))
+
+        self.assertEqual(event.result, engine.SUPPLY_RESULT_BASE_ALREADY_FULL)
+        self.assertEqual(event.supply_amount, 0)
+        self.assertEqual(state.remaining_fuel, 4)
+        self.assertEqual(state.base_visit_count, 1)
+        self.assertEqual(state.base_refuel_count, 0)
+        self.assertEqual(state.last_supply_source, engine.SupplySource(kind="R", position=(7, 7)))
 
     def test_resource_supply_can_apply_after_arriving_with_zero_fuel(self) -> None:
-        settings = engine.GameSettings(initial_fuel=1, resource_supply=5)
+        settings = engine.GameSettings(initial_fuel=1, max_fuel=16, resource_supply=5)
         state = make_state(
             actual_map=make_actual_map(cells=filled_cells("."), resource_positions=((2, 1),)),
             settings=settings,
@@ -303,11 +340,67 @@ class ApplyCommandTests(unittest.TestCase):
 
         event = engine.apply_command(state, "E")
 
-        self.assertTrue(event.supply_applied)
+        self.assertEqual(event.supply_result, engine.SUPPLY_RESULT_RESOURCE_REFUELED)
         self.assertEqual(event.supply_source, engine.SupplySource(kind="R", position=(2, 1)))
         self.assertEqual(state.remaining_fuel, 5)
+        self.assertEqual(state.used_resource_positions, {(2, 1)})
+        self.assertEqual(state.resource_visit_count, 1)
+        self.assertEqual(state.resource_refuel_count, 1)
 
-    def test_supply_source_position_survives_later_movement(self) -> None:
+    def test_resource_supply_is_capped_by_max_fuel(self) -> None:
+        settings = engine.GameSettings(initial_fuel=16, max_fuel=16, resource_supply=5)
+        state = make_state(
+            actual_map=make_actual_map(cells=filled_cells("."), resource_positions=((2, 1),)),
+            settings=settings,
+            remaining_fuel=14,
+        )
+
+        event = engine.apply_command(state, "E")
+
+        self.assertEqual(event.supply_result, engine.SUPPLY_RESULT_RESOURCE_REFUELED)
+        self.assertEqual(event.supply_amount, 3)
+        self.assertEqual(event.fuel_before_supply, 13)
+        self.assertEqual(event.fuel_after_supply, 16)
+        self.assertEqual(state.remaining_fuel, 16)
+
+    def test_unused_resource_is_not_consumed_when_arriving_already_full(self) -> None:
+        settings = engine.GameSettings(initial_fuel=16, max_fuel=16, resource_supply=5)
+        state = make_state(
+            actual_map=make_actual_map(cells=filled_cells("."), resource_positions=((2, 1),)),
+            settings=settings,
+            remaining_fuel=16,
+            last_supply_source=engine.SupplySource(kind="B", position=(4, 4)),
+        )
+
+        event = engine.apply_resource_supply(state, (2, 1))
+
+        self.assertEqual(event.result, engine.SUPPLY_RESULT_RESOURCE_ALREADY_FULL)
+        self.assertEqual(event.supply_amount, 0)
+        self.assertEqual(state.used_resource_positions, set())
+        self.assertEqual(state.resource_visit_count, 1)
+        self.assertEqual(state.resource_refuel_count, 0)
+        self.assertEqual(state.last_supply_source, engine.SupplySource(kind="B", position=(4, 4)))
+
+    def test_used_resource_can_be_revisited_without_refueling(self) -> None:
+        settings = engine.GameSettings(initial_fuel=4, max_fuel=16, resource_supply=5)
+        state = make_state(
+            actual_map=make_actual_map(cells=filled_cells("."), resource_positions=((2, 1),)),
+            settings=settings,
+            remaining_fuel=4,
+        )
+
+        first = engine.apply_command(state, "E")
+        engine.apply_command(state, "W")
+        second = engine.apply_command(state, "E")
+
+        self.assertEqual(first.supply_result, engine.SUPPLY_RESULT_RESOURCE_REFUELED)
+        self.assertEqual(second.supply_result, engine.SUPPLY_RESULT_RESOURCE_ALREADY_USED)
+        self.assertEqual(second.supply_amount, 0)
+        self.assertEqual(state.used_resource_positions, {(2, 1)})
+        self.assertEqual(state.resource_visit_count, 2)
+        self.assertEqual(state.resource_refuel_count, 1)
+
+    def test_last_supply_source_survives_later_movement(self) -> None:
         settings = engine.GameSettings(initial_fuel=4, resource_supply=5)
         state = make_state(
             actual_map=make_actual_map(cells=filled_cells("."), resource_positions=((2, 1),)),
@@ -318,7 +411,7 @@ class ApplyCommandTests(unittest.TestCase):
         engine.apply_command(state, "E")
         engine.apply_command(state, "W")
 
-        self.assertEqual(state.supply_source, engine.SupplySource(kind="R", position=(2, 1)))
+        self.assertEqual(state.last_supply_source, engine.SupplySource(kind="R", position=(2, 1)))
 
     def test_arriving_at_home_with_zero_fuel_is_a_win(self) -> None:
         state = make_state(
@@ -401,7 +494,7 @@ class RunCommandsTests(unittest.TestCase):
         self.assertIsNone(log.generation_error)
 
     def test_run_commands_aborts_on_turn_limit(self) -> None:
-        settings = engine.GameSettings(initial_fuel=100)
+        settings = engine.GameSettings(initial_fuel=100, max_fuel=100)
         log = engine.run_commands(42, ["E"] * 100, settings=settings, max_turns=1)
 
         self.assertEqual(log.final_summary.outcome, engine.FINAL_OUTCOME_ABORTED_TURN_LIMIT)
@@ -446,20 +539,25 @@ class RunCommandsTests(unittest.TestCase):
                 "generation_error",
             ],
         )
-        self.assertEqual(payload["schema_version"], 2)
+        self.assertEqual(payload["schema_version"], 3)
         self.assertIn("outcome", payload["final_summary"])
         self.assertIn("path", payload["final_summary"])
-        self.assertIn("supply_source", payload["final_summary"])
+        self.assertIn("last_supply_source", payload["final_summary"])
+        self.assertIn("used_resource_positions", payload["final_summary"])
         if payload["events"]:
             self.assertIn("supply_source", payload["events"][0])
+            self.assertIn("supply_result", payload["events"][0])
+            self.assertIn("fuel_before_supply", payload["events"][0])
+            self.assertIn("fuel_after_supply", payload["events"][0])
+            self.assertIn("supply_amount", payload["events"][0])
             self.assertIn("required_fuel", payload["events"][0])
             self.assertIn("discovered_cells", payload["events"][0])
         json.loads(log.to_json())
 
-    def test_game_log_serializes_structured_supply_source(self) -> None:
+    def test_game_log_serializes_structured_last_supply_source(self) -> None:
         state = make_state(
             actual_map=make_actual_map(cells=filled_cells("."), base_position=(2, 1)),
-            settings=engine.GameSettings(initial_fuel=1, base_supply=3, resource_count=0),
+            settings=engine.GameSettings(initial_fuel=1, max_fuel=4, resource_count=0),
             remaining_fuel=1,
             requested_seed=1,
             effective_seed=1,
@@ -475,11 +573,55 @@ class RunCommandsTests(unittest.TestCase):
             },
         )
         self.assertEqual(
-            payload["final_summary"]["supply_source"],
+            payload["final_summary"]["last_supply_source"],
             {
                 "kind": "B",
                 "position": {"x": 2, "y": 1},
             },
+        )
+
+    def test_supply_helpers_cover_all_supply_results(self) -> None:
+        cells = filled_cells(".")
+        actual_map = make_actual_map(
+            cells=cells,
+            base_position=(2, 1),
+            resource_positions=((3, 1),),
+        )
+        settings = engine.GameSettings(initial_fuel=4, max_fuel=4, resource_supply=5)
+
+        base_full_state = make_state(
+            actual_map=actual_map,
+            settings=settings,
+            remaining_fuel=4,
+        )
+        resource_full_state = make_state(
+            actual_map=actual_map,
+            settings=settings,
+            player_position=(2, 1),
+            visited_cells={(1, 1), (2, 1)},
+            path=[(1, 1), (2, 1)],
+            remaining_fuel=4,
+            base_visit_count=1,
+        )
+        resource_used_state = make_state(
+            actual_map=actual_map,
+            settings=settings,
+            player_position=(2, 1),
+            visited_cells={(1, 1), (2, 1)},
+            path=[(1, 1), (2, 1)],
+            remaining_fuel=2,
+            used_resource_positions={(3, 1)},
+            base_visit_count=1,
+        )
+
+        self.assertEqual(engine.apply_base_supply(base_full_state, (2, 1)).result, engine.SUPPLY_RESULT_BASE_ALREADY_FULL)
+        self.assertEqual(
+            engine.apply_resource_supply(resource_full_state, (3, 1)).result,
+            engine.SUPPLY_RESULT_RESOURCE_ALREADY_FULL,
+        )
+        self.assertEqual(
+            engine.apply_resource_supply(resource_used_state, (3, 1)).result,
+            engine.SUPPLY_RESULT_RESOURCE_ALREADY_USED,
         )
 
     def test_game_log_serializes_structured_generation_error(self) -> None:

--- a/experiments/galactic_exodus/test_play.py
+++ b/experiments/galactic_exodus/test_play.py
@@ -157,6 +157,27 @@ class PlayCliTests(unittest.TestCase):
             ["INSUFFICIENT FUEL: NEED 3, HAVE 2"],
         )
 
+    def test_turn_messages_cover_supply_results(self) -> None:
+        base_state = make_state(
+            actual_map=make_actual_map(cells=filled_cells("."), base_position=(2, 1)),
+            settings=engine.GameSettings(initial_fuel=3, max_fuel=5, resource_count=0),
+            remaining_fuel=3,
+        )
+        resource_state = make_state(
+            actual_map=make_actual_map(cells=filled_cells("."), resource_positions=((2, 1),)),
+            settings=engine.GameSettings(initial_fuel=3, max_fuel=16, resource_supply=5),
+            remaining_fuel=3,
+        )
+
+        base_event = engine.apply_command(base_state, "E")
+        resource_event = engine.apply_command(resource_state, "E")
+
+        self.assertIn("REFUELED AT B(2,1): 2 -> 5", play.format_event_messages(base_state, base_event))
+        self.assertIn(
+            "REFUELED AT R(2,1): +5 (2 -> 7)",
+            play.format_event_messages(resource_state, resource_event),
+        )
+
     def test_generation_error_is_reported_separately(self) -> None:
         with patch.object(
             engine,
@@ -184,7 +205,7 @@ class PlayCliTests(unittest.TestCase):
 
         self.assertEqual(first, second)
 
-    def test_json_log_writes_schema_version_2(self) -> None:
+    def test_json_log_writes_schema_version_3(self) -> None:
         with tempfile.TemporaryDirectory(dir=".tmp") as tmp_dir:
             log_path = Path(tmp_dir) / "play-log.json"
 
@@ -198,9 +219,25 @@ class PlayCliTests(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         self.assertEqual(stderr, "")
         self.assertTrue(stdout.endswith("COMMAND> "))
-        self.assertEqual(payload["schema_version"], 2)
+        self.assertEqual(payload["schema_version"], 3)
         self.assertEqual(payload["final_summary"]["outcome"], engine.FINAL_OUTCOME_ABORTED_NO_POLICY_ACTION)
         self.assertIsNone(payload["generation_error"])
+
+    def test_state_panel_uses_fixed_supply_fields(self) -> None:
+        state = make_state(
+            actual_map=make_actual_map(cells=filled_cells("."), resource_positions=((3, 2), (2, 3))),
+            remaining_fuel=7,
+            used_resource_positions={(2, 3), (3, 2)},
+            last_supply_source=engine.SupplySource(kind="R", position=(3, 2)),
+        )
+
+        stdout = io.StringIO()
+        play.render_state(state, stdout)
+        rendered = stdout.getvalue()
+
+        self.assertIn("FUEL: 7/16\n", rendered)
+        self.assertIn("LAST SUPPLY: R(3,2)\n", rendered)
+        self.assertIn("USED R: (2,3),(3,2)\n", rendered)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 概要

Closes #1066

Galactic Exodus Phase 1A prototype の補給モデルを更新し、基地 `B` の再補給と資源 `R` の座標ごとの個別消費を実装しました。

## 変更内容

- `GameSettings` に `max_fuel` を追加し、`initial_fuel <= max_fuel` を検証
- `GameState` を `used_resource_positions`、B/R の visit/refuel counters、`last_supply_source` を持つモデルへ更新
- `B` は到着ごとに満タンまで補給し、満タン到着時は visit のみ加算
- `R` は未使用かつ燃料が実増加した到着時だけ消費し、使用済み `R` 再訪時は補給しない
- `TurnEvent` と `final_summary` / `snapshot` を schema version 3 の supply 契約へ更新
- CLI 状態表示を `FUEL: <remaining>/<max>`、`LAST SUPPLY`、`USED R` へ変更
- 補給結果文言を `BASE_REFUELED` / `RESOURCE_ALREADY_USED` などの固定仕様へ合わせて更新
- engine / CLI / README のテストと説明を新補給モデルへ更新

## 確認

- `python -m unittest experiments.galactic_exodus.test_engine experiments.galactic_exodus.test_play experiments.galactic_exodus.test_simulate experiments.galactic_exodus.test_metrics experiments.galactic_exodus.test_fuel_metrics`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
