### PR TITLE
Phase 2B2: SRS descriptor検証と決定的minimal map生成を追加

### DIFF
--- a/experiments/galactic_exodus/srs/fixtures/base_minimal_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/base_minimal_9x9.json
@@ -1,0 +1,29 @@
+{
+  "descriptor": {
+    "sector_id": "base-1",
+    "sector_type": "BASE",
+    "sector_seed": 2001,
+    "entry_edge": "S",
+    "blocked_edges": []
+  },
+  "expected": {
+    "width": 9,
+    "height": 9,
+    "player_position": [4, 8],
+    "warp_flags": {
+      "4,0": ["N"],
+      "8,4": ["E"],
+      "4,8": ["S"],
+      "0,4": ["W"]
+    },
+    "terrain_counts": {
+      "FLOOR": 81
+    },
+    "object_counts": {
+      "PLANET": 2,
+      "STAR": 1,
+      "STATION": 1
+    },
+    "known_discovered_count": 0
+  }
+}

--- a/experiments/galactic_exodus/srs/fixtures/normal_minimal_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/normal_minimal_9x9.json
@@ -1,0 +1,29 @@
+{
+  "descriptor": {
+    "sector_id": "normal-1",
+    "sector_type": "NORMAL",
+    "sector_seed": 1001,
+    "entry_edge": "S",
+    "blocked_edges": []
+  },
+  "expected": {
+    "width": 9,
+    "height": 9,
+    "player_position": [4, 8],
+    "warp_flags": {
+      "4,0": ["N"],
+      "8,4": ["E"],
+      "4,8": ["S"],
+      "0,4": ["W"]
+    },
+    "terrain_counts": {
+      "FLOOR": 81
+    },
+    "object_counts": {
+      "PLANET": 2,
+      "SALVAGE": 1,
+      "STAR": 1
+    },
+    "known_discovered_count": 0
+  }
+}

--- a/experiments/galactic_exodus/srs/fixtures/resource_minimal_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/resource_minimal_9x9.json
@@ -1,0 +1,29 @@
+{
+  "descriptor": {
+    "sector_id": "resource-1",
+    "sector_type": "RESOURCE",
+    "sector_seed": 3001,
+    "entry_edge": "S",
+    "blocked_edges": []
+  },
+  "expected": {
+    "width": 9,
+    "height": 9,
+    "player_position": [4, 8],
+    "warp_flags": {
+      "4,0": ["N"],
+      "8,4": ["E"],
+      "4,8": ["S"],
+      "0,4": ["W"]
+    },
+    "terrain_counts": {
+      "FLOOR": 81
+    },
+    "object_counts": {
+      "PLANET": 2,
+      "RESOURCE_CACHE": 1,
+      "STAR": 1
+    },
+    "known_discovered_count": 0
+  }
+}

--- a/experiments/galactic_exodus/srs/fixtures/rift_n_blocked_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/rift_n_blocked_9x9.json
@@ -1,0 +1,30 @@
+{
+  "descriptor": {
+    "sector_id": "rift-n-1",
+    "sector_type": "RIFT",
+    "sector_seed": 4001,
+    "entry_edge": "S",
+    "blocked_edges": ["N"]
+  },
+  "expected": {
+    "width": 9,
+    "height": 9,
+    "player_position": [4, 8],
+    "warp_flags": {
+      "8,4": ["E"],
+      "4,8": ["S"],
+      "0,4": ["W"]
+    },
+    "blocked_warp_positions": ["4,0"],
+    "terrain_counts": {
+      "FLOOR": 72,
+      "RIFT_BARRIER": 9
+    },
+    "object_counts": {
+      "PLANET": 2,
+      "SALVAGE": 1,
+      "STAR": 1
+    },
+    "known_discovered_count": 0
+  }
+}

--- a/experiments/galactic_exodus/srs/generate.py
+++ b/experiments/galactic_exodus/srs/generate.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import random
+from typing import Iterable
+
+from experiments.galactic_exodus.srs.contracts import SrsContracts
+from experiments.galactic_exodus.srs.model import (
+    Direction,
+    Position,
+    SectorDescriptor,
+    SectorType,
+    SrsActualMap,
+    SrsCell,
+    SrsGameState,
+    SrsKnownState,
+    SrsObjectState,
+    SrsObjectType,
+    SrsPersistentState,
+    SrsTerrainType,
+    validate_sector_descriptor as validate_sector_descriptor,
+)
+
+
+class SrsGenerationError(ValueError):
+    pass
+
+
+MAP_WIDTH = 9
+MAP_HEIGHT = 9
+MAP_CENTER = Position(4, 4)
+
+EDGE_POSITIONS = {
+    Direction.N: Position(4, 0),
+    Direction.E: Position(8, 4),
+    Direction.S: Position(4, 8),
+    Direction.W: Position(0, 4),
+}
+
+SECTOR_EXTRA_OBJECTS = {
+    SectorType.NORMAL: ((SrsObjectType.SALVAGE, "salvage-1"),),
+    SectorType.BASE: ((SrsObjectType.STATION, "station-1"),),
+    SectorType.RESOURCE: ((SrsObjectType.RESOURCE_CACHE, "resource-cache-1"),),
+    SectorType.RIFT: ((SrsObjectType.SALVAGE, "salvage-1"),),
+}
+
+
+def create_sector(
+    descriptor: SectorDescriptor,
+    *,
+    width: int = MAP_WIDTH,
+    height: int = MAP_HEIGHT,
+    contracts: SrsContracts,
+) -> SrsGameState:
+    validate_sector_descriptor(descriptor)
+    if width != MAP_WIDTH or height != MAP_HEIGHT:
+        raise SrsGenerationError("only 9x9 sector generation is supported")
+
+    cells = _make_floor_cells(width=width, height=height)
+    _apply_rift_barriers(cells, descriptor.blocked_edges)
+    _apply_warp_flags(cells, descriptor)
+
+    player_position = EDGE_POSITIONS[descriptor.entry_edge]
+    objects = _place_objects(cells, descriptor, player_position)
+
+    actual_map = SrsActualMap(
+        width=width,
+        height=height,
+        cells=tuple(tuple(row) for row in cells),
+    )
+    known_state = SrsKnownState(discovered_cells=frozenset())
+    persistent_state = SrsPersistentState(
+        generated_map_id=f"{descriptor.sector_id}:{descriptor.sector_seed}",
+        generation_schema_version=contracts.generation.generation_schema_version,
+        generation_seed=descriptor.sector_seed,
+        sector_type=descriptor.sector_type,
+        blocked_edges=descriptor.blocked_edges,
+        warp_flags={
+            position: cell.warp_flags
+            for position, cell in _iter_cells(actual_map)
+            if cell.warp_flags
+        },
+        celestial_body_positions={
+            object_id: state.position
+            for object_id, state in objects.items()
+            if state.object_type in {SrsObjectType.STAR, SrsObjectType.PLANET}
+        },
+        consumed_object_ids=frozenset(),
+        activated_object_ids=frozenset(),
+        discovered_cells=frozenset(),
+    )
+    return SrsGameState(
+        descriptor=descriptor,
+        actual_map=actual_map,
+        known_state=known_state,
+        persistent_state=persistent_state,
+        player_position=player_position,
+        objects=objects,
+        srs_turn=0,
+        fuel=0,
+        max_fuel=0,
+    )
+
+
+def _make_floor_cells(*, width: int, height: int) -> list[list[SrsCell]]:
+    return [
+        [SrsCell(terrain=SrsTerrainType.FLOOR) for _ in range(width)]
+        for _ in range(height)
+    ]
+
+
+def _apply_rift_barriers(cells: list[list[SrsCell]], blocked_edges: frozenset[Direction]) -> None:
+    for edge in blocked_edges:
+        if edge is Direction.N:
+            for x in range(len(cells[0])):
+                cells[0][x] = SrsCell(terrain=SrsTerrainType.RIFT_BARRIER)
+        elif edge is Direction.E:
+            for row in cells:
+                row[-1] = SrsCell(terrain=SrsTerrainType.RIFT_BARRIER)
+        elif edge is Direction.S:
+            for x in range(len(cells[-1])):
+                cells[-1][x] = SrsCell(terrain=SrsTerrainType.RIFT_BARRIER)
+        elif edge is Direction.W:
+            for row in cells:
+                row[0] = SrsCell(terrain=SrsTerrainType.RIFT_BARRIER)
+
+
+def _apply_warp_flags(cells: list[list[SrsCell]], descriptor: SectorDescriptor) -> None:
+    open_edges = {
+        direction
+        for direction in Direction
+        if direction not in descriptor.blocked_edges
+    }
+    for direction in open_edges:
+        position = EDGE_POSITIONS[direction]
+        base = cells[position.y][position.x]
+        cells[position.y][position.x] = SrsCell(
+            terrain=base.terrain,
+            object_id=base.object_id,
+            actor_id=base.actor_id,
+            warp_flags=frozenset({direction}),
+        )
+
+
+def _place_objects(
+    cells: list[list[SrsCell]],
+    descriptor: SectorDescriptor,
+    player_position: Position,
+) -> dict[str, SrsObjectState]:
+    object_specs = [
+        (SrsObjectType.STAR, "star-1"),
+        (SrsObjectType.PLANET, "planet-1"),
+        (SrsObjectType.PLANET, "planet-2"),
+        *SECTOR_EXTRA_OBJECTS.get(descriptor.sector_type, ()),
+    ]
+    candidates = _collect_object_candidates(cells, player_position=player_position)
+    if len(candidates) < len(object_specs):
+        raise SrsGenerationError("not enough placement candidates for requested objects")
+
+    rng = random.Random(descriptor.sector_seed)
+    shuffled = list(candidates)
+    rng.shuffle(shuffled)
+
+    objects: dict[str, SrsObjectState] = {}
+    for (object_type, object_id), position in zip(object_specs, shuffled[: len(object_specs)], strict=True):
+        cells[position.y][position.x] = SrsCell(
+            terrain=cells[position.y][position.x].terrain,
+            object_id=object_id,
+            actor_id=cells[position.y][position.x].actor_id,
+            warp_flags=cells[position.y][position.x].warp_flags,
+        )
+        objects[object_id] = SrsObjectState(
+            object_id=object_id,
+            object_type=object_type,
+            position=position,
+        )
+    return objects
+
+
+def _collect_object_candidates(
+    cells: list[list[SrsCell]],
+    *,
+    player_position: Position,
+) -> list[Position]:
+    candidates: list[Position] = []
+    for y, row in enumerate(cells):
+        for x, cell in enumerate(row):
+            position = Position(x, y)
+            if position == player_position:
+                continue
+            if cell.terrain is not SrsTerrainType.FLOOR:
+                continue
+            if cell.warp_flags:
+                continue
+            if cell.object_id is not None:
+                continue
+            candidates.append(position)
+    return candidates
+
+
+def _iter_cells(actual_map: SrsActualMap) -> Iterable[tuple[Position, SrsCell]]:
+    for y, row in enumerate(actual_map.cells):
+        for x, cell in enumerate(row):
+            yield Position(x, y), cell

--- a/experiments/galactic_exodus/srs/model.py
+++ b/experiments/galactic_exodus/srs/model.py
@@ -186,9 +186,26 @@ class SrsGameState:
     known_state: SrsKnownState
     persistent_state: SrsPersistentState
     player_position: Position
+    objects: Mapping[str, SrsObjectState] = field(default_factory=dict)
     srs_turn: int = 0
     fuel: int = 0
     max_fuel: int = 0
+
+    def __post_init__(self) -> None:
+        normalized_objects = _freeze_mapping(self.objects)
+        if any(object_id != state.object_id for object_id, state in normalized_objects.items()):
+            raise SrsModelError("objects mapping keys must match SrsObjectState.object_id")
+
+        map_object_ids = {
+            cell.object_id
+            for row in self.actual_map.cells
+            for cell in row
+            if cell.object_id is not None
+        }
+        if map_object_ids != set(normalized_objects):
+            raise SrsModelError("actual_map object_id values must match objects mapping keys")
+
+        object.__setattr__(self, "objects", normalized_objects)
 
 
 @dataclass(frozen=True, slots=True)

--- a/experiments/galactic_exodus/srs/test_generate.py
+++ b/experiments/galactic_exodus/srs/test_generate.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+import json
+import unittest
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from experiments.galactic_exodus.srs.contracts import load_default_contracts
+from experiments.galactic_exodus.srs.generate import EDGE_POSITIONS, SrsGenerationError, create_sector
+from experiments.galactic_exodus.srs.model import (
+    Direction,
+    Position,
+    SectorDescriptor,
+    SectorType,
+    SrsGameState,
+    SrsModelError,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SRS_DIR = REPO_ROOT / "experiments" / "galactic_exodus" / "srs"
+FIXTURES_DIR = SRS_DIR / "fixtures"
+
+
+def summarize_state(state: SrsGameState) -> dict[str, Any]:
+    terrain_counts = Counter(
+        cell.terrain.value
+        for row in state.actual_map.cells
+        for cell in row
+    )
+    warp_flags = {
+        f"{position.x},{position.y}": sorted(cell.warp_flags, key=lambda direction: direction.value)
+        for position, cell in _iter_cells(state)
+        if cell.warp_flags
+    }
+    object_counts = Counter(object_state.object_type.value for object_state in state.objects.values())
+    object_positions = {
+        object_id: [object_state.position.x, object_state.position.y]
+        for object_id, object_state in sorted(state.objects.items())
+    }
+    return {
+        "width": state.actual_map.width,
+        "height": state.actual_map.height,
+        "player_position": [state.player_position.x, state.player_position.y],
+        "warp_flags": {
+            key: [direction.value for direction in flags]
+            for key, flags in warp_flags.items()
+        },
+        "terrain_counts": dict(sorted(terrain_counts.items())),
+        "object_counts": dict(sorted(object_counts.items())),
+        "object_positions": object_positions,
+        "blocked_warp_positions": [
+            f"{position.x},{position.y}"
+            for direction, position in sorted(
+                ((direction, EDGE_POSITIONS[direction]) for direction in state.descriptor.blocked_edges),
+                key=lambda item: item[0].value,
+            )
+        ],
+        "known_discovered_count": len(state.known_state.discovered_cells),
+    }
+
+
+def _iter_cells(state: SrsGameState):
+    for y, row in enumerate(state.actual_map.cells):
+        for x, cell in enumerate(row):
+            yield Position(x, y), cell
+
+
+class SrsGenerateTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.contracts = load_default_contracts(REPO_ROOT)
+
+    def test_same_seed_same_map(self) -> None:
+        descriptor = SectorDescriptor("normal-1", SectorType.NORMAL, 1001, Direction.S)
+        first = create_sector(descriptor, contracts=self.contracts)
+        second = create_sector(descriptor, contracts=self.contracts)
+
+        self.assertEqual(summarize_state(first), summarize_state(second))
+
+    def test_different_seed_changes_summary(self) -> None:
+        first = create_sector(
+            SectorDescriptor("normal-1", SectorType.NORMAL, 1001, Direction.S),
+            contracts=self.contracts,
+        )
+        second = create_sector(
+            SectorDescriptor("normal-1", SectorType.NORMAL, 1002, Direction.S),
+            contracts=self.contracts,
+        )
+
+        self.assertNotEqual(
+            summarize_state(first)["object_positions"],
+            summarize_state(second)["object_positions"],
+        )
+
+    def test_rift_requires_blocked_edges(self) -> None:
+        descriptor = SectorDescriptor("rift-1", SectorType.RIFT, 4001, Direction.S)
+        with self.assertRaises(SrsModelError):
+            create_sector(descriptor, contracts=self.contracts)
+
+    def test_non_rift_rejects_blocked_edges(self) -> None:
+        descriptor = SectorDescriptor(
+            "normal-1",
+            SectorType.NORMAL,
+            1001,
+            Direction.S,
+            blocked_edges=frozenset({Direction.N}),
+        )
+        with self.assertRaises(SrsModelError):
+            create_sector(descriptor, contracts=self.contracts)
+
+    def test_entry_edge_blocked_is_rejected(self) -> None:
+        descriptor = SectorDescriptor(
+            "rift-1",
+            SectorType.RIFT,
+            4001,
+            Direction.N,
+            blocked_edges=frozenset({Direction.N}),
+        )
+        with self.assertRaises(SrsModelError):
+            create_sector(descriptor, contracts=self.contracts)
+
+    def test_rejects_non_9x9_size(self) -> None:
+        descriptor = SectorDescriptor("normal-1", SectorType.NORMAL, 1001, Direction.S)
+        with self.assertRaisesRegex(SrsGenerationError, "only 9x9"):
+            create_sector(descriptor, width=11, contracts=self.contracts)
+
+    def test_blocked_edge_has_no_warp_flags(self) -> None:
+        state = create_sector(
+            SectorDescriptor(
+                "rift-1",
+                SectorType.RIFT,
+                4001,
+                Direction.S,
+                blocked_edges=frozenset({Direction.N}),
+            ),
+            contracts=self.contracts,
+        )
+
+        self.assertNotIn("4,0", summarize_state(state)["warp_flags"])
+
+    def test_non_blocked_edges_have_warp_candidates(self) -> None:
+        state = create_sector(
+            SectorDescriptor(
+                "rift-1",
+                SectorType.RIFT,
+                4001,
+                Direction.S,
+                blocked_edges=frozenset({Direction.N}),
+            ),
+            contracts=self.contracts,
+        )
+
+        self.assertEqual(
+            summarize_state(state)["warp_flags"],
+            {
+                "0,4": ["W"],
+                "4,8": ["S"],
+                "8,4": ["E"],
+            },
+        )
+
+    def test_star_exactly_one(self) -> None:
+        state = create_sector(
+            SectorDescriptor("normal-1", SectorType.NORMAL, 1001, Direction.S),
+            contracts=self.contracts,
+        )
+
+        self.assertEqual(summarize_state(state)["object_counts"]["STAR"], 1)
+
+    def test_planet_count_for_9x9_is_two(self) -> None:
+        state = create_sector(
+            SectorDescriptor("normal-1", SectorType.NORMAL, 1001, Direction.S),
+            contracts=self.contracts,
+        )
+
+        self.assertEqual(summarize_state(state)["object_counts"]["PLANET"], 2)
+
+    def test_normal_has_one_salvage(self) -> None:
+        state = create_sector(
+            SectorDescriptor("normal-1", SectorType.NORMAL, 1001, Direction.S),
+            contracts=self.contracts,
+        )
+
+        self.assertEqual(summarize_state(state)["object_counts"]["SALVAGE"], 1)
+
+    def test_base_has_one_station(self) -> None:
+        state = create_sector(
+            SectorDescriptor("base-1", SectorType.BASE, 2001, Direction.S),
+            contracts=self.contracts,
+        )
+
+        self.assertEqual(summarize_state(state)["object_counts"]["STATION"], 1)
+
+    def test_resource_has_one_resource_cache(self) -> None:
+        state = create_sector(
+            SectorDescriptor("resource-1", SectorType.RESOURCE, 3001, Direction.S),
+            contracts=self.contracts,
+        )
+
+        self.assertEqual(summarize_state(state)["object_counts"]["RESOURCE_CACHE"], 1)
+
+    def test_rift_has_one_salvage(self) -> None:
+        state = create_sector(
+            SectorDescriptor(
+                "rift-1",
+                SectorType.RIFT,
+                4001,
+                Direction.S,
+                blocked_edges=frozenset({Direction.N}),
+            ),
+            contracts=self.contracts,
+        )
+
+        self.assertEqual(summarize_state(state)["object_counts"]["SALVAGE"], 1)
+
+    def test_actual_map_and_known_state_are_separated(self) -> None:
+        state = create_sector(
+            SectorDescriptor("normal-1", SectorType.NORMAL, 1001, Direction.S),
+            contracts=self.contracts,
+        )
+
+        self.assertTrue(any(cell.object_id is not None for _, cell in _iter_cells(state)))
+        self.assertEqual(state.known_state.discovered_cells, frozenset())
+
+    def test_persistent_state_records_generation_identity(self) -> None:
+        descriptor = SectorDescriptor(
+            "rift-1",
+            SectorType.RIFT,
+            4001,
+            Direction.S,
+            blocked_edges=frozenset({Direction.N}),
+        )
+        state = create_sector(descriptor, contracts=self.contracts)
+
+        self.assertEqual(state.persistent_state.generated_map_id, "rift-1:4001")
+        self.assertEqual(state.persistent_state.generation_seed, 4001)
+        self.assertEqual(state.persistent_state.blocked_edges, frozenset({Direction.N}))
+        self.assertEqual(state.persistent_state.warp_flags[Position(8, 4)], frozenset({Direction.E}))
+        self.assertEqual(
+            set(state.persistent_state.celestial_body_positions),
+            {"star-1", "planet-1", "planet-2"},
+        )
+
+    def test_fixture_normal_minimal_9x9(self) -> None:
+        self.assert_fixture("normal_minimal_9x9.json")
+
+    def test_fixture_base_minimal_9x9(self) -> None:
+        self.assert_fixture("base_minimal_9x9.json")
+
+    def test_fixture_resource_minimal_9x9(self) -> None:
+        self.assert_fixture("resource_minimal_9x9.json")
+
+    def test_fixture_rift_n_blocked_9x9(self) -> None:
+        self.assert_fixture("rift_n_blocked_9x9.json")
+
+    def assert_fixture(self, filename: str) -> None:
+        payload = json.loads((FIXTURES_DIR / filename).read_text(encoding="utf-8"))
+        descriptor_json = payload["descriptor"]
+        descriptor = SectorDescriptor(
+            sector_id=descriptor_json["sector_id"],
+            sector_type=SectorType(descriptor_json["sector_type"]),
+            sector_seed=descriptor_json["sector_seed"],
+            entry_edge=Direction(descriptor_json["entry_edge"]),
+            blocked_edges=frozenset(Direction(edge) for edge in descriptor_json["blocked_edges"]),
+        )
+        state = create_sector(descriptor, contracts=self.contracts)
+        summary = summarize_state(state)
+        expected = payload["expected"]
+
+        for key, value in expected.items():
+            self.assertEqual(summary[key], value)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experiments/galactic_exodus/srs/test_model.py
+++ b/experiments/galactic_exodus/srs/test_model.py
@@ -9,7 +9,12 @@ from experiments.galactic_exodus.srs.model import (
     SectorType,
     SrsActualMap,
     SrsCell,
+    SrsGameState,
     SrsModelError,
+    SrsKnownState,
+    SrsObjectState,
+    SrsObjectType,
+    SrsPersistentState,
     SrsTerrainType,
     validate_sector_descriptor,
 )
@@ -78,6 +83,103 @@ class SrsModelTests(unittest.TestCase):
         )
         with self.assertRaisesRegex(SrsModelError, "entry_edge must not be blocked"):
             validate_sector_descriptor(descriptor)
+
+    def test_game_state_freezes_objects_mapping(self) -> None:
+        position = Position(0, 0)
+        state = SrsGameState(
+            descriptor=SectorDescriptor(
+                sector_id="N-1",
+                sector_type=SectorType.NORMAL,
+                sector_seed=1,
+                entry_edge=Direction.N,
+            ),
+            actual_map=SrsActualMap(
+                width=1,
+                height=1,
+                cells=((SrsCell(SrsTerrainType.FLOOR, object_id="star-1"),),),
+            ),
+            known_state=SrsKnownState(),
+            persistent_state=SrsPersistentState(
+                generated_map_id="N-1:1",
+                generation_schema_version=1,
+                generation_seed=1,
+                sector_type=SectorType.NORMAL,
+                blocked_edges=frozenset(),
+            ),
+            player_position=position,
+            objects={
+                "star-1": SrsObjectState(
+                    object_id="star-1",
+                    object_type=SrsObjectType.STAR,
+                    position=position,
+                )
+            },
+        )
+
+        with self.assertRaises(TypeError):
+            state.objects["planet-1"] = SrsObjectState(
+                object_id="planet-1",
+                object_type=SrsObjectType.PLANET,
+                position=Position(0, 0),
+            )
+
+    def test_game_state_rejects_object_key_mismatch(self) -> None:
+        with self.assertRaisesRegex(SrsModelError, "objects mapping keys must match"):
+            SrsGameState(
+                descriptor=SectorDescriptor(
+                    sector_id="N-1",
+                    sector_type=SectorType.NORMAL,
+                    sector_seed=1,
+                    entry_edge=Direction.N,
+                ),
+                actual_map=SrsActualMap(
+                    width=1,
+                    height=1,
+                    cells=((SrsCell(SrsTerrainType.FLOOR, object_id="star-1"),),),
+                ),
+                known_state=SrsKnownState(),
+                persistent_state=SrsPersistentState(
+                    generated_map_id="N-1:1",
+                    generation_schema_version=1,
+                    generation_seed=1,
+                    sector_type=SectorType.NORMAL,
+                    blocked_edges=frozenset(),
+                ),
+                player_position=Position(0, 0),
+                objects={
+                    "bad-key": SrsObjectState(
+                        object_id="star-1",
+                        object_type=SrsObjectType.STAR,
+                        position=Position(0, 0),
+                    )
+                },
+            )
+
+    def test_game_state_rejects_map_object_mismatch(self) -> None:
+        with self.assertRaisesRegex(SrsModelError, "actual_map object_id values must match"):
+            SrsGameState(
+                descriptor=SectorDescriptor(
+                    sector_id="N-1",
+                    sector_type=SectorType.NORMAL,
+                    sector_seed=1,
+                    entry_edge=Direction.N,
+                ),
+                actual_map=SrsActualMap(
+                    width=1,
+                    height=1,
+                    cells=((SrsCell(SrsTerrainType.FLOOR, object_id="star-1"),),),
+                ),
+                known_state=SrsKnownState(),
+                persistent_state=SrsPersistentState(
+                    generated_map_id="N-1:1",
+                    generation_schema_version=1,
+                    generation_seed=1,
+                    sector_type=SectorType.NORMAL,
+                    blocked_edges=frozenset(),
+                ),
+                player_position=Position(0, 0),
+                objects={},
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #1105
Refs #1080

## 概要

Phase 2B2 として、SRS descriptor validation と決定的な 9x9 minimal map generator を追加します。

## 追加内容

- `generate.py`
  - `SrsGenerationError`
  - `create_sector(...)`
  - 9x9 固定の minimal map 生成
  - entry edge 中央への player 配置
  - edge 中央への `warp_flags` 生成
  - RIFT blocked edge の `RIFT_BARRIER` 化
  - STAR / PLANET / sector type 別 object 配置
- `model.py`
  - `SrsGameState.objects` を追加
  - `actual_map` 上の `object_id` と `objects` の整合性チェックを追加
- `test_generate.py`
  - deterministic generation
  - descriptor validation
  - 9x9 制約
  - RIFT blocked edge の barrier / warp flag
  - sector type 別 object 配置
  - fixture summary 照合
- fixtures
  - `normal_minimal_9x9.json`
  - `base_minimal_9x9.json`
  - `resource_minimal_9x9.json`
  - `rift_n_blocked_9x9.json`

## 仕様

- 9x9 のみ生成する
- 同一 descriptor / seed からは同一 summary を返す
- seed が異なると object 配置 summary が変わり得る
- entry 位置は辺中央
- RIFT 以外は N/E/S/W すべてに warp flag を置く
- RIFT は blocked edge に warp flag を置かない
- RIFT blocked edge 外周は `RIFT_BARRIER` にする
- STAR exactly 1
- PLANET exactly 2
- NORMAL は SALVAGE exactly 1
- BASE は STATION exactly 1
- RESOURCE は RESOURCE_CACHE exactly 1
- RIFT は SALVAGE exactly 1
- known state は初期空

## 確認

```bash
python -m unittest experiments.galactic_exodus.srs.test_generate
python -m unittest experiments.galactic_exodus.srs.test_model
python -m unittest experiments.galactic_exodus.srs.test_contracts
```

## 非対象

- full generation profile
- 移動処理
- 観測更新
- object interaction
- warp/exit 実行
- render
