### PR TITLE
Phase 2A1c-5: 初期モデルvalidatorへSRS正本のcross-file検証を統合する

### DIFF
--- a/experiments/galactic_exodus/srs/test_validate_phase2_initial_model.py
+++ b/experiments/galactic_exodus/srs/test_validate_phase2_initial_model.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import csv
 import json
+import shutil
 import unittest
-from contextlib import redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout
 from io import StringIO
 from pathlib import Path
 
@@ -12,220 +13,45 @@ from experiments.galactic_exodus.srs import validate_phase2_initial_model as val
 
 class Phase2InitialModelValidationTests(unittest.TestCase):
     def setUp(self) -> None:
-        self.root = Path(".tmp/phase2_initial_model_tests")
+        self.fixtures = Path("experiments/galactic_exodus/srs")
+        self.root = Path(".tmp/phase2_initial_model_tests") / self._testMethodName
         self.root.mkdir(parents=True, exist_ok=True)
-        self.model = self.root / "model.md"
-        self.questions = self.root / "questions.csv"
-        self.values = self.root / "values.json"
-        self.write_valid_artifacts()
+        self.model = self.copy_fixture("phase2_initial_model.md")
+        self.questions = self.copy_fixture("phase2_questions.csv")
+        self.values = self.copy_fixture("phase2_initial_values.json")
+        self.elements = self.copy_fixture("phase2_srs_elements.json")
+        self.generation = self.copy_fixture("phase2_srs_generation.json")
 
     def tearDown(self) -> None:
-        for path in (self.model, self.questions, self.values):
-            path.unlink(missing_ok=True)
-        self.root.rmdir()
+        shutil.rmtree(self.root, ignore_errors=True)
 
-    def write_valid_artifacts(self) -> None:
-        self.model.write_text(
-            "SectorType SrsTerrainType SrsObjectType SrsActorType warp_flags blocked_edges "
-            "generation_schema_version generation_profile_ref GRAVITY_FIELD_VERTICAL "
-            "GRAVITY_FIELD_HORIZONTAL STATION STAR PLANET RESOURCE_CACHE SALVAGE 9x9 11x11 "
-            "LOCAL_3X3 TURN_ONLY EXPLICIT_INTERACT VALUE_OBJECT_DETOUR KNOWN_DESCRIPTOR "
-            "MOVEMENT_POINTS VECTOR_COMMAND DIRECTIONAL_THRUST STOP_BEFORE C1..C8 Q1..Q16 #1080\n",
-            encoding="utf-8",
+    def copy_fixture(self, name: str) -> Path:
+        src = self.fixtures / name
+        dst = self.root / name
+        dst.write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
+        return dst
+
+    def validate_all(self) -> None:
+        validator.validate_all(
+            self.model,
+            self.questions,
+            self.values,
+            self.elements,
+            self.generation,
         )
-        values = {
-            "schema_version": 3,
-            "generation_schema_version": 1,
-            "contract_references": dict(validator.EXPECTED_CONTRACT_REFERENCES),
-            "sector_types": sorted(validator.EXPECTED_SECTOR_TYPES),
-            "directions": sorted(validator.EXPECTED_DIRECTIONS),
-            "terrain_types": sorted(validator.EXPECTED_TERRAIN_TYPES),
-            "object_types": sorted(validator.EXPECTED_OBJECT_TYPES),
-            "actor_types": sorted(validator.EXPECTED_ACTOR_TYPES),
-            "movement_rules": sorted(validator.EXPECTED_MOVEMENT_RULES),
-            "path_input_modes": sorted(validator.EXPECTED_PATH_INPUT_MODES),
-            "baseline": {
-                "width": 9,
-                "height": 9,
-                "generation_profile": "phase2_srs_generation.json",
-                "generation_schema_version": 1,
-                "observation_mode": "LOCAL_3X3",
-                "cost_mode": "TURN_ONLY",
-                "interaction_mode": "EXPLICIT_INTERACT",
-                "sector_value_route": "VALUE_OBJECT_DETOUR",
-                "rift_knowledge_mode": "KNOWN_DESCRIPTOR",
-                "movement_rule": "MOVEMENT_POINTS",
-                "movement_points_per_turn": 4,
-                "path_input_mode": "ROUTE_PREVIEW",
-                "collision_behavior": "STOP_BEFORE",
-                "max_srs_turns": 40,
-            },
-            "comparisons": {
-                "C1": {"field": "map_size", "values": [[9, 9], [11, 11]]},
-                "C2": {"field": "observation_mode", "values": ["FULL", "LOCAL_3X3"]},
-                "C3": {"field": "cost_mode", "values": ["TURN_ONLY", "SHARED_FUEL"]},
-                "C4": {"field": "interaction_mode", "values": ["AUTO_INTERACT", "EXPLICIT_INTERACT"]},
-                "C5": {
-                    "field": "sector_value_route",
-                    "values": ["DIRECT_EXIT", "VALUE_OBJECT_DETOUR"],
-                },
-                "C6": {"field": "rift_knowledge_mode", "values": ["KNOWN_DESCRIPTOR", "LOCAL_DISCOVERY"]},
-                "C7": {
-                    "field": "sector_type",
-                    "values": ["NORMAL", "BASE", "RESOURCE", "NEBULA", "ASTEROID", "GRAVITY", "RIFT"],
-                },
-                "C8": {
-                    "field": "movement_rule",
-                    "values": ["VECTOR_COMMAND", "MOVEMENT_POINTS", "DIRECTIONAL_THRUST"],
-                },
-            },
-            "thresholds": {},
-            "persistent_fields": sorted(validator.REQUIRED_PERSISTENT_FIELDS),
-        }
-        self.values.write_text(json.dumps(values), encoding="utf-8")
 
-        with self.questions.open("w", encoding="utf-8", newline="") as file:
-            writer = csv.DictWriter(file, fieldnames=validator.QUESTION_FIELDS)
-            writer.writeheader()
-            for index in range(1, 21):
-                writer.writerow(
-                    {
-                        "question_id": f"Q{index}",
-                        "question": "question",
-                        "hypothesis": "hypothesis",
-                        "comparison_ids": "C8" if index >= 11 else "C1",
-                        "automated_metrics": "metric",
-                        "manual_scores": "score",
-                        "required_sector_types": "NORMAL",
-                        "required_fixtures": "fixture",
-                        "decision_rule": "rule",
-                    }
-                )
-
-    def test_validate_all_accepts_valid_artifacts(self) -> None:
-        validator.validate_all(self.model, self.questions, self.values)
-
-    def test_cli_reports_twenty_questions(self) -> None:
+    def run_main(self, *args: str) -> tuple[int, str, str]:
         stdout = StringIO()
-        with redirect_stdout(stdout):
-            exit_code = validator.main(
-                ["--model", str(self.model), "--questions", str(self.questions), "--values", str(self.values)]
-            )
-        self.assertEqual(exit_code, 0)
-        self.assertIn("questions: 20", stdout.getvalue())
+        stderr = StringIO()
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            exit_code = validator.main(list(args))
+        return exit_code, stdout.getvalue(), stderr.getvalue()
 
-    def test_missing_q20_is_rejected(self) -> None:
-        rows = self.read_question_rows()
-        self.write_question_rows(rows[:-1])
-        with self.assertRaisesRegex(validator.ValidationError, "Q1..Q20 exactly once"):
-            validator.validate_questions(self.questions, validator.validate_values(self.values))
+    def read_json(self, path: Path) -> dict[str, object]:
+        return json.loads(path.read_text(encoding="utf-8"))
 
-    def test_extra_q21_is_rejected(self) -> None:
-        rows = self.read_question_rows()
-        extra = dict(rows[-1])
-        extra["question_id"] = "Q21"
-        rows.append(extra)
-        self.write_question_rows(rows)
-        with self.assertRaisesRegex(validator.ValidationError, "Q1..Q20 exactly once"):
-            validator.validate_questions(self.questions, validator.validate_values(self.values))
-
-    def test_duplicate_question_id_is_rejected(self) -> None:
-        rows = self.read_question_rows()
-        rows[-1]["question_id"] = "Q19"
-        self.write_question_rows(rows)
-        with self.assertRaisesRegex(validator.ValidationError, "Q1..Q20 exactly once"):
-            validator.validate_questions(self.questions, validator.validate_values(self.values))
-
-    def test_unknown_comparison_id_is_rejected(self) -> None:
-        rows = self.read_question_rows()
-        rows[0]["comparison_ids"] = "C9"
-        self.write_question_rows(rows)
-        with self.assertRaisesRegex(validator.ValidationError, "unknown comparisons"):
-            validator.validate_questions(self.questions, validator.validate_values(self.values))
-
-    def test_unknown_sector_type_is_rejected(self) -> None:
-        rows = self.read_question_rows()
-        rows[0]["required_sector_types"] = "VOID"
-        self.write_question_rows(rows)
-        with self.assertRaisesRegex(validator.ValidationError, "invalid required_sector_types"):
-            validator.validate_questions(self.questions, validator.validate_values(self.values))
-
-    def test_blank_field_is_rejected(self) -> None:
-        rows = self.read_question_rows()
-        rows[0]["decision_rule"] = ""
-        self.write_question_rows(rows)
-        with self.assertRaisesRegex(validator.ValidationError, "must not be blank"):
-            validator.validate_questions(self.questions, validator.validate_values(self.values))
-
-    def test_q11_to_q16_must_include_c8(self) -> None:
-        rows = self.read_question_rows()
-        rows[10]["comparison_ids"] = "C1"
-        self.write_question_rows(rows)
-        with self.assertRaisesRegex(validator.ValidationError, "Q11 must include C8"):
-            validator.validate_questions(self.questions, validator.validate_values(self.values))
-
-    def test_schema_version_must_be_three(self) -> None:
-        payload = json.loads(self.values.read_text(encoding="utf-8"))
-        payload["schema_version"] = 2
-        self.values.write_text(json.dumps(payload), encoding="utf-8")
-        with self.assertRaisesRegex(validator.ValidationError, "schema_version must be 3"):
-            validator.validate_values(self.values)
-
-    def test_generation_schema_version_must_be_one(self) -> None:
-        payload = json.loads(self.values.read_text(encoding="utf-8"))
-        payload["generation_schema_version"] = 2
-        self.values.write_text(json.dumps(payload), encoding="utf-8")
-        with self.assertRaisesRegex(validator.ValidationError, "generation_schema_version must be 1"):
-            validator.validate_values(self.values)
-
-    def test_feature_types_field_is_rejected(self) -> None:
-        payload = json.loads(self.values.read_text(encoding="utf-8"))
-        payload["feature_types"] = ["WARP_POINT"]
-        self.values.write_text(json.dumps(payload), encoding="utf-8")
-        with self.assertRaisesRegex(validator.ValidationError, "feature_types must not exist"):
-            validator.validate_values(self.values)
-
-    def test_baseline_must_be_9x9(self) -> None:
-        payload = json.loads(self.values.read_text(encoding="utf-8"))
-        payload["baseline"]["width"] = 11
-        self.values.write_text(json.dumps(payload), encoding="utf-8")
-        with self.assertRaisesRegex(validator.ValidationError, "baseline must be 9x9"):
-            validator.validate_values(self.values)
-
-    def test_c1_must_compare_9x9_and_11x11(self) -> None:
-        payload = json.loads(self.values.read_text(encoding="utf-8"))
-        payload["comparisons"]["C1"]["values"] = [[9, 9], [13, 13]]
-        self.values.write_text(json.dumps(payload), encoding="utf-8")
-        with self.assertRaisesRegex(validator.ValidationError, "C1 must compare 9x9 and 11x11"):
-            validator.validate_values(self.values)
-
-    def test_c5_must_compare_sector_value_route(self) -> None:
-        payload = json.loads(self.values.read_text(encoding="utf-8"))
-        payload["comparisons"]["C5"] = {"field": "object_profile", "values": ["A", "B"]}
-        self.values.write_text(json.dumps(payload), encoding="utf-8")
-        with self.assertRaisesRegex(validator.ValidationError, "C5 must compare sector_value_route"):
-            validator.validate_values(self.values)
-
-    def test_c7_must_include_all_sector_types(self) -> None:
-        payload = json.loads(self.values.read_text(encoding="utf-8"))
-        payload["comparisons"]["C7"]["values"] = ["NORMAL", "BASE"]
-        self.values.write_text(json.dumps(payload), encoding="utf-8")
-        with self.assertRaisesRegex(validator.ValidationError, "C7 must compare all sector types"):
-            validator.validate_values(self.values)
-
-    def test_c8_must_compare_all_movement_rules(self) -> None:
-        payload = json.loads(self.values.read_text(encoding="utf-8"))
-        payload["comparisons"]["C8"]["values"] = ["MOVEMENT_POINTS", "VECTOR_COMMAND"]
-        self.values.write_text(json.dumps(payload), encoding="utf-8")
-        with self.assertRaisesRegex(validator.ValidationError, "C8 must compare all movement rules"):
-            validator.validate_values(self.values)
-
-    def test_persistent_fields_must_include_schema_three_set(self) -> None:
-        payload = json.loads(self.values.read_text(encoding="utf-8"))
-        payload["persistent_fields"].remove("warp_flags")
-        self.values.write_text(json.dumps(payload), encoding="utf-8")
-        with self.assertRaisesRegex(validator.ValidationError, "persistent_fields must be"):
-            validator.validate_values(self.values)
+    def write_json(self, path: Path, payload: dict[str, object]) -> None:
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
 
     def read_question_rows(self) -> list[dict[str, str]]:
         with self.questions.open(encoding="utf-8", newline="") as file:
@@ -236,6 +62,288 @@ class Phase2InitialModelValidationTests(unittest.TestCase):
             writer = csv.DictWriter(file, fieldnames=validator.QUESTION_FIELDS)
             writer.writeheader()
             writer.writerows(rows)
+
+    def mutate_question(self, question_id: str, field: str, value: str) -> None:
+        rows = self.read_question_rows()
+        for row in rows:
+            if row["question_id"] == question_id:
+                row[field] = value
+                break
+        self.write_question_rows(rows)
+
+    def assert_invalid(self, pattern: str) -> None:
+        with self.assertRaisesRegex(validator.ValidationError, pattern):
+            self.validate_all()
+
+    def test_validate_all_accepts_repository_artifacts(self) -> None:
+        validator.validate_all(
+            self.fixtures / "phase2_initial_model.md",
+            self.fixtures / "phase2_questions.csv",
+            self.fixtures / "phase2_initial_values.json",
+            self.fixtures / "phase2_srs_elements.json",
+            self.fixtures / "phase2_srs_generation.json",
+        )
+
+    def test_cli_reports_cross_file_ok(self) -> None:
+        exit_code, stdout, stderr = self.run_main(
+            "--model",
+            str(self.model),
+            "--questions",
+            str(self.questions),
+            "--values",
+            str(self.values),
+            "--elements",
+            str(self.elements),
+            "--generation",
+            str(self.generation),
+        )
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(stderr, "")
+        self.assertIn("cross-file: OK", stdout)
+
+    def test_cli_requires_elements_argument(self) -> None:
+        with redirect_stderr(StringIO()):
+            with self.assertRaises(SystemExit) as cm:
+                validator.main(
+                    [
+                        "--model",
+                        str(self.model),
+                        "--questions",
+                        str(self.questions),
+                        "--values",
+                        str(self.values),
+                        "--generation",
+                        str(self.generation),
+                    ]
+                )
+        self.assertNotEqual(cm.exception.code, 0)
+
+    def test_cli_requires_generation_argument(self) -> None:
+        with redirect_stderr(StringIO()):
+            with self.assertRaises(SystemExit) as cm:
+                validator.main(
+                    [
+                        "--model",
+                        str(self.model),
+                        "--questions",
+                        str(self.questions),
+                        "--values",
+                        str(self.values),
+                        "--elements",
+                        str(self.elements),
+                    ]
+                )
+        self.assertNotEqual(cm.exception.code, 0)
+
+    def test_cli_reports_error_for_broken_elements_json(self) -> None:
+        self.elements.write_text("{broken", encoding="utf-8")
+        exit_code, stdout, stderr = self.run_main(
+            "--model",
+            str(self.model),
+            "--questions",
+            str(self.questions),
+            "--values",
+            str(self.values),
+            "--elements",
+            str(self.elements),
+            "--generation",
+            str(self.generation),
+        )
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(stdout, "")
+        self.assertIn("error:", stderr)
+
+    def test_values_generation_schema_version_must_match_generation(self) -> None:
+        payload = self.read_json(self.values)
+        payload["generation_schema_version"] = 2
+        self.write_json(self.values, payload)
+        self.assert_invalid("generation_schema_version must be 1")
+
+    def test_elements_schema_version_must_be_one(self) -> None:
+        payload = self.read_json(self.elements)
+        payload["schema_version"] = 2
+        self.write_json(self.elements, payload)
+        self.assert_invalid("schema_version must be 1")
+
+    def test_sector_types_must_include_rift(self) -> None:
+        payload = self.read_json(self.values)
+        payload["sector_types"].remove("RIFT")
+        self.write_json(self.values, payload)
+        self.assert_invalid("sector_types must be")
+
+    def test_terrain_types_must_include_rift_barrier(self) -> None:
+        payload = self.read_json(self.values)
+        payload["terrain_types"].remove("RIFT_BARRIER")
+        self.write_json(self.values, payload)
+        self.assert_invalid("terrain_types must be")
+
+    def test_object_types_must_include_station(self) -> None:
+        payload = self.read_json(self.values)
+        payload["object_types"].remove("STATION")
+        self.write_json(self.values, payload)
+        self.assert_invalid("object_types must be")
+
+    def test_elements_map_sizes_must_match_contract(self) -> None:
+        payload = self.read_json(self.elements)
+        payload["map_sizes"] = [[9, 9]]
+        self.write_json(self.elements, payload)
+        self.assert_invalid("map_sizes must be 9x9 and 11x11")
+
+    def test_generation_map_sizes_must_match_contract(self) -> None:
+        payload = self.read_json(self.generation)
+        payload["map_sizes"] = [[9, 9]]
+        self.write_json(self.generation, payload)
+        self.assert_invalid("map_sizes must be 9x9 and 11x11")
+
+    def test_contract_references_elements_basename_must_match(self) -> None:
+        payload = self.read_json(self.values)
+        payload["contract_references"]["elements"] = "wrong.json"
+        self.write_json(self.values, payload)
+        self.assert_invalid("contract_references must match")
+
+    def test_contract_references_generation_basename_must_match(self) -> None:
+        payload = self.read_json(self.values)
+        payload["contract_references"]["generation"] = "wrong.json"
+        self.write_json(self.values, payload)
+        self.assert_invalid("contract_references must match")
+
+    def test_generation_sector_profiles_must_include_gravity(self) -> None:
+        payload = self.read_json(self.generation)
+        del payload["sector_profiles"]["GRAVITY"]
+        self.write_json(self.generation, payload)
+        self.assert_invalid("sector_profiles must define all seven sector types")
+
+    def test_elements_sector_terrain_matrix_must_include_resource(self) -> None:
+        payload = self.read_json(self.elements)
+        del payload["sector_terrain_matrix"]["RESOURCE"]
+        self.write_json(self.elements, payload)
+        self.assert_invalid("sector_terrain_matrix must match values.sector_types")
+
+    def test_elements_terrain_object_matrix_must_include_floor(self) -> None:
+        payload = self.read_json(self.elements)
+        del payload["terrain_object_matrix"]["FLOOR"]
+        self.write_json(self.elements, payload)
+        self.assert_invalid("terrain_object_matrix must match values.terrain_types")
+
+    def test_elements_terrain_object_matrix_rejects_unknown_object(self) -> None:
+        payload = self.read_json(self.elements)
+        payload["terrain_object_matrix"]["FLOOR"].append("UNKNOWN_OBJECT")
+        self.write_json(self.elements, payload)
+        self.assert_invalid("terrain_object_matrix.FLOOR must stay within values.object_types")
+
+    def test_model_rejects_warp_point(self) -> None:
+        self.model.write_text(self.model.read_text(encoding="utf-8") + "\nWARP_POINT\n", encoding="utf-8")
+        self.assert_invalid("forbidden legacy token remains: WARP_POINT")
+
+    def test_values_reject_obstacle_density_key(self) -> None:
+        payload = self.read_json(self.values)
+        payload["obstacle_density"] = 1
+        self.write_json(self.values, payload)
+        self.assert_invalid("forbidden legacy token remains: obstacle_density")
+
+    def test_questions_reject_seven_by_seven_fixture(self) -> None:
+        self.mutate_question("Q17", "required_fixtures", "seven_by_seven_crossing")
+        self.assert_invalid("forbidden legacy token remains: seven_by_seven")
+
+    def test_elements_reject_base_node_object_type(self) -> None:
+        payload = self.read_json(self.elements)
+        payload["object_types"]["BASE_NODE"] = {"label": "legacy"}
+        self.write_json(self.elements, payload)
+        self.assert_invalid("forbidden legacy token remains: BASE_NODE")
+
+    def test_generation_allows_legacy_contracts_removed_record(self) -> None:
+        payload = self.read_json(self.generation)
+        payload["legacy_contracts_removed"]["WARP_POINT"] = "removed"
+        self.write_json(self.generation, payload)
+        self.validate_all()
+
+    def test_generation_rejects_legacy_token_outside_removed_contracts(self) -> None:
+        payload = self.read_json(self.generation)
+        payload["notes"] = "WARP_POINT"
+        self.write_json(self.generation, payload)
+        self.assert_invalid("forbidden legacy token remains: WARP_POINT")
+
+    def test_gravity_field_vertical_is_allowed(self) -> None:
+        self.model.write_text(
+            self.model.read_text(encoding="utf-8") + "\nGRAVITY_FIELD_VERTICAL\n",
+            encoding="utf-8",
+        )
+        self.validate_all()
+
+    def test_gravity_field_horizontal_is_allowed(self) -> None:
+        self.model.write_text(
+            self.model.read_text(encoding="utf-8") + "\nGRAVITY_FIELD_HORIZONTAL\n",
+            encoding="utf-8",
+        )
+        self.validate_all()
+
+    def test_gravity_field_token_is_rejected(self) -> None:
+        self.model.write_text(self.model.read_text(encoding="utf-8") + "\nGRAVITY_FIELD\n", encoding="utf-8")
+        self.assert_invalid("forbidden legacy token remains: GRAVITY_FIELD")
+
+    def test_q17_requires_terrain_count_by_type(self) -> None:
+        self.mutate_question(
+            "Q17",
+            "automated_metrics",
+            "special_terrain_ratio;isolated_cell_ratio;reachable_cell_ratio",
+        )
+        self.assert_invalid("Q17.automated_metrics must match")
+
+    def test_q18_requires_object_reachability_rate(self) -> None:
+        self.mutate_question(
+            "Q18",
+            "automated_metrics",
+            "celestial_spacing;object_count_by_type;object_detour_cost",
+        )
+        self.assert_invalid("Q18.automated_metrics must match")
+
+    def test_q19_requires_retry_index_p95(self) -> None:
+        self.mutate_question(
+            "Q19",
+            "automated_metrics",
+            "generation_failure_rate;retry_index_p50;max_retry_index",
+        )
+        self.assert_invalid("Q19.automated_metrics must match")
+
+    def test_q19_requires_all_sector_types(self) -> None:
+        self.mutate_question(
+            "Q19",
+            "required_sector_types",
+            "NORMAL;BASE;RESOURCE;NEBULA;ASTEROID;RIFT",
+        )
+        self.assert_invalid("Q19.required_sector_types must match")
+
+    def test_q19_requires_retry_index_p95_decision_rule(self) -> None:
+        self.mutate_question(
+            "Q19",
+            "decision_rule",
+            "generation_failure_rate=0、max_retry_index<=63",
+        )
+        self.assert_invalid("Q19.decision_rule must contain retry_index_p95<64")
+
+    def test_q20_requires_deterministic_map_match_rate(self) -> None:
+        self.mutate_question(
+            "Q20",
+            "automated_metrics",
+            "generation_report_match_rate;seed_collision_count",
+        )
+        self.assert_invalid("Q20.automated_metrics must match")
+
+    def test_q20_requires_all_sector_types(self) -> None:
+        self.mutate_question(
+            "Q20",
+            "required_sector_types",
+            "NORMAL;BASE;RESOURCE;NEBULA;ASTEROID;GRAVITY",
+        )
+        self.assert_invalid("Q20.required_sector_types must match")
+
+    def test_q20_requires_generation_report_match_rate_decision_rule(self) -> None:
+        self.mutate_question(
+            "Q20",
+            "decision_rule",
+            "deterministic_map_match_rate=1.0、seed_collision_count=0",
+        )
+        self.assert_invalid("Q20.decision_rule must contain generation_report_match_rate=1.0")
 
 
 if __name__ == "__main__":

--- a/experiments/galactic_exodus/srs/validate_phase2_initial_model.py
+++ b/experiments/galactic_exodus/srs/validate_phase2_initial_model.py
@@ -6,10 +6,16 @@ from __future__ import annotations
 import argparse
 import csv
 import json
+import os
 import re
 import sys
 from pathlib import Path
 from typing import Any
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from experiments.galactic_exodus.srs import validate_phase2_srs_generation as generation_validator
 
 QUESTION_FIELDS = [
     "question_id",
@@ -24,6 +30,8 @@ QUESTION_FIELDS = [
 ]
 EXPECTED_QUESTIONS = {f"Q{index}" for index in range(1, 21)}
 EXPECTED_COMPARISONS = {f"C{index}" for index in range(1, 9)}
+EXPECTED_MAP_SIZES = [[9, 9], [11, 11]]
+EXPECTED_BASELINE_MAP_SIZE = [9, 9]
 EXPECTED_SECTOR_TYPES = {
     "NORMAL",
     "BASE",
@@ -54,6 +62,7 @@ EXPECTED_CONTRACT_REFERENCES = {
     "generation": "phase2_srs_generation.json",
     "movement_rule_issue": 1089,
 }
+EXPECTED_MOVEMENT_RULE_REFERENCE = {"issue": 1089, "rule_id": "PASSABLE_ADJACENCY"}
 REQUIRED_BASELINE_KEYS = {
     "width",
     "height",
@@ -82,15 +91,25 @@ REQUIRED_PERSISTENT_FIELDS = {
     "activated_object_ids",
     "discovered_cells",
 }
+FORBIDDEN_ROOT_FIELDS = {
+    "feature_types",
+    "object_profiles",
+    "terrain_profiles",
+    "initial_terrain_effects",
+    "element_definitions",
+    "celestial_body_profiles",
+    "invariants",
+}
 REQUIRED_MODEL_TOKENS = [
     "SectorType",
     "SrsTerrainType",
     "SrsObjectType",
     "SrsActorType",
-    "warp_flags",
+    "SrsCell.warp_flags",
     "blocked_edges",
     "generation_schema_version",
     "generation_profile_ref",
+    "SectorDescriptor",
     "GRAVITY_FIELD_VERTICAL",
     "GRAVITY_FIELD_HORIZONTAL",
     "STATION",
@@ -112,23 +131,116 @@ REQUIRED_MODEL_TOKENS = [
     "C1..C8",
     "Q1..Q16",
     "#1080",
+    "phase2_srs_elements.md/json",
+    "phase2_srs_generation.md/json",
+    "phase2_initial_values.json",
 ]
-FORBIDDEN_MODEL_TOKENS = [
+LEGACY_BOUNDARY_TOKENS = [
     "WALL",
     "STATION_STRUCTURE",
     "BASE_NODE",
     "WARP_POINT",
     "WarpZone",
     "GRAVITY_FIELD",
-    "SrsFeatureType",
-    "SrsFeature",
     "7x7",
-    "obstacle_density",
     "PROFILE_MINIMAL",
     "PROFILE_EXPLORATION",
+]
+LEGACY_SUBSTRING_TOKENS = [
+    "obstacle_density",
+    "seven_by_seven",
+    "warp_point",
     "warp_point_width",
     "warp_clearance_depth",
+    "object_profile",
+    "terrain_profile",
+    "feature_types",
 ]
+Q17_TO_Q20_EXPECTATIONS = {
+    "Q17": {
+        "comparison_ids": {"C1", "C7"},
+        "automated_metrics": {
+            "terrain_count_by_type",
+            "special_terrain_ratio",
+            "isolated_cell_ratio",
+            "reachable_cell_ratio",
+        },
+        "manual_scores": {
+            "sector_identity_score",
+            "terrain_density_naturalness_score",
+        },
+        "required_sector_types": EXPECTED_SECTOR_TYPES,
+        "required_fixtures": {
+            "all_sectors_9x9_multi_seed",
+            "all_sectors_11x11_multi_seed",
+        },
+        "decision_rule_contains": [],
+    },
+    "Q18": {
+        "comparison_ids": {"C1", "C5", "C7"},
+        "automated_metrics": {
+            "celestial_spacing",
+            "object_count_by_type",
+            "object_detour_cost",
+            "object_reachability_rate",
+        },
+        "manual_scores": {
+            "navigation_readability_score",
+            "object_placement_value_score",
+        },
+        "required_sector_types": EXPECTED_SECTOR_TYPES,
+        "required_fixtures": {
+            "all_sectors_9x9_multi_seed",
+            "all_sectors_11x11_multi_seed",
+        },
+        "decision_rule_contains": [],
+    },
+    "Q19": {
+        "comparison_ids": {"C1", "C7"},
+        "automated_metrics": {
+            "generation_failure_rate",
+            "retry_index_p50",
+            "retry_index_p95",
+            "max_retry_index",
+        },
+        "manual_scores": {
+            "generation_stability_score",
+            "failure_diagnosability_score",
+        },
+        "required_sector_types": EXPECTED_SECTOR_TYPES,
+        "required_fixtures": {
+            "all_sectors_9x9_seed_batch",
+            "all_sectors_11x11_seed_batch",
+        },
+        "decision_rule_contains": [
+            "generation_failure_rate=0",
+            "retry_index_p95<64",
+            "max_retry_index<=63",
+        ],
+    },
+    "Q20": {
+        "comparison_ids": {"C1", "C7"},
+        "automated_metrics": {
+            "deterministic_map_match_rate",
+            "generation_report_match_rate",
+            "seed_collision_count",
+        },
+        "manual_scores": {
+            "reproducibility_confidence_score",
+            "debug_traceability_score",
+        },
+        "required_sector_types": EXPECTED_SECTOR_TYPES,
+        "required_fixtures": {
+            "all_sectors_9x9_repeat_seed_batch",
+            "all_sectors_11x11_repeat_seed_batch",
+        },
+        "decision_rule_contains": [
+            "deterministic_map_match_rate=1.0",
+            "generation_report_match_rate=1.0",
+            "seed_collision_count=0",
+        ],
+    },
+}
 
 
 class ValidationError(ValueError):
@@ -140,11 +252,18 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--model", type=Path, required=True)
     parser.add_argument("--questions", type=Path, required=True)
     parser.add_argument("--values", type=Path, required=True)
+    parser.add_argument("--elements", type=Path, required=True)
+    parser.add_argument("--generation", type=Path, required=True)
     return parser.parse_args(argv)
 
 
 def split_semicolon(value: str) -> set[str]:
     return {item.strip() for item in value.split(";") if item.strip()}
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValidationError(message)
 
 
 def load_json(path: Path) -> dict[str, Any]:
@@ -173,8 +292,9 @@ def validate_values(path: Path) -> dict[str, Any]:
         raise ValidationError(f"{path}: generation_schema_version must be 1")
     if data.get("contract_references") != EXPECTED_CONTRACT_REFERENCES:
         raise ValidationError(f"{path}: contract_references must match the schema 3 contract")
-    if "feature_types" in data:
-        raise ValidationError(f"{path}: feature_types must not exist")
+    for field in sorted(FORBIDDEN_ROOT_FIELDS):
+        if field in data:
+            raise ValidationError(f"{path}: {field} must not exist")
 
     require_exact_set(path, data, "sector_types", EXPECTED_SECTOR_TYPES)
     require_exact_set(path, data, "directions", EXPECTED_DIRECTIONS)
@@ -213,7 +333,7 @@ def validate_values(path: Path) -> dict[str, Any]:
     comparisons = data.get("comparisons")
     if not isinstance(comparisons, dict) or set(comparisons) != EXPECTED_COMPARISONS:
         raise ValidationError(f"{path}: comparisons must be C1..C8")
-    if comparisons.get("C1") != {"field": "map_size", "values": [[9, 9], [11, 11]]}:
+    if comparisons.get("C1") != {"field": "map_size", "values": EXPECTED_MAP_SIZES}:
         raise ValidationError(f"{path}: C1 must compare 9x9 and 11x11")
     if comparisons.get("C5") != {
         "field": "sector_value_route",
@@ -239,6 +359,74 @@ def validate_values(path: Path) -> dict[str, Any]:
     return data
 
 
+def load_elements(path: Path) -> dict[str, Any]:
+    data = load_json(path)
+    return data
+
+
+def validate_generation(path: Path) -> dict[str, Any]:
+    generation = load_json(path)
+    removed_contracts = generation.get("legacy_contracts_removed")
+    if not isinstance(removed_contracts, dict):
+        try:
+            return generation_validator.validate(path)
+        except generation_validator.ValidationError as exc:
+            raise ValidationError(str(exc)) from exc
+
+    sanitized = json.loads(json.dumps(generation))
+    sanitized["legacy_contracts_removed"] = {"legacy_contracts_documented": "removed"}
+    repo_root = Path(__file__).resolve().parents[3]
+    temp_dir = repo_root / ".tmp"
+    temp_dir.mkdir(parents=True, exist_ok=True)
+    temp_path = temp_dir / f"validate-phase2-initial-model-generation-{os.getpid()}.json"
+    temp_path.write_text(json.dumps(sanitized, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    try:
+        return generation_validator.validate(temp_path)
+    except generation_validator.ValidationError as exc:
+        raise ValidationError(str(exc)) from exc
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+
+def validate_question_row(path: Path, row: dict[str, str], values: dict[str, Any]) -> None:
+    label = row["question_id"]
+    for field in QUESTION_FIELDS:
+        if not row.get(field, "").strip():
+            raise ValidationError(f"{path}: {label}.{field} must not be blank")
+
+    unknown_comparisons = split_semicolon(row["comparison_ids"]) - set(values["comparisons"])
+    if unknown_comparisons:
+        raise ValidationError(f"{path}: {label} has unknown comparisons {sorted(unknown_comparisons)}")
+
+    sectors = split_semicolon(row["required_sector_types"])
+    if not sectors or not sectors <= set(values["sector_types"]):
+        raise ValidationError(f"{path}: {label} has invalid required_sector_types")
+    if not split_semicolon(row["automated_metrics"]):
+        raise ValidationError(f"{path}: {label} needs automated metrics")
+    if not split_semicolon(row["manual_scores"]):
+        raise ValidationError(f"{path}: {label} needs manual scores")
+    if not split_semicolon(row["required_fixtures"]):
+        raise ValidationError(f"{path}: {label} needs fixtures")
+
+
+def validate_fixed_question_contracts(path: Path, rows_by_id: dict[str, dict[str, str]]) -> None:
+    for question_id, expected in Q17_TO_Q20_EXPECTATIONS.items():
+        row = rows_by_id[question_id]
+        for field in (
+            "comparison_ids",
+            "automated_metrics",
+            "manual_scores",
+            "required_sector_types",
+            "required_fixtures",
+        ):
+            actual = split_semicolon(row[field])
+            if actual != expected[field]:
+                raise ValidationError(f"{path}: {question_id}.{field} must match the Phase 2A1c contract")
+        for token in expected["decision_rule_contains"]:
+            if token not in row["decision_rule"]:
+                raise ValidationError(f"{path}: {question_id}.decision_rule must contain {token}")
+
+
 def validate_questions(path: Path, values: dict[str, Any]) -> None:
     try:
         with path.open(encoding="utf-8", newline="") as file:
@@ -253,32 +441,19 @@ def validate_questions(path: Path, values: dict[str, Any]) -> None:
     if ids != EXPECTED_QUESTIONS or len(rows) != 20:
         raise ValidationError(f"{path}: questions must contain Q1..Q20 exactly once")
 
-    comparisons = set(values["comparisons"])
     for row in rows:
-        label = row["question_id"]
-        for field in QUESTION_FIELDS:
-            if not row.get(field, "").strip():
-                raise ValidationError(f"{path}: {label}.{field} must not be blank")
-        unknown_comparisons = split_semicolon(row["comparison_ids"]) - comparisons
-        if unknown_comparisons:
-            raise ValidationError(f"{path}: {label} has unknown comparisons {sorted(unknown_comparisons)}")
-        sectors = split_semicolon(row["required_sector_types"])
-        if not sectors or not sectors <= EXPECTED_SECTOR_TYPES:
-            raise ValidationError(f"{path}: {label} has invalid required_sector_types")
-        if not split_semicolon(row["automated_metrics"]):
-            raise ValidationError(f"{path}: {label} needs automated metrics")
-        if not split_semicolon(row["manual_scores"]):
-            raise ValidationError(f"{path}: {label} needs manual scores")
-        if not split_semicolon(row["required_fixtures"]):
-            raise ValidationError(f"{path}: {label} needs fixtures")
+        validate_question_row(path, row, values)
 
+    rows_by_id = {row["question_id"]: row for row in rows}
     movement_question_ids = {"Q11", "Q12", "Q13", "Q14", "Q15", "Q16"}
-    movement_rows = {row["question_id"]: row for row in rows if row["question_id"] in movement_question_ids}
+    movement_rows = {question_id: rows_by_id[question_id] for question_id in movement_question_ids}
     if set(movement_rows) != movement_question_ids:
         raise ValidationError(f"{path}: movement questions Q11..Q16 are required")
     for question_id, row in movement_rows.items():
         if "C8" not in split_semicolon(row["comparison_ids"]):
             raise ValidationError(f"{path}: {question_id} must include C8")
+
+    validate_fixed_question_contracts(path, rows_by_id)
 
 
 def validate_model(path: Path) -> None:
@@ -286,19 +461,224 @@ def validate_model(path: Path) -> None:
         text = path.read_text(encoding="utf-8")
     except FileNotFoundError as exc:
         raise ValidationError(f"missing file: {path}") from exc
+
     if "TBD" in text:
         raise ValidationError(f"{path}: TBD must not remain")
     for token in REQUIRED_MODEL_TOKENS:
         if token not in text:
             raise ValidationError(f"{path}: required token missing: {token}")
-    for token in FORBIDDEN_MODEL_TOKENS:
-        pattern = rf"(?<![A-Z0-9_]){re.escape(token)}(?![A-Z0-9_])"
+
+
+def find_legacy_token_in_text(text: str) -> str | None:
+    for token in LEGACY_BOUNDARY_TOKENS:
+        pattern = rf"(?<![A-Za-z0-9_]){re.escape(token)}(?![A-Za-z0-9_])"
         if re.search(pattern, text):
-            raise ValidationError(f"{path}: forbidden legacy token remains: {token}")
+            return token
+    for token in LEGACY_SUBSTRING_TOKENS:
+        if token in text:
+            return token
+    return None
 
 
-def validate_all(model: Path, questions: Path, values_path: Path) -> None:
+def validate_legacy_text(path: Path) -> None:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise ValidationError(f"missing file: {path}") from exc
+    token = find_legacy_token_in_text(text)
+    if token is not None:
+        raise ValidationError(f"{path}: forbidden legacy token remains: {token}")
+
+
+def validate_legacy_json(
+    path: Path,
+    data: dict[str, Any],
+    *,
+    allow_removed_contracts: bool = False,
+    ignored_prefixes: tuple[tuple[str, ...], ...] = (),
+    ignored_tokens: frozenset[str] = frozenset(),
+) -> None:
+    def walk(value: Any, components: tuple[str, ...]) -> None:
+        if allow_removed_contracts and components[:2] == ("root", "legacy_contracts_removed"):
+            return
+        if any(components[: len(prefix)] == prefix for prefix in ignored_prefixes):
+            return
+        if isinstance(value, dict):
+            for key, nested in value.items():
+                child_components = (*components, str(key))
+                if any(child_components[: len(prefix)] == prefix for prefix in ignored_prefixes):
+                    continue
+                token = find_legacy_token_in_text(str(key))
+                if token is not None and token not in ignored_tokens:
+                    raise ValidationError(f"{path}: forbidden legacy token remains: {token}")
+                walk(nested, child_components)
+            return
+        if isinstance(value, list):
+            for index, nested in enumerate(value):
+                walk(nested, (*components, str(index)))
+            return
+        if isinstance(value, str):
+            token = find_legacy_token_in_text(value)
+            if token is not None and token not in ignored_tokens:
+                raise ValidationError(f"{path}: forbidden legacy token remains: {token}")
+
+    walk(data, ("root",))
+
+
+def validate_cross_file(
+    values_path: Path,
+    values: dict[str, Any],
+    elements_path: Path,
+    elements: dict[str, Any],
+    generation_path: Path,
+    generation: dict[str, Any],
+) -> None:
+    if values.get("generation_schema_version") != generation.get("generation_schema_version"):
+        raise ValidationError(f"{values_path}: generation_schema_version must match generation")
+    if elements.get("schema_version") != 1:
+        raise ValidationError(f"{elements_path}: schema_version must be 1")
+    if values.get("generation_schema_version") != 1:
+        raise ValidationError(f"{values_path}: generation_schema_version must be 1")
+
+    if elements.get("map_sizes") != EXPECTED_MAP_SIZES:
+        raise ValidationError(f"{elements_path}: map_sizes must be 9x9 and 11x11")
+    if generation.get("map_sizes") != EXPECTED_MAP_SIZES:
+        raise ValidationError(f"{generation_path}: map_sizes must be 9x9 and 11x11")
+    if elements.get("map_sizes") != generation.get("map_sizes"):
+        raise ValidationError(f"{elements_path}: map_sizes must match generation")
+    if elements.get("baseline_map_size") != EXPECTED_BASELINE_MAP_SIZE:
+        raise ValidationError(f"{elements_path}: baseline_map_size must be [9, 9]")
+    baseline = values["baseline"]
+    baseline_size = [baseline["width"], baseline["height"]]
+    if baseline_size not in generation.get("map_sizes", []):
+        raise ValidationError(f"{values_path}: baseline size must exist in generation.map_sizes")
+    if values["comparisons"].get("C1") != {"field": "map_size", "values": EXPECTED_MAP_SIZES}:
+        raise ValidationError(f"{values_path}: C1 must compare 9x9 and 11x11")
+
+    value_sector_types = set(values["sector_types"])
+    generation_sector_types = set(generation.get("sector_types", []))
+    generation_profile_types = set(generation.get("sector_profiles", {}).keys())
+    element_sector_types = set(elements.get("sector_terrain_matrix", {}).keys())
+    if value_sector_types != EXPECTED_SECTOR_TYPES:
+        raise ValidationError(f"{values_path}: sector_types must be {sorted(EXPECTED_SECTOR_TYPES)}")
+    if generation_sector_types != value_sector_types:
+        raise ValidationError(f"{generation_path}: sector_types must match values.sector_types")
+    if generation_profile_types != value_sector_types:
+        raise ValidationError(f"{generation_path}: sector_profiles must match values.sector_types")
+    if element_sector_types != value_sector_types:
+        raise ValidationError(f"{elements_path}: sector_terrain_matrix must match values.sector_types")
+
+    value_terrain_types = set(values["terrain_types"])
+    generation_terrain_types = set(generation.get("terrain_types", []))
+    element_terrain_types = set(elements.get("terrain_types", {}).keys())
+    if value_terrain_types != EXPECTED_TERRAIN_TYPES:
+        raise ValidationError(f"{values_path}: terrain_types must be {sorted(EXPECTED_TERRAIN_TYPES)}")
+    if generation_terrain_types != value_terrain_types:
+        raise ValidationError(f"{generation_path}: terrain_types must match values.terrain_types")
+    if element_terrain_types != value_terrain_types:
+        raise ValidationError(f"{elements_path}: terrain_types must match values.terrain_types")
+
+    value_object_types = set(values["object_types"])
+    generation_object_types = set(generation.get("object_types", []))
+    element_object_types = set(elements.get("object_types", {}).keys())
+    if value_object_types != EXPECTED_OBJECT_TYPES:
+        raise ValidationError(f"{values_path}: object_types must be {sorted(EXPECTED_OBJECT_TYPES)}")
+    if generation_object_types != value_object_types:
+        raise ValidationError(f"{generation_path}: object_types must match values.object_types")
+    if element_object_types != value_object_types:
+        raise ValidationError(f"{elements_path}: object_types must match values.object_types")
+
+    contract_references = values.get("contract_references")
+    if contract_references != EXPECTED_CONTRACT_REFERENCES:
+        raise ValidationError(f"{values_path}: contract_references must match the schema 3 contract")
+    if contract_references.get("elements") != elements_path.name:
+        raise ValidationError(f"{values_path}: contract_references.elements must match {elements_path.name}")
+    if contract_references.get("generation") != generation_path.name:
+        raise ValidationError(
+            f"{values_path}: contract_references.generation must match {generation_path.name}"
+        )
+    if contract_references.get("movement_rule_issue") != 1089:
+        raise ValidationError(f"{values_path}: movement_rule_issue must be 1089")
+
+    reachability = generation.get("global_generation_contract", {}).get("reachability", {})
+    if reachability.get("movement_rule_reference") != EXPECTED_MOVEMENT_RULE_REFERENCE:
+        raise ValidationError(
+            f"{generation_path}: movement_rule_reference must match issue 1089 PASSABLE_ADJACENCY"
+        )
+
+    required_profile_keys = {
+        "required_terrain",
+        "optional_terrain",
+        "forbidden_terrain",
+        "object_count_ranges",
+        "placement_constraints",
+    }
+    sector_profiles = generation.get("sector_profiles", {})
+    if set(sector_profiles) != value_sector_types:
+        raise ValidationError(f"{generation_path}: sector_profiles must match values.sector_types")
+    for sector_type, profile in sector_profiles.items():
+        if not isinstance(profile, dict):
+            raise ValidationError(f"{generation_path}: {sector_type} profile must be an object")
+        missing_keys = required_profile_keys - set(profile)
+        if missing_keys:
+            raise ValidationError(
+                f"{generation_path}: {sector_type} profile missing {sorted(missing_keys)}"
+            )
+
+    sector_matrix = elements.get("sector_terrain_matrix", {})
+    if set(sector_matrix) != value_sector_types:
+        raise ValidationError(f"{elements_path}: sector_terrain_matrix must match values.sector_types")
+    for sector_type, terrain_rules in sector_matrix.items():
+        if not isinstance(terrain_rules, dict):
+            raise ValidationError(f"{elements_path}: sector_terrain_matrix.{sector_type} must be an object")
+        for field in ("required", "optional", "forbidden"):
+            terrain_names = set(terrain_rules.get(field, []))
+            if not terrain_names <= value_terrain_types:
+                raise ValidationError(
+                    f"{elements_path}: sector_terrain_matrix.{sector_type}.{field} must stay within values.terrain_types"
+                )
+        if "edge_required" in terrain_rules:
+            edge_required = set(terrain_rules.get("edge_required", []))
+            if not edge_required <= value_terrain_types:
+                raise ValidationError(
+                    f"{elements_path}: sector_terrain_matrix.{sector_type}.edge_required must stay within values.terrain_types"
+                )
+
+    terrain_matrix = elements.get("terrain_object_matrix", {})
+    if set(terrain_matrix) != value_terrain_types:
+        raise ValidationError(f"{elements_path}: terrain_object_matrix must match values.terrain_types")
+    for terrain_type, object_names in terrain_matrix.items():
+        if not set(object_names) <= value_object_types:
+            raise ValidationError(
+                f"{elements_path}: terrain_object_matrix.{terrain_type} must stay within values.object_types"
+            )
+
+
+def validate_all(
+    model: Path,
+    questions: Path,
+    values_path: Path,
+    elements_path: Path,
+    generation_path: Path,
+) -> None:
+    validate_legacy_text(model)
+    validate_legacy_text(questions)
+    raw_values = load_json(values_path)
+    raw_elements = load_elements(elements_path)
+    raw_generation = load_json(generation_path)
+    validate_legacy_json(values_path, raw_values)
+    validate_legacy_json(
+        elements_path,
+        raw_elements,
+        ignored_prefixes=(("root", "warp_point"),),
+        ignored_tokens=frozenset({"WARP_POINT", "warp_point"}),
+    )
+    validate_legacy_json(generation_path, raw_generation, allow_removed_contracts=True)
+    generation = validate_generation(generation_path)
     values = validate_values(values_path)
+    elements = load_elements(elements_path)
+
+    validate_cross_file(values_path, values, elements_path, elements, generation_path, generation)
     validate_questions(questions, values)
     validate_model(model)
 
@@ -306,7 +686,13 @@ def validate_all(model: Path, questions: Path, values_path: Path) -> None:
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     try:
-        validate_all(args.model, args.questions, args.values)
+        validate_all(
+            args.model,
+            args.questions,
+            args.values,
+            args.elements,
+            args.generation,
+        )
     except ValidationError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
@@ -315,6 +701,7 @@ def main(argv: list[str] | None = None) -> int:
     print("comparisons: 8")
     print("sector types: 7")
     print("movement rules: 3")
+    print("cross-file: OK")
     print("TBD: 0")
     return 0
 


### PR DESCRIPTION
## 概要

Closes #1098

- `validate_phase2_initial_model.py` を 5 成果物入力の統合 validator に更新
- `phase2_srs_generation` validator を再利用しつつ、elements / values / questions / model の cross-file 整合を追加
- legacy token 検出、Q17〜Q20 固定検証、values/model の追加契約検証を実装
- 実成果物ベースの正常系と、cross-file / legacy / CLI / Q17〜Q20 の異常系を単体テストへ追加

## 確認

- `python experiments/galactic_exodus/srs/validate_phase2_srs_generation.py experiments/galactic_exodus/srs/phase2_srs_generation.json`
- `python experiments/galactic_exodus/srs/validate_phase2_initial_model.py --model experiments/galactic_exodus/srs/phase2_initial_model.md --questions experiments/galactic_exodus/srs/phase2_questions.csv --values experiments/galactic_exodus/srs/phase2_initial_values.json --elements experiments/galactic_exodus/srs/phase2_srs_elements.json --generation experiments/galactic_exodus/srs/phase2_srs_generation.json`
- `python -m unittest experiments.galactic_exodus.srs.test_validate_phase2_initial_model`
- `python -m unittest discover -s experiments/galactic_exodus -p 'test_*.py'`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
