### PR TITLE
Phase 2B3: LOCAL_MOVEMENT観測とknown/persistent stateを実装

### DIFF
--- a/experiments/galactic_exodus/srs/engine.py
+++ b/experiments/galactic_exodus/srs/engine.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Mapping
+
+from experiments.galactic_exodus.srs.contracts import SrsContracts
+from experiments.galactic_exodus.srs.model import (
+    Position,
+    SectorDescriptor,
+    SrsActualMap,
+    SrsCell,
+    SrsGameState,
+    SrsKnownState,
+    SrsObjectState,
+    SrsPersistentState,
+    SrsTerrainType,
+)
+
+
+class SrsObservationError(ValueError):
+    pass
+
+
+def observation_size_for_terrain(
+    terrain: SrsTerrainType,
+    contracts: SrsContracts,
+) -> int:
+    observation = contracts.movement.observation.get("LOCAL_MOVEMENT")
+    if not isinstance(observation, Mapping):
+        raise SrsObservationError("LOCAL_MOVEMENT observation contract is required")
+
+    default_size = _validated_observation_size(observation.get("default_size"), field_name="default_size")
+    nebula_size = _validated_observation_size(observation.get("nebula_size"), field_name="nebula_size")
+
+    if terrain is SrsTerrainType.NEBULA:
+        return nebula_size
+    return default_size
+
+
+def observation_area(
+    actual_map: SrsActualMap,
+    *,
+    center: Position,
+    size: int,
+) -> frozenset[Position]:
+    if not actual_map.contains(center):
+        raise SrsObservationError(f"observation center out of bounds: {center}")
+    radius = _validated_observation_size(size, field_name="size") // 2
+    positions = {
+        Position(x, y)
+        for y in range(center.y - radius, center.y + radius + 1)
+        for x in range(center.x - radius, center.x + radius + 1)
+        if 0 <= x < actual_map.width and 0 <= y < actual_map.height
+    }
+    return frozenset(positions)
+
+
+def reveal_observation(
+    state: SrsGameState,
+    *,
+    center: Position,
+    contracts: SrsContracts,
+    mark_visited: bool = True,
+) -> SrsGameState:
+    if not state.actual_map.contains(center):
+        raise SrsObservationError(f"observation center out of bounds: {center}")
+
+    terrain = state.actual_map.cell_at(center).terrain
+    size = observation_size_for_terrain(terrain, contracts)
+    revealed_positions = observation_area(state.actual_map, center=center, size=size)
+    known_cells = dict(state.known_state.known_cells)
+    for position in revealed_positions:
+        known_cells[position] = state.actual_map.cell_at(position)
+
+    discovered_cells = state.known_state.discovered_cells | revealed_positions
+    visited_cells = state.known_state.visited_cells
+    if mark_visited:
+        visited_cells = visited_cells | frozenset({center})
+
+    known_state = SrsKnownState(
+        discovered_cells=discovered_cells,
+        known_cells=known_cells,
+        visited_cells=visited_cells,
+    )
+    persistent_state = replace(
+        state.persistent_state,
+        discovered_cells=known_state.discovered_cells,
+    )
+    return replace(
+        state,
+        known_state=known_state,
+        persistent_state=persistent_state,
+    )
+
+
+def reveal_full_observation(
+    state: SrsGameState,
+) -> SrsGameState:
+    discovered_cells = frozenset(_iter_positions(state.actual_map))
+    known_cells = {
+        position: state.actual_map.cell_at(position)
+        for position in discovered_cells
+    }
+    known_state = SrsKnownState(
+        discovered_cells=discovered_cells,
+        known_cells=known_cells,
+        visited_cells=state.known_state.visited_cells,
+    )
+    persistent_state = replace(
+        state.persistent_state,
+        discovered_cells=discovered_cells,
+    )
+    return replace(
+        state,
+        known_state=known_state,
+        persistent_state=persistent_state,
+    )
+
+
+def known_cell_at(
+    state: SrsGameState,
+    position: Position,
+) -> SrsCell | None:
+    return state.known_state.known_cells.get(position)
+
+
+def snapshot_srs_state(
+    state: SrsGameState,
+) -> SrsPersistentState:
+    return replace(
+        state.persistent_state,
+        discovered_cells=state.known_state.discovered_cells,
+    )
+
+
+def restore_srs_state(
+    *,
+    descriptor: SectorDescriptor,
+    actual_map: SrsActualMap,
+    persistent: SrsPersistentState,
+    player_position: Position,
+    objects: Mapping[str, SrsObjectState],
+) -> SrsGameState:
+    discovered_cells = frozenset(persistent.discovered_cells)
+    _validate_positions_within_map(discovered_cells, actual_map=actual_map, context="persistent discovered cell")
+    known_cells = {
+        position: actual_map.cell_at(position)
+        for position in discovered_cells
+    }
+    return SrsGameState(
+        descriptor=descriptor,
+        actual_map=actual_map,
+        known_state=SrsKnownState(
+            discovered_cells=discovered_cells,
+            known_cells=known_cells,
+            visited_cells=frozenset(),
+        ),
+        persistent_state=persistent,
+        player_position=player_position,
+        objects=objects,
+        srs_turn=0,
+        fuel=0,
+        max_fuel=0,
+    )
+
+
+def _validated_observation_size(value: object, *, field_name: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0 or value % 2 == 0:
+        raise SrsObservationError(f"{field_name} must be an odd positive integer")
+    return value
+
+
+def _iter_positions(actual_map: SrsActualMap):
+    for y, row in enumerate(actual_map.cells):
+        for x, _ in enumerate(row):
+            yield Position(x, y)
+
+
+def _validate_positions_within_map(
+    positions: frozenset[Position],
+    *,
+    actual_map: SrsActualMap,
+    context: str,
+) -> None:
+    for position in positions:
+        if not actual_map.contains(position):
+            raise SrsObservationError(f"{context} out of bounds: {position}")

--- a/experiments/galactic_exodus/srs/model.py
+++ b/experiments/galactic_exodus/srs/model.py
@@ -148,9 +148,20 @@ class SrsActualMap:
 @dataclass(frozen=True, slots=True)
 class SrsKnownState:
     discovered_cells: frozenset[Position] = frozenset()
+    known_cells: Mapping[Position, SrsCell] = field(default_factory=dict)
+    visited_cells: frozenset[Position] = frozenset()
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "discovered_cells", frozenset(self.discovered_cells))
+        discovered_cells = frozenset(self.discovered_cells)
+        known_cells = _freeze_mapping(self.known_cells)
+        visited_cells = frozenset(self.visited_cells)
+
+        if not set(known_cells).issubset(discovered_cells):
+            raise SrsModelError("known_cells keys must be a subset of discovered_cells")
+
+        object.__setattr__(self, "discovered_cells", discovered_cells)
+        object.__setattr__(self, "known_cells", known_cells)
+        object.__setattr__(self, "visited_cells", visited_cells)
 
 
 @dataclass(frozen=True, slots=True)

--- a/experiments/galactic_exodus/srs/test_model.py
+++ b/experiments/galactic_exodus/srs/test_model.py
@@ -181,6 +181,28 @@ class SrsModelTests(unittest.TestCase):
                 objects={},
             )
 
+    def test_known_state_freezes_known_cells(self) -> None:
+        state = SrsKnownState(
+            discovered_cells={Position(0, 0)},
+            known_cells={Position(0, 0): SrsCell(SrsTerrainType.FLOOR)},
+        )
+
+        with self.assertRaises(TypeError):
+            state.known_cells[Position(1, 1)] = SrsCell(SrsTerrainType.NEBULA)
+
+    def test_known_state_freezes_visited_cells(self) -> None:
+        state = SrsKnownState(visited_cells={Position(0, 0)})
+
+        with self.assertRaises(AttributeError):
+            state.visited_cells.add(Position(1, 1))
+
+    def test_known_state_rejects_known_cell_outside_discovered_cells(self) -> None:
+        with self.assertRaisesRegex(SrsModelError, "known_cells keys must be a subset"):
+            SrsKnownState(
+                discovered_cells={Position(0, 0)},
+                known_cells={Position(1, 1): SrsCell(SrsTerrainType.FLOOR)},
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/experiments/galactic_exodus/srs/test_observation.py
+++ b/experiments/galactic_exodus/srs/test_observation.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from experiments.galactic_exodus.srs.contracts import load_default_contracts
+from experiments.galactic_exodus.srs.engine import (
+    known_cell_at,
+    observation_area,
+    observation_size_for_terrain,
+    restore_srs_state,
+    reveal_full_observation,
+    reveal_observation,
+    snapshot_srs_state,
+)
+from experiments.galactic_exodus.srs.generate import create_sector
+from experiments.galactic_exodus.srs.model import (
+    Direction,
+    Position,
+    SectorDescriptor,
+    SectorType,
+    SrsActualMap,
+    SrsCell,
+    SrsGameState,
+    SrsTerrainType,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def make_state(
+    *,
+    sector_type: SectorType = SectorType.NORMAL,
+    sector_seed: int = 1001,
+    entry_edge: Direction = Direction.S,
+    blocked_edges: frozenset[Direction] = frozenset(),
+) -> SrsGameState:
+    contracts = load_default_contracts(REPO_ROOT)
+    descriptor = SectorDescriptor(
+        sector_id=f"{sector_type.value.lower()}-{sector_seed}",
+        sector_type=sector_type,
+        sector_seed=sector_seed,
+        entry_edge=entry_edge,
+        blocked_edges=blocked_edges,
+    )
+    return create_sector(descriptor, contracts=contracts)
+
+
+def replace_cell_terrain(
+    state: SrsGameState,
+    position: Position,
+    terrain: SrsTerrainType,
+) -> SrsGameState:
+    rows = [list(row) for row in state.actual_map.cells]
+    current = state.actual_map.cell_at(position)
+    rows[position.y][position.x] = SrsCell(
+        terrain=terrain,
+        object_id=current.object_id,
+        actor_id=current.actor_id,
+        warp_flags=current.warp_flags,
+    )
+    actual_map = SrsActualMap(
+        width=state.actual_map.width,
+        height=state.actual_map.height,
+        cells=tuple(tuple(row) for row in rows),
+    )
+    return SrsGameState(
+        descriptor=state.descriptor,
+        actual_map=actual_map,
+        known_state=state.known_state,
+        persistent_state=state.persistent_state,
+        player_position=state.player_position,
+        objects=state.objects,
+        srs_turn=state.srs_turn,
+        fuel=state.fuel,
+        max_fuel=state.max_fuel,
+    )
+
+
+class SrsObservationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.contracts = load_default_contracts(REPO_ROOT)
+
+    def test_observation_size_for_floor_is_5(self) -> None:
+        self.assertEqual(
+            observation_size_for_terrain(SrsTerrainType.FLOOR, self.contracts),
+            5,
+        )
+
+    def test_observation_size_for_nebula_is_3(self) -> None:
+        self.assertEqual(
+            observation_size_for_terrain(SrsTerrainType.NEBULA, self.contracts),
+            3,
+        )
+
+    def test_observation_area_clips_at_map_edge(self) -> None:
+        state = make_state()
+
+        area = observation_area(state.actual_map, center=Position(0, 0), size=5)
+
+        self.assertEqual(len(area), 9)
+        self.assertIn(Position(0, 0), area)
+        self.assertIn(Position(2, 2), area)
+        self.assertNotIn(Position(3, 3), area)
+
+    def test_observation_area_rejects_out_of_bounds_center(self) -> None:
+        state = make_state()
+
+        with self.assertRaisesRegex(ValueError, "out of bounds"):
+            observation_area(state.actual_map, center=Position(-1, 0), size=5)
+
+    def test_full_observation_reveals_all_cells(self) -> None:
+        state = make_state()
+
+        revealed = reveal_full_observation(state)
+
+        self.assertEqual(len(revealed.known_state.discovered_cells), 81)
+        self.assertEqual(len(revealed.known_state.known_cells), 81)
+        self.assertEqual(revealed.persistent_state.discovered_cells, revealed.known_state.discovered_cells)
+        self.assertEqual(revealed.known_state.visited_cells, frozenset())
+
+    def test_local_movement_floor_reveals_5x5(self) -> None:
+        state = make_state()
+
+        revealed = reveal_observation(
+            state,
+            center=Position(4, 4),
+            contracts=self.contracts,
+        )
+
+        self.assertEqual(len(revealed.known_state.discovered_cells), 25)
+        self.assertEqual(len(revealed.known_state.known_cells), 25)
+        self.assertEqual(revealed.persistent_state.discovered_cells, revealed.known_state.discovered_cells)
+
+    def test_local_movement_nebula_reveals_3x3(self) -> None:
+        state = replace_cell_terrain(make_state(), Position(4, 4), SrsTerrainType.NEBULA)
+
+        revealed = reveal_observation(
+            state,
+            center=Position(4, 4),
+            contracts=self.contracts,
+        )
+
+        self.assertEqual(len(revealed.known_state.discovered_cells), 9)
+        self.assertEqual(len(revealed.known_state.known_cells), 9)
+
+    def test_known_map_is_cumulative(self) -> None:
+        state = make_state()
+        first = reveal_observation(
+            state,
+            center=Position(4, 4),
+            contracts=self.contracts,
+        )
+
+        second = reveal_observation(
+            first,
+            center=Position(6, 4),
+            contracts=self.contracts,
+        )
+
+        self.assertEqual(len(first.known_state.discovered_cells), 25)
+        self.assertEqual(len(second.known_state.discovered_cells), 35)
+        self.assertTrue(first.known_state.discovered_cells.issubset(second.known_state.discovered_cells))
+
+    def test_reveal_observation_marks_center_visited(self) -> None:
+        state = make_state()
+
+        revealed = reveal_observation(
+            state,
+            center=Position(4, 4),
+            contracts=self.contracts,
+        )
+
+        self.assertEqual(revealed.known_state.visited_cells, frozenset({Position(4, 4)}))
+
+    def test_rejected_command_does_not_reveal_when_observation_not_called(self) -> None:
+        state = make_state()
+
+        self.assertEqual(state.known_state.discovered_cells, frozenset())
+        self.assertEqual(state.known_state.known_cells, {})
+
+    def test_first_blocked_cell_collision_does_not_reveal_when_observation_not_called(self) -> None:
+        state = make_state(
+            sector_type=SectorType.RIFT,
+            sector_seed=4001,
+            blocked_edges=frozenset({Direction.N}),
+        )
+
+        self.assertEqual(state.known_state.discovered_cells, frozenset())
+        self.assertEqual(state.known_state.known_cells, {})
+
+    def test_known_cell_at_returns_none_for_unseen_cell(self) -> None:
+        state = make_state()
+
+        self.assertIsNone(known_cell_at(state, Position(4, 4)))
+
+    def test_known_cell_at_returns_known_cell_for_seen_cell(self) -> None:
+        state = reveal_observation(
+            make_state(),
+            center=Position(4, 4),
+            contracts=self.contracts,
+        )
+
+        self.assertEqual(
+            known_cell_at(state, Position(4, 4)),
+            state.actual_map.cell_at(Position(4, 4)),
+        )
+
+    def test_snapshot_srs_state_uses_known_discovered_cells(self) -> None:
+        state = reveal_observation(
+            make_state(),
+            center=Position(4, 4),
+            contracts=self.contracts,
+        )
+
+        snapshot = snapshot_srs_state(state)
+
+        self.assertEqual(snapshot.discovered_cells, state.known_state.discovered_cells)
+
+    def test_restore_srs_state_restores_discovered_cells_and_known_cells(self) -> None:
+        original = reveal_observation(
+            make_state(),
+            center=Position(4, 4),
+            contracts=self.contracts,
+        )
+        persistent = snapshot_srs_state(original)
+
+        restored = restore_srs_state(
+            descriptor=original.descriptor,
+            actual_map=original.actual_map,
+            persistent=persistent,
+            player_position=Position(0, 4),
+            objects=original.objects,
+        )
+
+        self.assertEqual(restored.known_state.discovered_cells, original.known_state.discovered_cells)
+        self.assertEqual(dict(restored.known_state.known_cells), dict(original.known_state.known_cells))
+        self.assertEqual(restored.persistent_state, persistent)
+
+    def test_restore_srs_state_does_not_restore_visited_cells(self) -> None:
+        original = reveal_observation(
+            make_state(),
+            center=Position(4, 4),
+            contracts=self.contracts,
+        )
+        persistent = snapshot_srs_state(original)
+
+        restored = restore_srs_state(
+            descriptor=original.descriptor,
+            actual_map=original.actual_map,
+            persistent=persistent,
+            player_position=Position(0, 4),
+            objects=original.objects,
+        )
+
+        self.assertEqual(restored.known_state.visited_cells, frozenset())
+        self.assertEqual(restored.srs_turn, 0)
+        self.assertEqual(restored.fuel, 0)
+        self.assertEqual(restored.max_fuel, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1106
Refs #1080

## 概要

Phase 2B3として、LOCAL_MOVEMENT観測とknown/persistent stateを実装します。

## 追加内容

- `engine.py`
  - `SrsObservationError`
  - `observation_size_for_terrain(...)`
  - `observation_area(...)`
  - `reveal_observation(...)`
  - `reveal_full_observation(...)`
  - `known_cell_at(...)`
  - `snapshot_srs_state(...)`
  - `restore_srs_state(...)`

- `model.py`
  - `SrsKnownState.known_cells`
  - `SrsKnownState.visited_cells`

- `test_observation.py`
  - FULL観測
  - LOCAL_MOVEMENT 5x5
  - NEBULA 3x3
  - known累積
  - visited state
  - snapshot/restore
  - 未観測cellの秘匿

## 仕様

- 通常terrainは5x5を開示する
- NEBULAは3x3を開示する
- map外はclipする
- known_cellsには開示済みcellだけを保持する
- known_cell_atは未観測cellではNoneを返す
- visited_cellsは現在滞在中だけの状態として扱う
- persistentにはvisited_cellsを保存しない
- snapshotはknown_state.discovered_cellsをpersistentへ反映する
- restoreはpersistent.discovered_cellsからknown_cellsを復元する

## 確認

```bash
python -m unittest experiments.galactic_exodus.srs.test_observation
python -m unittest experiments.galactic_exodus.srs.test_generate
python -m unittest experiments.galactic_exodus.srs.test_model
python -m unittest experiments.galactic_exodus.srs.test_contracts
```

## 非対象

- movement commandの完全実装
- MOVE_ROUTE / MOVE_TO
- turn消費
- fuel消費
- object interaction
- warp/exit実行
- render
