### PR TITLE
SRS生成profile仕様書とJSON契約を追加

### DIFF
--- a/experiments/galactic_exodus/srs/phase2_srs_generation.json
+++ b/experiments/galactic_exodus/srs/phase2_srs_generation.json
@@ -281,8 +281,8 @@
       ],
       "seed_hash_algorithm": "SHA-256",
       "seed_encoding": {
-        "serialization": "CANONICAL_JSON_UTF8",
-        "field_order": [
+        "serialization": "CANONICAL_JSON_OBJECT_UTF8",
+        "required_fields": [
           "generation_schema_version",
           "galaxy_seed",
           "sector_x",
@@ -310,8 +310,8 @@
       "python_reference_rng": "random.Random(seed)",
       "tbx_port_requirement": "MATCH_FIXTURES_OR_INVARIANTS",
       "attempt_seed": {
-        "input_fields": ["base_seed", "retry_index"],
-        "encoding": "SAME_AS_BASE_SEED_ENCODING"
+        "payload_fields": ["base_seed", "retry_index"],
+        "serialization": "SAME_CANONICAL_JSON_OBJECT_ENCODING_AS_BASE_SEED"
       },
       "derived_seed_labels": [
         "terrain_seed",
@@ -319,8 +319,8 @@
         "object_seed"
       ],
       "derived_seed_encoding": {
-        "input_fields": ["attempt_seed", "phase_label"],
-        "encoding": "SAME_AS_BASE_SEED_ENCODING"
+        "payload_fields": ["attempt_seed", "phase_label"],
+        "serialization": "SAME_CANONICAL_JSON_OBJECT_ENCODING_AS_BASE_SEED"
       },
       "retry": {
         "seed_source": "ATTEMPT_SEED_FROM_BASE_SEED_AND_RETRY_INDEX",

--- a/experiments/galactic_exodus/srs/phase2_srs_generation.json
+++ b/experiments/galactic_exodus/srs/phase2_srs_generation.json
@@ -202,7 +202,14 @@
         "VALIDATE_SPECIAL_TERRAIN_LIMIT",
         "REDUCE_OPTIONAL_TERRAIN_IN_FIXED_PRIORITY_WITHOUT_REROLL",
         "REVALIDATE_REQUIRED_TERRAIN_MINIMUMS"
-      ]
+      ],
+      "optional_terrain_reduction_rule": {
+        "unit": "ONE_CELL_PER_STEP",
+        "scan_order": "SECTOR_PROFILE_PRIORITY_ORDER",
+        "restart_priority_scan_after_each_decrement": true,
+        "stop_when_within_limit": true,
+        "fail_if_no_optional_terrain_can_be_reduced": true
+      }
     },
     "clustering": {
       "clustered_terrains": [
@@ -273,17 +280,55 @@
         "sector_descriptor"
       ],
       "seed_hash_algorithm": "SHA-256",
+      "seed_encoding": {
+        "serialization": "CANONICAL_JSON_UTF8",
+        "field_order": [
+          "generation_schema_version",
+          "galaxy_seed",
+          "sector_x",
+          "sector_y",
+          "sector_descriptor"
+        ],
+        "unicode_normalization": "NFC",
+        "object_key_order": "LEXICOGRAPHIC_ASCENDING",
+        "set_like_field_encoding": "SORTED_ARRAY",
+        "sector_descriptor_encoding": {
+          "serialization": "CANONICAL_JSON_OBJECT",
+          "object_key_order": "LEXICOGRAPHIC_ASCENDING",
+          "blocked_edges_encoding": {
+            "container": "ARRAY",
+            "order": ["N", "E", "S", "W"]
+          },
+          "future_fields_rule": "APPLY_SAME_CANONICAL_JSON_RULES"
+        },
+        "digest_to_integer": {
+          "bytes": "FULL_32_BYTES",
+          "byte_order": "BIG_ENDIAN",
+          "signed": false
+        }
+      },
       "python_reference_rng": "random.Random(seed)",
       "tbx_port_requirement": "MATCH_FIXTURES_OR_INVARIANTS",
+      "attempt_seed": {
+        "input_fields": ["base_seed", "retry_index"],
+        "encoding": "SAME_AS_BASE_SEED_ENCODING"
+      },
       "derived_seed_labels": [
         "terrain_seed",
         "celestial_seed",
         "object_seed"
       ],
+      "derived_seed_encoding": {
+        "input_fields": ["attempt_seed", "phase_label"],
+        "encoding": "SAME_AS_BASE_SEED_ENCODING"
+      },
       "retry": {
-        "seed_source": "BASE_SEED_PLUS_RETRY_INDEX",
+        "seed_source": "ATTEMPT_SEED_FROM_BASE_SEED_AND_RETRY_INDEX",
         "scope": "FULL_MAP_REGENERATION",
-        "max_retry_count": 64,
+        "attempt_count_max": 64,
+        "retry_index_min": 0,
+        "retry_index_max": 63,
+        "initial_attempt_retry_index": 0,
         "fallback_map": false
       },
       "versioning": {
@@ -306,6 +351,7 @@
     "NORMAL": {
       "required_terrain": ["FLOOR"],
       "optional_terrain": ["DEBRIS"],
+      "optional_terrain_reduction_priority": ["DEBRIS"],
       "forbidden_terrain": [
         "NEBULA",
         "ASTEROID_FIELD",
@@ -392,6 +438,7 @@
     "BASE": {
       "required_terrain": ["FLOOR"],
       "optional_terrain": ["DEBRIS"],
+      "optional_terrain_reduction_priority": ["DEBRIS"],
       "forbidden_terrain": [
         "NEBULA",
         "ASTEROID_FIELD",
@@ -477,6 +524,7 @@
     "RESOURCE": {
       "required_terrain": ["FLOOR", "DEBRIS"],
       "optional_terrain": ["ASTEROID_FIELD", "ASTEROID"],
+      "optional_terrain_reduction_priority": ["ASTEROID", "ASTEROID_FIELD"],
       "forbidden_terrain": [
         "NEBULA",
         "GRAVITY_FIELD_VERTICAL",
@@ -586,6 +634,7 @@
     "NEBULA": {
       "required_terrain": ["FLOOR", "NEBULA"],
       "optional_terrain": ["DEBRIS"],
+      "optional_terrain_reduction_priority": ["DEBRIS"],
       "forbidden_terrain": [
         "ASTEROID_FIELD",
         "ASTEROID",
@@ -679,6 +728,7 @@
     "ASTEROID": {
       "required_terrain": ["FLOOR", "ASTEROID_FIELD", "ASTEROID"],
       "optional_terrain": ["DEBRIS"],
+      "optional_terrain_reduction_priority": ["DEBRIS"],
       "forbidden_terrain": [
         "NEBULA",
         "GRAVITY_FIELD_VERTICAL",
@@ -788,6 +838,10 @@
     "GRAVITY": {
       "required_terrain": ["FLOOR"],
       "optional_terrain": ["GRAVITY_FIELD_VERTICAL", "GRAVITY_FIELD_HORIZONTAL"],
+      "optional_terrain_reduction_priority": [
+        "GRAVITY_FIELD_HORIZONTAL",
+        "GRAVITY_FIELD_VERTICAL"
+      ],
       "forbidden_terrain": [
         "DEBRIS",
         "NEBULA",
@@ -879,6 +933,13 @@
         "ASTEROID",
         "GRAVITY_FIELD_VERTICAL",
         "GRAVITY_FIELD_HORIZONTAL"
+      ],
+      "optional_terrain_reduction_priority": [
+        "DEBRIS",
+        "ASTEROID_FIELD",
+        "ASTEROID",
+        "GRAVITY_FIELD_HORIZONTAL",
+        "GRAVITY_FIELD_VERTICAL"
       ],
       "forbidden_terrain": ["NEBULA"],
       "terrain_count_ranges": {

--- a/experiments/galactic_exodus/srs/phase2_srs_generation.json
+++ b/experiments/galactic_exodus/srs/phase2_srs_generation.json
@@ -1,0 +1,1020 @@
+{
+  "generation_schema_version": 1,
+  "map_sizes": [[9, 9], [11, 11]],
+  "sector_types": [
+    "NORMAL",
+    "BASE",
+    "RESOURCE",
+    "NEBULA",
+    "ASTEROID",
+    "GRAVITY",
+    "RIFT"
+  ],
+  "terrain_types": [
+    "FLOOR",
+    "DEBRIS",
+    "NEBULA",
+    "ASTEROID_FIELD",
+    "ASTEROID",
+    "GRAVITY_FIELD_VERTICAL",
+    "GRAVITY_FIELD_HORIZONTAL",
+    "RIFT_DISTORTION",
+    "RIFT_BARRIER"
+  ],
+  "object_types": [
+    "STAR",
+    "PLANET",
+    "STATION",
+    "RESOURCE_CACHE",
+    "SALVAGE"
+  ],
+  "legacy_contracts_removed": {
+    "generic_obstacle_density": true,
+    "fixed_single_cell_edge_entry_feature": true,
+    "entry_descriptor_specific_representation": true,
+    "generic_impassable_terrain_name": true,
+    "legacy_base_object_name": true,
+    "legacy_base_structure_terrain_name": true
+  },
+  "constraint_definitions": {
+    "CELESTIAL_NOT_ON_OUTER_EDGE": {
+      "subjects": ["STAR", "PLANET"],
+      "type": "outer_edge_forbidden"
+    },
+    "CELESTIAL_PAIR_MIN_CHEBYSHEV_2": {
+      "subjects": ["STAR", "PLANET"],
+      "type": "pairwise_min_chebyshev_distance",
+      "min_distance": 2
+    },
+    "CELESTIAL_FROM_WARP_FLAG_MIN_CHEBYSHEV_2": {
+      "subjects": ["STAR", "PLANET"],
+      "anchor": "warp_flagged_cell",
+      "type": "anchor_min_chebyshev_distance",
+      "min_distance": 2
+    },
+    "STATION_FROM_CELESTIAL_MIN_CHEBYSHEV_2": {
+      "subjects": ["STATION"],
+      "anchors": ["STAR", "PLANET"],
+      "type": "anchor_min_chebyshev_distance",
+      "min_distance": 2
+    },
+    "STATION_NEIGHBORHOOD_RESERVED_FLOOR": {
+      "subjects": ["STATION"],
+      "type": "neighbor_reserved_terrain",
+      "metric": "chebyshev",
+      "radius": 1,
+      "reserved_terrain": "FLOOR"
+    },
+    "VALUE_OBJECT_FROM_WARP_FLAG_MIN_CHEBYSHEV_2": {
+      "subjects": ["RESOURCE_CACHE", "SALVAGE"],
+      "anchor": "warp_flagged_cell",
+      "type": "anchor_min_chebyshev_distance",
+      "min_distance": 2
+    },
+    "VALUE_OBJECT_FROM_IMPASSABLE_CELESTIAL_MIN_CHEBYSHEV_2": {
+      "subjects": ["RESOURCE_CACHE", "SALVAGE"],
+      "anchors": ["STAR", "PLANET", "STATION"],
+      "type": "anchor_min_chebyshev_distance",
+      "min_distance": 2
+    },
+    "VALUE_OBJECTS_INDIVIDUALLY_REACHABLE": {
+      "subjects": ["RESOURCE_CACHE", "SALVAGE"],
+      "type": "must_be_reachable_individually"
+    },
+    "RESOURCE_FIELD_IMPASSABLE_BALANCE": {
+      "sector_type": "RESOURCE",
+      "type": "terrain_count_relation",
+      "left": ["ASTEROID_FIELD", "ASTEROID"],
+      "operator": "<=",
+      "right": ["DEBRIS"]
+    },
+    "ASTEROID_CLUSTER_IMPASSABLE_BALANCE": {
+      "sector_type": "ASTEROID",
+      "type": "terrain_count_relation",
+      "left": ["ASTEROID"],
+      "operator": "<=",
+      "right": {
+        "terrain": "ASTEROID_FIELD",
+        "divisor": 2
+      }
+    },
+    "GRAVITY_TOTAL_MIN_1": {
+      "sector_type": "GRAVITY",
+      "type": "terrain_sum_min",
+      "terrains": ["GRAVITY_FIELD_VERTICAL", "GRAVITY_FIELD_HORIZONTAL"],
+      "min": 1
+    },
+    "RIFT_DISTORTION_BARRIER_ADJACENT_PERCENT": {
+      "sector_type": "RIFT",
+      "type": "candidate_percent_range",
+      "terrain": "RIFT_DISTORTION",
+      "candidate_pool": "BARRIER_INNER_ADJACENT_FLOOR",
+      "min_percent": 30,
+      "max_percent": 60,
+      "minimum_count": 1,
+      "selection_order": "SEEDED_SHUFFLE_AFTER_COORDINATE_ORDER"
+    }
+  },
+  "global_generation_contract": {
+    "floor_policy": {
+      "derived_as_residual_after_terrain_placement": true
+    },
+    "terrain_role_contract": {
+      "required_terrain_min_count": 1,
+      "optional_terrain_min_count": 0
+    },
+    "celestial_objects": {
+      "STAR": {
+        "count": 1
+      },
+      "PLANET": {
+        "9x9": {
+          "min": 2,
+          "max": 4
+        },
+        "11x11": {
+          "min": 3,
+          "max": 6
+        }
+      }
+    },
+    "value_objects": {
+      "allow_resource_cache_and_salvage_on_same_map": true,
+      "allow_same_cell_overlap": false
+    },
+    "warp": {
+      "representation": {
+        "per_cell_directional_flags": ["N", "E", "S", "W"],
+        "legacy_fixed_entry_feature_removed": true,
+        "legacy_entry_descriptor_removed": true
+      },
+      "reserved_floor_cluster": {
+        "min_width": 2,
+        "min_height": 2,
+        "min_clusters_per_open_edge": 1,
+        "allow_additional_qualifying_clusters": true,
+        "protect_all_qualifying_cluster_cells_from_terrain_overwrite": true
+      },
+      "flag_generation": {
+        "non_rift": "ALLOW_AND_REQUIRE_ON_EACH_EDGE_WITH_ADJACENT_SECTOR",
+        "rift_open_edge": "ALLOW_AND_REQUIRE",
+        "rift_blocked_edge": "FORBID_AND_FILL_WITH_RIFT_BARRIER",
+        "galaxy_outer_edge": "FORBID"
+      },
+      "corners": {
+        "evaluate_each_touching_direction_independently": true,
+        "allow_two_direction_flags": true
+      },
+      "object_rules": {
+        "forbid_objects_on_outer_edge_cells_with_warp_flags": true,
+        "allow_objects_on_inner_reserved_floor_cells": true
+      },
+      "arrival_selection": {
+        "candidate_rule": "OPPOSITE_EDGE_WITH_RETURN_FLAG",
+        "north_south": {
+          "primary": "MIN_ABS_DEST_X_MINUS_SOURCE_X",
+          "tie_break": ["LOWER_X", "LOWER_Y"]
+        },
+        "east_west": {
+          "primary": "MIN_ABS_DEST_Y_MINUS_SOURCE_Y",
+          "tie_break": ["LOWER_Y", "LOWER_X"]
+        },
+        "no_candidate_behavior": "INVALID_MAP_RETRY"
+      }
+    },
+    "generation_order": [
+      "FLOOR_INIT",
+      "RIFT_BARRIER",
+      "WARP_FLOOR_RESERVATION",
+      "REQUIRED_TERRAIN",
+      "OPTIONAL_TERRAIN",
+      "STAR",
+      "PLANET",
+      "STATION",
+      "VALUE_OBJECTS",
+      "WARP_FLAG_DERIVATION",
+      "VALIDATION"
+    ],
+    "terrain_count_resolution": {
+      "steps": [
+        "DRAW_REQUIRED_TERRAIN_IN_RANGE",
+        "DRAW_OPTIONAL_TERRAIN_IN_RANGE_ALLOWING_ZERO",
+        "VALIDATE_SPECIAL_TERRAIN_LIMIT",
+        "REDUCE_OPTIONAL_TERRAIN_IN_FIXED_PRIORITY_WITHOUT_REROLL",
+        "REVALIDATE_REQUIRED_TERRAIN_MINIMUMS"
+      ]
+    },
+    "clustering": {
+      "clustered_terrains": [
+        "NEBULA",
+        "ASTEROID_FIELD",
+        "DEBRIS",
+        "GRAVITY_FIELD_VERTICAL",
+        "GRAVITY_FIELD_HORIZONTAL",
+        "RIFT_DISTORTION"
+      ],
+      "isolated_single_cell_ratio_max": 0.2,
+      "forbid_small_isolated_regions": true,
+      "NEBULA": {
+        "9x9": {
+          "cluster_count": {
+            "min": 1,
+            "max": 2
+          },
+          "cluster_min_size": 4
+        },
+        "11x11": {
+          "cluster_count": {
+            "min": 1,
+            "max": 3
+          },
+          "cluster_min_size": 4
+        }
+      },
+      "ASTEROID": {
+        "place_asteroid_field_first": true,
+        "asteroid_internal_or_neighbor_ratio_min": 0.5
+      },
+      "GRAVITY": {
+        "per_orientation_with_positive_count_min_clusters": 1,
+        "prefer_same_orientation_within_cluster": true
+      },
+      "RIFT_DISTORTION": {
+        "candidate_order": "COORDINATE_ASCENDING",
+        "selection": "SEEDED_SHUFFLE",
+        "percent_range": {
+          "min": 30,
+          "max": 60
+        },
+        "minimum_count": 1
+      }
+    },
+    "reachability": {
+      "required_same_component_targets": [
+        "ALL_WARP_FLAGGED_CELLS",
+        "STATION",
+        "UNCONSUMED_RESOURCE_CACHE",
+        "UNCOLLECTED_SALVAGE"
+      ],
+      "movement_rule_reference": {
+        "issue": 1089,
+        "rule_id": "PASSABLE_ADJACENCY"
+      },
+      "passable_terrain_counts_as_reachable_even_if_high_cost": true,
+      "path_cost_limit_is_validation_input": false,
+      "all_other_passable_cells_should_also_share_component": true
+    },
+    "seed_and_retry": {
+      "seed_inputs": [
+        "generation_schema_version",
+        "galaxy_seed",
+        "sector_x",
+        "sector_y",
+        "sector_descriptor"
+      ],
+      "seed_hash_algorithm": "SHA-256",
+      "python_reference_rng": "random.Random(seed)",
+      "tbx_port_requirement": "MATCH_FIXTURES_OR_INVARIANTS",
+      "derived_seed_labels": [
+        "terrain_seed",
+        "celestial_seed",
+        "object_seed"
+      ],
+      "retry": {
+        "seed_source": "BASE_SEED_PLUS_RETRY_INDEX",
+        "scope": "FULL_MAP_REGENERATION",
+        "max_retry_count": 64,
+        "fallback_map": false
+      },
+      "versioning": {
+        "bump_generation_schema_version_when_seed_results_change": true
+      }
+    },
+    "generation_report_schema": {
+      "separate_from_game_log": true,
+      "required_fields": [
+        "seed",
+        "derived_seeds",
+        "retry_index",
+        "requested_counts",
+        "actual_counts",
+        "validation_results"
+      ]
+    }
+  },
+  "sector_profiles": {
+    "NORMAL": {
+      "required_terrain": ["FLOOR"],
+      "optional_terrain": ["DEBRIS"],
+      "forbidden_terrain": [
+        "NEBULA",
+        "ASTEROID_FIELD",
+        "ASTEROID",
+        "GRAVITY_FIELD_VERTICAL",
+        "GRAVITY_FIELD_HORIZONTAL",
+        "RIFT_DISTORTION",
+        "RIFT_BARRIER"
+      ],
+      "terrain_count_ranges": {
+        "9x9": {
+          "DEBRIS": {
+            "min": 0,
+            "max": 5
+          }
+        },
+        "11x11": {
+          "DEBRIS": {
+            "min": 0,
+            "max": 8
+          }
+        }
+      },
+      "special_terrain_limit": {
+        "9x9": {
+          "mode": "FIXED_MAX",
+          "counted_terrains": ["DEBRIS"],
+          "max": 5
+        },
+        "11x11": {
+          "mode": "FIXED_MAX",
+          "counted_terrains": ["DEBRIS"],
+          "max": 8
+        }
+      },
+      "impassable_cell_limit": {
+        "counted_terrains": ["ASTEROID"],
+        "counted_objects": ["STAR", "PLANET", "STATION"],
+        "excluded_terrains": ["RIFT_BARRIER"],
+        "9x9": 10,
+        "11x11": 15
+      },
+      "required_objects": ["STAR", "PLANET"],
+      "optional_objects": ["SALVAGE"],
+      "object_count_ranges": {
+        "9x9": {
+          "STAR": {
+            "min": 1,
+            "max": 1
+          },
+          "PLANET": {
+            "min": 2,
+            "max": 4
+          },
+          "SALVAGE": {
+            "min": 0,
+            "max": 1
+          }
+        },
+        "11x11": {
+          "STAR": {
+            "min": 1,
+            "max": 1
+          },
+          "PLANET": {
+            "min": 3,
+            "max": 6
+          },
+          "SALVAGE": {
+            "min": 0,
+            "max": 1
+          }
+        }
+      },
+      "placement_constraints": [
+        "CELESTIAL_NOT_ON_OUTER_EDGE",
+        "CELESTIAL_PAIR_MIN_CHEBYSHEV_2",
+        "CELESTIAL_FROM_WARP_FLAG_MIN_CHEBYSHEV_2",
+        "VALUE_OBJECT_FROM_WARP_FLAG_MIN_CHEBYSHEV_2",
+        "VALUE_OBJECT_FROM_IMPASSABLE_CELESTIAL_MIN_CHEBYSHEV_2",
+        "VALUE_OBJECTS_INDIVIDUALLY_REACHABLE"
+      ]
+    },
+    "BASE": {
+      "required_terrain": ["FLOOR"],
+      "optional_terrain": ["DEBRIS"],
+      "forbidden_terrain": [
+        "NEBULA",
+        "ASTEROID_FIELD",
+        "ASTEROID",
+        "GRAVITY_FIELD_VERTICAL",
+        "GRAVITY_FIELD_HORIZONTAL",
+        "RIFT_DISTORTION",
+        "RIFT_BARRIER"
+      ],
+      "terrain_count_ranges": {
+        "9x9": {
+          "DEBRIS": {
+            "min": 0,
+            "max": 4
+          }
+        },
+        "11x11": {
+          "DEBRIS": {
+            "min": 0,
+            "max": 6
+          }
+        }
+      },
+      "special_terrain_limit": {
+        "9x9": {
+          "mode": "FIXED_MAX",
+          "counted_terrains": ["DEBRIS"],
+          "max": 4
+        },
+        "11x11": {
+          "mode": "FIXED_MAX",
+          "counted_terrains": ["DEBRIS"],
+          "max": 6
+        }
+      },
+      "impassable_cell_limit": {
+        "counted_terrains": ["ASTEROID"],
+        "counted_objects": ["STAR", "PLANET", "STATION"],
+        "excluded_terrains": ["RIFT_BARRIER"],
+        "9x9": 10,
+        "11x11": 15
+      },
+      "required_objects": ["STAR", "PLANET", "STATION"],
+      "optional_objects": [],
+      "object_count_ranges": {
+        "9x9": {
+          "STAR": {
+            "min": 1,
+            "max": 1
+          },
+          "PLANET": {
+            "min": 2,
+            "max": 4
+          },
+          "STATION": {
+            "min": 1,
+            "max": 1
+          }
+        },
+        "11x11": {
+          "STAR": {
+            "min": 1,
+            "max": 1
+          },
+          "PLANET": {
+            "min": 3,
+            "max": 6
+          },
+          "STATION": {
+            "min": 1,
+            "max": 1
+          }
+        }
+      },
+      "placement_constraints": [
+        "CELESTIAL_NOT_ON_OUTER_EDGE",
+        "CELESTIAL_PAIR_MIN_CHEBYSHEV_2",
+        "CELESTIAL_FROM_WARP_FLAG_MIN_CHEBYSHEV_2",
+        "STATION_FROM_CELESTIAL_MIN_CHEBYSHEV_2",
+        "STATION_NEIGHBORHOOD_RESERVED_FLOOR"
+      ]
+    },
+    "RESOURCE": {
+      "required_terrain": ["FLOOR", "DEBRIS"],
+      "optional_terrain": ["ASTEROID_FIELD", "ASTEROID"],
+      "forbidden_terrain": [
+        "NEBULA",
+        "GRAVITY_FIELD_VERTICAL",
+        "GRAVITY_FIELD_HORIZONTAL",
+        "RIFT_DISTORTION",
+        "RIFT_BARRIER"
+      ],
+      "terrain_count_ranges": {
+        "9x9": {
+          "DEBRIS": {
+            "min": 6,
+            "max": 12
+          },
+          "ASTEROID_FIELD": {
+            "min": 0,
+            "max": 5
+          },
+          "ASTEROID": {
+            "min": 0,
+            "max": 2
+          }
+        },
+        "11x11": {
+          "DEBRIS": {
+            "min": 9,
+            "max": 18
+          },
+          "ASTEROID_FIELD": {
+            "min": 0,
+            "max": 8
+          },
+          "ASTEROID": {
+            "min": 0,
+            "max": 3
+          }
+        }
+      },
+      "special_terrain_limit": {
+        "9x9": {
+          "mode": "FIXED_MAX",
+          "counted_terrains": ["DEBRIS", "ASTEROID_FIELD", "ASTEROID"],
+          "max": 16
+        },
+        "11x11": {
+          "mode": "FIXED_MAX",
+          "counted_terrains": ["DEBRIS", "ASTEROID_FIELD", "ASTEROID"],
+          "max": 24
+        }
+      },
+      "impassable_cell_limit": {
+        "counted_terrains": ["ASTEROID"],
+        "counted_objects": ["STAR", "PLANET", "STATION"],
+        "excluded_terrains": ["RIFT_BARRIER"],
+        "9x9": 10,
+        "11x11": 15
+      },
+      "required_objects": ["STAR", "PLANET", "RESOURCE_CACHE"],
+      "optional_objects": ["SALVAGE"],
+      "object_count_ranges": {
+        "9x9": {
+          "STAR": {
+            "min": 1,
+            "max": 1
+          },
+          "PLANET": {
+            "min": 2,
+            "max": 4
+          },
+          "RESOURCE_CACHE": {
+            "min": 1,
+            "max": 2
+          },
+          "SALVAGE": {
+            "min": 0,
+            "max": 1
+          }
+        },
+        "11x11": {
+          "STAR": {
+            "min": 1,
+            "max": 1
+          },
+          "PLANET": {
+            "min": 3,
+            "max": 6
+          },
+          "RESOURCE_CACHE": {
+            "min": 1,
+            "max": 3
+          },
+          "SALVAGE": {
+            "min": 0,
+            "max": 1
+          }
+        }
+      },
+      "placement_constraints": [
+        "CELESTIAL_NOT_ON_OUTER_EDGE",
+        "CELESTIAL_PAIR_MIN_CHEBYSHEV_2",
+        "CELESTIAL_FROM_WARP_FLAG_MIN_CHEBYSHEV_2",
+        "VALUE_OBJECT_FROM_WARP_FLAG_MIN_CHEBYSHEV_2",
+        "VALUE_OBJECT_FROM_IMPASSABLE_CELESTIAL_MIN_CHEBYSHEV_2",
+        "VALUE_OBJECTS_INDIVIDUALLY_REACHABLE",
+        "RESOURCE_FIELD_IMPASSABLE_BALANCE"
+      ]
+    },
+    "NEBULA": {
+      "required_terrain": ["FLOOR", "NEBULA"],
+      "optional_terrain": ["DEBRIS"],
+      "forbidden_terrain": [
+        "ASTEROID_FIELD",
+        "ASTEROID",
+        "GRAVITY_FIELD_VERTICAL",
+        "GRAVITY_FIELD_HORIZONTAL",
+        "RIFT_DISTORTION",
+        "RIFT_BARRIER"
+      ],
+      "terrain_count_ranges": {
+        "9x9": {
+          "NEBULA": {
+            "min": 12,
+            "max": 22
+          },
+          "DEBRIS": {
+            "min": 0,
+            "max": 4
+          }
+        },
+        "11x11": {
+          "NEBULA": {
+            "min": 18,
+            "max": 32
+          },
+          "DEBRIS": {
+            "min": 0,
+            "max": 6
+          }
+        }
+      },
+      "special_terrain_limit": {
+        "9x9": {
+          "mode": "FIXED_MAX",
+          "counted_terrains": ["NEBULA", "DEBRIS"],
+          "max": 24
+        },
+        "11x11": {
+          "mode": "FIXED_MAX",
+          "counted_terrains": ["NEBULA", "DEBRIS"],
+          "max": 35
+        }
+      },
+      "impassable_cell_limit": {
+        "counted_terrains": ["ASTEROID"],
+        "counted_objects": ["STAR", "PLANET", "STATION"],
+        "excluded_terrains": ["RIFT_BARRIER"],
+        "9x9": 10,
+        "11x11": 15
+      },
+      "required_objects": ["STAR", "PLANET"],
+      "optional_objects": ["SALVAGE"],
+      "object_count_ranges": {
+        "9x9": {
+          "STAR": {
+            "min": 1,
+            "max": 1
+          },
+          "PLANET": {
+            "min": 2,
+            "max": 4
+          },
+          "SALVAGE": {
+            "min": 0,
+            "max": 1
+          }
+        },
+        "11x11": {
+          "STAR": {
+            "min": 1,
+            "max": 1
+          },
+          "PLANET": {
+            "min": 3,
+            "max": 6
+          },
+          "SALVAGE": {
+            "min": 0,
+            "max": 1
+          }
+        }
+      },
+      "placement_constraints": [
+        "CELESTIAL_NOT_ON_OUTER_EDGE",
+        "CELESTIAL_PAIR_MIN_CHEBYSHEV_2",
+        "CELESTIAL_FROM_WARP_FLAG_MIN_CHEBYSHEV_2",
+        "VALUE_OBJECT_FROM_WARP_FLAG_MIN_CHEBYSHEV_2",
+        "VALUE_OBJECT_FROM_IMPASSABLE_CELESTIAL_MIN_CHEBYSHEV_2",
+        "VALUE_OBJECTS_INDIVIDUALLY_REACHABLE"
+      ]
+    },
+    "ASTEROID": {
+      "required_terrain": ["FLOOR", "ASTEROID_FIELD", "ASTEROID"],
+      "optional_terrain": ["DEBRIS"],
+      "forbidden_terrain": [
+        "NEBULA",
+        "GRAVITY_FIELD_VERTICAL",
+        "GRAVITY_FIELD_HORIZONTAL",
+        "RIFT_DISTORTION",
+        "RIFT_BARRIER"
+      ],
+      "terrain_count_ranges": {
+        "9x9": {
+          "ASTEROID_FIELD": {
+            "min": 10,
+            "max": 18
+          },
+          "ASTEROID": {
+            "min": 3,
+            "max": 7
+          },
+          "DEBRIS": {
+            "min": 0,
+            "max": 4
+          }
+        },
+        "11x11": {
+          "ASTEROID_FIELD": {
+            "min": 15,
+            "max": 27
+          },
+          "ASTEROID": {
+            "min": 5,
+            "max": 10
+          },
+          "DEBRIS": {
+            "min": 0,
+            "max": 6
+          }
+        }
+      },
+      "special_terrain_limit": {
+        "9x9": {
+          "mode": "FIXED_MAX",
+          "counted_terrains": ["ASTEROID_FIELD", "ASTEROID", "DEBRIS"],
+          "max": 25
+        },
+        "11x11": {
+          "mode": "FIXED_MAX",
+          "counted_terrains": ["ASTEROID_FIELD", "ASTEROID", "DEBRIS"],
+          "max": 38
+        }
+      },
+      "impassable_cell_limit": {
+        "counted_terrains": ["ASTEROID"],
+        "counted_objects": ["STAR", "PLANET", "STATION"],
+        "excluded_terrains": ["RIFT_BARRIER"],
+        "9x9": 10,
+        "11x11": 15
+      },
+      "required_objects": ["STAR", "PLANET"],
+      "optional_objects": ["RESOURCE_CACHE", "SALVAGE"],
+      "object_count_ranges": {
+        "9x9": {
+          "STAR": {
+            "min": 1,
+            "max": 1
+          },
+          "PLANET": {
+            "min": 2,
+            "max": 4
+          },
+          "RESOURCE_CACHE": {
+            "min": 0,
+            "max": 1
+          },
+          "SALVAGE": {
+            "min": 0,
+            "max": 2
+          }
+        },
+        "11x11": {
+          "STAR": {
+            "min": 1,
+            "max": 1
+          },
+          "PLANET": {
+            "min": 3,
+            "max": 6
+          },
+          "RESOURCE_CACHE": {
+            "min": 0,
+            "max": 1
+          },
+          "SALVAGE": {
+            "min": 0,
+            "max": 2
+          }
+        }
+      },
+      "placement_constraints": [
+        "CELESTIAL_NOT_ON_OUTER_EDGE",
+        "CELESTIAL_PAIR_MIN_CHEBYSHEV_2",
+        "CELESTIAL_FROM_WARP_FLAG_MIN_CHEBYSHEV_2",
+        "VALUE_OBJECT_FROM_WARP_FLAG_MIN_CHEBYSHEV_2",
+        "VALUE_OBJECT_FROM_IMPASSABLE_CELESTIAL_MIN_CHEBYSHEV_2",
+        "VALUE_OBJECTS_INDIVIDUALLY_REACHABLE",
+        "ASTEROID_CLUSTER_IMPASSABLE_BALANCE"
+      ]
+    },
+    "GRAVITY": {
+      "required_terrain": ["FLOOR"],
+      "optional_terrain": ["GRAVITY_FIELD_VERTICAL", "GRAVITY_FIELD_HORIZONTAL"],
+      "forbidden_terrain": [
+        "DEBRIS",
+        "NEBULA",
+        "ASTEROID_FIELD",
+        "ASTEROID",
+        "RIFT_DISTORTION",
+        "RIFT_BARRIER"
+      ],
+      "terrain_count_ranges": {
+        "9x9": {
+          "GRAVITY_FIELD_TOTAL": {
+            "min": 10,
+            "max": 20
+          }
+        },
+        "11x11": {
+          "GRAVITY_FIELD_TOTAL": {
+            "min": 15,
+            "max": 30
+          }
+        }
+      },
+      "special_terrain_limit": {
+        "9x9": {
+          "mode": "FIXED_MAX",
+          "counted_terrains": ["GRAVITY_FIELD_VERTICAL", "GRAVITY_FIELD_HORIZONTAL"],
+          "max": 20
+        },
+        "11x11": {
+          "mode": "FIXED_MAX",
+          "counted_terrains": ["GRAVITY_FIELD_VERTICAL", "GRAVITY_FIELD_HORIZONTAL"],
+          "max": 30
+        }
+      },
+      "impassable_cell_limit": {
+        "counted_terrains": ["ASTEROID"],
+        "counted_objects": ["STAR", "PLANET", "STATION"],
+        "excluded_terrains": ["RIFT_BARRIER"],
+        "9x9": 10,
+        "11x11": 15
+      },
+      "required_objects": ["STAR", "PLANET"],
+      "optional_objects": ["SALVAGE"],
+      "object_count_ranges": {
+        "9x9": {
+          "STAR": {
+            "min": 1,
+            "max": 1
+          },
+          "PLANET": {
+            "min": 2,
+            "max": 4
+          },
+          "SALVAGE": {
+            "min": 0,
+            "max": 1
+          }
+        },
+        "11x11": {
+          "STAR": {
+            "min": 1,
+            "max": 1
+          },
+          "PLANET": {
+            "min": 3,
+            "max": 6
+          },
+          "SALVAGE": {
+            "min": 0,
+            "max": 1
+          }
+        }
+      },
+      "placement_constraints": [
+        "CELESTIAL_NOT_ON_OUTER_EDGE",
+        "CELESTIAL_PAIR_MIN_CHEBYSHEV_2",
+        "CELESTIAL_FROM_WARP_FLAG_MIN_CHEBYSHEV_2",
+        "VALUE_OBJECT_FROM_WARP_FLAG_MIN_CHEBYSHEV_2",
+        "VALUE_OBJECT_FROM_IMPASSABLE_CELESTIAL_MIN_CHEBYSHEV_2",
+        "VALUE_OBJECTS_INDIVIDUALLY_REACHABLE",
+        "GRAVITY_TOTAL_MIN_1"
+      ]
+    },
+    "RIFT": {
+      "required_terrain": ["FLOOR", "RIFT_DISTORTION", "RIFT_BARRIER"],
+      "optional_terrain": [
+        "DEBRIS",
+        "ASTEROID_FIELD",
+        "ASTEROID",
+        "GRAVITY_FIELD_VERTICAL",
+        "GRAVITY_FIELD_HORIZONTAL"
+      ],
+      "forbidden_terrain": ["NEBULA"],
+      "terrain_count_ranges": {
+        "9x9": {
+          "RIFT_DISTORTION": {
+            "candidate_pool": "BARRIER_INNER_ADJACENT_FLOOR",
+            "min_percent": 30,
+            "max_percent": 60,
+            "minimum_count": 1
+          },
+          "DEBRIS": {
+            "min": 0,
+            "max": 4
+          },
+          "ASTEROID_FIELD": {
+            "min": 0,
+            "max": 4
+          },
+          "ASTEROID": {
+            "min": 0,
+            "max": 2
+          },
+          "GRAVITY_FIELD_TOTAL": {
+            "min": 0,
+            "max": 5
+          }
+        },
+        "11x11": {
+          "RIFT_DISTORTION": {
+            "candidate_pool": "BARRIER_INNER_ADJACENT_FLOOR",
+            "min_percent": 30,
+            "max_percent": 60,
+            "minimum_count": 1
+          },
+          "DEBRIS": {
+            "min": 0,
+            "max": 6
+          },
+          "ASTEROID_FIELD": {
+            "min": 0,
+            "max": 6
+          },
+          "ASTEROID": {
+            "min": 0,
+            "max": 3
+          },
+          "GRAVITY_FIELD_TOTAL": {
+            "min": 0,
+            "max": 8
+          }
+        }
+      },
+      "special_terrain_limit": {
+        "9x9": {
+          "mode": "BASE_TERRAIN_PLUS_ADDITIONAL_MAX",
+          "base_terrain": "RIFT_BARRIER",
+          "counted_additional_terrains": [
+            "RIFT_DISTORTION",
+            "DEBRIS",
+            "ASTEROID_FIELD",
+            "ASTEROID",
+            "GRAVITY_FIELD_VERTICAL",
+            "GRAVITY_FIELD_HORIZONTAL"
+          ],
+          "additional_max": 14
+        },
+        "11x11": {
+          "mode": "BASE_TERRAIN_PLUS_ADDITIONAL_MAX",
+          "base_terrain": "RIFT_BARRIER",
+          "counted_additional_terrains": [
+            "RIFT_DISTORTION",
+            "DEBRIS",
+            "ASTEROID_FIELD",
+            "ASTEROID",
+            "GRAVITY_FIELD_VERTICAL",
+            "GRAVITY_FIELD_HORIZONTAL"
+          ],
+          "additional_max": 22
+        }
+      },
+      "impassable_cell_limit": {
+        "counted_terrains": ["ASTEROID"],
+        "counted_objects": ["STAR", "PLANET", "STATION"],
+        "excluded_terrains": ["RIFT_BARRIER"],
+        "9x9": 10,
+        "11x11": 15
+      },
+      "required_objects": ["STAR", "PLANET", "RESOURCE_CACHE", "SALVAGE"],
+      "optional_objects": [],
+      "object_count_ranges": {
+        "9x9": {
+          "STAR": {
+            "min": 1,
+            "max": 1
+          },
+          "PLANET": {
+            "min": 2,
+            "max": 4
+          },
+          "RESOURCE_CACHE": {
+            "min": 1,
+            "max": 2
+          },
+          "SALVAGE": {
+            "min": 1,
+            "max": 2
+          }
+        },
+        "11x11": {
+          "STAR": {
+            "min": 1,
+            "max": 1
+          },
+          "PLANET": {
+            "min": 3,
+            "max": 6
+          },
+          "RESOURCE_CACHE": {
+            "min": 1,
+            "max": 2
+          },
+          "SALVAGE": {
+            "min": 1,
+            "max": 2
+          }
+        }
+      },
+      "placement_constraints": [
+        "CELESTIAL_NOT_ON_OUTER_EDGE",
+        "CELESTIAL_PAIR_MIN_CHEBYSHEV_2",
+        "CELESTIAL_FROM_WARP_FLAG_MIN_CHEBYSHEV_2",
+        "VALUE_OBJECT_FROM_WARP_FLAG_MIN_CHEBYSHEV_2",
+        "VALUE_OBJECT_FROM_IMPASSABLE_CELESTIAL_MIN_CHEBYSHEV_2",
+        "VALUE_OBJECTS_INDIVIDUALLY_REACHABLE",
+        "RIFT_DISTORTION_BARRIER_ADJACENT_PERCENT"
+      ]
+    }
+  }
+}

--- a/experiments/galactic_exodus/srs/phase2_srs_generation.md
+++ b/experiments/galactic_exodus/srs/phase2_srs_generation.md
@@ -414,10 +414,10 @@ seed input:
   sector_descriptor
 
 seed construction:
-  canonical JSON UTF-8 bytesをSHA-256でhash
+  canonical JSON object UTF-8 bytesをSHA-256でhash
   digest全32 bytesをbig-endian unsigned integerへ変換
 
-field order:
+required fields:
   generation_schema_version
   galaxy_seed
   sector_x
@@ -432,7 +432,7 @@ normalization:
 sector_descriptor canonical form:
   canonical JSON object
   object keyは辞書順
-  blocked_edgesはN/E/S/W辞書順array
+  blocked_edgesはN/E/S/W方位順array
   将来field追加時も同じcanonical JSON規則を使う
 
 Python reference:
@@ -444,7 +444,7 @@ derived seeds:
   object_seed
 ```
 
-派生seedは、`retry_index`を含む再試行単位seedを先に作成し、その値とlabelを同じcanonical JSON規則でhashして求める。
+派生seedは、`retry_index`を含む再試行単位payloadをcanonical JSON objectとして直列化してattempt seedを作り、その値とlabelを同じcanonical JSON object規則でhashして求める。
 
 ```text
 attempt_seed input:

--- a/experiments/galactic_exodus/srs/phase2_srs_generation.md
+++ b/experiments/galactic_exodus/srs/phase2_srs_generation.md
@@ -301,6 +301,47 @@ Terrain個数決定:
 5. 必須Terrainの最低数を再検証
 ```
 
+任意Terrain削減アルゴリズム:
+
+```text
+1. SectorTypeごとの reduction priority を先頭から走査する
+2. 各Terrainがその最小値を上回っていれば1セルだけ減らす
+3. 1セル減らすたびに priority 走査を先頭へ戻す
+4. 合計上限を満たすまで繰り返す
+5. どの任意Terrainもこれ以上減らせなければ生成失敗
+```
+
+SectorType別 reduction priority:
+
+```text
+NORMAL:
+  DEBRIS
+
+BASE:
+  DEBRIS
+
+RESOURCE:
+  ASTEROID
+  ASTEROID_FIELD
+
+NEBULA:
+  DEBRIS
+
+ASTEROID:
+  DEBRIS
+
+GRAVITY:
+  GRAVITY_FIELD_HORIZONTAL
+  GRAVITY_FIELD_VERTICAL
+
+RIFT:
+  DEBRIS
+  ASTEROID_FIELD
+  ASTEROID
+  GRAVITY_FIELD_HORIZONTAL
+  GRAVITY_FIELD_VERTICAL
+```
+
 ## 7. クラスタ生成
 
 ```text
@@ -373,7 +414,26 @@ seed input:
   sector_descriptor
 
 seed construction:
-  SHA-256等で固定長整数化
+  canonical JSON UTF-8 bytesをSHA-256でhash
+  digest全32 bytesをbig-endian unsigned integerへ変換
+
+field order:
+  generation_schema_version
+  galaxy_seed
+  sector_x
+  sector_y
+  sector_descriptor
+
+normalization:
+  文字列はNFC
+  object keyは辞書順
+  set相当fieldは辞書順arrayへ正規化
+
+sector_descriptor canonical form:
+  canonical JSON object
+  object keyは辞書順
+  blocked_edgesはN/E/S/W辞書順array
+  将来field追加時も同じcanonical JSON規則を使う
 
 Python reference:
   random.Random(seed)
@@ -384,17 +444,35 @@ derived seeds:
   object_seed
 ```
 
+派生seedは、`retry_index`を含む再試行単位seedを先に作成し、その値とlabelを同じcanonical JSON規則でhashして求める。
+
+```text
+attempt_seed input:
+  base_seed
+  retry_index
+
+derived seed input:
+  attempt_seed
+  phase_label
+```
+
 TBX移植時は同一乱数列を要求せず、fixture一致または仕様不変条件一致を要求する。
 
 ### 9.2 再試行
 
 ```text
 失敗時:
-  元seedとretry_indexから派生seedを生成
+  base_seedとretry_indexからattempt_seedを生成
   マップ全体を再生成
 
-最大再試行:
-  64
+attempt数:
+  最大64
+
+retry_index:
+  0..63
+
+初回attempt:
+  retry_index = 0
 
 fallback map:
   なし

--- a/experiments/galactic_exodus/srs/phase2_srs_generation.md
+++ b/experiments/galactic_exodus/srs/phase2_srs_generation.md
@@ -1,0 +1,416 @@
+# Galactic Exodus Phase 2 SRS生成仕様
+
+## 1. 目的と対象範囲
+
+本書は、#1088で確定したSRS星系生成規則を、日本語仕様書と機械可読JSON契約へ固定する。
+
+対象成果物:
+
+```text
+experiments/galactic_exodus/srs/phase2_srs_generation.md
+experiments/galactic_exodus/srs/phase2_srs_generation.json
+```
+
+本書は生成契約のみを扱う。validator実装は#1092、既存初期モデル・評価条件への統合は#1093で扱う。
+
+## 2. 基本契約
+
+```text
+generation_schema_version = 1
+対応サイズ = 9x9 / 11x11
+obstacle_density = 廃止
+FLOOR = 他Terrain配置後の残余
+必須Terrain = 最低1以上
+任意Terrain = 0を許可
+```
+
+生成で使用するTerrain型:
+
+```text
+FLOOR
+DEBRIS
+NEBULA
+ASTEROID_FIELD
+ASTEROID
+GRAVITY_FIELD_VERTICAL
+GRAVITY_FIELD_HORIZONTAL
+RIFT_DISTORTION
+RIFT_BARRIER
+```
+
+生成で使用するObject型:
+
+```text
+STAR
+PLANET
+STATION
+RESOURCE_CACHE
+SALVAGE
+```
+
+以下の旧表現は本契約へ持ち込まない。
+
+```text
+汎用obstacle密度
+固定1マス入口feature
+入口descriptor専用表現
+汎用通行不能terrain名
+旧基地object名
+旧基地構造terrain名
+```
+
+## 3. SectorType別 generation profile
+
+### 3.1 Terrain構成
+
+| SectorType | required_terrain | optional_terrain | forbidden_terrain |
+|---|---|---|---|
+| `NORMAL` | `FLOOR` | `DEBRIS` | `NEBULA`, `ASTEROID_FIELD`, `ASTEROID`, `GRAVITY_FIELD_VERTICAL`, `GRAVITY_FIELD_HORIZONTAL`, `RIFT_DISTORTION`, `RIFT_BARRIER` |
+| `BASE` | `FLOOR` | `DEBRIS` | `NEBULA`, `ASTEROID_FIELD`, `ASTEROID`, `GRAVITY_FIELD_VERTICAL`, `GRAVITY_FIELD_HORIZONTAL`, `RIFT_DISTORTION`, `RIFT_BARRIER` |
+| `RESOURCE` | `FLOOR`, `DEBRIS` | `ASTEROID_FIELD`, `ASTEROID` | `NEBULA`, `GRAVITY_FIELD_VERTICAL`, `GRAVITY_FIELD_HORIZONTAL`, `RIFT_DISTORTION`, `RIFT_BARRIER` |
+| `NEBULA` | `FLOOR`, `NEBULA` | `DEBRIS` | `ASTEROID_FIELD`, `ASTEROID`, `GRAVITY_FIELD_VERTICAL`, `GRAVITY_FIELD_HORIZONTAL`, `RIFT_DISTORTION`, `RIFT_BARRIER` |
+| `ASTEROID` | `FLOOR`, `ASTEROID_FIELD`, `ASTEROID` | `DEBRIS` | `NEBULA`, `GRAVITY_FIELD_VERTICAL`, `GRAVITY_FIELD_HORIZONTAL`, `RIFT_DISTORTION`, `RIFT_BARRIER` |
+| `GRAVITY` | `FLOOR` | `GRAVITY_FIELD_VERTICAL`, `GRAVITY_FIELD_HORIZONTAL` | `DEBRIS`, `NEBULA`, `ASTEROID_FIELD`, `ASTEROID`, `RIFT_DISTORTION`, `RIFT_BARRIER` |
+| `RIFT` | `FLOOR`, `RIFT_DISTORTION`, `RIFT_BARRIER` | `DEBRIS`, `ASTEROID_FIELD`, `ASTEROID`, `GRAVITY_FIELD_VERTICAL`, `GRAVITY_FIELD_HORIZONTAL` | `NEBULA` |
+
+`GRAVITY`では個別の向きは任意Terrainとして扱うが、縦横合計セル数は必ず1以上とする。
+
+### 3.2 Terrain個数range
+
+#### 9x9
+
+| SectorType | Terrain | range |
+|---|---|---:|
+| `NORMAL` | `DEBRIS` | 0〜5 |
+| `BASE` | `DEBRIS` | 0〜4 |
+| `RESOURCE` | `DEBRIS` | 6〜12 |
+| `RESOURCE` | `ASTEROID_FIELD` | 0〜5 |
+| `RESOURCE` | `ASTEROID` | 0〜2 |
+| `NEBULA` | `NEBULA` | 12〜22 |
+| `NEBULA` | `DEBRIS` | 0〜4 |
+| `ASTEROID` | `ASTEROID_FIELD` | 10〜18 |
+| `ASTEROID` | `ASTEROID` | 3〜7 |
+| `ASTEROID` | `DEBRIS` | 0〜4 |
+| `GRAVITY` | `GRAVITY_FIELD_VERTICAL + GRAVITY_FIELD_HORIZONTAL` | 10〜20 |
+| `RIFT` | `RIFT_DISTORTION` | Barrier隣接候補の30〜60% |
+| `RIFT` | `DEBRIS` | 0〜4 |
+| `RIFT` | `ASTEROID_FIELD` | 0〜4 |
+| `RIFT` | `ASTEROID` | 0〜2 |
+| `RIFT` | `GRAVITY_FIELD_VERTICAL + GRAVITY_FIELD_HORIZONTAL` | 0〜5 |
+
+#### 11x11
+
+| SectorType | Terrain | range |
+|---|---|---:|
+| `NORMAL` | `DEBRIS` | 0〜8 |
+| `BASE` | `DEBRIS` | 0〜6 |
+| `RESOURCE` | `DEBRIS` | 9〜18 |
+| `RESOURCE` | `ASTEROID_FIELD` | 0〜8 |
+| `RESOURCE` | `ASTEROID` | 0〜3 |
+| `NEBULA` | `NEBULA` | 18〜32 |
+| `NEBULA` | `DEBRIS` | 0〜6 |
+| `ASTEROID` | `ASTEROID_FIELD` | 15〜27 |
+| `ASTEROID` | `ASTEROID` | 5〜10 |
+| `ASTEROID` | `DEBRIS` | 0〜6 |
+| `GRAVITY` | `GRAVITY_FIELD_VERTICAL + GRAVITY_FIELD_HORIZONTAL` | 15〜30 |
+| `RIFT` | `RIFT_DISTORTION` | Barrier隣接候補の30〜60% |
+| `RIFT` | `DEBRIS` | 0〜6 |
+| `RIFT` | `ASTEROID_FIELD` | 0〜6 |
+| `RIFT` | `ASTEROID` | 0〜3 |
+| `RIFT` | `GRAVITY_FIELD_VERTICAL + GRAVITY_FIELD_HORIZONTAL` | 0〜8 |
+
+### 3.3 特殊Terrain合計上限
+
+| SectorType | 9x9 | 11x11 |
+|---|---:|---:|
+| `NORMAL` | 5 | 8 |
+| `BASE` | 4 | 6 |
+| `RESOURCE` | 16 | 24 |
+| `NEBULA` | 24 | 35 |
+| `ASTEROID` | 25 | 38 |
+| `GRAVITY` | 20 | 30 |
+| `RIFT` | `RIFT_BARRIER`既定数 + 14 | `RIFT_BARRIER`既定数 + 22 |
+
+### 3.4 内部通行不能セル上限
+
+`RIFT_BARRIER`を除く内部通行不能セル上限:
+
+```text
+9x9  = 10
+11x11 = 15
+```
+
+対象:
+
+```text
+ASTEROID
+STAR
+PLANET
+STATION
+```
+
+### 3.5 Object構成と個数range
+
+天体Objectは全SectorType共通で次を適用する。
+
+```text
+STAR:
+  exactly 1
+
+PLANET:
+  9x9  = 2〜4
+  11x11 = 3〜6
+```
+
+SectorType別 profile:
+
+| SectorType | required_objects | optional_objects | object_count_ranges |
+|---|---|---|---|
+| `NORMAL` | `STAR`, `PLANET` | `SALVAGE` | `SALVAGE = 0..1` |
+| `BASE` | `STAR`, `PLANET`, `STATION` | なし | `STATION = 1` |
+| `RESOURCE` | `STAR`, `PLANET`, `RESOURCE_CACHE` | `SALVAGE` | `RESOURCE_CACHE = 9x9:1..2, 11x11:1..3`, `SALVAGE = 0..1` |
+| `NEBULA` | `STAR`, `PLANET` | `SALVAGE` | `SALVAGE = 0..1` |
+| `ASTEROID` | `STAR`, `PLANET` | `RESOURCE_CACHE`, `SALVAGE` | `RESOURCE_CACHE = 0..1`, `SALVAGE = 0..2` |
+| `GRAVITY` | `STAR`, `PLANET` | `SALVAGE` | `SALVAGE = 0..1` |
+| `RIFT` | `STAR`, `PLANET`, `RESOURCE_CACHE`, `SALVAGE` | なし | `RESOURCE_CACHE = 1..2`, `SALVAGE = 1..2` |
+
+`RESOURCE_CACHE`と`SALVAGE`は同一星系への同時配置を許可するが、同一セル重複は禁止する。
+
+## 4. 共通配置制約
+
+### 4.1 天体
+
+```text
+STAR / PLANET:
+  最外周禁止
+  星体同士のChebyshev距離2以上
+  warp flag付きセルからChebyshev距離1以内へ配置禁止
+
+STATION:
+  BASEにexactly 1
+  STAR / PLANETからChebyshev距離2以上
+  周囲8近傍をFLOOR予約
+```
+
+### 4.2 価値Object
+
+```text
+RESOURCE_CACHE / SALVAGE:
+  warp flag付きセルおよびChebyshev距離1以内へ配置禁止
+  STAR / PLANET / STATIONからChebyshev距離1以内へ配置禁止
+  各Objectを個別に到達可能へする
+```
+
+### 4.3 SectorType追加制約
+
+```text
+RESOURCE:
+  ASTEROID_FIELD + ASTEROID <= DEBRIS count
+
+ASTEROID:
+  ASTEROID count <= ASTEROID_FIELD count / 2
+
+GRAVITY:
+  GRAVITY_FIELD_VERTICAL + GRAVITY_FIELD_HORIZONTAL >= 1
+  縦横比率はseedで決定
+
+RIFT:
+  RIFT_DISTORTIONはBarrier内側隣接候補を座標順列挙し、
+  seeded shuffle後に30〜60%を選択する
+  最低1セル
+```
+
+## 5. warp仕様
+
+### 5.1 生成表現
+
+本契約は旧来の固定入口featureや入口descriptor専用表現を使用しない。
+
+```text
+各セルが方向別warp_flags = {N, E, S, W}を持つ
+```
+
+### 5.2 生成条件
+
+```text
+各有効辺に2x2以上のFLOORクラスタを最低1つ保証
+判定に使う2x2 FLOOR全体はTerrain上書き禁止
+warp flag付き最外周セルのみObject配置禁止
+内側予約セルはObject配置可
+```
+
+非RIFT:
+
+```text
+隣接Sectorがある各辺でwarp可能セルを1つ以上保証
+```
+
+RIFT:
+
+```text
+non-blocked edgeのみwarp flagを許可・保証
+blocked edgeはwarp flag禁止、RIFT_BARRIERで閉鎖
+```
+
+四隅:
+
+```text
+条件を満たす各方向を独立判定する
+必要なら2方向warpを許可する
+```
+
+### 5.3 到着セル選択
+
+出発方向に対応する隣接Sectorの反対辺にあり、戻り方向のwarp flagを持つセルを候補とする。
+
+```text
+N / S:
+  abs(destination.x - source.x)最小
+  tie-break = x昇順, y昇順
+
+E / W:
+  abs(destination.y - source.y)最小
+  tie-break = y昇順, x昇順
+```
+
+到着候補が存在しないマップは生成不正とし、決定的再試行を行う。実行時fallbackは設けない。
+
+## 6. 生成順
+
+```text
+1. FLOOR初期化
+2. RIFT_BARRIER
+3. warp用FLOOR予約
+4. 必須Terrain
+5. 任意Terrain
+6. STAR
+7. PLANET
+8. STATION
+9. 価値Object
+10. warp flag導出
+11. 検証
+```
+
+Terrain個数決定:
+
+```text
+1. 必須Terrainを範囲内で抽選
+2. 任意Terrainを0を含む範囲内で抽選
+3. SectorType別合計上限を検証
+4. 超過時は再抽選せず、固定優先順で任意Terrainを減らす
+5. 必須Terrainの最低数を再検証
+```
+
+## 7. クラスタ生成
+
+```text
+NEBULA
+ASTEROID_FIELD
+DEBRIS
+GRAVITY_FIELD_VERTICAL / HORIZONTAL
+RIFT_DISTORTION
+```
+
+上記は連結クラスタ生成を基本とする。共通制約:
+
+```text
+単独孤立セルは全体の20%以下
+小さな孤立領域を許可しない
+```
+
+個別制約:
+
+```text
+NEBULA:
+  9x9  = 1〜2クラスタ
+  11x11 = 1〜3クラスタ
+  各クラスタ最低4セル
+
+ASTEROID:
+  ASTEROID_FIELDを先に配置
+  ASTEROIDの50%以上をASTEROID_FIELD内部または8近傍へ配置
+
+GRAVITY:
+  count > 0 の向きごとに1つ以上のクラスタ
+  クラスタ内では同じ向きを優先
+
+RIFT_DISTORTION:
+  Barrier内側隣接候補を座標順列挙
+  seeded shuffle後に30〜60%を選択
+  最低1セル
+```
+
+## 8. 到達可能性
+
+以下を同一の通行可能連結成分へ含める。
+
+```text
+全warp flag付きセル
+STATION
+未消費RESOURCE_CACHE
+未取得SALVAGE
+```
+
+到達可能性判定:
+
+```text
+隣接規則は#1089の移動規則IDを参照する
+passable = true なら高コストTerrain経由でも到達可能
+経路コスト上限は生成妥当性条件へ含めない
+その他の通行可能セルも原則すべて同一成分とする
+```
+
+## 9. seed・再試行・generation report
+
+### 9.1 seedと派生seed
+
+```text
+seed input:
+  generation_schema_version
+  galaxy_seed
+  sector_x
+  sector_y
+  sector_descriptor
+
+seed construction:
+  SHA-256等で固定長整数化
+
+Python reference:
+  random.Random(seed)
+
+derived seeds:
+  terrain_seed
+  celestial_seed
+  object_seed
+```
+
+TBX移植時は同一乱数列を要求せず、fixture一致または仕様不変条件一致を要求する。
+
+### 9.2 再試行
+
+```text
+失敗時:
+  元seedとretry_indexから派生seedを生成
+  マップ全体を再生成
+
+最大再試行:
+  64
+
+fallback map:
+  なし
+```
+
+既存seedの結果が変わる生成規則変更では`generation_schema_version`を上げる。
+
+### 9.3 generation report schema
+
+通常GameLogとは分離し、少なくとも次を記録する。
+
+```text
+seed
+derived_seeds
+retry_index
+各Terrain/Objectの要求数
+各Terrain/Objectの実配置数
+検証結果
+```


### PR DESCRIPTION
## 概要

Closes #1091
Refs #1088

- `experiments/galactic_exodus/srs/phase2_srs_generation.md` を追加し、#1088で確定したSRS生成規則を日本語仕様書として整理
- `experiments/galactic_exodus/srs/phase2_srs_generation.json` を追加し、全7 `SectorType` の generation profile、warp規則、seed/retry、generation report契約を機械可読化
- issue完了条件に合わせて、固定入口featureや旧基地命名へ戻らない表現へ整理

## 確認

- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo fmt --check`
