### PR TITLE
Phase 2初期SRS契約をschema 3へ統合

### DIFF
--- a/experiments/galactic_exodus/srs/phase2_initial_model.md
+++ b/experiments/galactic_exodus/srs/phase2_initial_model.md
@@ -2,15 +2,16 @@
 
 ## 1. 目的
 
-本書は、星系内SRS移動・探索をPythonで検証するための初期仮説を固定する。最終仕様ではなく、#1080で追加判断なしにプロトタイプ実装できる入力契約である。
+本書は、星系内SRS移動・探索の初期検証で使用するモデル境界を固定する。最終仕様ではなく、#1080 のプロトタイプ実装と評価設計が同じ入力契約を参照できる状態を作る。
 
-## 2. 位置づけ
+## 2. 文書の責務
 
-- Phase 1の`GalacticMap.rift_edges`はマクロ評価用の縮約表現である。
-- Phase 2では`RIFT`を独立したLRS区画種別として扱う。
-- 最終ASCII/Braille/HUDは#1076で扱う。
-- 敵、戦闘、追跡は初期検証の非対象とする。
-- `NEBULA`、`ASTEROID`、`GRAVITY`は型と初期効果候補をPhase 2Aで定義し、Python実装は段階分けできる。
+- 要素型・通行性・効果の正本は `phase2_srs_elements.md/json`
+- `SectorType` 別生成profile、range、warp、配置制約、seed/retry の正本は `phase2_srs_generation.md/json`
+- baseline、比較条件、閾値、永続項目は `phase2_initial_values.json`
+- 本文では正本の値を再定義しない
+
+初期モデルでは、featureベースのwarp表現、統合前のTerrain/Object型、方向を持たない重力場型、固定入口幅、密度ベース生成は廃止した。正本型と生成規則は elements/generation 契約を参照する。
 
 ## 3. データモデル
 
@@ -28,23 +29,19 @@ SectorType =
 
 SrsTerrainType =
   FLOOR
-  WALL
-  STATION_STRUCTURE
   DEBRIS
   NEBULA
   ASTEROID_FIELD
   ASTEROID
-  GRAVITY_FIELD
+  GRAVITY_FIELD_VERTICAL
+  GRAVITY_FIELD_HORIZONTAL
   RIFT_DISTORTION
   RIFT_BARRIER
-
-SrsFeatureType =
-  WARP_POINT
 
 SrsObjectType =
   STAR
   PLANET
-  BASE_NODE
+  STATION
   RESOURCE_CACHE
   SALVAGE
 
@@ -53,591 +50,102 @@ SrsActorType =
 
 SrsCell:
   terrain: SrsTerrainType
-  feature: optional[SrsFeature]
   object_id: optional[str]
   actor_id: optional[str]
+  warp_flags: set[Direction]
 
 SectorDescriptor:
   sector_id: str
   sector_type: SectorType
-  sector_seed: int
+  sector_x: int
+  sector_y: int
   blocked_edges: set[Direction]
-  terrain_profile: TerrainProfile
-  object_profile: ObjectProfile
-
-SrsPersistentState:
-  generated_map_id
-  discovered_cells
-  consumed_object_ids
-  activated_object_ids
+  galaxy_seed: int
+  generation_schema_version: int
+  generation_profile_ref: str
 ```
 
-### 3.1 要素カテゴリの責務
+`SrsCell.warp_flags` は各セルの辺接続を直接表し、`SectorDescriptor` は銀河側で決まる blocked edge と seed を保持する。要素属性、配置可否、配置数range、特殊Terrain上限は正本JSONを参照する。
+
+## 4. Warp契約
+
+- warp は `SrsCell.warp_flags` の `N/E/S/W` で表現する
+- 接続可能な各辺に 2x2 以上の `FLOOR` 予約領域を最低 1 つ生成する
+- qualifying cluster の外周セルへ方向 flag を付与する
+- corner cell は複数方向 flag を保持できる
+- `RIFT` blocked edge と銀河外縁では flag を禁止する
+- 到着候補は反対辺の return flag 付きセルとする
+- 軸距離最小と契約済み tie-break で候補を選ぶ
+- 候補なしは生成失敗として retry する
+- 実行時 fallback map は持たない
+
+warp の具体的な配置制約、retry、seed 再現性、return flag の決定順序は `phase2_srs_generation.md/json` を参照する。
+
+## 5. 盤面と天体
 
 ```text
-terrain:
-  基礎通行性、移動コスト、観測効果を持つ
+盤面候補:
+  9x9
+  11x11
 
-feature:
-  terrain上に重なる非占有の機能地点
+baseline:
+  9x9
 
-object:
-  天体または取得・利用対象
-
-actor:
-  プレイヤーなどの移動主体
-```
-
-### 3.2 共通属性
-
-```text
-id
-category
-passable
-base_move_cost
-observation_effect
-can_host_feature
-can_host_object
-interaction_required
-consumable
-persistent_after_revisit
-state_after_use
-allowed_sector_types
-blocks_line_travel
-collision_behavior
-```
-
-必要に応じて次も持てる。
-
-```text
-forced_movement
-fuel_effect
-turn_effect
-visibility_rule
-directional_cost
-placement_constraints
-```
-
-### 3.3 不変条件
-
-```text
-RIFT:
-  blocked_edgesは1..3辺
-  少なくとも1辺は非blocked
-
-RIFT以外:
-  blocked_edgesは空集合
-
-全区画:
-  有効なWARP_POINT方向は非blocked
-  selected exit方向は非blocked
-  sector typeと内部object typeは独立
-  STARは必ず1個
-  PLANETは1個以上
-```
-
-4辺すべてblockedのRIFTは初期モデルでは生成しない。
-
-## 4. LRS/SRS接続とWARP_POINT
-
-各辺中央の星系間接続セルは、機能上の出入口だが、世界観上は周辺より重力が安定したワープ可能地点である。
-
-```text
-SrsFeature:
-  feature_type = WARP_POINT
-  direction = N | E | S | W
-  destination_sector = optional
-```
-
-各WARP_POINTは到着地点と出発地点を兼ねる。`ENTRY`と`EXIT`は別型として定義しない。
-
-```text
-LRSで西から東へ区画へ進入
-  → 移動先SRSのW側WARP_POINTに到着
-
-SRSのN側WARP_POINTからワープ
-  → LRSの北隣区画へ移動
-```
-
-WARP_POINTからの星系間移動は自動ではなく明示的な`WARP`行動とする。
-
-RIFTのblocked edge方向にはWARP_POINTを生成せず、外周を`RIFT_BARRIER`で閉鎖する。LRS境界は双方向に閉鎖される。
-
-```text
-sector AのEがblocked
-  ⇔
-sector BとのE/W境界が双方向にblocked
-```
-
-RIFT区画が閉鎖辺を所有する内部表現と、LRS境界が双方向に閉鎖される外部契約は分離する。
-
-## 5. SRS盤面
-
-比較対象は次の2種類とする。
-
-```text
-SMALL  = 7x7
-MEDIUM = 9x9
-```
-
-初期推奨値は`9x9`、比較対象は`7x7`とする。11x11以上は初期検証から外す。
-
-座標は0始まり、南西を`(0,0)`とし、北は`y+1`、東は`x+1`とする。幅・高さは奇数のみ許可する。
-
-### 5.1 WARP_POINT座標
-
-各辺中央1セルをWARP_POINT候補とする。
-
-```text
-N = (center_x, height-1)
-E = (width-1, center_y)
-S = (center_x, 0)
-W = (0, center_y)
-```
-
-到着時のプレイヤーはWARP_POINT上に配置する。WARP_POINTから盤面内部へ少なくとも1マス進めることを保証する。
-
-```text
-warp_clearance_depth = 1
-```
-
-WARP_POINTとその内側1セルには、通行不能terrainまたはobjectを配置しない。入口幅2以上は初期比較から外す。
-
-## 6. 恒星と惑星
-
-すべてのSectorTypeのSRSマップへ恒星と惑星を配置する。
-
-```text
 STAR:
-  count = exactly 1
-  category = CELESTIAL_BODY
-  passable = false
-  blocks_line_travel = true
-  interaction_required = false
-  consumable = false
-  persistent_after_revisit = true
-  collision_behavior = STOP_BEFORE
+  exactly 1
 
 PLANET:
-  count >= 1
-  category = CELESTIAL_BODY
-  passable = false
-  blocks_line_travel = true
-  interaction_required = false
-  consumable = false
-  persistent_after_revisit = true
-  collision_behavior = STOP_BEFORE
+  9x9 = 2..4
+  11x11 = 3..6
 ```
 
-初期配置数は盤面サイズ別に次を用いる。
+座標系、観測、移動コスト、`STOP_BEFORE`、天体・価値Objectの配置制約、特殊Terrain個数上限は正本契約を参照する。本文では profile 値を複製しない。
+
+## 6. 実装段階
 
 ```text
-7x7:
-  STAR = 1
-  PLANET = 1..3
-
-9x9:
-  STAR = 1
-  PLANET = 2..5
-```
-
-STARとPLANETは次と重ならない。
-
-```text
-WARP_POINT
-他のobject
-PLAYER初期位置
-```
-
-天体配置後も、全WARP_POINT間および必須objectまでの到達可能性を維持する。
-
-## 7. Terrain profile
-
-```text
-NORMAL:
-  FLOOR
-  WALL
-
-BASE:
-  FLOOR
-  STATION_STRUCTURE
-
-RESOURCE:
-  FLOOR
-  DEBRIS
-
-NEBULA:
-  FLOOR
-  NEBULA
-  初期効果候補 = 観測範囲縮小
-
-ASTEROID:
-  FLOOR
-  ASTEROID_FIELD
-  ASTEROID
-  ASTEROID_FIELD = 通行可能・高移動コスト
-  ASTEROID = 通行不能
-
-GRAVITY:
-  FLOOR
-  GRAVITY_FIELD
-  初期効果候補 = 方向依存移動コスト
-  強制移動は比較候補とし基準条件には含めない
-
-RIFT:
-  FLOOR
-  RIFT_DISTORTION
-  RIFT_BARRIER
-```
-
-地形効果は移動方式から独立したデータとして定義する。
-
-```text
-passable
-base_move_cost
-blocks_line_travel
-stops_on_entry
-observation_effect
-directional_cost
-forced_movement
-```
-
-## 8. Object profile
-
-天体objectは全profile・全SectorTypeへ必須配置する。以下は天体以外の価値objectだけを示す。
-
-```text
-PROFILE_MINIMAL:
-  NORMAL: なし
-  BASE: BASE_NODE 1個
-  RESOURCE: RESOURCE_CACHE 1個
-  NEBULA: なし
-  ASTEROID: なし
-  GRAVITY: なし
-  RIFT: なし
-
-PROFILE_EXPLORATION:
-  NORMAL: SALVAGE 0..1個
-  BASE: BASE_NODE 1個
-  RESOURCE: RESOURCE_CACHE 1個
-  NEBULA: SALVAGE 0..1個
-  ASTEROID: SALVAGEまたはRESOURCE_CACHE 0..1個
-  GRAVITY: SALVAGE 0..1個
-  RIFT: SALVAGEまたはRESOURCE_CACHE 0..1個
-```
-
-BASE/RESOURCEの効果量はPhase 1値を変更せず、SRS内部で到達が必要かだけを評価する。
-
-## 9. 重なり規則
-
-```text
-terrain + feature:
-  terrain.can_host_feature = trueの場合のみ可
-
-terrain + object:
-  terrain.can_host_object = trueの場合のみ可
-
-feature + object:
-  不可
-
-object + object:
-  不可
-
-actor + object:
-  object.passable = trueの場合のみ可
-
-actor + WARP_POINT:
-  可
-```
-
-セル通行可否は、terrain、feature、object、actor占有規則を合成して決定する。
-
-## 10. 移動方式
-
-LRSの`N/E/S/W`一歩移動をSRSの基準方式として固定しない。次の3方式を比較する。
-
-```text
-VECTOR_COMMAND:
-  角度 + 距離を指定
-  経路は直線をグリッドへラスタライズ
-
-MOVEMENT_POINTS:
-  1ターンの移動力内で経路または目的地を指定
-  terrain costを消費
-
-DIRECTIONAL_THRUST:
-  8方向 + 推進距離を指定
-  直線移動
-```
-
-移動ルールと入力方式を分離する。
-
-```text
-movement_rule:
-  VECTOR_COMMAND
-  MOVEMENT_POINTS
-  DIRECTIONAL_THRUST
-
-path_input_mode:
-  STEPWISE_ROUTE
-  DESTINATION_AUTO_PATH
-  ROUTE_PREVIEW
-```
-
-### 10.1 基準値
-
-```text
-movement_rule = MOVEMENT_POINTS
-movement_points_per_turn = 4
-path_input_mode = ROUTE_PREVIEW
-```
-
-`MOVEMENT_POINTS`を基準方式、`DIRECTIONAL_THRUST`を比較方式、`VECTOR_COMMAND`を実験方式とする。
-
-### 10.2 直線移動の衝突規則
-
-VECTOR_COMMANDとDIRECTIONAL_THRUSTでは、移動経路上の全セルを順番に判定する。
-
-```text
-STOP_BEFORE:
-  最初の通行不能セルの直前で停止
-  実際に通過した距離またはcostだけを消費
-  通行不能セルへは進入しない
-```
-
-未観測セルへの移動は許可するが、衝突・早期停止をGameLogへ記録する。
-
-### 10.3 行動契約
-
-```text
-MOVE_ROUTE <coordinates...>
-MOVE_TO <coordinate>
-VECTOR <angle> <distance>
-THRUST <direction8> <distance>
-INTERACT
-WARP <N|E|S|W>
-```
-
-有効なコマンドは選択中のmovement_ruleとpath_input_modeにより制限される。
-
-- `INTERACT`は現在cellのobjectを利用・取得する。
-- `WARP`は対応方向のWARP_POINT上にいる場合だけ成功する。
-- 1ターン中の複数セル移動後に観測を更新するタイミングは、通過セルごととする。
-
-interaction mode:
-
-```text
-AUTO_INTERACT
-EXPLICIT_INTERACT
-```
-
-## 11. 観測方式
-
-```text
-FULL:
-  開始時からSRS全体を既知
-
-LOCAL_3X3:
-  開始時と成功移動中の各通過cellで現在地周囲3x3を累積開示
-```
-
-閉鎖辺の知識:
-
-```text
-KNOWN_DESCRIPTOR:
-  sector typeとblocked edgesは進入時に既知
-
-LOCAL_DISCOVERY:
-  sector typeは既知、閉鎖外周は観測範囲に入った時点で既知
-```
-
-視線・SCAN方式は初期検証から外す。
-
-## 12. turn/fuel方式
-
-```text
-TURN_ONLY:
-  移動command / INTERACT / WARPはSRS turnだけを消費
-  LRS fuelは区画間移動時だけ消費
-
-SHARED_FUEL:
-  SRS移動では実際に消費したmovement costに応じてLRS fuelを消費
-  INTERACT / WARPはfuelを消費しない
-```
-
-「進入・離脱だけfuel消費」はPhase 1の区画間移動と重複するため初期比較から除外する。
-
-## 13. 内部生成
-
-生成順:
-
-```text
-1. 基本terrain
-2. 外周
-3. 非blocked辺中央へWARP_POINT
-4. RIFT閉鎖外周
-5. STAR 1個
-6. PLANET複数
-7. 内部terrain障害物
-8. 価値objects
-9. 到達可能性検証
-```
-
-障害物密度候補:
-
-```text
-LOW    = 0.10
-MEDIUM = 0.20
-```
-
-必須保証:
-
-- 全有効WARP_POINTが同一の通行可能領域に属する
-- 各WARP_POINTから盤面内部へ進める
-- 必須objectへ到達可能
-- 閉鎖外周は内側からも通過不能
-- STARはexactly 1
-- PLANET数は盤面サイズ別範囲内
-- 同一seedとdescriptorで同一map
-
-## 14. 再訪時の永続状態
-
-保持する:
-
-```text
-generated SRS map
-sector type
-blocked edges
-STAR / PLANET配置
-consumed/activated objects
-discovered cells
-```
-
-セッションごとに更新する:
-
-```text
-player position
-selected warp direction
-current events
-```
-
-visited cellsは独立永続化せず、discovered cellsへ統合する。
-
-## 15. 基準条件
-
-```text
-map_size                 = 9x9
-obstacle_density         = 0.20
-observation              = LOCAL_3X3
-cost_mode                = TURN_ONLY
-interaction_mode         = EXPLICIT_INTERACT
-object_profile           = PROFILE_EXPLORATION
-rift_knowledge           = KNOWN_DESCRIPTOR
-movement_rule            = MOVEMENT_POINTS
-movement_points_per_turn = 4
-path_input_mode           = ROUTE_PREVIEW
-warp_clearance_depth     = 1
-star_count               = 1
-planet_count             = 2..5
-max_srs_turns            = 40
-```
-
-## 16. 比較条件
-
-```text
-C1  7x7 vs 9x9
-C2  FULL vs LOCAL_3X3
-C3  TURN_ONLY vs SHARED_FUEL
-C4  AUTO_INTERACT vs EXPLICIT_INTERACT
-C5  PROFILE_MINIMAL vs PROFILE_EXPLORATION
-C6  KNOWN_DESCRIPTOR vs LOCAL_DISCOVERY
-C7  obstacle 0.10 vs 0.20
-C8  VECTOR_COMMAND vs MOVEMENT_POINTS vs DIRECTIONAL_THRUST
-```
-
-C8は3条件比較とし、負荷が高い場合は次の二段階へ分割できる。
-
-```text
-C8a VECTOR_COMMAND vs MOVEMENT_POINTS
-C8b C8aの勝者 vs DIRECTIONAL_THRUST
-```
-
-各比較では対象以外の条件を基準値へ固定する。全組合せ直積は行わない。
-
-## 17. 評価指標
-
-共通:
-
-```text
-goal_reach_rate
-median_srs_turn
-p90_srs_turn
-mean_commands_to_exit
-movement_distance
-wasted_movement
-collision_count
-blocked_command_count
-route_replanning_count
-explored_cell_ratio
-object_acquisition_rate
-fuel_or_turn_cost
-unreachable_state_rate
-```
-
-VECTOR_COMMAND:
-
-```text
-endpoint_rounding_error
-premature_collision_rate
-unknown_space_collision_rate
-requested_vs_actual_distance
-```
-
-MOVEMENT_POINTS:
-
-```text
-unused_movement_points
-path_cost_efficiency
-auto_path_override_count
-```
-
-## 18. 初期判断閾値
-
-これらは検証用の仮説であり、#1083で最終決定する。
-
-```text
-p90 SRS turn <= 25
-手動の区画長さ評価 >= 3.5 / 5
-方向感覚評価 >= 4.0 / 5
-探索価値評価 >= 3.5 / 5
-移動理解評価 >= 4.0 / 5
-操縦感評価 >= 3.5 / 5
-行動不能率 <= 0.01
-blocked edge無駄試行率 <= 0.15
-意図しない衝突率 <= 0.10
-```
-
-## 19. #1080への引き渡し
-
-#1080は次を追加判断なしで実装する。
-
 第一段階:
-
-- enumとdescriptor schema
-- `NORMAL / BASE / RESOURCE / RIFT`
-- terrain / feature / object / actor分離
-- WARP_POINTとRIFT閉鎖外周
-- STAR 1個とPLANET複数の配置
-- 7x7 / 9x9
-- object profiles
-- observation/cost/interaction modes
-- 3移動方式を切り替え可能な共通movement interface
-- persistent fields
-- C1..C8比較条件
-- Q1..Q16の必要指標とfixture
+  NORMAL
+  BASE
+  RESOURCE
+  RIFT
 
 第二段階:
+  NEBULA
+  ASTEROID
+  GRAVITY
+```
 
-- `NEBULA / ASTEROID / GRAVITY`
-- 観測縮小、高移動コスト、方向依存コスト
-- 必要に応じて重力場の強制移動比較
+ただし第一段階開始時点で、全 7 `SectorType` の型、profile、不変条件が正本に存在することを前提とする。
+
+## 7. 評価前提
+
+初期比較条件、baseline、永続状態、比較IDは `phase2_initial_values.json` と `phase2_questions.csv` を参照する。
+
+```text
+baseline:
+  LOCAL_3X3
+  TURN_ONLY
+  EXPLICIT_INTERACT
+  VALUE_OBJECT_DETOUR
+  KNOWN_DESCRIPTOR
+  MOVEMENT_POINTS
+  ROUTE_PREVIEW
+  STOP_BEFORE
+
+比較:
+  C1..C8
+
+質問:
+  Q1..Q16
+```
+
+移動方式の比較対象は次の 3 つとする。
+
+```text
+VECTOR_COMMAND
+MOVEMENT_POINTS
+DIRECTIONAL_THRUST
+```
+
+観測方式、相互作用方式、移動方式、persistent fields の確定値は `phase2_initial_values.json` を正本とする。

--- a/experiments/galactic_exodus/srs/phase2_initial_values.json
+++ b/experiments/galactic_exodus/srs/phase2_initial_values.json
@@ -1,5 +1,11 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
+  "generation_schema_version": 1,
+  "contract_references": {
+    "elements": "phase2_srs_elements.json",
+    "generation": "phase2_srs_generation.json",
+    "movement_rule_issue": 1089
+  },
   "sector_types": [
     "NORMAL",
     "BASE",
@@ -12,44 +18,28 @@
   "directions": ["N", "E", "S", "W"],
   "terrain_types": [
     "FLOOR",
-    "WALL",
-    "STATION_STRUCTURE",
     "DEBRIS",
     "NEBULA",
     "ASTEROID_FIELD",
     "ASTEROID",
-    "GRAVITY_FIELD",
+    "GRAVITY_FIELD_VERTICAL",
+    "GRAVITY_FIELD_HORIZONTAL",
     "RIFT_DISTORTION",
     "RIFT_BARRIER"
   ],
-  "feature_types": ["WARP_POINT"],
-  "object_types": ["STAR", "PLANET", "BASE_NODE", "RESOURCE_CACHE", "SALVAGE"],
+  "object_types": ["STAR", "PLANET", "STATION", "RESOURCE_CACHE", "SALVAGE"],
   "actor_types": ["PLAYER"],
   "movement_rules": ["VECTOR_COMMAND", "MOVEMENT_POINTS", "DIRECTIONAL_THRUST"],
   "path_input_modes": ["STEPWISE_ROUTE", "DESTINATION_AUTO_PATH", "ROUTE_PREVIEW"],
-  "invariants": {
-    "rift_blocked_edge_min": 1,
-    "rift_blocked_edge_max": 3,
-    "non_rift_blocked_edges": [],
-    "warp_point_must_be_open": true,
-    "selected_warp_direction_must_be_open": true,
-    "odd_map_dimensions_only": true,
-    "star_count": 1,
-    "planet_count_min": 1,
-    "warp_point_at_edge_midpoint": true,
-    "warp_point_object_overlap_allowed": false,
-    "all_warp_points_connected": true
-  },
   "baseline": {
     "width": 9,
     "height": 9,
-    "warp_point_width": 1,
-    "warp_clearance_depth": 1,
-    "obstacle_density": 0.2,
+    "generation_profile": "phase2_srs_generation.json",
+    "generation_schema_version": 1,
     "observation_mode": "LOCAL_3X3",
     "cost_mode": "TURN_ONLY",
     "interaction_mode": "EXPLICIT_INTERACT",
-    "object_profile": "PROFILE_EXPLORATION",
+    "sector_value_route": "VALUE_OBJECT_DETOUR",
     "rift_knowledge_mode": "KNOWN_DESCRIPTOR",
     "movement_rule": "MOVEMENT_POINTS",
     "movement_points_per_turn": 4,
@@ -57,117 +47,20 @@
     "collision_behavior": "STOP_BEFORE",
     "max_srs_turns": 40
   },
-  "celestial_body_profiles": {
-    "7x7": {
-      "STAR": {"count": 1},
-      "PLANET": {"count_min": 1, "count_max": 3}
-    },
-    "9x9": {
-      "STAR": {"count": 1},
-      "PLANET": {"count_min": 2, "count_max": 5}
-    }
-  },
-  "element_definitions": {
-    "STAR": {
-      "category": "CELESTIAL_BODY",
-      "passable": false,
-      "blocks_line_travel": true,
-      "interaction_required": false,
-      "consumable": false,
-      "persistent_after_revisit": true,
-      "state_after_use": "NONE",
-      "collision_behavior": "STOP_BEFORE",
-      "allowed_sector_types": [
-        "NORMAL",
-        "BASE",
-        "RESOURCE",
-        "NEBULA",
-        "ASTEROID",
-        "GRAVITY",
-        "RIFT"
-      ]
-    },
-    "PLANET": {
-      "category": "CELESTIAL_BODY",
-      "passable": false,
-      "blocks_line_travel": true,
-      "interaction_required": false,
-      "consumable": false,
-      "persistent_after_revisit": true,
-      "state_after_use": "NONE",
-      "collision_behavior": "STOP_BEFORE",
-      "allowed_sector_types": [
-        "NORMAL",
-        "BASE",
-        "RESOURCE",
-        "NEBULA",
-        "ASTEROID",
-        "GRAVITY",
-        "RIFT"
-      ]
-    },
-    "WARP_POINT": {
-      "category": "TRANSIT",
-      "passable": true,
-      "interaction_required": true,
-      "persistent_after_revisit": true,
-      "can_host_object": false,
-      "placement": "EDGE_MIDPOINT"
-    }
-  },
-  "terrain_profiles": {
-    "NORMAL": ["FLOOR", "WALL"],
-    "BASE": ["FLOOR", "STATION_STRUCTURE"],
-    "RESOURCE": ["FLOOR", "DEBRIS"],
-    "NEBULA": ["FLOOR", "NEBULA"],
-    "ASTEROID": ["FLOOR", "ASTEROID_FIELD", "ASTEROID"],
-    "GRAVITY": ["FLOOR", "GRAVITY_FIELD"],
-    "RIFT": ["FLOOR", "RIFT_DISTORTION", "RIFT_BARRIER"]
-  },
-  "initial_terrain_effects": {
-    "NEBULA": {"observation_effect": "REDUCE_LOCAL_RANGE"},
-    "ASTEROID_FIELD": {"passable": true, "base_move_cost": 2},
-    "ASTEROID": {"passable": false, "blocks_line_travel": true},
-    "GRAVITY_FIELD": {"passable": true, "directional_cost": true, "forced_movement": false},
-    "RIFT_BARRIER": {"passable": false, "blocks_line_travel": true}
-  },
   "comparisons": {
-    "C1": {"field": "map_size", "values": [[7, 7], [9, 9]]},
+    "C1": {"field": "map_size", "values": [[9, 9], [11, 11]]},
     "C2": {"field": "observation_mode", "values": ["FULL", "LOCAL_3X3"]},
     "C3": {"field": "cost_mode", "values": ["TURN_ONLY", "SHARED_FUEL"]},
     "C4": {"field": "interaction_mode", "values": ["AUTO_INTERACT", "EXPLICIT_INTERACT"]},
-    "C5": {"field": "object_profile", "values": ["PROFILE_MINIMAL", "PROFILE_EXPLORATION"]},
+    "C5": {"field": "sector_value_route", "values": ["DIRECT_EXIT", "VALUE_OBJECT_DETOUR"]},
     "C6": {"field": "rift_knowledge_mode", "values": ["KNOWN_DESCRIPTOR", "LOCAL_DISCOVERY"]},
-    "C7": {"field": "obstacle_density", "values": [0.1, 0.2]},
+    "C7": {
+      "field": "sector_type",
+      "values": ["NORMAL", "BASE", "RESOURCE", "NEBULA", "ASTEROID", "GRAVITY", "RIFT"]
+    },
     "C8": {
       "field": "movement_rule",
       "values": ["VECTOR_COMMAND", "MOVEMENT_POINTS", "DIRECTIONAL_THRUST"]
-    }
-  },
-  "object_profiles": {
-    "PROFILE_MINIMAL": {
-      "NORMAL": [],
-      "BASE": [{"type": "BASE_NODE", "count": 1}],
-      "RESOURCE": [{"type": "RESOURCE_CACHE", "count": 1}],
-      "NEBULA": [],
-      "ASTEROID": [],
-      "GRAVITY": [],
-      "RIFT": []
-    },
-    "PROFILE_EXPLORATION": {
-      "NORMAL": [{"type": "SALVAGE", "count_min": 0, "count_max": 1}],
-      "BASE": [{"type": "BASE_NODE", "count": 1}],
-      "RESOURCE": [{"type": "RESOURCE_CACHE", "count": 1}],
-      "NEBULA": [{"type": "SALVAGE", "count_min": 0, "count_max": 1}],
-      "ASTEROID": [
-        {"type": "SALVAGE", "count_min": 0, "count_max": 1, "exclusive_group": "asteroid_value"},
-        {"type": "RESOURCE_CACHE", "count_min": 0, "count_max": 1, "exclusive_group": "asteroid_value"}
-      ],
-      "GRAVITY": [{"type": "SALVAGE", "count_min": 0, "count_max": 1}],
-      "RIFT": [
-        {"type": "SALVAGE", "count_min": 0, "count_max": 1, "exclusive_group": "rift_value"},
-        {"type": "RESOURCE_CACHE", "count_min": 0, "count_max": 1, "exclusive_group": "rift_value"}
-      ]
     }
   },
   "thresholds": {
@@ -183,8 +76,11 @@
   },
   "persistent_fields": [
     "generated_map_id",
+    "generation_schema_version",
+    "generation_seed",
     "sector_type",
     "blocked_edges",
+    "warp_flags",
     "celestial_body_positions",
     "consumed_object_ids",
     "activated_object_ids",

--- a/experiments/galactic_exodus/srs/test_validate_phase2_initial_model.py
+++ b/experiments/galactic_exodus/srs/test_validate_phase2_initial_model.py
@@ -23,46 +23,33 @@ class Phase2InitialModelValidationTests(unittest.TestCase):
 
     def write_valid_artifacts(self) -> None:
         self.model.write_text(
-            "NEBULA ASTEROID GRAVITY RIFT blocked_edges SrsTerrainType SrsFeatureType "
-            "SrsObjectType SrsActorType WARP_POINT STAR PLANET STOP_BEFORE VECTOR_COMMAND "
-            "MOVEMENT_POINTS DIRECTIONAL_THRUST 7x7 9x9 LOCAL_3X3 TURN_ONLY SHARED_FUEL "
-            "AUTO_INTERACT EXPLICIT_INTERACT PROFILE_MINIMAL PROFILE_EXPLORATION "
-            "C1 C8 Q1..Q16 #1080\n",
+            "SectorType SrsTerrainType SrsObjectType SrsActorType warp_flags blocked_edges "
+            "generation_schema_version generation_profile_ref GRAVITY_FIELD_VERTICAL "
+            "GRAVITY_FIELD_HORIZONTAL STATION STAR PLANET RESOURCE_CACHE SALVAGE 9x9 11x11 "
+            "LOCAL_3X3 TURN_ONLY EXPLICIT_INTERACT VALUE_OBJECT_DETOUR KNOWN_DESCRIPTOR "
+            "MOVEMENT_POINTS VECTOR_COMMAND DIRECTIONAL_THRUST STOP_BEFORE C1..C8 Q1..Q16 #1080\n",
             encoding="utf-8",
         )
         values = {
-            "schema_version": 2,
+            "schema_version": 3,
+            "generation_schema_version": 1,
+            "contract_references": dict(validator.EXPECTED_CONTRACT_REFERENCES),
             "sector_types": sorted(validator.EXPECTED_SECTOR_TYPES),
             "directions": sorted(validator.EXPECTED_DIRECTIONS),
             "terrain_types": sorted(validator.EXPECTED_TERRAIN_TYPES),
-            "feature_types": sorted(validator.EXPECTED_FEATURE_TYPES),
             "object_types": sorted(validator.EXPECTED_OBJECT_TYPES),
             "actor_types": sorted(validator.EXPECTED_ACTOR_TYPES),
             "movement_rules": sorted(validator.EXPECTED_MOVEMENT_RULES),
             "path_input_modes": sorted(validator.EXPECTED_PATH_INPUT_MODES),
-            "invariants": {
-                "rift_blocked_edge_min": 1,
-                "rift_blocked_edge_max": 3,
-                "non_rift_blocked_edges": [],
-                "warp_point_must_be_open": True,
-                "selected_warp_direction_must_be_open": True,
-                "odd_map_dimensions_only": True,
-                "star_count": 1,
-                "planet_count_min": 1,
-                "warp_point_at_edge_midpoint": True,
-                "warp_point_object_overlap_allowed": False,
-                "all_warp_points_connected": True,
-            },
             "baseline": {
                 "width": 9,
                 "height": 9,
-                "warp_point_width": 1,
-                "warp_clearance_depth": 1,
-                "obstacle_density": 0.2,
+                "generation_profile": "phase2_srs_generation.json",
+                "generation_schema_version": 1,
                 "observation_mode": "LOCAL_3X3",
                 "cost_mode": "TURN_ONLY",
                 "interaction_mode": "EXPLICIT_INTERACT",
-                "object_profile": "PROFILE_EXPLORATION",
+                "sector_value_route": "VALUE_OBJECT_DETOUR",
                 "rift_knowledge_mode": "KNOWN_DESCRIPTOR",
                 "movement_rule": "MOVEMENT_POINTS",
                 "movement_points_per_turn": 4,
@@ -70,50 +57,24 @@ class Phase2InitialModelValidationTests(unittest.TestCase):
                 "collision_behavior": "STOP_BEFORE",
                 "max_srs_turns": 40,
             },
-            "celestial_body_profiles": {
-                "7x7": {
-                    "STAR": {"count": 1},
-                    "PLANET": {"count_min": 1, "count_max": 3},
-                },
-                "9x9": {
-                    "STAR": {"count": 1},
-                    "PLANET": {"count_min": 2, "count_max": 5},
-                },
-            },
-            "element_definitions": {
-                object_type: {
-                    "category": "CELESTIAL_BODY",
-                    "passable": False,
-                    "blocks_line_travel": True,
-                    "persistent_after_revisit": True,
-                    "collision_behavior": "STOP_BEFORE",
-                    "allowed_sector_types": sorted(validator.EXPECTED_SECTOR_TYPES),
-                }
-                for object_type in ("STAR", "PLANET")
-            }
-            | {
-                "WARP_POINT": {
-                    "passable": True,
-                    "placement": "EDGE_MIDPOINT",
-                    "can_host_object": False,
-                }
-            },
-            "terrain_profiles": {
-                sector: ["FLOOR"] for sector in validator.EXPECTED_SECTOR_TYPES
-            },
             "comparisons": {
-                **{
-                    f"C{index}": {"field": f"field_{index}", "values": [0, 1]}
-                    for index in range(1, 8)
+                "C1": {"field": "map_size", "values": [[9, 9], [11, 11]]},
+                "C2": {"field": "observation_mode", "values": ["FULL", "LOCAL_3X3"]},
+                "C3": {"field": "cost_mode", "values": ["TURN_ONLY", "SHARED_FUEL"]},
+                "C4": {"field": "interaction_mode", "values": ["AUTO_INTERACT", "EXPLICIT_INTERACT"]},
+                "C5": {
+                    "field": "sector_value_route",
+                    "values": ["DIRECT_EXIT", "VALUE_OBJECT_DETOUR"],
+                },
+                "C6": {"field": "rift_knowledge_mode", "values": ["KNOWN_DESCRIPTOR", "LOCAL_DISCOVERY"]},
+                "C7": {
+                    "field": "sector_type",
+                    "values": ["NORMAL", "BASE", "RESOURCE", "NEBULA", "ASTEROID", "GRAVITY", "RIFT"],
                 },
                 "C8": {
                     "field": "movement_rule",
-                    "values": sorted(validator.EXPECTED_MOVEMENT_RULES),
+                    "values": ["VECTOR_COMMAND", "MOVEMENT_POINTS", "DIRECTIONAL_THRUST"],
                 },
-            },
-            "object_profiles": {
-                profile: {sector: [] for sector in validator.EXPECTED_SECTOR_TYPES}
-                for profile in ("PROFILE_MINIMAL", "PROFILE_EXPLORATION")
             },
             "thresholds": {},
             "persistent_fields": sorted(validator.REQUIRED_PERSISTENT_FIELDS),
@@ -141,84 +102,68 @@ class Phase2InitialModelValidationTests(unittest.TestCase):
     def test_validate_all_accepts_valid_artifacts(self) -> None:
         validator.validate_all(self.model, self.questions, self.values)
 
-    def test_even_baseline_dimension_is_rejected(self) -> None:
+    def test_schema_version_must_be_three(self) -> None:
         payload = json.loads(self.values.read_text(encoding="utf-8"))
-        payload["baseline"]["width"] = 8
+        payload["schema_version"] = 2
         self.values.write_text(json.dumps(payload), encoding="utf-8")
-        with self.assertRaisesRegex(validator.ValidationError, "odd integer"):
+        with self.assertRaisesRegex(validator.ValidationError, "schema_version must be 3"):
             validator.validate_values(self.values)
 
-    def test_non_rift_blocked_edges_must_be_empty(self) -> None:
+    def test_generation_schema_version_must_be_one(self) -> None:
         payload = json.loads(self.values.read_text(encoding="utf-8"))
-        payload["invariants"]["non_rift_blocked_edges"] = ["N"]
+        payload["generation_schema_version"] = 2
         self.values.write_text(json.dumps(payload), encoding="utf-8")
-        with self.assertRaisesRegex(validator.ValidationError, "non-RIFT"):
+        with self.assertRaisesRegex(validator.ValidationError, "generation_schema_version must be 1"):
             validator.validate_values(self.values)
 
-    def test_star_count_must_be_one(self) -> None:
+    def test_feature_types_field_is_rejected(self) -> None:
         payload = json.loads(self.values.read_text(encoding="utf-8"))
-        payload["celestial_body_profiles"]["9x9"]["STAR"]["count"] = 2
+        payload["feature_types"] = ["WARP_POINT"]
         self.values.write_text(json.dumps(payload), encoding="utf-8")
-        with self.assertRaisesRegex(validator.ValidationError, "STAR count"):
+        with self.assertRaisesRegex(validator.ValidationError, "feature_types must not exist"):
             validator.validate_values(self.values)
 
-    def test_planet_must_be_impassable(self) -> None:
+    def test_baseline_must_be_9x9(self) -> None:
         payload = json.loads(self.values.read_text(encoding="utf-8"))
-        payload["element_definitions"]["PLANET"]["passable"] = True
+        payload["baseline"]["width"] = 11
         self.values.write_text(json.dumps(payload), encoding="utf-8")
-        with self.assertRaisesRegex(validator.ValidationError, "PLANET must be impassable"):
+        with self.assertRaisesRegex(validator.ValidationError, "baseline must be 9x9"):
             validator.validate_values(self.values)
 
-    def test_warp_point_cannot_host_object(self) -> None:
+    def test_c1_must_compare_9x9_and_11x11(self) -> None:
         payload = json.loads(self.values.read_text(encoding="utf-8"))
-        payload["element_definitions"]["WARP_POINT"]["can_host_object"] = True
+        payload["comparisons"]["C1"]["values"] = [[9, 9], [13, 13]]
         self.values.write_text(json.dumps(payload), encoding="utf-8")
-        with self.assertRaisesRegex(validator.ValidationError, "must not host objects"):
+        with self.assertRaisesRegex(validator.ValidationError, "C1 must compare 9x9 and 11x11"):
+            validator.validate_values(self.values)
+
+    def test_c5_must_compare_sector_value_route(self) -> None:
+        payload = json.loads(self.values.read_text(encoding="utf-8"))
+        payload["comparisons"]["C5"] = {"field": "object_profile", "values": ["A", "B"]}
+        self.values.write_text(json.dumps(payload), encoding="utf-8")
+        with self.assertRaisesRegex(validator.ValidationError, "C5 must compare sector_value_route"):
+            validator.validate_values(self.values)
+
+    def test_c7_must_include_all_sector_types(self) -> None:
+        payload = json.loads(self.values.read_text(encoding="utf-8"))
+        payload["comparisons"]["C7"]["values"] = ["NORMAL", "BASE"]
+        self.values.write_text(json.dumps(payload), encoding="utf-8")
+        with self.assertRaisesRegex(validator.ValidationError, "C7 must compare all sector types"):
             validator.validate_values(self.values)
 
     def test_c8_must_compare_all_movement_rules(self) -> None:
         payload = json.loads(self.values.read_text(encoding="utf-8"))
         payload["comparisons"]["C8"]["values"] = ["MOVEMENT_POINTS", "VECTOR_COMMAND"]
         self.values.write_text(json.dumps(payload), encoding="utf-8")
-        with self.assertRaisesRegex(validator.ValidationError, "all movement rules"):
+        with self.assertRaisesRegex(validator.ValidationError, "C8 must compare all movement rules"):
             validator.validate_values(self.values)
 
-    def test_missing_question_is_rejected(self) -> None:
-        rows = list(csv.DictReader(self.questions.open(encoding="utf-8", newline="")))
-        with self.questions.open("w", encoding="utf-8", newline="") as file:
-            writer = csv.DictWriter(file, fieldnames=validator.QUESTION_FIELDS)
-            writer.writeheader()
-            writer.writerows(rows[:-1])
-        values = validator.validate_values(self.values)
-        with self.assertRaisesRegex(validator.ValidationError, "Q1..Q16"):
-            validator.validate_questions(self.questions, values)
-
-    def test_movement_question_requires_c8(self) -> None:
-        rows = list(csv.DictReader(self.questions.open(encoding="utf-8", newline="")))
-        rows[10]["comparison_ids"] = "C1"
-        with self.questions.open("w", encoding="utf-8", newline="") as file:
-            writer = csv.DictWriter(file, fieldnames=validator.QUESTION_FIELDS)
-            writer.writeheader()
-            writer.writerows(rows)
-        values = validator.validate_values(self.values)
-        with self.assertRaisesRegex(validator.ValidationError, "Q11 must include C8"):
-            validator.validate_questions(self.questions, values)
-
-    def test_unknown_comparison_is_rejected(self) -> None:
-        rows = list(csv.DictReader(self.questions.open(encoding="utf-8", newline="")))
-        rows[0]["comparison_ids"] = "C99"
-        with self.questions.open("w", encoding="utf-8", newline="") as file:
-            writer = csv.DictWriter(file, fieldnames=validator.QUESTION_FIELDS)
-            writer.writeheader()
-            writer.writerows(rows)
-        values = validator.validate_values(self.values)
-        with self.assertRaisesRegex(validator.ValidationError, "unknown comparisons"):
-            validator.validate_questions(self.questions, values)
-
-    def test_tbd_is_rejected(self) -> None:
-        self.model.write_text(self.model.read_text(encoding="utf-8") + "TBD\n", encoding="utf-8")
-        with self.assertRaisesRegex(validator.ValidationError, "TBD"):
-            validator.validate_model(self.model)
+    def test_persistent_fields_must_include_schema_three_set(self) -> None:
+        payload = json.loads(self.values.read_text(encoding="utf-8"))
+        payload["persistent_fields"].remove("warp_flags")
+        self.values.write_text(json.dumps(payload), encoding="utf-8")
+        with self.assertRaisesRegex(validator.ValidationError, "persistent_fields must be"):
+            validator.validate_values(self.values)
 
 
 if __name__ == "__main__":

--- a/experiments/galactic_exodus/srs/validate_phase2_initial_model.py
+++ b/experiments/galactic_exodus/srs/validate_phase2_initial_model.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import csv
 import json
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -35,31 +36,33 @@ EXPECTED_SECTOR_TYPES = {
 EXPECTED_DIRECTIONS = {"N", "E", "S", "W"}
 EXPECTED_TERRAIN_TYPES = {
     "FLOOR",
-    "WALL",
-    "STATION_STRUCTURE",
     "DEBRIS",
     "NEBULA",
     "ASTEROID_FIELD",
     "ASTEROID",
-    "GRAVITY_FIELD",
+    "GRAVITY_FIELD_VERTICAL",
+    "GRAVITY_FIELD_HORIZONTAL",
     "RIFT_DISTORTION",
     "RIFT_BARRIER",
 }
-EXPECTED_FEATURE_TYPES = {"WARP_POINT"}
-EXPECTED_OBJECT_TYPES = {"STAR", "PLANET", "BASE_NODE", "RESOURCE_CACHE", "SALVAGE"}
+EXPECTED_OBJECT_TYPES = {"STAR", "PLANET", "STATION", "RESOURCE_CACHE", "SALVAGE"}
 EXPECTED_ACTOR_TYPES = {"PLAYER"}
 EXPECTED_MOVEMENT_RULES = {"VECTOR_COMMAND", "MOVEMENT_POINTS", "DIRECTIONAL_THRUST"}
 EXPECTED_PATH_INPUT_MODES = {"STEPWISE_ROUTE", "DESTINATION_AUTO_PATH", "ROUTE_PREVIEW"}
+EXPECTED_CONTRACT_REFERENCES = {
+    "elements": "phase2_srs_elements.json",
+    "generation": "phase2_srs_generation.json",
+    "movement_rule_issue": 1089,
+}
 REQUIRED_BASELINE_KEYS = {
     "width",
     "height",
-    "warp_point_width",
-    "warp_clearance_depth",
-    "obstacle_density",
+    "generation_profile",
+    "generation_schema_version",
     "observation_mode",
     "cost_mode",
     "interaction_mode",
-    "object_profile",
+    "sector_value_route",
     "rift_knowledge_mode",
     "movement_rule",
     "movement_points_per_turn",
@@ -69,13 +72,63 @@ REQUIRED_BASELINE_KEYS = {
 }
 REQUIRED_PERSISTENT_FIELDS = {
     "generated_map_id",
+    "generation_schema_version",
+    "generation_seed",
     "sector_type",
     "blocked_edges",
+    "warp_flags",
     "celestial_body_positions",
     "consumed_object_ids",
     "activated_object_ids",
     "discovered_cells",
 }
+REQUIRED_MODEL_TOKENS = [
+    "SectorType",
+    "SrsTerrainType",
+    "SrsObjectType",
+    "SrsActorType",
+    "warp_flags",
+    "blocked_edges",
+    "generation_schema_version",
+    "generation_profile_ref",
+    "GRAVITY_FIELD_VERTICAL",
+    "GRAVITY_FIELD_HORIZONTAL",
+    "STATION",
+    "STAR",
+    "PLANET",
+    "RESOURCE_CACHE",
+    "SALVAGE",
+    "9x9",
+    "11x11",
+    "LOCAL_3X3",
+    "TURN_ONLY",
+    "EXPLICIT_INTERACT",
+    "VALUE_OBJECT_DETOUR",
+    "KNOWN_DESCRIPTOR",
+    "MOVEMENT_POINTS",
+    "VECTOR_COMMAND",
+    "DIRECTIONAL_THRUST",
+    "STOP_BEFORE",
+    "C1..C8",
+    "Q1..Q16",
+    "#1080",
+]
+FORBIDDEN_MODEL_TOKENS = [
+    "WALL",
+    "STATION_STRUCTURE",
+    "BASE_NODE",
+    "WARP_POINT",
+    "WarpZone",
+    "GRAVITY_FIELD",
+    "SrsFeatureType",
+    "SrsFeature",
+    "7x7",
+    "obstacle_density",
+    "PROFILE_MINIMAL",
+    "PROFILE_EXPLORATION",
+    "warp_point_width",
+    "warp_clearance_depth",
+]
 
 
 class ValidationError(ValueError):
@@ -112,152 +165,71 @@ def require_exact_set(path: Path, data: dict[str, Any], key: str, expected: set[
         raise ValidationError(f"{path}: {key} must be {sorted(expected)}")
 
 
-def validate_celestial_profiles(path: Path, data: dict[str, Any]) -> None:
-    profiles = data.get("celestial_body_profiles")
-    if not isinstance(profiles, dict) or set(profiles) != {"7x7", "9x9"}:
-        raise ValidationError(f"{path}: celestial_body_profiles must define 7x7 and 9x9")
-    for size, profile in profiles.items():
-        if not isinstance(profile, dict) or set(profile) != {"STAR", "PLANET"}:
-            raise ValidationError(f"{path}: {size} celestial profile must define STAR and PLANET")
-        if profile["STAR"].get("count") != 1:
-            raise ValidationError(f"{path}: {size} STAR count must be exactly 1")
-        planet = profile["PLANET"]
-        minimum = planet.get("count_min")
-        maximum = planet.get("count_max")
-        if not isinstance(minimum, int) or not isinstance(maximum, int) or minimum < 1 or maximum < minimum:
-            raise ValidationError(f"{path}: {size} PLANET range must be valid and start at 1 or more")
-
-
-def validate_element_definitions(path: Path, data: dict[str, Any]) -> None:
-    definitions = data.get("element_definitions")
-    if not isinstance(definitions, dict):
-        raise ValidationError(f"{path}: element_definitions must be an object")
-    for object_type in ("STAR", "PLANET"):
-        definition = definitions.get(object_type)
-        if not isinstance(definition, dict):
-            raise ValidationError(f"{path}: missing {object_type} definition")
-        if definition.get("passable") is not False:
-            raise ValidationError(f"{path}: {object_type} must be impassable")
-        if definition.get("blocks_line_travel") is not True:
-            raise ValidationError(f"{path}: {object_type} must block line travel")
-        if definition.get("persistent_after_revisit") is not True:
-            raise ValidationError(f"{path}: {object_type} must persist after revisit")
-        if definition.get("collision_behavior") != "STOP_BEFORE":
-            raise ValidationError(f"{path}: {object_type} collision behavior must be STOP_BEFORE")
-        if set(definition.get("allowed_sector_types", [])) != EXPECTED_SECTOR_TYPES:
-            raise ValidationError(f"{path}: {object_type} must be allowed in every sector type")
-    warp = definitions.get("WARP_POINT")
-    if not isinstance(warp, dict):
-        raise ValidationError(f"{path}: missing WARP_POINT definition")
-    if warp.get("passable") is not True or warp.get("placement") != "EDGE_MIDPOINT":
-        raise ValidationError(f"{path}: WARP_POINT must be passable and placed at edge midpoint")
-    if warp.get("can_host_object") is not False:
-        raise ValidationError(f"{path}: WARP_POINT must not host objects")
-
-
 def validate_values(path: Path) -> dict[str, Any]:
     data = load_json(path)
-    if data.get("schema_version") != 2:
-        raise ValidationError(f"{path}: schema_version must be 2")
+    if data.get("schema_version") != 3:
+        raise ValidationError(f"{path}: schema_version must be 3")
+    if data.get("generation_schema_version") != 1:
+        raise ValidationError(f"{path}: generation_schema_version must be 1")
+    if data.get("contract_references") != EXPECTED_CONTRACT_REFERENCES:
+        raise ValidationError(f"{path}: contract_references must match the schema 3 contract")
+    if "feature_types" in data:
+        raise ValidationError(f"{path}: feature_types must not exist")
 
     require_exact_set(path, data, "sector_types", EXPECTED_SECTOR_TYPES)
     require_exact_set(path, data, "directions", EXPECTED_DIRECTIONS)
     require_exact_set(path, data, "terrain_types", EXPECTED_TERRAIN_TYPES)
-    require_exact_set(path, data, "feature_types", EXPECTED_FEATURE_TYPES)
     require_exact_set(path, data, "object_types", EXPECTED_OBJECT_TYPES)
     require_exact_set(path, data, "actor_types", EXPECTED_ACTOR_TYPES)
     require_exact_set(path, data, "movement_rules", EXPECTED_MOVEMENT_RULES)
     require_exact_set(path, data, "path_input_modes", EXPECTED_PATH_INPUT_MODES)
 
-    invariants = data.get("invariants")
-    if not isinstance(invariants, dict):
-        raise ValidationError(f"{path}: invariants must be an object")
-    if invariants.get("rift_blocked_edge_min") != 1:
-        raise ValidationError(f"{path}: RIFT blocked-edge minimum must be 1")
-    if invariants.get("rift_blocked_edge_max") != 3:
-        raise ValidationError(f"{path}: RIFT blocked-edge maximum must be 3")
-    if invariants.get("non_rift_blocked_edges") != []:
-        raise ValidationError(f"{path}: non-RIFT blocked edges must be empty")
-    for key in (
-        "warp_point_must_be_open",
-        "selected_warp_direction_must_be_open",
-        "odd_map_dimensions_only",
-        "warp_point_at_edge_midpoint",
-        "all_warp_points_connected",
-    ):
-        if invariants.get(key) is not True:
-            raise ValidationError(f"{path}: invariant {key} must be true")
-    if invariants.get("star_count") != 1:
-        raise ValidationError(f"{path}: invariant star_count must be 1")
-    if invariants.get("planet_count_min", 0) < 1:
-        raise ValidationError(f"{path}: invariant planet_count_min must be at least 1")
-    if invariants.get("warp_point_object_overlap_allowed") is not False:
-        raise ValidationError(f"{path}: WARP_POINT/object overlap must be forbidden")
-
     baseline = data.get("baseline")
     if not isinstance(baseline, dict):
         raise ValidationError(f"{path}: baseline must be an object")
-    missing_baseline = REQUIRED_BASELINE_KEYS - set(baseline)
+    baseline_keys = set(baseline)
+    missing_baseline = REQUIRED_BASELINE_KEYS - baseline_keys
     if missing_baseline:
         raise ValidationError(f"{path}: baseline missing {sorted(missing_baseline)}")
-    for dimension in ("width", "height"):
-        value = baseline[dimension]
-        if isinstance(value, bool) or not isinstance(value, int) or value < 5 or value % 2 == 0:
-            raise ValidationError(f"{path}: baseline {dimension} must be an odd integer >= 5")
-    density = baseline["obstacle_density"]
-    if not isinstance(density, (int, float)) or isinstance(density, bool) or not 0 <= density < 1:
-        raise ValidationError(f"{path}: obstacle_density must be in [0, 1)")
-    if baseline["warp_point_width"] != 1:
-        raise ValidationError(f"{path}: initial warp_point_width must be 1")
-    if not isinstance(baseline["warp_clearance_depth"], int) or baseline["warp_clearance_depth"] < 1:
-        raise ValidationError(f"{path}: warp_clearance_depth must be an integer >= 1")
-    if baseline["movement_rule"] not in EXPECTED_MOVEMENT_RULES:
+    extra_baseline = baseline_keys - REQUIRED_BASELINE_KEYS
+    if extra_baseline:
+        raise ValidationError(f"{path}: baseline has unexpected keys {sorted(extra_baseline)}")
+    if baseline.get("width") != 9 or baseline.get("height") != 9:
+        raise ValidationError(f"{path}: baseline must be 9x9")
+    if baseline.get("generation_profile") != "phase2_srs_generation.json":
+        raise ValidationError(f"{path}: baseline generation_profile must be phase2_srs_generation.json")
+    if baseline.get("generation_schema_version") != 1:
+        raise ValidationError(f"{path}: baseline generation_schema_version must be 1")
+    if baseline.get("movement_rule") not in EXPECTED_MOVEMENT_RULES:
         raise ValidationError(f"{path}: invalid baseline movement_rule")
-    if baseline["path_input_mode"] not in EXPECTED_PATH_INPUT_MODES:
+    if baseline.get("path_input_mode") not in EXPECTED_PATH_INPUT_MODES:
         raise ValidationError(f"{path}: invalid baseline path_input_mode")
-    if baseline["collision_behavior"] != "STOP_BEFORE":
+    if baseline.get("collision_behavior") != "STOP_BEFORE":
         raise ValidationError(f"{path}: baseline collision_behavior must be STOP_BEFORE")
-    movement_points = baseline["movement_points_per_turn"]
+    movement_points = baseline.get("movement_points_per_turn")
     if not isinstance(movement_points, int) or movement_points < 1:
         raise ValidationError(f"{path}: movement_points_per_turn must be an integer >= 1")
-
-    validate_celestial_profiles(path, data)
-    validate_element_definitions(path, data)
-
-    terrain_profiles = data.get("terrain_profiles")
-    if not isinstance(terrain_profiles, dict) or set(terrain_profiles) != EXPECTED_SECTOR_TYPES:
-        raise ValidationError(f"{path}: terrain_profiles must define every sector type")
-    for sector_type, terrain_types in terrain_profiles.items():
-        if not isinstance(terrain_types, list) or not terrain_types:
-            raise ValidationError(f"{path}: {sector_type} terrain profile must not be empty")
-        unknown = set(terrain_types) - EXPECTED_TERRAIN_TYPES
-        if unknown:
-            raise ValidationError(f"{path}: {sector_type} has unknown terrain types {sorted(unknown)}")
 
     comparisons = data.get("comparisons")
     if not isinstance(comparisons, dict) or set(comparisons) != EXPECTED_COMPARISONS:
         raise ValidationError(f"{path}: comparisons must be C1..C8")
-    for comparison_id, comparison in comparisons.items():
-        if not isinstance(comparison, dict):
-            raise ValidationError(f"{path}: {comparison_id} must be an object")
-        if not isinstance(comparison.get("field"), str) or not comparison["field"]:
-            raise ValidationError(f"{path}: {comparison_id}.field must be non-empty")
-        values = comparison.get("values")
-        if not isinstance(values, list) or len(values) < 2 or len({json.dumps(v, sort_keys=True) for v in values}) != len(values):
-            raise ValidationError(f"{path}: {comparison_id}.values must contain distinct values")
-    if comparisons["C8"].get("field") != "movement_rule":
-        raise ValidationError(f"{path}: C8 must compare movement_rule")
-    if set(comparisons["C8"].get("values", [])) != EXPECTED_MOVEMENT_RULES:
+    if comparisons.get("C1") != {"field": "map_size", "values": [[9, 9], [11, 11]]}:
+        raise ValidationError(f"{path}: C1 must compare 9x9 and 11x11")
+    if comparisons.get("C5") != {
+        "field": "sector_value_route",
+        "values": ["DIRECT_EXIT", "VALUE_OBJECT_DETOUR"],
+    }:
+        raise ValidationError(f"{path}: C5 must compare sector_value_route")
+    if comparisons.get("C7") != {
+        "field": "sector_type",
+        "values": ["NORMAL", "BASE", "RESOURCE", "NEBULA", "ASTEROID", "GRAVITY", "RIFT"],
+    }:
+        raise ValidationError(f"{path}: C7 must compare all sector types")
+    if comparisons.get("C8") != {
+        "field": "movement_rule",
+        "values": ["VECTOR_COMMAND", "MOVEMENT_POINTS", "DIRECTIONAL_THRUST"],
+    }:
         raise ValidationError(f"{path}: C8 must compare all movement rules")
-
-    profiles = data.get("object_profiles")
-    if not isinstance(profiles, dict):
-        raise ValidationError(f"{path}: object_profiles must be an object")
-    if set(profiles) != {"PROFILE_MINIMAL", "PROFILE_EXPLORATION"}:
-        raise ValidationError(f"{path}: exactly two object profiles are required")
-    for profile_name, profile in profiles.items():
-        if not isinstance(profile, dict) or set(profile) != EXPECTED_SECTOR_TYPES:
-            raise ValidationError(f"{path}: {profile_name} must define every sector type")
 
     persistent = set(data.get("persistent_fields", []))
     if persistent != REQUIRED_PERSISTENT_FIELDS:
@@ -316,40 +288,13 @@ def validate_model(path: Path) -> None:
         raise ValidationError(f"missing file: {path}") from exc
     if "TBD" in text:
         raise ValidationError(f"{path}: TBD must not remain")
-    required_tokens = [
-        "NEBULA",
-        "ASTEROID",
-        "GRAVITY",
-        "RIFT",
-        "blocked_edges",
-        "SrsTerrainType",
-        "SrsFeatureType",
-        "SrsObjectType",
-        "SrsActorType",
-        "WARP_POINT",
-        "STAR",
-        "PLANET",
-        "STOP_BEFORE",
-        "VECTOR_COMMAND",
-        "MOVEMENT_POINTS",
-        "DIRECTIONAL_THRUST",
-        "7x7",
-        "9x9",
-        "LOCAL_3X3",
-        "TURN_ONLY",
-        "SHARED_FUEL",
-        "AUTO_INTERACT",
-        "EXPLICIT_INTERACT",
-        "PROFILE_MINIMAL",
-        "PROFILE_EXPLORATION",
-        "C1",
-        "C8",
-        "Q1..Q16",
-        "#1080",
-    ]
-    for token in required_tokens:
+    for token in REQUIRED_MODEL_TOKENS:
         if token not in text:
             raise ValidationError(f"{path}: required token missing: {token}")
+    for token in FORBIDDEN_MODEL_TOKENS:
+        pattern = rf"(?<![A-Z0-9_]){re.escape(token)}(?![A-Z0-9_])"
+        if re.search(pattern, text):
+            raise ValidationError(f"{path}: forbidden legacy token remains: {token}")
 
 
 def validate_all(model: Path, questions: Path, values_path: Path) -> None:


### PR DESCRIPTION
## 概要

Closes #1093

Phase 2 SRS の初期モデルと初期値を、`elements` / `generation` 正本を参照する schema 3 契約へ更新しました。

## 変更内容

- 初期モデルと初期値を正本参照型へ更新
- `phase2_initial_values.json` の schema を 3、`generation_schema_version` を 1 へ更新
- `phase2_initial_model.md` から旧 token と旧契約記述を除去し、warp / 盤面 / 実装段階 / 評価前提を正本参照へ整理
- 既存 validator / tests を schema 3 への最低限の CI 追従に更新
- validator/tests の変更理由を schema version 3 への最低限の CI 追従に限定
- `phase2_questions.csv` は変更していない

## 含めていないもの

- `phase2_questions.csv` の更新は #1097
- cross-file validator 統合は #1098
- Q17〜Q20 検証は #1098

## 確認

- `python experiments/galactic_exodus/srs/validate_phase2_initial_model.py --model experiments/galactic_exodus/srs/phase2_initial_model.md --questions experiments/galactic_exodus/srs/phase2_questions.csv --values experiments/galactic_exodus/srs/phase2_initial_values.json`
- `python -m unittest experiments.galactic_exodus.srs.test_validate_phase2_initial_model`
- `python -m unittest discover -s experiments/galactic_exodus -p 'test_*.py'`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo fmt --check`
