### PR TITLE
Phase 2A1a: SRS地形の数値効果と配置規則を確定

### DIFF
--- a/experiments/galactic_exodus/srs/phase2_srs_elements.json
+++ b/experiments/galactic_exodus/srs/phase2_srs_elements.json
@@ -1,0 +1,222 @@
+{
+  "schema_version": 1,
+  "map_sizes": [[9, 9], [11, 11]],
+  "baseline_map_size": [9, 9],
+  "geometric_costs": {
+    "orthogonal": 10,
+    "diagonal": 14
+  },
+  "observation": {
+    "default_size": 5,
+    "nebula_size": 3,
+    "update_after_each_successful_step": true,
+    "known_map_is_cumulative": true,
+    "use_destination_terrain": true
+  },
+  "terrain_types": {
+    "FLOOR": {
+      "passable": true,
+      "move_multiplier": 1,
+      "observation_size": 5,
+      "blocks_line_travel": false,
+      "can_host_feature": true,
+      "allowed_features": ["WARP_POINT"]
+    },
+    "DEBRIS": {
+      "passable": true,
+      "move_multiplier": 2,
+      "observation_size": 5,
+      "blocks_line_travel": false,
+      "can_host_feature": false,
+      "allowed_features": []
+    },
+    "NEBULA": {
+      "passable": true,
+      "move_multiplier": 2,
+      "observation_size": 3,
+      "blocks_line_travel": false,
+      "can_host_feature": false,
+      "allowed_features": []
+    },
+    "ASTEROID_FIELD": {
+      "passable": true,
+      "move_multiplier": 3,
+      "observation_size": 5,
+      "blocks_line_travel": false,
+      "can_host_feature": false,
+      "allowed_features": []
+    },
+    "ASTEROID": {
+      "passable": false,
+      "move_multiplier": null,
+      "observation_size": null,
+      "blocks_line_travel": true,
+      "can_host_feature": false,
+      "allowed_features": [],
+      "collision_behavior": "STOP_BEFORE",
+      "movement_cost_consumed_on_collision": false
+    },
+    "GRAVITY_FIELD_VERTICAL": {
+      "passable": true,
+      "move_multiplier": 1,
+      "observation_size": 5,
+      "blocks_line_travel": false,
+      "can_host_feature": false,
+      "allowed_features": [],
+      "gravity_axis": "VERTICAL",
+      "double_cost_when_axis_changes": "X"
+    },
+    "GRAVITY_FIELD_HORIZONTAL": {
+      "passable": true,
+      "move_multiplier": 1,
+      "observation_size": 5,
+      "blocks_line_travel": false,
+      "can_host_feature": false,
+      "allowed_features": [],
+      "gravity_axis": "HORIZONTAL",
+      "double_cost_when_axis_changes": "Y"
+    },
+    "RIFT_DISTORTION": {
+      "passable": true,
+      "move_multiplier": 2,
+      "observation_size": 5,
+      "blocks_line_travel": false,
+      "can_host_feature": false,
+      "allowed_features": [],
+      "placement": "RANDOM_INNER_ADJACENT_TO_RIFT_BARRIER"
+    },
+    "RIFT_BARRIER": {
+      "passable": false,
+      "move_multiplier": null,
+      "observation_size": null,
+      "blocks_line_travel": true,
+      "can_host_feature": false,
+      "allowed_features": [],
+      "collision_behavior": "STOP_BEFORE",
+      "movement_cost_consumed_on_collision": false,
+      "placement": "BLOCKED_EDGE_BOUNDARY"
+    }
+  },
+  "impassable_elements": [
+    "ASTEROID",
+    "RIFT_BARRIER",
+    "STAR",
+    "PLANET",
+    "STATION"
+  ],
+  "object_types": {
+    "STAR": {
+      "passable": false,
+      "blocks_line_travel": true,
+      "collision_behavior": "STOP_BEFORE",
+      "movement_cost_consumed_on_collision": false
+    },
+    "PLANET": {
+      "passable": false,
+      "blocks_line_travel": true,
+      "collision_behavior": "STOP_BEFORE",
+      "movement_cost_consumed_on_collision": false
+    },
+    "STATION": {
+      "passable": false,
+      "blocks_line_travel": true,
+      "collision_behavior": "STOP_BEFORE",
+      "movement_cost_consumed_on_collision": false,
+      "interaction_range": "ADJACENT",
+      "effect": "REFUEL_TO_MAX",
+      "reusable": true
+    },
+    "RESOURCE_CACHE": {
+      "passable": true
+    },
+    "SALVAGE": {
+      "passable": true
+    }
+  },
+  "warp_point": {
+    "allowed_terrain": ["FLOOR"],
+    "edge_midpoint_only": true,
+    "inner_adjacent_terrain": "FLOOR",
+    "allows_object": false,
+    "forbidden_on_rift_blocked_edge": true
+  },
+  "sector_terrain_matrix": {
+    "NORMAL": {
+      "required": ["FLOOR"],
+      "optional": ["DEBRIS"],
+      "forbidden": ["NEBULA", "ASTEROID_FIELD", "ASTEROID", "GRAVITY_FIELD_VERTICAL", "GRAVITY_FIELD_HORIZONTAL", "RIFT_DISTORTION", "RIFT_BARRIER"]
+    },
+    "BASE": {
+      "required": ["FLOOR"],
+      "optional": ["DEBRIS"],
+      "forbidden": ["NEBULA", "ASTEROID_FIELD", "ASTEROID", "GRAVITY_FIELD_VERTICAL", "GRAVITY_FIELD_HORIZONTAL", "RIFT_DISTORTION", "RIFT_BARRIER"]
+    },
+    "RESOURCE": {
+      "required": ["FLOOR", "DEBRIS"],
+      "optional": ["ASTEROID_FIELD", "ASTEROID"],
+      "forbidden": ["NEBULA", "GRAVITY_FIELD_VERTICAL", "GRAVITY_FIELD_HORIZONTAL", "RIFT_DISTORTION", "RIFT_BARRIER"]
+    },
+    "NEBULA": {
+      "required": ["FLOOR", "NEBULA"],
+      "optional": ["DEBRIS"],
+      "forbidden": ["ASTEROID_FIELD", "ASTEROID", "GRAVITY_FIELD_VERTICAL", "GRAVITY_FIELD_HORIZONTAL", "RIFT_DISTORTION", "RIFT_BARRIER"]
+    },
+    "ASTEROID": {
+      "required": ["FLOOR", "ASTEROID_FIELD", "ASTEROID"],
+      "optional": ["DEBRIS"],
+      "forbidden": ["NEBULA", "GRAVITY_FIELD_VERTICAL", "GRAVITY_FIELD_HORIZONTAL", "RIFT_DISTORTION", "RIFT_BARRIER"]
+    },
+    "GRAVITY": {
+      "required": ["FLOOR"],
+      "optional": ["GRAVITY_FIELD_VERTICAL", "GRAVITY_FIELD_HORIZONTAL"],
+      "forbidden": ["DEBRIS", "NEBULA", "ASTEROID_FIELD", "ASTEROID", "RIFT_DISTORTION", "RIFT_BARRIER"],
+      "invariants": {
+        "gravity_field_total_min": 1,
+        "orientation_mix": "RANDOM"
+      }
+    },
+    "RIFT": {
+      "required": ["FLOOR", "RIFT_DISTORTION"],
+      "optional": ["DEBRIS", "ASTEROID_FIELD", "ASTEROID", "GRAVITY_FIELD_VERTICAL", "GRAVITY_FIELD_HORIZONTAL"],
+      "forbidden": ["NEBULA"],
+      "edge_required": ["RIFT_BARRIER"]
+    }
+  },
+  "terrain_object_matrix": {
+    "FLOOR": ["STAR", "PLANET", "STATION", "RESOURCE_CACHE", "SALVAGE"],
+    "DEBRIS": ["RESOURCE_CACHE", "SALVAGE"],
+    "NEBULA": ["STAR", "PLANET", "RESOURCE_CACHE", "SALVAGE"],
+    "ASTEROID_FIELD": ["RESOURCE_CACHE", "SALVAGE"],
+    "ASTEROID": [],
+    "GRAVITY_FIELD_VERTICAL": ["STAR", "PLANET", "RESOURCE_CACHE", "SALVAGE"],
+    "GRAVITY_FIELD_HORIZONTAL": ["STAR", "PLANET", "RESOURCE_CACHE", "SALVAGE"],
+    "RIFT_DISTORTION": ["RESOURCE_CACHE", "SALVAGE"],
+    "RIFT_BARRIER": []
+  },
+  "common_object_constraints": {
+    "max_objects_per_cell": 1,
+    "objects_forbidden_on_warp_point": true,
+    "objects_forbidden_on_impassable_terrain": true,
+    "star_count": 1,
+    "planet_count_min": 2,
+    "station_count_in_base": 1,
+    "station_terrain": "FLOOR"
+  },
+  "deferred_to": {
+    "1088": [
+      "terrain_density_and_counts",
+      "gravity_field_total_amount",
+      "rift_distortion_amount_probability",
+      "celestial_counts_spacing",
+      "deterministic_generation_retry"
+    ],
+    "1089": [
+      "turn_consumption_on_stop_before",
+      "partial_route_position",
+      "diagonal_corner_cutting",
+      "movement_budget_exhaustion",
+      "vector_rasterization",
+      "directional_thrust_limits"
+    ]
+  }
+}

--- a/experiments/galactic_exodus/srs/phase2_srs_elements.md
+++ b/experiments/galactic_exodus/srs/phase2_srs_elements.md
@@ -1,0 +1,271 @@
+# Galactic Exodus Phase 2 SRS terrain effects
+
+## 1. Scope
+
+This document records the decisions from #1086 for SRS terrain, map-element passability, observation, movement-cost calculation, WARP_POINT placement, and Terrain/Object compatibility.
+
+Generation density and counts remain in #1088. Exact command resolution and turn handling remain in #1089.
+
+## 2. Map sizes
+
+```text
+supported map sizes:
+  9x9
+  11x11
+
+baseline:
+  9x9
+```
+
+`7x7` is not supported by the Phase 2 SRS model.
+
+## 3. Terrain types
+
+```text
+FLOOR
+DEBRIS
+NEBULA
+ASTEROID_FIELD
+ASTEROID
+GRAVITY_FIELD_VERTICAL
+GRAVITY_FIELD_HORIZONTAL
+RIFT_DISTORTION
+RIFT_BARRIER
+```
+
+`WALL` is not used. Impassable cells must have a setting-specific type.
+
+## 4. Object types relevant to movement
+
+```text
+STAR
+PLANET
+STATION
+RESOURCE_CACHE
+SALVAGE
+```
+
+`STATION_STRUCTURE` and `BASE_NODE` are replaced by one impassable, adjacent-interaction `STATION` object.
+
+## 5. Terrain attributes
+
+| id | Japanese name | passable | move multiplier | observation | blocks movement/line travel | can host WARP_POINT |
+|---|---|---:|---:|---|---:|---:|
+| `FLOOR` | 通常空間 | true | 1 | 5x5 | false | true |
+| `DEBRIS` | デブリ帯 | true | 2 | 5x5 | false | false |
+| `NEBULA` | 星雲 | true | 2 | 3x3 | false | false |
+| `ASTEROID_FIELD` | 小惑星密集域 | true | 3 | 5x5 | false | false |
+| `ASTEROID` | 大型小惑星 | false | - | - | true | false |
+| `GRAVITY_FIELD_VERTICAL` | 南北重力異常領域 | true | 1 or 2 | 5x5 | false | false |
+| `GRAVITY_FIELD_HORIZONTAL` | 東西重力異常領域 | true | 1 or 2 | 5x5 | false | false |
+| `RIFT_DISTORTION` | 断層歪曲領域 | true | 2 | 5x5 | false | false |
+| `RIFT_BARRIER` | 断層障壁 | false | - | - | true | false |
+
+Only `passable = false` elements block movement and straight-line travel. Passable terrain never blocks a route even when it increases cost or reduces observation.
+
+## 6. Observation
+
+Observation is updated after every successful one-cell step.
+
+```text
+1. move to the next cell
+2. inspect the destination terrain
+3. NEBULA -> observe 3x3; otherwise -> observe 5x5
+4. merge the result into the persistent discovered map
+5. continue to the next step when movement remains
+```
+
+Known cells are cumulative and are not forgotten when entering NEBULA.
+
+A failed move that does not enter a new cell does not trigger destination-cell observation.
+
+## 7. Geometric movement cost
+
+Use integer Euclidean approximation:
+
+```text
+ORTHOGONAL_COST = 10
+DIAGONAL_COST = 14
+```
+
+Route cost is the sum of actual one-cell steps. It is not calculated only from the route endpoints.
+
+```text
+step_cost = geometric_step_cost
+          * destination_terrain_multiplier
+          * gravity_multiplier
+```
+
+Examples:
+
+| destination terrain | orthogonal | diagonal |
+|---|---:|---:|
+| `FLOOR` | 10 | 14 |
+| `DEBRIS` | 20 | 28 |
+| `NEBULA` | 20 | 28 |
+| `ASTEROID_FIELD` | 30 | 42 |
+| `RIFT_DISTORTION` | 20 | 28 |
+
+## 8. Gravity fields
+
+### `GRAVITY_FIELD_VERTICAL`
+
+A north-south gravity field. A step whose X coordinate changes has double cost.
+
+```text
+if dx != 0:
+  gravity_multiplier = 2
+else:
+  gravity_multiplier = 1
+```
+
+### `GRAVITY_FIELD_HORIZONTAL`
+
+An east-west gravity field. A step whose Y coordinate changes has double cost.
+
+```text
+if dy != 0:
+  gravity_multiplier = 2
+else:
+  gravity_multiplier = 1
+```
+
+Diagonal movement changes both axes, so it is doubled in either gravity-field type.
+
+In a GRAVITY sector, vertical and horizontal cells are selected randomly. Either type alone or both types may occur, but their total count must be at least one. Total placement amount is decided in #1088.
+
+## 9. Impassable elements and STOP_BEFORE
+
+The shared impassable set is:
+
+```text
+ASTEROID
+RIFT_BARRIER
+STAR
+PLANET
+STATION
+```
+
+All use the same behavior:
+
+```text
+collision_behavior = STOP_BEFORE
+movement_cost_consumed = false
+```
+
+Detailed turn consumption, partial-route position, and command semantics are decided in #1089.
+
+## 10. WARP_POINT feature placement
+
+A WARP_POINT represents a gravity-stable location suitable for inter-sector warp.
+
+```text
+WARP_POINT may be placed on FLOOR only.
+```
+
+Generation invariants:
+
+```text
+valid edge midpoint:
+  terrain = FLOOR
+  feature = WARP_POINT
+
+inner adjacent cell:
+  terrain = FLOOR
+
+WARP_POINT cell:
+  no object
+
+RIFT blocked edge:
+  no WARP_POINT
+```
+
+## 11. SectorType x Terrain matrix
+
+Legend:
+
+- `required`: at least one or structurally required
+- `optional`: allowed by the sector profile
+- `forbidden`: not allowed
+- `blocked-edge-required`: required on each blocked edge
+
+| SectorType | FLOOR | DEBRIS | NEBULA | ASTEROID_FIELD | ASTEROID | GRAVITY_VERTICAL | GRAVITY_HORIZONTAL | RIFT_DISTORTION | RIFT_BARRIER |
+|---|---|---|---|---|---|---|---|---|---|
+| `NORMAL` | required | optional | forbidden | forbidden | forbidden | forbidden | forbidden | forbidden | forbidden |
+| `BASE` | required | optional | forbidden | forbidden | forbidden | forbidden | forbidden | forbidden | forbidden |
+| `RESOURCE` | required | required | forbidden | optional | optional | forbidden | forbidden | forbidden | forbidden |
+| `NEBULA` | required | optional | required | forbidden | forbidden | forbidden | forbidden | forbidden | forbidden |
+| `ASTEROID` | required | optional | forbidden | required | required | forbidden | forbidden | forbidden | forbidden |
+| `GRAVITY` | required | forbidden | forbidden | forbidden | forbidden | optional-or-required | optional-or-required | forbidden | forbidden |
+| `RIFT` | required | optional | forbidden | optional | optional | optional | optional | required | blocked-edge-required |
+
+Additional GRAVITY invariant:
+
+```text
+count(GRAVITY_FIELD_VERTICAL)
++ count(GRAVITY_FIELD_HORIZONTAL)
+>= 1
+```
+
+`RIFT_DISTORTION` is placed randomly among passable cells immediately inside and adjacent to `RIFT_BARRIER`. Placement amount is decided in #1088.
+
+## 12. Terrain x Object matrix
+
+| Terrain | STAR | PLANET | STATION | RESOURCE_CACHE | SALVAGE |
+|---|---:|---:|---:|---:|---:|
+| `FLOOR` | true | true | true | true | true |
+| `DEBRIS` | false | false | false | true | true |
+| `NEBULA` | true | true | false | true | true |
+| `ASTEROID_FIELD` | false | false | false | true | true |
+| `ASTEROID` | false | false | false | false | false |
+| `GRAVITY_FIELD_VERTICAL` | true | true | false | true | true |
+| `GRAVITY_FIELD_HORIZONTAL` | true | true | false | true | true |
+| `RIFT_DISTORTION` | false | false | false | true | true |
+| `RIFT_BARRIER` | false | false | false | false | false |
+
+Common object invariants:
+
+```text
+WARP_POINT cell:
+  no object
+
+impassable terrain:
+  no object
+
+one cell:
+  at most one object
+
+STAR:
+  exactly 1 per SRS map
+
+PLANET:
+  multiple per SRS map
+
+STATION:
+  exactly 1 in BASE sectors
+  FLOOR only
+  impassable
+  adjacent INTERACT
+```
+
+## 13. Deferred decisions
+
+The following are intentionally delegated:
+
+```text
+#1088:
+  terrain counts and density
+  gravity-field total amount
+  RIFT_DISTORTION amount/probability
+  STAR/PLANET counts and spacing
+  deterministic placement retry rules
+
+#1089:
+  command schemas
+  turn consumption on STOP_BEFORE
+  partial-route position
+  diagonal corner cutting
+  movement-budget exhaustion
+  VECTOR_COMMAND rasterization
+  DIRECTIONAL_THRUST limits
+```

--- a/experiments/galactic_exodus/srs/phase2_srs_elements.md
+++ b/experiments/galactic_exodus/srs/phase2_srs_elements.md
@@ -1,25 +1,25 @@
-# Galactic Exodus Phase 2 SRS terrain effects
+# Galactic Exodus Phase 2 SRS地形・要素仕様
 
-## 1. Scope
+## 1. 目的と対象範囲
 
-This document records the decisions from #1086 for SRS terrain, map-element passability, observation, movement-cost calculation, WARP_POINT placement, and Terrain/Object compatibility.
+本書は、#1086で確定したSRS地形、マップ要素の通行可否、観測、移動コスト計算、`WARP_POINT`配置、Terrain/Object配置互換性を記録する。
 
-Generation density and counts remain in #1088. Exact command resolution and turn handling remain in #1089.
+地形の配置数・密度は#1088で扱い、移動commandの厳密な解決規則とturn処理は#1089で扱う。
 
-## 2. Map sizes
+## 2. 盤面サイズ
 
 ```text
-supported map sizes:
+対応サイズ:
   9x9
   11x11
 
-baseline:
+基準サイズ:
   9x9
 ```
 
-`7x7` is not supported by the Phase 2 SRS model.
+Phase 2 SRSモデルでは`7x7`を使用しない。
 
-## 3. Terrain types
+## 3. Terrain型
 
 ```text
 FLOOR
@@ -33,9 +33,9 @@ RIFT_DISTORTION
 RIFT_BARRIER
 ```
 
-`WALL` is not used. Impassable cells must have a setting-specific type.
+`WALL`は使用しない。通行不能セルには、世界観上の意味を持つ個別の型を使用する。
 
-## 4. Object types relevant to movement
+## 4. 移動判定に関係するObject型
 
 ```text
 STAR
@@ -45,50 +45,50 @@ RESOURCE_CACHE
 SALVAGE
 ```
 
-`STATION_STRUCTURE` and `BASE_NODE` are replaced by one impassable, adjacent-interaction `STATION` object.
+`STATION_STRUCTURE`と`BASE_NODE`は廃止し、通行不能かつ隣接操作可能な1セルObjectである`STATION`へ統合する。
 
-## 5. Terrain attributes
+## 5. Terrain属性
 
-| id | Japanese name | passable | move multiplier | observation | blocks movement/line travel | can host WARP_POINT |
+| ID | 和名 | 通行可能 | 移動倍率 | 観測範囲 | 移動・直線航行を遮断 | `WARP_POINT`配置可 |
 |---|---|---:|---:|---|---:|---:|
 | `FLOOR` | 通常空間 | true | 1 | 5x5 | false | true |
 | `DEBRIS` | デブリ帯 | true | 2 | 5x5 | false | false |
 | `NEBULA` | 星雲 | true | 2 | 3x3 | false | false |
 | `ASTEROID_FIELD` | 小惑星密集域 | true | 3 | 5x5 | false | false |
 | `ASTEROID` | 大型小惑星 | false | - | - | true | false |
-| `GRAVITY_FIELD_VERTICAL` | 南北重力異常領域 | true | 1 or 2 | 5x5 | false | false |
-| `GRAVITY_FIELD_HORIZONTAL` | 東西重力異常領域 | true | 1 or 2 | 5x5 | false | false |
+| `GRAVITY_FIELD_VERTICAL` | 南北重力異常領域 | true | 1または2 | 5x5 | false | false |
+| `GRAVITY_FIELD_HORIZONTAL` | 東西重力異常領域 | true | 1または2 | 5x5 | false | false |
 | `RIFT_DISTORTION` | 断層歪曲領域 | true | 2 | 5x5 | false | false |
 | `RIFT_BARRIER` | 断層障壁 | false | - | - | true | false |
 
-Only `passable = false` elements block movement and straight-line travel. Passable terrain never blocks a route even when it increases cost or reduces observation.
+`passable = false`の要素だけが移動と直線航行を遮断する。通行可能Terrainは、移動コスト増加や観測範囲縮小の効果を持っていても経路を遮断しない。
 
-## 6. Observation
+## 6. 観測
 
-Observation is updated after every successful one-cell step.
+観測は成功した1セル移動ごとに更新する。
 
 ```text
-1. move to the next cell
-2. inspect the destination terrain
-3. NEBULA -> observe 3x3; otherwise -> observe 5x5
-4. merge the result into the persistent discovered map
-5. continue to the next step when movement remains
+1. 次のセルへ移動する
+2. 移動先セルのterrainを確認する
+3. NEBULAなら3x3、それ以外なら5x5を観測する
+4. 観測結果を永続的な既知マップへ統合する
+5. 移動が残っていれば次の1セルへ進む
 ```
 
-Known cells are cumulative and are not forgotten when entering NEBULA.
+既知セルは累積保持し、`NEBULA`へ進入しても過去に発見した情報を忘れない。
 
-A failed move that does not enter a new cell does not trigger destination-cell observation.
+新しいセルへの移動が成立しなかった場合、移動先セル基準の観測更新は発生しない。
 
-## 7. Geometric movement cost
+## 7. 幾何学的な移動コスト
 
-Use integer Euclidean approximation:
+ユークリッド距離を整数で近似する。
 
 ```text
 ORTHOGONAL_COST = 10
 DIAGONAL_COST = 14
 ```
 
-Route cost is the sum of actual one-cell steps. It is not calculated only from the route endpoints.
+経路コストは、実際に通過した1セル単位のstep costを合計する。始点と終点の座標差だけでは計算しない。
 
 ```text
 step_cost = geometric_step_cost
@@ -96,9 +96,9 @@ step_cost = geometric_step_cost
           * gravity_multiplier
 ```
 
-Examples:
+例:
 
-| destination terrain | orthogonal | diagonal |
+| 移動先Terrain | 縦横移動 | 斜め移動 |
 |---|---:|---:|
 | `FLOOR` | 10 | 14 |
 | `DEBRIS` | 20 | 28 |
@@ -106,11 +106,11 @@ Examples:
 | `ASTEROID_FIELD` | 30 | 42 |
 | `RIFT_DISTORTION` | 20 | 28 |
 
-## 8. Gravity fields
+## 8. 重力異常領域
 
 ### `GRAVITY_FIELD_VERTICAL`
 
-A north-south gravity field. A step whose X coordinate changes has double cost.
+南北方向に沿った重力異常領域であり、X座標の変化を伴う移動のコストを2倍にする。
 
 ```text
 if dx != 0:
@@ -121,7 +121,7 @@ else:
 
 ### `GRAVITY_FIELD_HORIZONTAL`
 
-An east-west gravity field. A step whose Y coordinate changes has double cost.
+東西方向に沿った重力異常領域であり、Y座標の変化を伴う移動のコストを2倍にする。
 
 ```text
 if dy != 0:
@@ -130,13 +130,13 @@ else:
   gravity_multiplier = 1
 ```
 
-Diagonal movement changes both axes, so it is doubled in either gravity-field type.
+斜め移動ではX座標とY座標の両方が変化するため、どちらの重力異常領域でもコストが2倍になる。
 
-In a GRAVITY sector, vertical and horizontal cells are selected randomly. Either type alone or both types may occur, but their total count must be at least one. Total placement amount is decided in #1088.
+`GRAVITY`星系では、南北・東西の重力異常セルをランダムに選択する。片方のみ、または両方の混在を許可するが、合計配置数は必ず1セル以上とする。総配置量は#1088で決定する。
 
-## 9. Impassable elements and STOP_BEFORE
+## 9. 通行不能要素と`STOP_BEFORE`
 
-The shared impassable set is:
+共通の通行不能要素は次のとおり。
 
 ```text
 ASTEROID
@@ -146,60 +146,60 @@ PLANET
 STATION
 ```
 
-All use the same behavior:
+すべて共通して次の挙動を使用する。
 
 ```text
 collision_behavior = STOP_BEFORE
 movement_cost_consumed = false
 ```
 
-Detailed turn consumption, partial-route position, and command semantics are decided in #1089.
+turn消費、途中まで進んだ場合の最終位置、command全体の扱いは#1089で決定する。
 
-## 10. WARP_POINT feature placement
+## 10. `WARP_POINT`の配置
 
-A WARP_POINT represents a gravity-stable location suitable for inter-sector warp.
+`WARP_POINT`は、隣接星系へワープ可能な重力の安定した地点を表す。
 
 ```text
-WARP_POINT may be placed on FLOOR only.
+WARP_POINTはFLOOR上にのみ配置可能
 ```
 
-Generation invariants:
+生成時の不変条件:
 
 ```text
-valid edge midpoint:
+有効な辺中央:
   terrain = FLOOR
   feature = WARP_POINT
 
-inner adjacent cell:
+内側隣接セル:
   terrain = FLOOR
 
-WARP_POINT cell:
-  no object
+WARP_POINTセル:
+  object配置不可
 
-RIFT blocked edge:
-  no WARP_POINT
+RIFTのblocked edge:
+  WARP_POINTを生成しない
 ```
 
-## 11. SectorType x Terrain matrix
+## 11. SectorType × Terrainマトリクス
 
-Legend:
+凡例:
 
-- `required`: at least one or structurally required
-- `optional`: allowed by the sector profile
-- `forbidden`: not allowed
-- `blocked-edge-required`: required on each blocked edge
+- `必須`: 1セル以上、または構造上必ず必要
+- `任意`: Sector profileに応じて配置可能
+- `禁止`: 配置不可
+- `blocked辺に必須`: 各blocked edgeに対応して必須
 
 | SectorType | FLOOR | DEBRIS | NEBULA | ASTEROID_FIELD | ASTEROID | GRAVITY_VERTICAL | GRAVITY_HORIZONTAL | RIFT_DISTORTION | RIFT_BARRIER |
 |---|---|---|---|---|---|---|---|---|---|
-| `NORMAL` | required | optional | forbidden | forbidden | forbidden | forbidden | forbidden | forbidden | forbidden |
-| `BASE` | required | optional | forbidden | forbidden | forbidden | forbidden | forbidden | forbidden | forbidden |
-| `RESOURCE` | required | required | forbidden | optional | optional | forbidden | forbidden | forbidden | forbidden |
-| `NEBULA` | required | optional | required | forbidden | forbidden | forbidden | forbidden | forbidden | forbidden |
-| `ASTEROID` | required | optional | forbidden | required | required | forbidden | forbidden | forbidden | forbidden |
-| `GRAVITY` | required | forbidden | forbidden | forbidden | forbidden | optional-or-required | optional-or-required | forbidden | forbidden |
-| `RIFT` | required | optional | forbidden | optional | optional | optional | optional | required | blocked-edge-required |
+| `NORMAL` | 必須 | 任意 | 禁止 | 禁止 | 禁止 | 禁止 | 禁止 | 禁止 | 禁止 |
+| `BASE` | 必須 | 任意 | 禁止 | 禁止 | 禁止 | 禁止 | 禁止 | 禁止 | 禁止 |
+| `RESOURCE` | 必須 | 必須 | 禁止 | 任意 | 任意 | 禁止 | 禁止 | 禁止 | 禁止 |
+| `NEBULA` | 必須 | 任意 | 必須 | 禁止 | 禁止 | 禁止 | 禁止 | 禁止 | 禁止 |
+| `ASTEROID` | 必須 | 任意 | 禁止 | 必須 | 必須 | 禁止 | 禁止 | 禁止 | 禁止 |
+| `GRAVITY` | 必須 | 禁止 | 禁止 | 禁止 | 禁止 | 必須または任意 | 必須または任意 | 禁止 | 禁止 |
+| `RIFT` | 必須 | 任意 | 禁止 | 任意 | 任意 | 任意 | 任意 | 必須 | blocked辺に必須 |
 
-Additional GRAVITY invariant:
+`GRAVITY`星系には、次の追加不変条件を適用する。
 
 ```text
 count(GRAVITY_FIELD_VERTICAL)
@@ -207,65 +207,65 @@ count(GRAVITY_FIELD_VERTICAL)
 >= 1
 ```
 
-`RIFT_DISTORTION` is placed randomly among passable cells immediately inside and adjacent to `RIFT_BARRIER`. Placement amount is decided in #1088.
+`RIFT_DISTORTION`は、`RIFT_BARRIER`の内側に隣接する通行可能候補セルへランダムに配置する。配置量は#1088で決定する。
 
-## 12. Terrain x Object matrix
+## 12. Terrain × Objectマトリクス
 
 | Terrain | STAR | PLANET | STATION | RESOURCE_CACHE | SALVAGE |
 |---|---:|---:|---:|---:|---:|
-| `FLOOR` | true | true | true | true | true |
-| `DEBRIS` | false | false | false | true | true |
-| `NEBULA` | true | true | false | true | true |
-| `ASTEROID_FIELD` | false | false | false | true | true |
-| `ASTEROID` | false | false | false | false | false |
-| `GRAVITY_FIELD_VERTICAL` | true | true | false | true | true |
-| `GRAVITY_FIELD_HORIZONTAL` | true | true | false | true | true |
-| `RIFT_DISTORTION` | false | false | false | true | true |
-| `RIFT_BARRIER` | false | false | false | false | false |
+| `FLOOR` | 可 | 可 | 可 | 可 | 可 |
+| `DEBRIS` | 不可 | 不可 | 不可 | 可 | 可 |
+| `NEBULA` | 可 | 可 | 不可 | 可 | 可 |
+| `ASTEROID_FIELD` | 不可 | 不可 | 不可 | 可 | 可 |
+| `ASTEROID` | 不可 | 不可 | 不可 | 不可 | 不可 |
+| `GRAVITY_FIELD_VERTICAL` | 可 | 可 | 不可 | 可 | 可 |
+| `GRAVITY_FIELD_HORIZONTAL` | 可 | 可 | 不可 | 可 | 可 |
+| `RIFT_DISTORTION` | 不可 | 不可 | 不可 | 可 | 可 |
+| `RIFT_BARRIER` | 不可 | 不可 | 不可 | 不可 | 不可 |
 
-Common object invariants:
+Object配置の共通不変条件:
 
 ```text
-WARP_POINT cell:
-  no object
+WARP_POINTセル:
+  object配置不可
 
-impassable terrain:
-  no object
+通行不能Terrain:
+  object配置不可
 
-one cell:
-  at most one object
+1セル:
+  objectは最大1個
 
 STAR:
-  exactly 1 per SRS map
+  SRSマップごとにexactly 1
 
 PLANET:
-  multiple per SRS map
+  SRSマップごとに複数
 
 STATION:
-  exactly 1 in BASE sectors
-  FLOOR only
-  impassable
-  adjacent INTERACT
+  BASE星系にexactly 1
+  FLOOR上のみ
+  通行不能
+  隣接セルからINTERACT
 ```
 
-## 13. Deferred decisions
+## 13. 後続Issueへ委譲する事項
 
-The following are intentionally delegated:
+以下は意図的に後続Issueへ委譲する。
 
 ```text
 #1088:
-  terrain counts and density
-  gravity-field total amount
-  RIFT_DISTORTION amount/probability
-  STAR/PLANET counts and spacing
-  deterministic placement retry rules
+  terrainの配置数・密度
+  重力異常領域の総配置量
+  RIFT_DISTORTIONの配置量・確率
+  STAR / PLANETの個数・間隔
+  決定的生成の再試行規則
 
 #1089:
-  command schemas
-  turn consumption on STOP_BEFORE
-  partial-route position
-  diagonal corner cutting
-  movement-budget exhaustion
-  VECTOR_COMMAND rasterization
-  DIRECTIONAL_THRUST limits
+  command schema
+  STOP_BEFORE時のturn消費
+  途中停止時の最終位置
+  斜め移動のcorner cutting
+  movement budget不足時の処理
+  VECTOR_COMMANDの経路ラスタライズ
+  DIRECTIONAL_THRUSTの距離上限
 ```

--- a/experiments/galactic_exodus/srs/test_validate_phase2_srs_elements.py
+++ b/experiments/galactic_exodus/srs/test_validate_phase2_srs_elements.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from experiments.galactic_exodus.srs import validate_phase2_srs_elements as validator
+
+
+class Phase2SrsElementsValidationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.path = Path(self.tempdir.name) / "elements.json"
+        source = Path(__file__).with_name("phase2_srs_elements.json")
+        self.payload = json.loads(source.read_text(encoding="utf-8"))
+        self.write()
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def write(self) -> None:
+        self.path.write_text(json.dumps(self.payload), encoding="utf-8")
+
+    def test_valid_contract_is_accepted(self) -> None:
+        validator.validate(self.path)
+
+    def test_7x7_is_rejected(self) -> None:
+        self.payload["map_sizes"] = [[7, 7], [9, 9]]
+        self.write()
+        with self.assertRaisesRegex(validator.ValidationError, "9x9 and 11x11"):
+            validator.validate(self.path)
+
+    def test_nebula_observation_must_be_3(self) -> None:
+        self.payload["terrain_types"]["NEBULA"]["observation_size"] = 5
+        self.write()
+        with self.assertRaisesRegex(validator.ValidationError, "NEBULA"):
+            validator.validate(self.path)
+
+    def test_only_floor_hosts_warp_point(self) -> None:
+        self.payload["terrain_types"]["DEBRIS"]["can_host_feature"] = True
+        self.write()
+        with self.assertRaisesRegex(validator.ValidationError, "DEBRIS must not host features"):
+            validator.validate(self.path)
+
+    def test_gravity_axis_contract_is_enforced(self) -> None:
+        self.payload["terrain_types"]["GRAVITY_FIELD_VERTICAL"][
+            "double_cost_when_axis_changes"
+        ] = "Y"
+        self.write()
+        with self.assertRaisesRegex(validator.ValidationError, "vertical gravity"):
+            validator.validate(self.path)
+
+    def test_impassable_collision_must_not_consume_cost(self) -> None:
+        self.payload["object_types"]["PLANET"]["movement_cost_consumed_on_collision"] = True
+        self.write()
+        with self.assertRaisesRegex(validator.ValidationError, "PLANET collision"):
+            validator.validate(self.path)
+
+    def test_station_must_be_floor_only(self) -> None:
+        self.payload["terrain_object_matrix"]["NEBULA"].append("STATION")
+        self.write()
+        with self.assertRaisesRegex(validator.ValidationError, "STATION must be FLOOR-only"):
+            validator.validate(self.path)
+
+    def test_impassable_terrain_cannot_host_objects(self) -> None:
+        self.payload["terrain_object_matrix"]["ASTEROID"] = ["SALVAGE"]
+        self.write()
+        with self.assertRaisesRegex(validator.ValidationError, "impassable terrain"):
+            validator.validate(self.path)
+
+    def test_gravity_sector_requires_at_least_one_field(self) -> None:
+        self.payload["sector_terrain_matrix"]["GRAVITY"]["invariants"][
+            "gravity_field_total_min"
+        ] = 0
+        self.write()
+        with self.assertRaisesRegex(validator.ValidationError, "at least one gravity field"):
+            validator.validate(self.path)
+
+    def test_removed_wall_must_not_return(self) -> None:
+        self.payload["terrain_types"]["WALL"] = dict(
+            self.payload["terrain_types"]["ASTEROID"]
+        )
+        self.write()
+        with self.assertRaisesRegex(validator.ValidationError, "exact expected set"):
+            validator.validate(self.path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experiments/galactic_exodus/srs/validate_phase2_srs_elements.py
+++ b/experiments/galactic_exodus/srs/validate_phase2_srs_elements.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Validate Galactic Exodus Phase 2 SRS terrain and placement contracts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+EXPECTED_TERRAINS = {
+    "FLOOR",
+    "DEBRIS",
+    "NEBULA",
+    "ASTEROID_FIELD",
+    "ASTEROID",
+    "GRAVITY_FIELD_VERTICAL",
+    "GRAVITY_FIELD_HORIZONTAL",
+    "RIFT_DISTORTION",
+    "RIFT_BARRIER",
+}
+EXPECTED_SECTORS = {"NORMAL", "BASE", "RESOURCE", "NEBULA", "ASTEROID", "GRAVITY", "RIFT"}
+EXPECTED_OBJECTS = {"STAR", "PLANET", "STATION", "RESOURCE_CACHE", "SALVAGE"}
+IMPASSABLE = {"ASTEROID", "RIFT_BARRIER", "STAR", "PLANET", "STATION"}
+
+
+class ValidationError(ValueError):
+    """Raised when the SRS elements contract is inconsistent."""
+
+
+def load(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValidationError(f"missing file: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValidationError(f"invalid JSON in {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValidationError("root must be an object")
+    return data
+
+
+def validate(path: Path) -> dict[str, Any]:
+    data = load(path)
+    if data.get("schema_version") != 1:
+        raise ValidationError("schema_version must be 1")
+    if data.get("map_sizes") != [[9, 9], [11, 11]]:
+        raise ValidationError("map_sizes must be 9x9 and 11x11")
+    if data.get("baseline_map_size") != [9, 9]:
+        raise ValidationError("baseline_map_size must be 9x9")
+
+    costs = data.get("geometric_costs", {})
+    if costs != {"orthogonal": 10, "diagonal": 14}:
+        raise ValidationError("geometric costs must be 10 and 14")
+
+    observation = data.get("observation", {})
+    expected_observation = {
+        "default_size": 5,
+        "nebula_size": 3,
+        "update_after_each_successful_step": True,
+        "known_map_is_cumulative": True,
+        "use_destination_terrain": True,
+    }
+    if observation != expected_observation:
+        raise ValidationError("observation contract mismatch")
+
+    terrains = data.get("terrain_types")
+    if not isinstance(terrains, dict) or set(terrains) != EXPECTED_TERRAINS:
+        raise ValidationError("terrain_types must contain the exact expected set")
+    if "WALL" in terrains or "STATION_STRUCTURE" in terrains:
+        raise ValidationError("removed terrain types must not remain")
+
+    for terrain_id, terrain in terrains.items():
+        if not isinstance(terrain.get("passable"), bool):
+            raise ValidationError(f"{terrain_id}.passable must be boolean")
+        if terrain["passable"] and terrain.get("blocks_line_travel") is not False:
+            raise ValidationError(f"{terrain_id}: passable terrain must not block line travel")
+        if not terrain["passable"]:
+            if terrain.get("blocks_line_travel") is not True:
+                raise ValidationError(f"{terrain_id}: impassable terrain must block line travel")
+            if terrain.get("collision_behavior") != "STOP_BEFORE":
+                raise ValidationError(f"{terrain_id}: collision behavior must be STOP_BEFORE")
+            if terrain.get("movement_cost_consumed_on_collision") is not False:
+                raise ValidationError(f"{terrain_id}: collision must not consume movement cost")
+
+    if terrains["FLOOR"].get("allowed_features") != ["WARP_POINT"]:
+        raise ValidationError("FLOOR must host WARP_POINT")
+    for terrain_id in EXPECTED_TERRAINS - {"FLOOR"}:
+        if terrains[terrain_id].get("can_host_feature") is not False:
+            raise ValidationError(f"{terrain_id} must not host features")
+
+    if terrains["NEBULA"].get("move_multiplier") != 2 or terrains["NEBULA"].get("observation_size") != 3:
+        raise ValidationError("NEBULA must have cost 2 and observation 3x3")
+    if terrains["DEBRIS"].get("move_multiplier") != 2:
+        raise ValidationError("DEBRIS cost must be 2")
+    if terrains["ASTEROID_FIELD"].get("move_multiplier") != 3:
+        raise ValidationError("ASTEROID_FIELD cost must be 3")
+    if terrains["RIFT_DISTORTION"].get("move_multiplier") != 2:
+        raise ValidationError("RIFT_DISTORTION cost must be 2")
+    if terrains["RIFT_DISTORTION"].get("placement") != "RANDOM_INNER_ADJACENT_TO_RIFT_BARRIER":
+        raise ValidationError("RIFT_DISTORTION placement mismatch")
+
+    vertical = terrains["GRAVITY_FIELD_VERTICAL"]
+    horizontal = terrains["GRAVITY_FIELD_HORIZONTAL"]
+    if vertical.get("double_cost_when_axis_changes") != "X":
+        raise ValidationError("vertical gravity must double X-changing movement")
+    if horizontal.get("double_cost_when_axis_changes") != "Y":
+        raise ValidationError("horizontal gravity must double Y-changing movement")
+
+    objects = data.get("object_types")
+    if not isinstance(objects, dict) or set(objects) != EXPECTED_OBJECTS:
+        raise ValidationError("object_types must contain the exact expected set")
+    if "BASE_NODE" in objects:
+        raise ValidationError("BASE_NODE must not remain")
+    for object_id in {"STAR", "PLANET", "STATION"}:
+        obj = objects[object_id]
+        if obj.get("passable") is not False or obj.get("blocks_line_travel") is not True:
+            raise ValidationError(f"{object_id} must be impassable and block line travel")
+        if obj.get("collision_behavior") != "STOP_BEFORE":
+            raise ValidationError(f"{object_id} must use STOP_BEFORE")
+        if obj.get("movement_cost_consumed_on_collision") is not False:
+            raise ValidationError(f"{object_id} collision must not consume movement cost")
+    if objects["STATION"].get("interaction_range") != "ADJACENT":
+        raise ValidationError("STATION must use adjacent interaction")
+
+    if set(data.get("impassable_elements", [])) != IMPASSABLE:
+        raise ValidationError("impassable_elements mismatch")
+
+    warp = data.get("warp_point", {})
+    if warp.get("allowed_terrain") != ["FLOOR"]:
+        raise ValidationError("WARP_POINT must be FLOOR-only")
+    for key in ("edge_midpoint_only", "allows_object", "forbidden_on_rift_blocked_edge"):
+        if key == "allows_object":
+            if warp.get(key) is not False:
+                raise ValidationError("WARP_POINT must forbid objects")
+        elif warp.get(key) is not True:
+            raise ValidationError(f"warp_point.{key} must be true")
+    if warp.get("inner_adjacent_terrain") != "FLOOR":
+        raise ValidationError("WARP_POINT inner adjacent terrain must be FLOOR")
+
+    sector_matrix = data.get("sector_terrain_matrix")
+    if not isinstance(sector_matrix, dict) or set(sector_matrix) != EXPECTED_SECTORS:
+        raise ValidationError("sector_terrain_matrix must define every sector")
+    gravity_invariants = sector_matrix["GRAVITY"].get("invariants", {})
+    if gravity_invariants.get("gravity_field_total_min") != 1:
+        raise ValidationError("GRAVITY must contain at least one gravity field cell")
+    if gravity_invariants.get("orientation_mix") != "RANDOM":
+        raise ValidationError("GRAVITY orientation mix must be random")
+
+    object_matrix = data.get("terrain_object_matrix")
+    if not isinstance(object_matrix, dict) or set(object_matrix) != EXPECTED_TERRAINS:
+        raise ValidationError("terrain_object_matrix must define every terrain")
+    for terrain_id, allowed in object_matrix.items():
+        if not isinstance(allowed, list) or not set(allowed) <= EXPECTED_OBJECTS:
+            raise ValidationError(f"{terrain_id}: invalid allowed objects")
+    if set(object_matrix["FLOOR"]) != EXPECTED_OBJECTS:
+        raise ValidationError("FLOOR must allow all current objects")
+    if object_matrix["ASTEROID"] or object_matrix["RIFT_BARRIER"]:
+        raise ValidationError("impassable terrain must not host objects")
+    if "STATION" in set().union(*(set(v) for k, v in object_matrix.items() if k != "FLOOR")):
+        raise ValidationError("STATION must be FLOOR-only")
+
+    constraints = data.get("common_object_constraints", {})
+    if constraints.get("max_objects_per_cell") != 1:
+        raise ValidationError("max_objects_per_cell must be 1")
+    if constraints.get("objects_forbidden_on_warp_point") is not True:
+        raise ValidationError("objects must be forbidden on WARP_POINT")
+    if constraints.get("objects_forbidden_on_impassable_terrain") is not True:
+        raise ValidationError("objects must be forbidden on impassable terrain")
+    if constraints.get("star_count") != 1:
+        raise ValidationError("STAR count must be 1")
+    if constraints.get("planet_count_min", 0) < 2:
+        raise ValidationError("PLANET count minimum must be at least 2")
+    if constraints.get("station_count_in_base") != 1 or constraints.get("station_terrain") != "FLOOR":
+        raise ValidationError("BASE must contain one FLOOR STATION")
+
+    deferred = data.get("deferred_to", {})
+    if set(deferred) != {"1088", "1089"}:
+        raise ValidationError("deferred decisions must target #1088 and #1089")
+
+    return data
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", type=Path)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        validate(args.path)
+    except ValidationError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    print("Phase 2 SRS elements: OK")
+    print("terrain types: 9")
+    print("object types: 5")
+    print("map sizes: 9x9, 11x11")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #1086

## 概要

Galactic Exodus Phase 2 SRSのterrain、通行不能要素、観測、移動コスト、WARP_POINT配置、Terrain/Object配置可否を機械可読な契約として追加します。

このPRはPR #1084の作業ブランチ `issue-1079-phase2-srs-initial-model` をbaseとするstacked PRです。

## 成果物

```text
experiments/galactic_exodus/srs/phase2_srs_elements.md
experiments/galactic_exodus/srs/phase2_srs_elements.json
experiments/galactic_exodus/srs/validate_phase2_srs_elements.py
experiments/galactic_exodus/srs/test_validate_phase2_srs_elements.py
```

## 主な決定

- 盤面サイズは9x9 / 11x11、基準は9x9
- `WALL`を削除
- `STATION_STRUCTURE` / `BASE_NODE`を1セルの`STATION`へ統合
- 通常観測5x5、NEBULA観測3x3
- 成功した1マス移動ごとに移動先terrainを基準に観測更新
- 縦横移動cost 10、斜め移動cost 14
- `DEBRIS` cost 2
- `NEBULA` cost 2
- `ASTEROID_FIELD` cost 3
- `RIFT_DISTORTION` cost 2
- `GRAVITY_FIELD_VERTICAL`はX軸変化時に2倍
- `GRAVITY_FIELD_HORIZONTAL`はY軸変化時に2倍
- GRAVITY星系では縦横の混在比率をランダム化し、合計1セル以上を保証
- passable=falseの要素だけが移動と直線航行を遮断
- `ASTEROID / RIFT_BARRIER / STAR / PLANET / STATION`は共通して`STOP_BEFORE`、移動cost非消費
- WARP_POINTはFLOOR上だけに配置可能
- SectorType × TerrainおよびTerrain × Objectマトリクスを固定
- RIFT_DISTORTIONはRIFT_BARRIER内側隣接候補へランダム配置

## 委譲事項

```text
#1088:
  terrain配置量・密度
  GRAVITY総配置量
  RIFT_DISTORTION配置量・確率
  天体数・間隔
  決定的生成の再試行

#1089:
  STOP_BEFORE時のturn
  途中停止位置
  corner cutting
  movement budget不足
  VECTOR経路列挙
  THRUST上限
```

## 検証

```bash
python experiments/galactic_exodus/srs/validate_phase2_srs_elements.py \
  experiments/galactic_exodus/srs/phase2_srs_elements.json

python -m unittest \
  experiments.galactic_exodus.srs.test_validate_phase2_srs_elements
```
