### PR TITLE
Phase 2B1: SRS contract loaderと基礎モデルを追加

### DIFF
--- a/experiments/galactic_exodus/srs/__init__.py
+++ b/experiments/galactic_exodus/srs/__init__.py
@@ -1,0 +1,1 @@
+"""Galactic Exodus Phase 2 SRS prototype."""

--- a/experiments/galactic_exodus/srs/contracts.py
+++ b/experiments/galactic_exodus/srs/contracts.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Mapping
+
+from experiments.galactic_exodus.srs.model import CostMode, Direction, MovementRule, ObservationMode
+
+
+class SrsContractError(ValueError):
+    pass
+
+
+def _freeze_mapping(mapping: Mapping[str, Any]) -> Mapping[str, Any]:
+    return MappingProxyType(dict(mapping))
+
+
+@dataclass(frozen=True, slots=True)
+class InitialValuesContract:
+    schema_version: int
+    generation_schema_version: int
+    baseline_observation_mode: ObservationMode
+    baseline_cost_mode: CostMode
+    baseline_movement_rule: MovementRule
+    movement_points_per_turn: int
+    max_srs_turns: int
+
+
+@dataclass(frozen=True, slots=True)
+class SrsElementsContract:
+    schema_version: int
+    raw: Mapping[str, Any]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "raw", _freeze_mapping(self.raw))
+
+
+@dataclass(frozen=True, slots=True)
+class SrsGenerationContract:
+    generation_schema_version: int
+    map_sizes: tuple[tuple[int, int], ...]
+    raw: Mapping[str, Any]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "map_sizes", tuple(tuple(size) for size in self.map_sizes))
+        object.__setattr__(self, "raw", _freeze_mapping(self.raw))
+
+
+@dataclass(frozen=True, slots=True)
+class SrsMovementContract:
+    movement_schema_version: int
+    directions: tuple[Direction, ...]
+    baseline_observation_mode: ObservationMode
+    baseline_cost_mode: CostMode
+    baseline_movement_rule: MovementRule
+    movement_cost_budget_raw: int
+    orthogonal_raw_cost: int
+    diagonal_raw_cost: int
+    command_turn_rules: Mapping[str, Any]
+    movement_rules: Mapping[str, Any]
+    observation: Mapping[str, Any]
+    interaction: Mapping[str, Any]
+    warp_exit: Mapping[str, Any]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "directions", tuple(self.directions))
+        object.__setattr__(self, "command_turn_rules", _freeze_mapping(self.command_turn_rules))
+        object.__setattr__(self, "movement_rules", _freeze_mapping(self.movement_rules))
+        object.__setattr__(self, "observation", _freeze_mapping(self.observation))
+        object.__setattr__(self, "interaction", _freeze_mapping(self.interaction))
+        object.__setattr__(self, "warp_exit", _freeze_mapping(self.warp_exit))
+
+
+@dataclass(frozen=True, slots=True)
+class SrsContracts:
+    initial_values: InitialValuesContract
+    elements: SrsElementsContract
+    generation: SrsGenerationContract
+    movement: SrsMovementContract
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise SrsContractError(f"missing contract file: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise SrsContractError(f"invalid JSON in {path}: {exc}") from exc
+    except OSError as exc:
+        raise SrsContractError(f"failed to read contract file {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise SrsContractError(f"{path}: root must be an object")
+    return payload
+
+
+def _enum(enum_type: type[Enum], value: str, *, field_name: str):
+    try:
+        return enum_type(value)
+    except ValueError as exc:
+        raise SrsContractError(f"{field_name} must be one of {[item.value for item in enum_type]}") from exc
+
+
+def _reject_legacy_observation_mode(value: str) -> None:
+    if value == "LOCAL_3X3":
+        raise SrsContractError("LOCAL_3X3 is legacy; use LOCAL_MOVEMENT")
+
+
+def _require_equal(actual: Any, expected: Any, *, field_name: str) -> None:
+    if actual != expected:
+        raise SrsContractError(f"{field_name} must be {expected!r}")
+
+
+def load_initial_values(path: Path) -> InitialValuesContract:
+    payload = _load_json(path)
+    baseline = payload.get("baseline")
+    if not isinstance(baseline, dict):
+        raise SrsContractError("baseline must be an object")
+
+    observation_mode = baseline.get("observation_mode")
+    _reject_legacy_observation_mode(observation_mode)
+    _require_equal(payload.get("schema_version"), 3, field_name="schema_version")
+    _require_equal(payload.get("generation_schema_version"), 1, field_name="generation_schema_version")
+    _require_equal(observation_mode, "LOCAL_MOVEMENT", field_name="baseline.observation_mode")
+    _require_equal(baseline.get("cost_mode"), "TURN_ONLY", field_name="baseline.cost_mode")
+    _require_equal(baseline.get("movement_rule"), "MOVEMENT_POINTS", field_name="baseline.movement_rule")
+    _require_equal(baseline.get("movement_points_per_turn"), 4, field_name="baseline.movement_points_per_turn")
+    _require_equal(baseline.get("max_srs_turns"), 40, field_name="baseline.max_srs_turns")
+
+    return InitialValuesContract(
+        schema_version=payload["schema_version"],
+        generation_schema_version=payload["generation_schema_version"],
+        baseline_observation_mode=_enum(
+            ObservationMode,
+            observation_mode,
+            field_name="baseline.observation_mode",
+        ),
+        baseline_cost_mode=_enum(CostMode, baseline["cost_mode"], field_name="baseline.cost_mode"),
+        baseline_movement_rule=_enum(
+            MovementRule,
+            baseline["movement_rule"],
+            field_name="baseline.movement_rule",
+        ),
+        movement_points_per_turn=baseline["movement_points_per_turn"],
+        max_srs_turns=baseline["max_srs_turns"],
+    )
+
+
+def load_srs_elements(path: Path) -> SrsElementsContract:
+    payload = _load_json(path)
+    _require_equal(payload.get("schema_version"), 1, field_name="schema_version")
+    return SrsElementsContract(schema_version=payload["schema_version"], raw=payload)
+
+
+def load_srs_generation(path: Path) -> SrsGenerationContract:
+    payload = _load_json(path)
+    _require_equal(payload.get("generation_schema_version"), 1, field_name="generation_schema_version")
+    _require_equal(payload.get("map_sizes"), [[9, 9], [11, 11]], field_name="map_sizes")
+    return SrsGenerationContract(
+        generation_schema_version=payload["generation_schema_version"],
+        map_sizes=tuple(tuple(size) for size in payload["map_sizes"]),
+        raw=payload,
+    )
+
+
+def load_srs_movement(path: Path) -> SrsMovementContract:
+    payload = _load_json(path)
+    baseline = payload.get("baseline")
+    cost_units = payload.get("cost_units")
+    observation = payload.get("observation")
+    if not isinstance(baseline, dict):
+        raise SrsContractError("baseline must be an object")
+    if not isinstance(cost_units, dict):
+        raise SrsContractError("cost_units must be an object")
+    if not isinstance(observation, dict):
+        raise SrsContractError("observation must be an object")
+
+    observation_mode = baseline.get("observation_mode")
+    _reject_legacy_observation_mode(observation_mode)
+    _require_equal(payload.get("movement_schema_version"), 1, field_name="movement_schema_version")
+    _require_equal(payload.get("directions"), ["N", "E", "S", "W"], field_name="directions")
+    _require_equal(observation_mode, "LOCAL_MOVEMENT", field_name="baseline.observation_mode")
+    _require_equal(baseline.get("cost_mode"), "TURN_ONLY", field_name="baseline.cost_mode")
+    _require_equal(baseline.get("movement_rule"), "MOVEMENT_POINTS", field_name="baseline.movement_rule")
+    _require_equal(cost_units.get("movement_cost_budget_raw"), 40, field_name="cost_units.movement_cost_budget_raw")
+    _require_equal(cost_units.get("orthogonal_raw_cost"), 10, field_name="cost_units.orthogonal_raw_cost")
+    _require_equal(cost_units.get("diagonal_raw_cost"), 14, field_name="cost_units.diagonal_raw_cost")
+
+    if "FULL" not in observation:
+        raise SrsContractError("observation must define FULL")
+    if "LOCAL_MOVEMENT" not in observation:
+        raise SrsContractError("observation must define LOCAL_MOVEMENT")
+    if "LOCAL_3X3" in observation:
+        raise SrsContractError("LOCAL_3X3 is legacy; use LOCAL_MOVEMENT")
+
+    return SrsMovementContract(
+        movement_schema_version=payload["movement_schema_version"],
+        directions=tuple(_enum(Direction, value, field_name="directions") for value in payload["directions"]),
+        baseline_observation_mode=_enum(
+            ObservationMode,
+            observation_mode,
+            field_name="baseline.observation_mode",
+        ),
+        baseline_cost_mode=_enum(CostMode, baseline["cost_mode"], field_name="baseline.cost_mode"),
+        baseline_movement_rule=_enum(
+            MovementRule,
+            baseline["movement_rule"],
+            field_name="baseline.movement_rule",
+        ),
+        movement_cost_budget_raw=cost_units["movement_cost_budget_raw"],
+        orthogonal_raw_cost=cost_units["orthogonal_raw_cost"],
+        diagonal_raw_cost=cost_units["diagonal_raw_cost"],
+        command_turn_rules=payload.get("command_turn_rules", {}),
+        movement_rules=payload.get("movement_rules", {}),
+        observation=observation,
+        interaction=payload.get("interaction", {}),
+        warp_exit=payload.get("warp_exit", {}),
+    )
+
+
+def load_default_contracts(root: Path) -> SrsContracts:
+    base = root / "experiments" / "galactic_exodus" / "srs"
+    contracts = SrsContracts(
+        initial_values=load_initial_values(base / "phase2_initial_values.json"),
+        elements=load_srs_elements(base / "phase2_srs_elements.json"),
+        generation=load_srs_generation(base / "phase2_srs_generation.json"),
+        movement=load_srs_movement(base / "phase2_srs_movement.json"),
+    )
+
+    if contracts.initial_values.baseline_observation_mode != contracts.movement.baseline_observation_mode:
+        raise SrsContractError("baseline observation mode mismatch between initial values and movement contract")
+    if contracts.initial_values.baseline_cost_mode != contracts.movement.baseline_cost_mode:
+        raise SrsContractError("baseline cost mode mismatch between initial values and movement contract")
+    if contracts.initial_values.baseline_movement_rule != contracts.movement.baseline_movement_rule:
+        raise SrsContractError("baseline movement rule mismatch between initial values and movement contract")
+    if contracts.initial_values.movement_points_per_turn * 10 != contracts.movement.movement_cost_budget_raw:
+        raise SrsContractError("movement_points_per_turn does not match movement_cost_budget_raw")
+
+    return contracts

--- a/experiments/galactic_exodus/srs/model.py
+++ b/experiments/galactic_exodus/srs/model.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from types import MappingProxyType
+from typing import Any, Mapping
+
+
+class SrsModelError(ValueError):
+    pass
+
+
+class Direction(str, Enum):
+    N = "N"
+    E = "E"
+    S = "S"
+    W = "W"
+
+
+class SectorType(str, Enum):
+    NORMAL = "NORMAL"
+    BASE = "BASE"
+    RESOURCE = "RESOURCE"
+    NEBULA = "NEBULA"
+    ASTEROID = "ASTEROID"
+    GRAVITY = "GRAVITY"
+    RIFT = "RIFT"
+
+
+class SrsTerrainType(str, Enum):
+    FLOOR = "FLOOR"
+    DEBRIS = "DEBRIS"
+    NEBULA = "NEBULA"
+    ASTEROID_FIELD = "ASTEROID_FIELD"
+    ASTEROID = "ASTEROID"
+    GRAVITY_FIELD_VERTICAL = "GRAVITY_FIELD_VERTICAL"
+    GRAVITY_FIELD_HORIZONTAL = "GRAVITY_FIELD_HORIZONTAL"
+    RIFT_DISTORTION = "RIFT_DISTORTION"
+    RIFT_BARRIER = "RIFT_BARRIER"
+
+
+class SrsObjectType(str, Enum):
+    STAR = "STAR"
+    PLANET = "PLANET"
+    STATION = "STATION"
+    RESOURCE_CACHE = "RESOURCE_CACHE"
+    SALVAGE = "SALVAGE"
+
+
+class SrsActorType(str, Enum):
+    PLAYER = "PLAYER"
+
+
+class CostMode(str, Enum):
+    TURN_ONLY = "TURN_ONLY"
+    SHARED_FUEL = "SHARED_FUEL"
+
+
+class MovementRule(str, Enum):
+    VECTOR_COMMAND = "VECTOR_COMMAND"
+    MOVEMENT_POINTS = "MOVEMENT_POINTS"
+    DIRECTIONAL_THRUST = "DIRECTIONAL_THRUST"
+
+
+class ObservationMode(str, Enum):
+    FULL = "FULL"
+    LOCAL_MOVEMENT = "LOCAL_MOVEMENT"
+
+
+class InteractionMode(str, Enum):
+    AUTO_INTERACT = "AUTO_INTERACT"
+    EXPLICIT_INTERACT = "EXPLICIT_INTERACT"
+
+
+class CollisionBehavior(str, Enum):
+    STOP_BEFORE = "STOP_BEFORE"
+
+
+def _freeze_mapping(mapping: Mapping[Any, Any]) -> Mapping[Any, Any]:
+    return MappingProxyType(dict(mapping))
+
+
+@dataclass(frozen=True, slots=True)
+class Position:
+    x: int
+    y: int
+
+
+@dataclass(frozen=True, slots=True)
+class SectorDescriptor:
+    sector_id: str
+    sector_type: SectorType
+    sector_seed: int
+    entry_edge: Direction
+    blocked_edges: frozenset[Direction] = frozenset()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "blocked_edges", frozenset(self.blocked_edges))
+
+
+@dataclass(frozen=True, slots=True)
+class SrsObjectState:
+    object_id: str
+    object_type: SrsObjectType
+    position: Position
+    consumed: bool = False
+    activated: bool = False
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "metadata", _freeze_mapping(self.metadata))
+
+
+@dataclass(frozen=True, slots=True)
+class SrsCell:
+    terrain: SrsTerrainType
+    object_id: str | None = None
+    actor_id: str | None = None
+    warp_flags: frozenset[Direction] = frozenset()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "warp_flags", frozenset(self.warp_flags))
+
+
+@dataclass(frozen=True, slots=True)
+class SrsActualMap:
+    width: int
+    height: int
+    cells: tuple[tuple[SrsCell, ...], ...]
+
+    def __post_init__(self) -> None:
+        normalized = tuple(tuple(row) for row in self.cells)
+        if self.height != len(normalized):
+            raise SrsModelError("height must match number of rows in cells")
+        if any(len(row) != self.width for row in normalized):
+            raise SrsModelError("each cells row must match map width")
+        object.__setattr__(self, "cells", normalized)
+
+    def contains(self, position: Position) -> bool:
+        return 0 <= position.x < self.width and 0 <= position.y < self.height
+
+    def cell_at(self, position: Position) -> SrsCell:
+        if not self.contains(position):
+            raise IndexError(f"position out of bounds: {position}")
+        return self.cells[position.y][position.x]
+
+
+@dataclass(frozen=True, slots=True)
+class SrsKnownState:
+    discovered_cells: frozenset[Position] = frozenset()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "discovered_cells", frozenset(self.discovered_cells))
+
+
+@dataclass(frozen=True, slots=True)
+class SrsPersistentState:
+    generated_map_id: str
+    generation_schema_version: int
+    generation_seed: int
+    sector_type: SectorType
+    blocked_edges: frozenset[Direction]
+    warp_flags: Mapping[Position, frozenset[Direction]] = field(default_factory=dict)
+    celestial_body_positions: Mapping[str, Position] = field(default_factory=dict)
+    consumed_object_ids: frozenset[str] = frozenset()
+    activated_object_ids: frozenset[str] = frozenset()
+    discovered_cells: frozenset[Position] = frozenset()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "blocked_edges", frozenset(self.blocked_edges))
+        object.__setattr__(
+            self,
+            "warp_flags",
+            _freeze_mapping({position: frozenset(flags) for position, flags in self.warp_flags.items()}),
+        )
+        object.__setattr__(self, "celestial_body_positions", _freeze_mapping(self.celestial_body_positions))
+        object.__setattr__(self, "consumed_object_ids", frozenset(self.consumed_object_ids))
+        object.__setattr__(self, "activated_object_ids", frozenset(self.activated_object_ids))
+        object.__setattr__(self, "discovered_cells", frozenset(self.discovered_cells))
+
+
+@dataclass(frozen=True, slots=True)
+class SrsGameState:
+    descriptor: SectorDescriptor
+    actual_map: SrsActualMap
+    known_state: SrsKnownState
+    persistent_state: SrsPersistentState
+    player_position: Position
+    srs_turn: int = 0
+    fuel: int = 0
+    max_fuel: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class SrsTurnEvent:
+    srs_turn: int
+    event_type: str
+    payload: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "payload", _freeze_mapping(self.payload))
+
+
+@dataclass(frozen=True, slots=True)
+class SrsGameLog:
+    events: tuple[SrsTurnEvent, ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "events", tuple(self.events))
+
+
+def validate_sector_descriptor(descriptor: SectorDescriptor) -> None:
+    if descriptor.sector_type is SectorType.RIFT:
+        if not descriptor.blocked_edges:
+            raise SrsModelError("RIFT sector requires at least one blocked edge")
+    elif descriptor.blocked_edges:
+        raise SrsModelError("only RIFT sector may have blocked edges")
+
+    if descriptor.entry_edge in descriptor.blocked_edges:
+        raise SrsModelError("entry_edge must not be blocked")

--- a/experiments/galactic_exodus/srs/phase2_srs_elements.json
+++ b/experiments/galactic_exodus/srs/phase2_srs_elements.json
@@ -20,7 +20,7 @@
       "observation_size": 5,
       "blocks_line_travel": false,
       "can_host_feature": true,
-      "allowed_features": ["WARP_POINT"]
+      "allowed_features": ["WARP_FLAG"]
     },
     "DEBRIS": {
       "passable": true,

--- a/experiments/galactic_exodus/srs/test_contracts.py
+++ b/experiments/galactic_exodus/srs/test_contracts.py
@@ -22,9 +22,7 @@ SRS_DIR = REPO_ROOT / "experiments" / "galactic_exodus" / "srs"
 
 class SrsContractTests(unittest.TestCase):
     def setUp(self) -> None:
-        tmp_root = REPO_ROOT / ".tmp"
-        tmp_root.mkdir(exist_ok=True)
-        self._temp_dir = tempfile.TemporaryDirectory(dir=tmp_root)
+        self._temp_dir = tempfile.TemporaryDirectory()
         self.temp_dir = Path(self._temp_dir.name)
         self.addCleanup(self._temp_dir.cleanup)
 

--- a/experiments/galactic_exodus/srs/test_contracts.py
+++ b/experiments/galactic_exodus/srs/test_contracts.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from experiments.galactic_exodus.srs.contracts import (
+    SrsContractError,
+    load_default_contracts,
+    load_initial_values,
+    load_srs_elements,
+    load_srs_generation,
+    load_srs_movement,
+)
+from experiments.galactic_exodus.srs.model import Direction, ObservationMode
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SRS_DIR = REPO_ROOT / "experiments" / "galactic_exodus" / "srs"
+
+
+class SrsContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        tmp_root = REPO_ROOT / ".tmp"
+        tmp_root.mkdir(exist_ok=True)
+        self._temp_dir = tempfile.TemporaryDirectory(dir=tmp_root)
+        self.temp_dir = Path(self._temp_dir.name)
+        self.addCleanup(self._temp_dir.cleanup)
+
+    def write_json(self, filename: str, payload: object) -> Path:
+        path = self.temp_dir / filename
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        return path
+
+    def test_load_movement_contract_accepts_repository_file(self) -> None:
+        contract = load_srs_movement(SRS_DIR / "phase2_srs_movement.json")
+        self.assertEqual(contract.directions, (Direction.N, Direction.E, Direction.S, Direction.W))
+
+    def test_load_initial_values_accepts_local_movement(self) -> None:
+        contract = load_initial_values(SRS_DIR / "phase2_initial_values.json")
+        self.assertIs(contract.baseline_observation_mode, ObservationMode.LOCAL_MOVEMENT)
+
+    def test_load_default_contracts_cross_checks_baseline(self) -> None:
+        contracts = load_default_contracts(REPO_ROOT)
+        self.assertEqual(contracts.initial_values.baseline_cost_mode, contracts.movement.baseline_cost_mode)
+        self.assertEqual(
+            contracts.initial_values.movement_points_per_turn * 10,
+            contracts.movement.movement_cost_budget_raw,
+        )
+
+    def test_rejects_legacy_local_3x3_in_movement_contract(self) -> None:
+        payload = json.loads((SRS_DIR / "phase2_srs_movement.json").read_text(encoding="utf-8"))
+        payload["observation"]["LOCAL_3X3"] = {"default_size": 3}
+        with self.assertRaisesRegex(SrsContractError, "LOCAL_3X3 is legacy"):
+            load_srs_movement(self.write_json("legacy-movement.json", payload))
+
+    def test_rejects_legacy_local_3x3_in_initial_values(self) -> None:
+        payload = json.loads((SRS_DIR / "phase2_initial_values.json").read_text(encoding="utf-8"))
+        payload["baseline"]["observation_mode"] = "LOCAL_3X3"
+        with self.assertRaisesRegex(SrsContractError, "LOCAL_3X3 is legacy"):
+            load_initial_values(self.write_json("legacy-initial.json", payload))
+
+    def test_load_srs_elements_keeps_raw_payload(self) -> None:
+        contract = load_srs_elements(SRS_DIR / "phase2_srs_elements.json")
+        self.assertEqual(contract.schema_version, 1)
+        self.assertEqual(contract.raw["baseline_map_size"], [9, 9])
+
+    def test_load_srs_generation_reads_map_sizes(self) -> None:
+        contract = load_srs_generation(SRS_DIR / "phase2_srs_generation.json")
+        self.assertEqual(contract.map_sizes, ((9, 9), (11, 11)))
+
+    def test_missing_contract_file_raises_contract_error(self) -> None:
+        with self.assertRaisesRegex(SrsContractError, "missing contract file"):
+            load_srs_generation(self.temp_dir / "missing.json")
+
+    def test_invalid_json_raises_contract_error(self) -> None:
+        path = self.temp_dir / "invalid.json"
+        path.write_text("{not-json}", encoding="utf-8")
+        with self.assertRaisesRegex(SrsContractError, "invalid JSON"):
+            load_srs_elements(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experiments/galactic_exodus/srs/test_model.py
+++ b/experiments/galactic_exodus/srs/test_model.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import unittest
+
+from experiments.galactic_exodus.srs.model import (
+    Direction,
+    Position,
+    SectorDescriptor,
+    SectorType,
+    SrsActualMap,
+    SrsCell,
+    SrsModelError,
+    SrsTerrainType,
+    validate_sector_descriptor,
+)
+
+
+class SrsModelTests(unittest.TestCase):
+    def test_direction_enum_round_trip(self) -> None:
+        self.assertIs(Direction(Direction.N.value), Direction.N)
+
+    def test_sector_type_enum_round_trip(self) -> None:
+        self.assertIs(SectorType(SectorType.RIFT.value), SectorType.RIFT)
+
+    def test_position_equality(self) -> None:
+        self.assertEqual(Position(2, 3), Position(2, 3))
+
+    def test_actual_map_contains(self) -> None:
+        actual_map = SrsActualMap(
+            width=2,
+            height=2,
+            cells=(
+                (SrsCell(SrsTerrainType.FLOOR), SrsCell(SrsTerrainType.DEBRIS)),
+                (SrsCell(SrsTerrainType.NEBULA), SrsCell(SrsTerrainType.ASTEROID_FIELD)),
+            ),
+        )
+        self.assertTrue(actual_map.contains(Position(1, 1)))
+        self.assertFalse(actual_map.contains(Position(2, 1)))
+
+    def test_actual_map_cell_at(self) -> None:
+        cell = SrsCell(SrsTerrainType.RIFT_DISTORTION)
+        actual_map = SrsActualMap(width=1, height=1, cells=((cell,),))
+        self.assertIs(actual_map.cell_at(Position(0, 0)), cell)
+
+    def test_actual_map_cell_at_rejects_out_of_bounds(self) -> None:
+        actual_map = SrsActualMap(width=1, height=1, cells=((SrsCell(SrsTerrainType.FLOOR),),))
+        with self.assertRaisesRegex(IndexError, "position out of bounds"):
+            actual_map.cell_at(Position(-1, 0))
+
+    def test_sector_descriptor_rift_requires_blocked_edges(self) -> None:
+        descriptor = SectorDescriptor(
+            sector_id="R-1",
+            sector_type=SectorType.RIFT,
+            sector_seed=1,
+            entry_edge=Direction.N,
+        )
+        with self.assertRaisesRegex(SrsModelError, "requires at least one blocked edge"):
+            validate_sector_descriptor(descriptor)
+
+    def test_sector_descriptor_non_rift_rejects_blocked_edges(self) -> None:
+        descriptor = SectorDescriptor(
+            sector_id="N-1",
+            sector_type=SectorType.NORMAL,
+            sector_seed=1,
+            entry_edge=Direction.N,
+            blocked_edges=frozenset({Direction.E}),
+        )
+        with self.assertRaisesRegex(SrsModelError, "only RIFT sector may have blocked edges"):
+            validate_sector_descriptor(descriptor)
+
+    def test_sector_descriptor_entry_edge_must_not_be_blocked(self) -> None:
+        descriptor = SectorDescriptor(
+            sector_id="R-2",
+            sector_type=SectorType.RIFT,
+            sector_seed=1,
+            entry_edge=Direction.W,
+            blocked_edges=frozenset({Direction.W}),
+        )
+        with self.assertRaisesRegex(SrsModelError, "entry_edge must not be blocked"):
+            validate_sector_descriptor(descriptor)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experiments/galactic_exodus/srs/test_validate_phase2_srs_elements.py
+++ b/experiments/galactic_exodus/srs/test_validate_phase2_srs_elements.py
@@ -37,7 +37,7 @@ class Phase2SrsElementsValidationTests(unittest.TestCase):
         with self.assertRaisesRegex(validator.ValidationError, "NEBULA"):
             validator.validate(self.path)
 
-    def test_only_floor_hosts_warp_point(self) -> None:
+    def test_only_floor_hosts_warp_flag(self) -> None:
         self.payload["terrain_types"]["DEBRIS"]["can_host_feature"] = True
         self.write()
         with self.assertRaisesRegex(validator.ValidationError, "DEBRIS must not host features"):

--- a/experiments/galactic_exodus/srs/validate_phase2_srs_elements.py
+++ b/experiments/galactic_exodus/srs/validate_phase2_srs_elements.py
@@ -84,8 +84,8 @@ def validate(path: Path) -> dict[str, Any]:
             if terrain.get("movement_cost_consumed_on_collision") is not False:
                 raise ValidationError(f"{terrain_id}: collision must not consume movement cost")
 
-    if terrains["FLOOR"].get("allowed_features") != ["WARP_POINT"]:
-        raise ValidationError("FLOOR must host WARP_POINT")
+    if terrains["FLOOR"].get("allowed_features") != ["WARP_FLAG"]:
+        raise ValidationError("FLOOR must host WARP_FLAG")
     for terrain_id in EXPECTED_TERRAINS - {"FLOOR"}:
         if terrains[terrain_id].get("can_host_feature") is not False:
             raise ValidationError(f"{terrain_id} must not host features")


### PR DESCRIPTION
Closes #1104

## 概要

Phase 2B SRS Python prototype の最初の実装単位として、SRS 基礎モデルと contract loader を追加します。

## 追加内容

- `__init__.py`
  - SRS prototype package marker
- `model.py`
  - Direction / SectorType / Terrain / Object / Movement / Observation などの Enum
  - Position / SectorDescriptor / SrsCell / SrsActualMap / SrsKnownState / SrsPersistentState / SrsGameState
  - SectorDescriptor validation
- `contracts.py`
  - `phase2_initial_values.json`
  - `phase2_srs_elements.json`
  - `phase2_srs_generation.json`
  - `phase2_srs_movement.json`
  - 上記を読み込む loader
  - initial values と movement contract の baseline 整合チェック
- validator sync
  - `phase2_srs_elements.json` の legacy `WARP_POINT` を `WARP_FLAG` へ同期
  - elements validator / test の期待値を更新

## 重要な仕様

- `LOCAL_MOVEMENT` を正式な観測 mode として扱う
- 旧 `LOCAL_3X3` は reject する
- `TURN_ONLY` / `MOVEMENT_POINTS` / `movement_points_per_turn=4` を baseline として読み込む
- RIFT 以外の `blocked_edges` を reject する
- RIFT の空 `blocked_edges` を reject する

## 確認

```bash
python -m unittest experiments.galactic_exodus.srs.test_model
python -m unittest experiments.galactic_exodus.srs.test_contracts
python -m unittest experiments.galactic_exodus.srs.test_validate_phase2_srs_elements
python experiments/galactic_exodus/srs/validate_phase2_srs_elements.py experiments/galactic_exodus/srs/phase2_srs_elements.json
python experiments/galactic_exodus/srs/validate_phase2_srs_movement.py \
  experiments/galactic_exodus/srs/phase2_srs_movement.json
python experiments/galactic_exodus/srs/validate_phase2_initial_model.py \
  --model experiments/galactic_exodus/srs/phase2_initial_model.md \
  --questions experiments/galactic_exodus/srs/phase2_questions.csv \
  --values experiments/galactic_exodus/srs/phase2_initial_values.json \
  --elements experiments/galactic_exodus/srs/phase2_srs_elements.json \
  --generation experiments/galactic_exodus/srs/phase2_srs_generation.json
```

## 非対象

- map 生成
- 移動処理
- 観測更新
- object interaction
- warp/exit
- render
