### PR TITLE
Phase 1B: 断層辺を通常空間に接する辺へ制限

### DIFF
--- a/experiments/galactic_exodus/simulate.py
+++ b/experiments/galactic_exodus/simulate.py
@@ -198,7 +198,7 @@ def generate_map(seed: int, resource_count: int, rift_density: float = DEFAULT_R
     for position in r_positions:
         cells[position] = "R"
 
-    rift_edges = sample_rift_edges(seed, rift_density)
+    rift_edges = sample_rift_edges(seed, rift_density, cells)
 
     return GalacticMap(
         seed=seed,
@@ -262,9 +262,22 @@ def rift_count_for_density(rift_density: float) -> int:
     return round(TOTAL_UNDIRECTED_EDGES * rift_density)
 
 
-def sample_rift_edges(seed: int, rift_density: float) -> tuple[Edge, ...]:
+def eligible_rift_edges(cells: Cells) -> list[Edge]:
+    return [
+        edge
+        for edge in undirected_adjacent_edges()
+        if cells[edge[0]] == "." or cells[edge[1]] == "."
+    ]
+
+
+def sample_rift_edges(seed: int, rift_density: float, cells: Cells) -> tuple[Edge, ...]:
     rift_count = rift_count_for_density(rift_density)
-    edges = undirected_adjacent_edges()
+    edges = eligible_rift_edges(cells)
+    if len(edges) < rift_count:
+        raise ValueError(
+            "eligible rift edges are insufficient for requested rift density: "
+            f"eligible={len(edges)} requested={rift_count}"
+        )
     rng = random.Random(f"{seed}:rift")
     selected = rng.sample(edges, rift_count)
     return tuple(sorted(selected))

--- a/experiments/galactic_exodus/test_simulate.py
+++ b/experiments/galactic_exodus/test_simulate.py
@@ -189,12 +189,55 @@ class RiftGenerationTests(unittest.TestCase):
             simulate.rift_count_for_density(1.01)
 
     def test_sample_rift_edges_is_deterministic_and_unique(self) -> None:
-        first = simulate.sample_rift_edges(42, 0.10)
-        second = simulate.sample_rift_edges(42, 0.10)
+        cells = filled_cells(".")
+
+        first = simulate.sample_rift_edges(42, 0.10, cells)
+        second = simulate.sample_rift_edges(42, 0.10, cells)
 
         self.assertEqual(first, second)
         self.assertEqual(len(first), 11)
         self.assertEqual(len(set(first)), 11)
+
+    def test_eligible_rift_edges_excludes_edges_with_no_plain_endpoint(self) -> None:
+        cells = filled_cells("N")
+        cells[(1, 1)] = "."
+        cells[(2, 2)] = "."
+
+        eligible = set(simulate.eligible_rift_edges(cells))
+
+        self.assertIn(simulate.normalize_edge((1, 1), (2, 1)), eligible)
+        self.assertIn(simulate.normalize_edge((2, 2), (2, 3)), eligible)
+        self.assertNotIn(simulate.normalize_edge((3, 2), (3, 3)), eligible)
+        self.assertNotIn(simulate.normalize_edge((3, 3), (4, 3)), eligible)
+
+    def test_eligible_rift_edges_include_plain_to_special_and_plain_to_plain_edges(self) -> None:
+        cells = filled_cells("N")
+        cells[(1, 1)] = "S"
+        cells[(2, 1)] = "."
+        cells[(2, 2)] = "."
+        cells[(3, 2)] = "B"
+
+        eligible = set(simulate.eligible_rift_edges(cells))
+
+        self.assertIn(simulate.normalize_edge((1, 1), (2, 1)), eligible)
+        self.assertIn(simulate.normalize_edge((2, 1), (2, 2)), eligible)
+        self.assertIn(simulate.normalize_edge((2, 2), (3, 2)), eligible)
+
+    def test_sample_rift_edges_only_selects_edges_with_plain_endpoint(self) -> None:
+        galactic_map = simulate.generate_map(42, 3)
+
+        for start, goal in galactic_map.rift_edges:
+            self.assertTrue(
+                galactic_map.cells[start] == "." or galactic_map.cells[goal] == ".",
+                msg=f"rift edge must touch plain space: {(start, goal)}",
+            )
+
+    def test_sample_rift_edges_raises_when_eligible_edges_are_insufficient(self) -> None:
+        cells = filled_cells("N")
+        cells[(1, 1)] = "."
+
+        with self.assertRaisesRegex(ValueError, "eligible rift edges"):
+            simulate.sample_rift_edges(42, 0.10, cells)
 
 
 class AnalysisAndOutputTests(unittest.TestCase):
@@ -227,13 +270,13 @@ class AnalysisAndOutputTests(unittest.TestCase):
         analysis = simulate.analyze_paths(galactic_map)
 
         self.assertTrue(analysis.reachable)
-        self.assertEqual(analysis.best_cost, 17)
+        self.assertEqual(analysis.best_cost, 16)
         self.assertEqual(analysis.best_path_length, 14)
-        self.assertEqual(analysis.cost_to_base, 8)
+        self.assertEqual(analysis.cost_to_base, 7)
         self.assertEqual(analysis.cost_base_to_goal, 9)
-        self.assertEqual(analysis.best_cost_via_base, 17)
+        self.assertEqual(analysis.best_cost_via_base, 16)
         self.assertEqual(analysis.best_cost_via_base, analysis.cost_to_base + analysis.cost_base_to_goal)
-        self.assertEqual(analysis.best_cost_without_base, 17)
+        self.assertEqual(analysis.best_cost_without_base, 16)
         self.assertEqual(analysis.base_route_advantage_raw, 0)
         self.assertFalse(analysis.base_is_mandatory)
         self.assertEqual(simulate.classify_verdict(analysis), "ACCEPT")
@@ -326,9 +369,9 @@ class AnalysisAndOutputTests(unittest.TestCase):
             simulate.CostContributionAnalysis(
                 plain_cost=14,
                 terrain_only_cost=15,
-                full_cost=17,
+                full_cost=16,
                 terrain_extra_cost=1,
-                rift_detour_cost=2,
+                rift_detour_cost=1,
             ),
         )
 
@@ -407,21 +450,21 @@ class AnalysisAndOutputTests(unittest.TestCase):
         self.assertIn("  initial_fuel: 16", output)
         self.assertIn("  base_supply: 8", output)
         self.assertIn("  resource_supply: 5", output)
-        self.assertIn("  fuel_feasible_direct: no", output)
+        self.assertIn("  fuel_feasible_direct: yes", output)
         self.assertIn("  fuel_feasible_via_base: yes", output)
         self.assertIn("  fuel_feasible_via_resource: yes", output)
-        self.assertIn("  S_to_H_cost: 17", output)
+        self.assertIn("  S_to_H_cost: 16", output)
         self.assertIn("  S_to_H_steps: 14", output)
-        self.assertIn("  S_to_B_cost: 8", output)
+        self.assertIn("  S_to_B_cost: 7", output)
         self.assertIn("  B_to_H_cost: 9", output)
-        self.assertIn("  S_to_H_via_B_cost: 17", output)
-        self.assertIn("  S_to_H_without_B_cost: 17", output)
+        self.assertIn("  S_to_H_via_B_cost: 16", output)
+        self.assertIn("  S_to_H_without_B_cost: 16", output)
         self.assertIn("  base_is_mandatory: no", output)
         self.assertIn("  plain_cost: 14", output)
         self.assertIn("  terrain_only_cost: 15", output)
-        self.assertIn("  full_cost: 17", output)
+        self.assertIn("  full_cost: 16", output)
         self.assertIn("  terrain_extra_cost: 1", output)
-        self.assertIn("  rift_detour_cost: 2", output)
+        self.assertIn("  rift_detour_cost: 1", output)
         self.assertIn("  verdict: ACCEPT", output)
         self.assertIn("  priority_1: REJECT_TOO_HARD", output)
         self.assertIn("  priority_2: REJECT_BASE_MANDATORY", output)


### PR DESCRIPTION
## 概要

Closes #1073

Galactic Exodus の断層生成を、通常空間 `.` に接する無向隣接辺だけから抽選するよう修正しました。
あわせて、eligible 辺が指定本数に足りない場合は明示エラーにし、seed 42 の既存期待値を新仕様に更新しました。

## 変更内容

- `simulate.py` に eligible な断層候補辺を列挙する `eligible_rift_edges()` を追加
- `generate_map()` が地形と `S/H/B/R` 配置確定後の `cells` を使って断層辺を抽選するよう変更
- `sample_rift_edges()` で eligible 辺数不足時に明示的な `ValueError` を返すよう変更
- `test_simulate.py` に候補辺制約、決定性、候補不足エラー、生成済み断層の契約テストを追加
- 新しい断層候補制約に合わせて seed 42 の分析期待値を更新

## 確認

- `python3 -m unittest experiments.galactic_exodus.test_simulate`
- `python3 -m unittest experiments.galactic_exodus.test_engine`
- `python3 -m unittest discover -s experiments/galactic_exodus`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo fmt --check`
