### PR TITLE
Phase 2B4: MOVE_ROUTE・STOP_BEFORE・GameLogを実装

### DIFF
--- a/experiments/galactic_exodus/srs/engine.py
+++ b/experiments/galactic_exodus/srs/engine.py
@@ -1,16 +1,29 @@
 from __future__ import annotations
 
 from dataclasses import replace
-from typing import Mapping
+from typing import Any, Mapping, Sequence
 
 from experiments.galactic_exodus.srs.contracts import SrsContracts
+from experiments.galactic_exodus.srs.log import (
+    MOVE_ACCEPTED,
+    MOVE_REJECTED,
+    OBSERVATION_UPDATED,
+    STOPPED_BEFORE_IMPASSABLE,
+    make_turn_event,
+)
 from experiments.galactic_exodus.srs.model import (
+    Direction,
+    CostMode,
+    MovementRule,
     Position,
     SectorDescriptor,
     SrsActualMap,
     SrsCell,
+    SrsCommand,
+    SrsCommandResult,
     SrsGameState,
     SrsKnownState,
+    SrsObjectType,
     SrsObjectState,
     SrsPersistentState,
     SrsTerrainType,
@@ -18,6 +31,10 @@ from experiments.galactic_exodus.srs.model import (
 
 
 class SrsObservationError(ValueError):
+    pass
+
+
+class SrsMovementError(ValueError):
     pass
 
 
@@ -164,6 +181,116 @@ def restore_srs_state(
     )
 
 
+def movement_raw_cost_for_step(
+    destination: SrsCell,
+    *,
+    direction: Direction,
+    contracts: SrsContracts,
+) -> int:
+    if direction not in contracts.movement.directions:
+        raise SrsMovementError(f"unsupported movement direction: {direction}")
+
+    terrain_multipliers = {
+        SrsTerrainType.FLOOR: 1,
+        SrsTerrainType.DEBRIS: 2,
+        SrsTerrainType.NEBULA: 2,
+        SrsTerrainType.ASTEROID_FIELD: 3,
+        SrsTerrainType.GRAVITY_FIELD_VERTICAL: 1,
+        SrsTerrainType.GRAVITY_FIELD_HORIZONTAL: 1,
+        SrsTerrainType.RIFT_DISTORTION: 1,
+    }
+    multiplier = terrain_multipliers.get(destination.terrain)
+    if multiplier is None:
+        raise SrsMovementError(f"impassable terrain has no movement cost: {destination.terrain.value}")
+    return contracts.movement.orthogonal_raw_cost * multiplier
+
+
+def is_impassable_cell(
+    state: SrsGameState,
+    position: Position,
+) -> bool:
+    if not state.actual_map.contains(position):
+        return True
+
+    cell = state.actual_map.cell_at(position)
+    if cell.terrain in {SrsTerrainType.ASTEROID, SrsTerrainType.RIFT_BARRIER}:
+        return True
+    if cell.object_id is None:
+        return False
+
+    object_type = state.objects[cell.object_id].object_type
+    return object_type in {
+        SrsObjectType.STAR,
+        SrsObjectType.PLANET,
+        SrsObjectType.STATION,
+    }
+
+
+def resolve_move_route(
+    state: SrsGameState,
+    route: Sequence[Direction],
+    *,
+    contracts: SrsContracts,
+) -> tuple[tuple[Position, ...], Position | None, int]:
+    entered_cells: list[Position] = []
+    blocked_position: Position | None = None
+    raw_cost = 0
+    current = state.player_position
+
+    for direction in route:
+        next_position = _step_position(current, direction)
+        if is_impassable_cell(state, next_position):
+            blocked_position = next_position
+            break
+
+        destination = state.actual_map.cell_at(next_position)
+        step_cost = movement_raw_cost_for_step(destination, direction=direction, contracts=contracts)
+        if raw_cost + step_cost > contracts.movement.movement_cost_budget_raw:
+            break
+
+        entered_cells.append(next_position)
+        raw_cost += step_cost
+        current = next_position
+
+    return tuple(entered_cells), blocked_position, raw_cost
+
+
+def apply_srs_command(
+    state: SrsGameState,
+    command: SrsCommand,
+    *,
+    contracts: SrsContracts,
+) -> SrsCommandResult:
+    if command.command_type == "MOVE_ROUTE":
+        return _apply_move_route(state, command, contracts=contracts)
+    if command.command_type == "MOVE_TO":
+        return _rejected_command_result(
+            state,
+            command_type=command.command_type,
+            outcome="REJECTED_MOVE_TO_UNIMPLEMENTED",
+        )
+    return _rejected_command_result(
+        state,
+        command_type=command.command_type,
+        outcome="REJECTED_UNKNOWN_COMMAND",
+    )
+
+
+def run_srs_commands(
+    state: SrsGameState,
+    commands: Sequence[SrsCommand],
+    *,
+    contracts: SrsContracts,
+) -> SrsCommandResult:
+    current_state = state
+    all_events: list[Any] = []
+    for command in commands:
+        result = apply_srs_command(current_state, command, contracts=contracts)
+        current_state = result.state
+        all_events.extend(result.events)
+    return SrsCommandResult(state=current_state, events=tuple(all_events))
+
+
 def _validated_observation_size(value: object, *, field_name: str) -> int:
     if not isinstance(value, int) or isinstance(value, bool) or value <= 0 or value % 2 == 0:
         raise SrsObservationError(f"{field_name} must be an odd positive integer")
@@ -185,3 +312,182 @@ def _validate_positions_within_map(
     for position in positions:
         if not actual_map.contains(position):
             raise SrsObservationError(f"{context} out of bounds: {position}")
+
+
+def _apply_move_route(
+    state: SrsGameState,
+    command: SrsCommand,
+    *,
+    contracts: SrsContracts,
+) -> SrsCommandResult:
+    if not all(direction in contracts.movement.directions for direction in command.route):
+        return _rejected_command_result(
+            state,
+            command_type=command.command_type,
+            outcome="REJECTED_UNKNOWN_COMMAND",
+        )
+
+    entered_cells, blocked_position, movement_raw_cost = resolve_move_route(
+        state,
+        command.route,
+        contracts=contracts,
+    )
+    if not entered_cells and blocked_position is None:
+        return _rejected_command_result(
+            state,
+            command_type=command.command_type,
+            outcome="REJECTED_ZERO_STEP",
+        )
+
+    next_turn = state.srs_turn + _movement_turn_cost(contracts)
+
+    if not entered_cells:
+        result_state = replace(state, srs_turn=next_turn)
+        event = _movement_event(
+            srs_turn=next_turn,
+            event_type=STOPPED_BEFORE_IMPASSABLE,
+            command_type=command.command_type,
+            start_position=state.player_position,
+            end_position=state.player_position,
+            entered_cells=(),
+            blocked_position=blocked_position,
+            movement_raw_cost=0,
+            observation_updates=(),
+            outcome="STOPPED_BEFORE_IMPASSABLE",
+        )
+        return SrsCommandResult(state=result_state, events=(event,))
+
+    current_state = replace(
+        state,
+        player_position=entered_cells[-1],
+        srs_turn=next_turn,
+    )
+    observation_updates: list[Position] = []
+    observation_events = []
+    for center in entered_cells:
+        previous_count = len(current_state.known_state.discovered_cells)
+        current_state = reveal_observation(current_state, center=center, contracts=contracts)
+        total_count = len(current_state.known_state.discovered_cells)
+        observation_updates.append(center)
+        observation_events.append(
+            make_turn_event(
+                srs_turn=next_turn,
+                event_type=OBSERVATION_UPDATED,
+                payload={
+                    "center": _position_to_list(center),
+                    "newly_discovered_count": total_count - previous_count,
+                    "total_discovered_count": total_count,
+                },
+            )
+        )
+
+    movement_event_type = MOVE_ACCEPTED if blocked_position is None else STOPPED_BEFORE_IMPASSABLE
+    outcome = _movement_outcome(
+        route=command.route,
+        entered_cells=entered_cells,
+        blocked_position=blocked_position,
+    )
+    movement_event = _movement_event(
+        srs_turn=next_turn,
+        event_type=movement_event_type,
+        command_type=command.command_type,
+        start_position=state.player_position,
+        end_position=entered_cells[-1],
+        entered_cells=entered_cells,
+        blocked_position=blocked_position,
+        movement_raw_cost=movement_raw_cost,
+        observation_updates=tuple(observation_updates),
+        outcome=outcome,
+    )
+    return SrsCommandResult(
+        state=current_state,
+        events=(movement_event, *observation_events),
+    )
+
+
+def _rejected_command_result(
+    state: SrsGameState,
+    *,
+    command_type: str,
+    outcome: str,
+) -> SrsCommandResult:
+    event = _movement_event(
+        srs_turn=state.srs_turn,
+        event_type=MOVE_REJECTED,
+        command_type=command_type,
+        start_position=state.player_position,
+        end_position=state.player_position,
+        entered_cells=(),
+        blocked_position=None,
+        movement_raw_cost=0,
+        observation_updates=(),
+        outcome=outcome,
+    )
+    return SrsCommandResult(state=state, events=(event,))
+
+
+def _movement_event(
+    *,
+    srs_turn: int,
+    event_type: str,
+    command_type: str,
+    start_position: Position,
+    end_position: Position,
+    entered_cells: Sequence[Position],
+    blocked_position: Position | None,
+    movement_raw_cost: int,
+    observation_updates: Sequence[Position],
+    outcome: str,
+):
+    return make_turn_event(
+        srs_turn=srs_turn,
+        event_type=event_type,
+        payload={
+            "command_type": command_type,
+            "movement_rule": MovementRule.MOVEMENT_POINTS.value,
+            "cost_mode": CostMode.TURN_ONLY.value,
+            "start_position": _position_to_list(start_position),
+            "end_position": _position_to_list(end_position),
+            "entered_cells": [_position_to_list(position) for position in entered_cells],
+            "blocked_position": None if blocked_position is None else _position_to_list(blocked_position),
+            "movement_raw_cost": movement_raw_cost,
+            "fuel_delta": 0,
+            "observation_updates": [_position_to_list(position) for position in observation_updates],
+            "outcome": outcome,
+        },
+    )
+
+
+def _movement_outcome(
+    *,
+    route: Sequence[Direction],
+    entered_cells: Sequence[Position],
+    blocked_position: Position | None,
+) -> str:
+    if blocked_position is not None:
+        return "STOPPED_BEFORE_IMPASSABLE"
+    if len(entered_cells) < len(route):
+        return "BUDGET_EXHAUSTED"
+    return "ACCEPTED"
+
+
+def _movement_turn_cost(contracts: SrsContracts) -> int:
+    turn_cost = contracts.movement.command_turn_rules.get("movement_turn_cost")
+    if not isinstance(turn_cost, int) or isinstance(turn_cost, bool) or turn_cost <= 0:
+        raise SrsMovementError("movement_turn_cost must be a positive integer")
+    return turn_cost
+
+
+def _step_position(position: Position, direction: Direction) -> Position:
+    deltas = {
+        Direction.N: (0, -1),
+        Direction.E: (1, 0),
+        Direction.S: (0, 1),
+        Direction.W: (-1, 0),
+    }
+    dx, dy = deltas[direction]
+    return Position(position.x + dx, position.y + dy)
+
+
+def _position_to_list(position: Position) -> list[int]:
+    return [position.x, position.y]

--- a/experiments/galactic_exodus/srs/log.py
+++ b/experiments/galactic_exodus/srs/log.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from experiments.galactic_exodus.srs.model import SrsGameLog, SrsTurnEvent
+
+
+MOVE_ACCEPTED = "MOVE_ACCEPTED"
+MOVE_REJECTED = "MOVE_REJECTED"
+STOPPED_BEFORE_IMPASSABLE = "STOPPED_BEFORE_IMPASSABLE"
+OBSERVATION_UPDATED = "OBSERVATION_UPDATED"
+
+
+def make_turn_event(
+    *,
+    srs_turn: int,
+    event_type: str,
+    payload: Mapping[str, Any],
+) -> SrsTurnEvent:
+    return SrsTurnEvent(
+        srs_turn=srs_turn,
+        event_type=event_type,
+        payload=dict(payload),
+    )
+
+
+def build_srs_log(events: Sequence[SrsTurnEvent]) -> SrsGameLog:
+    return SrsGameLog(events=tuple(events))

--- a/experiments/galactic_exodus/srs/model.py
+++ b/experiments/galactic_exodus/srs/model.py
@@ -237,6 +237,37 @@ class SrsGameLog:
         object.__setattr__(self, "events", tuple(self.events))
 
 
+@dataclass(frozen=True, slots=True)
+class SrsCommand:
+    command_type: str
+    route: tuple[Direction, ...] = ()
+    target: Position | None = None
+
+    def __post_init__(self) -> None:
+        command_type = str(self.command_type)
+        try:
+            route = tuple(Direction(direction) for direction in self.route)
+        except ValueError as exc:
+            raise SrsModelError("route must contain only Direction values") from exc
+
+        if command_type == "MOVE_ROUTE" and not route:
+            raise SrsModelError("MOVE_ROUTE requires a non-empty route")
+        if command_type == "MOVE_TO" and self.target is None:
+            raise SrsModelError("MOVE_TO requires a target")
+
+        object.__setattr__(self, "command_type", command_type)
+        object.__setattr__(self, "route", route)
+
+
+@dataclass(frozen=True, slots=True)
+class SrsCommandResult:
+    state: SrsGameState
+    events: tuple[SrsTurnEvent, ...]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "events", tuple(self.events))
+
+
 def validate_sector_descriptor(descriptor: SectorDescriptor) -> None:
     if descriptor.sector_type is SectorType.RIFT:
         if not descriptor.blocked_edges:

--- a/experiments/galactic_exodus/srs/test_engine_movement.py
+++ b/experiments/galactic_exodus/srs/test_engine_movement.py
@@ -1,0 +1,342 @@
+from __future__ import annotations
+
+import unittest
+from dataclasses import replace
+from pathlib import Path
+
+from experiments.galactic_exodus.srs.contracts import load_default_contracts
+from experiments.galactic_exodus.srs.engine import apply_srs_command, run_srs_commands
+from experiments.galactic_exodus.srs.generate import create_sector
+from experiments.galactic_exodus.srs.log import (
+    MOVE_ACCEPTED,
+    MOVE_REJECTED,
+    OBSERVATION_UPDATED,
+    STOPPED_BEFORE_IMPASSABLE,
+)
+from experiments.galactic_exodus.srs.model import (
+    Direction,
+    Position,
+    SectorDescriptor,
+    SectorType,
+    SrsActualMap,
+    SrsCell,
+    SrsCommand,
+    SrsGameState,
+    SrsObjectState,
+    SrsObjectType,
+    SrsTerrainType,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def make_state(
+    *,
+    sector_type: SectorType = SectorType.NORMAL,
+    sector_seed: int = 1001,
+    entry_edge: Direction = Direction.S,
+    blocked_edges: frozenset[Direction] = frozenset(),
+    fuel: int = 0,
+    max_fuel: int = 0,
+) -> SrsGameState:
+    contracts = load_default_contracts(REPO_ROOT)
+    descriptor = SectorDescriptor(
+        sector_id=f"{sector_type.value.lower()}-{sector_seed}",
+        sector_type=sector_type,
+        sector_seed=sector_seed,
+        entry_edge=entry_edge,
+        blocked_edges=blocked_edges,
+    )
+    state = create_sector(descriptor, contracts=contracts)
+    return replace(
+        _clear_objects(state),
+        fuel=fuel,
+        max_fuel=max_fuel,
+    )
+
+
+def replace_cell_terrain(
+    state: SrsGameState,
+    position: Position,
+    terrain: SrsTerrainType,
+) -> SrsGameState:
+    rows = [list(row) for row in state.actual_map.cells]
+    current = state.actual_map.cell_at(position)
+    rows[position.y][position.x] = SrsCell(
+        terrain=terrain,
+        object_id=current.object_id,
+        actor_id=current.actor_id,
+        warp_flags=current.warp_flags,
+    )
+    return replace(state, actual_map=_build_map(state, rows))
+
+
+def place_object(
+    state: SrsGameState,
+    position: Position,
+    object_type: SrsObjectType,
+    object_id: str,
+) -> SrsGameState:
+    rows = [list(row) for row in state.actual_map.cells]
+    current = state.actual_map.cell_at(position)
+    rows[position.y][position.x] = SrsCell(
+        terrain=current.terrain,
+        object_id=object_id,
+        actor_id=current.actor_id,
+        warp_flags=current.warp_flags,
+    )
+    return replace(
+        state,
+        actual_map=_build_map(state, rows),
+        objects={
+            **state.objects,
+            object_id: SrsObjectState(
+                object_id=object_id,
+                object_type=object_type,
+                position=position,
+            ),
+        },
+    )
+
+
+def _clear_objects(state: SrsGameState) -> SrsGameState:
+    rows = []
+    for row in state.actual_map.cells:
+        rows.append(
+            [
+                SrsCell(
+                    terrain=cell.terrain,
+                    object_id=None,
+                    actor_id=cell.actor_id,
+                    warp_flags=cell.warp_flags,
+                )
+                for cell in row
+            ]
+        )
+    return replace(state, actual_map=_build_map(state, rows), objects={})
+
+
+def _build_map(state: SrsGameState, rows: list[list[SrsCell]]) -> SrsActualMap:
+    return SrsActualMap(
+        width=state.actual_map.width,
+        height=state.actual_map.height,
+        cells=tuple(tuple(row) for row in rows),
+    )
+
+
+class SrsEngineMovementTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.contracts = load_default_contracts(REPO_ROOT)
+
+    def test_move_route_consumes_one_turn(self) -> None:
+        state = make_state()
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(command_type="MOVE_ROUTE", route=(Direction.N,)),
+            contracts=self.contracts,
+        )
+
+        self.assertEqual(result.state.srs_turn, 1)
+
+    def test_turn_only_does_not_consume_fuel(self) -> None:
+        state = make_state(fuel=7, max_fuel=9)
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(command_type="MOVE_ROUTE", route=(Direction.N,)),
+            contracts=self.contracts,
+        )
+
+        self.assertEqual(result.state.fuel, 7)
+        self.assertEqual(result.events[0].payload["fuel_delta"], 0)
+
+    def test_move_route_executes_longest_prefix_within_budget(self) -> None:
+        state = make_state()
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(
+                command_type="MOVE_ROUTE",
+                route=(Direction.N, Direction.N, Direction.N, Direction.N, Direction.N),
+            ),
+            contracts=self.contracts,
+        )
+
+        self.assertEqual(result.state.player_position, Position(4, 4))
+        self.assertEqual(result.events[0].event_type, MOVE_ACCEPTED)
+        self.assertEqual(result.events[0].payload["movement_raw_cost"], 40)
+        self.assertEqual(result.events[0].payload["outcome"], "BUDGET_EXHAUSTED")
+
+    def test_debris_cost_shortens_movement(self) -> None:
+        state = replace_cell_terrain(make_state(), Position(4, 7), SrsTerrainType.DEBRIS)
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(
+                command_type="MOVE_ROUTE",
+                route=(Direction.N, Direction.N, Direction.N, Direction.N),
+            ),
+            contracts=self.contracts,
+        )
+
+        self.assertEqual(result.state.player_position, Position(4, 5))
+        self.assertEqual(result.events[0].payload["movement_raw_cost"], 40)
+
+    def test_asteroid_field_cost_shortens_movement(self) -> None:
+        state = replace_cell_terrain(make_state(), Position(4, 7), SrsTerrainType.ASTEROID_FIELD)
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(
+                command_type="MOVE_ROUTE",
+                route=(Direction.N, Direction.N, Direction.N),
+            ),
+            contracts=self.contracts,
+        )
+
+        self.assertEqual(result.state.player_position, Position(4, 6))
+        self.assertEqual(result.events[0].payload["movement_raw_cost"], 40)
+
+    def test_stop_before_first_blocked_cell(self) -> None:
+        state = replace_cell_terrain(
+            make_state(
+                sector_type=SectorType.RIFT,
+                entry_edge=Direction.S,
+                blocked_edges=frozenset({Direction.N}),
+            ),
+            Position(4, 7),
+            SrsTerrainType.RIFT_BARRIER,
+        )
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(command_type="MOVE_ROUTE", route=(Direction.N,)),
+            contracts=self.contracts,
+        )
+
+        self.assertEqual(result.state.player_position, state.player_position)
+        self.assertEqual(result.state.srs_turn, 1)
+        self.assertEqual(result.events[0].event_type, STOPPED_BEFORE_IMPASSABLE)
+        self.assertEqual(result.events[0].payload["movement_raw_cost"], 0)
+        self.assertEqual(result.events[0].payload["observation_updates"], [])
+
+    def test_stop_before_after_partial_movement(self) -> None:
+        state = place_object(make_state(), Position(4, 5), SrsObjectType.STAR, "star-blocker")
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(
+                command_type="MOVE_ROUTE",
+                route=(Direction.N, Direction.N, Direction.N, Direction.N),
+            ),
+            contracts=self.contracts,
+        )
+
+        self.assertEqual(result.state.player_position, Position(4, 6))
+        self.assertEqual(result.events[0].event_type, STOPPED_BEFORE_IMPASSABLE)
+        self.assertEqual(result.events[0].payload["blocked_position"], [4, 5])
+        self.assertEqual(result.events[0].payload["movement_raw_cost"], 20)
+
+    def test_budget_stop_is_move_accepted_not_blocked(self) -> None:
+        state = make_state()
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(
+                command_type="MOVE_ROUTE",
+                route=(Direction.N, Direction.N, Direction.N, Direction.N, Direction.W),
+            ),
+            contracts=self.contracts,
+        )
+
+        self.assertEqual(result.events[0].event_type, MOVE_ACCEPTED)
+        self.assertIsNone(result.events[0].payload["blocked_position"])
+        self.assertEqual(result.events[0].payload["outcome"], "BUDGET_EXHAUSTED")
+
+    def test_successful_steps_update_observation(self) -> None:
+        state = make_state()
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(command_type="MOVE_ROUTE", route=(Direction.N, Direction.N)),
+            contracts=self.contracts,
+        )
+
+        self.assertEqual([event.event_type for event in result.events], [MOVE_ACCEPTED, OBSERVATION_UPDATED, OBSERVATION_UPDATED])
+        self.assertEqual(result.events[0].payload["observation_updates"], [[4, 7], [4, 6]])
+        self.assertEqual(result.state.known_state.visited_cells, frozenset({Position(4, 7), Position(4, 6)}))
+
+    def test_partial_blocked_updates_observation_for_entered_cells_only(self) -> None:
+        state = place_object(make_state(), Position(4, 5), SrsObjectType.STATION, "station-blocker")
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(command_type="MOVE_ROUTE", route=(Direction.N, Direction.N, Direction.N)),
+            contracts=self.contracts,
+        )
+
+        self.assertEqual([event.event_type for event in result.events], [STOPPED_BEFORE_IMPASSABLE, OBSERVATION_UPDATED, OBSERVATION_UPDATED])
+        self.assertEqual(result.events[0].payload["observation_updates"], [[4, 7], [4, 6]])
+        self.assertNotIn(Position(4, 5), result.state.known_state.visited_cells)
+
+    def test_rejected_command_no_turn_no_observation(self) -> None:
+        state = make_state()
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(command_type="INTERACT"),
+            contracts=self.contracts,
+        )
+
+        self.assertEqual(result.state, state)
+        self.assertEqual(len(result.state.known_state.discovered_cells), 0)
+        self.assertEqual([event.event_type for event in result.events], [MOVE_REJECTED])
+
+    def test_move_to_is_rejected_until_1114(self) -> None:
+        state = make_state()
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(command_type="MOVE_TO", target=Position(4, 7)),
+            contracts=self.contracts,
+        )
+
+        self.assertEqual(result.events[0].event_type, MOVE_REJECTED)
+        self.assertEqual(result.events[0].payload["outcome"], "REJECTED_MOVE_TO_UNIMPLEMENTED")
+
+    def test_impassable_star_blocks_movement(self) -> None:
+        state = place_object(make_state(), Position(4, 7), SrsObjectType.STAR, "star-blocker")
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(command_type="MOVE_ROUTE", route=(Direction.N,)),
+            contracts=self.contracts,
+        )
+
+        self.assertEqual(result.events[0].event_type, STOPPED_BEFORE_IMPASSABLE)
+        self.assertEqual(result.events[0].payload["blocked_position"], [4, 7])
+
+    def test_run_srs_commands_accumulates_events(self) -> None:
+        state = make_state()
+
+        result = run_srs_commands(
+            state,
+            (
+                SrsCommand(command_type="MOVE_ROUTE", route=(Direction.N,)),
+                SrsCommand(command_type="INTERACT"),
+            ),
+            contracts=self.contracts,
+        )
+
+        self.assertEqual(result.state.srs_turn, 1)
+        self.assertEqual(
+            [event.event_type for event in result.events],
+            [MOVE_ACCEPTED, OBSERVATION_UPDATED, MOVE_REJECTED],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experiments/galactic_exodus/srs/test_log.py
+++ b/experiments/galactic_exodus/srs/test_log.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import unittest
+
+from experiments.galactic_exodus.srs.log import (
+    MOVE_ACCEPTED,
+    MOVE_REJECTED,
+    OBSERVATION_UPDATED,
+    build_srs_log,
+    make_turn_event,
+)
+
+
+class SrsLogTests(unittest.TestCase):
+    def test_make_turn_event_freezes_payload(self) -> None:
+        event = make_turn_event(
+            srs_turn=1,
+            event_type=MOVE_ACCEPTED,
+            payload={"value": 1},
+        )
+
+        with self.assertRaises(TypeError):
+            event.payload["value"] = 2
+
+    def test_build_srs_log_preserves_event_order(self) -> None:
+        first = make_turn_event(srs_turn=1, event_type=MOVE_ACCEPTED, payload={})
+        second = make_turn_event(srs_turn=1, event_type=OBSERVATION_UPDATED, payload={})
+
+        log = build_srs_log([first, second])
+
+        self.assertEqual(log.events, (first, second))
+
+    def test_move_accepted_payload_has_required_fields(self) -> None:
+        event = make_turn_event(
+            srs_turn=1,
+            event_type=MOVE_ACCEPTED,
+            payload={
+                "command_type": "MOVE_ROUTE",
+                "movement_rule": "MOVEMENT_POINTS",
+                "cost_mode": "TURN_ONLY",
+                "start_position": [4, 8],
+                "end_position": [4, 7],
+                "entered_cells": [[4, 7]],
+                "blocked_position": None,
+                "movement_raw_cost": 10,
+                "fuel_delta": 0,
+                "observation_updates": [[4, 7]],
+                "outcome": "ACCEPTED",
+            },
+        )
+
+        self.assertEqual(
+            set(event.payload),
+            {
+                "command_type",
+                "movement_rule",
+                "cost_mode",
+                "start_position",
+                "end_position",
+                "entered_cells",
+                "blocked_position",
+                "movement_raw_cost",
+                "fuel_delta",
+                "observation_updates",
+                "outcome",
+            },
+        )
+
+    def test_move_rejected_payload_has_required_fields(self) -> None:
+        event = make_turn_event(
+            srs_turn=0,
+            event_type=MOVE_REJECTED,
+            payload={
+                "command_type": "MOVE_TO",
+                "movement_rule": "MOVEMENT_POINTS",
+                "cost_mode": "TURN_ONLY",
+                "start_position": [4, 8],
+                "end_position": [4, 8],
+                "entered_cells": [],
+                "blocked_position": None,
+                "movement_raw_cost": 0,
+                "fuel_delta": 0,
+                "observation_updates": [],
+                "outcome": "REJECTED_MOVE_TO_UNIMPLEMENTED",
+            },
+        )
+
+        self.assertEqual(event.payload["movement_raw_cost"], 0)
+        self.assertEqual(event.payload["observation_updates"], [])
+
+    def test_observation_updated_payload_has_required_fields(self) -> None:
+        event = make_turn_event(
+            srs_turn=1,
+            event_type=OBSERVATION_UPDATED,
+            payload={
+                "center": [4, 7],
+                "newly_discovered_count": 25,
+                "total_discovered_count": 25,
+            },
+        )
+
+        self.assertEqual(
+            set(event.payload),
+            {"center", "newly_discovered_count", "total_discovered_count"},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experiments/galactic_exodus/srs/test_model.py
+++ b/experiments/galactic_exodus/srs/test_model.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import unittest
 
 from experiments.galactic_exodus.srs.model import (
+    SrsCommand,
+    SrsCommandResult,
     Direction,
     Position,
     SectorDescriptor,
@@ -202,6 +204,44 @@ class SrsModelTests(unittest.TestCase):
                 discovered_cells={Position(0, 0)},
                 known_cells={Position(1, 1): SrsCell(SrsTerrainType.FLOOR)},
             )
+
+    def test_srs_command_rejects_empty_move_route(self) -> None:
+        with self.assertRaisesRegex(SrsModelError, "MOVE_ROUTE requires a non-empty route"):
+            SrsCommand(command_type="MOVE_ROUTE")
+
+    def test_srs_command_rejects_move_to_without_target(self) -> None:
+        with self.assertRaisesRegex(SrsModelError, "MOVE_TO requires a target"):
+            SrsCommand(command_type="MOVE_TO")
+
+    def test_srs_command_normalizes_route_to_tuple(self) -> None:
+        command = SrsCommand(command_type="MOVE_ROUTE", route=[Direction.N, Direction.E])
+        self.assertEqual(command.route, (Direction.N, Direction.E))
+
+    def test_srs_command_result_freezes_events(self) -> None:
+        state = SrsGameState(
+            descriptor=SectorDescriptor(
+                sector_id="N-1",
+                sector_type=SectorType.NORMAL,
+                sector_seed=1,
+                entry_edge=Direction.N,
+            ),
+            actual_map=SrsActualMap(width=1, height=1, cells=((SrsCell(SrsTerrainType.FLOOR),),)),
+            known_state=SrsKnownState(),
+            persistent_state=SrsPersistentState(
+                generated_map_id="N-1:1",
+                generation_schema_version=1,
+                generation_seed=1,
+                sector_type=SectorType.NORMAL,
+                blocked_edges=frozenset(),
+            ),
+            player_position=Position(0, 0),
+            objects={},
+        )
+        result = SrsCommandResult(
+            state=state,
+            events=[],
+        )
+        self.assertEqual(result.events, ())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #1107
Refs #1080

## 概要

Phase 2B4として、MOVE_ROUTE、STOP_BEFORE、movement GameLogを実装します。

## 追加内容

- `engine.py`
  - `SrsMovementError`
  - `apply_srs_command(...)`
  - `run_srs_commands(...)`
  - `movement_raw_cost_for_step(...)`
  - `is_impassable_cell(...)`
  - `resolve_move_route(...)`

- `log.py`
  - `MOVE_ACCEPTED`
  - `MOVE_REJECTED`
  - `STOPPED_BEFORE_IMPASSABLE`
  - `OBSERVATION_UPDATED`
  - `make_turn_event(...)`
  - `build_srs_log(...)`

- `model.py`
  - `SrsCommand`
  - `SrsCommandResult`

- `test_engine_movement.py`
  - MOVE_ROUTE
  - MOVEMENT_POINTS budget
  - STOP_BEFORE
  - TURN_ONLY
  - LOCAL_MOVEMENT観測接続

- `test_log.py`
  - event payload
  - event ordering

## 仕様

- MOVE_ROUTEを実行する
- 1 command は1 SRS turnを消費する
- rejected commandはturn/fuel/observationを変更しない
- first blocked cellはSTOP_BEFOREとしてturnだけ消費する
- partial blockedは最後のpassable cellで停止する
- routeはmovement_cost_budget_raw=40内の最長prefixを実行する
- TURN_ONLYはfuelを消費しない
- entered passable cellごとにLOCAL_MOVEMENT観測を更新する
- movement / observation eventsをSrsTurnEventとして返す
- MOVE_TOは#1114で実装するため、このPRではrejectする

## 確認

```bash
python -m unittest experiments.galactic_exodus.srs.test_engine_movement
python -m unittest experiments.galactic_exodus.srs.test_log
python -m unittest experiments.galactic_exodus.srs.test_observation
python -m unittest experiments.galactic_exodus.srs.test_generate
python -m unittest experiments.galactic_exodus.srs.test_model
python -m unittest experiments.galactic_exodus.srs.test_contracts
```

## 非対象

- MOVE_TO実行
- SHARED_FUEL
- VECTOR_COMMAND実行
- DIRECTIONAL_THRUST実行
- object interaction
- warp/exit実行
- render
