### PR TITLE
Phase 2B4b: SRS MOVE_TO known BFSを実装

### DIFF
--- a/experiments/galactic_exodus/srs/engine.py
+++ b/experiments/galactic_exodus/srs/engine.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import deque
 from dataclasses import replace
 from typing import Any, Mapping, Sequence
 
@@ -255,6 +256,39 @@ def resolve_move_route(
     return tuple(entered_cells), blocked_position, raw_cost
 
 
+def route_to_known_target(
+    state: SrsGameState,
+    target: Position,
+) -> tuple[Direction, ...]:
+    start = state.player_position
+    if start == target:
+        return ()
+
+    came_from: dict[Position, tuple[Position, Direction] | None] = {start: None}
+    frontier: deque[Position] = deque([start])
+    directions = (Direction.N, Direction.E, Direction.S, Direction.W)
+
+    while frontier:
+        current = frontier.popleft()
+        for direction in directions:
+            next_position = _step_position(current, direction)
+            if next_position in came_from:
+                continue
+            if next_position not in state.known_state.discovered_cells:
+                continue
+            if not state.actual_map.contains(next_position):
+                continue
+            if is_impassable_cell(state, next_position):
+                continue
+
+            came_from[next_position] = (current, direction)
+            if next_position == target:
+                return _reconstruct_route(came_from, start=start, target=target)
+            frontier.append(next_position)
+
+    raise SrsMovementError(f"no route to known target: {target}")
+
+
 def apply_srs_command(
     state: SrsGameState,
     command: SrsCommand,
@@ -264,11 +298,7 @@ def apply_srs_command(
     if command.command_type == "MOVE_ROUTE":
         return _apply_move_route(state, command, contracts=contracts)
     if command.command_type == "MOVE_TO":
-        return _rejected_command_result(
-            state,
-            command_type=command.command_type,
-            outcome="REJECTED_MOVE_TO_UNIMPLEMENTED",
-        )
+        return _apply_move_to(state, command, contracts=contracts)
     return _rejected_command_result(
         state,
         command_type=command.command_type,
@@ -405,11 +435,74 @@ def _apply_move_route(
     )
 
 
+def _apply_move_to(
+    state: SrsGameState,
+    command: SrsCommand,
+    *,
+    contracts: SrsContracts,
+) -> SrsCommandResult:
+    target = command.target
+    if target is None:
+        raise SrsMovementError("MOVE_TO requires a target")
+    if not state.actual_map.contains(target):
+        return _rejected_command_result(
+            state,
+            command_type=command.command_type,
+            outcome="REJECTED_OUT_OF_BOUNDS",
+            target_position=target,
+            resolved_route=(),
+        )
+    if target == state.player_position:
+        return _rejected_command_result(
+            state,
+            command_type=command.command_type,
+            outcome="REJECTED_SAME_POSITION",
+            target_position=target,
+            resolved_route=(),
+        )
+    if target not in state.known_state.discovered_cells:
+        return _rejected_command_result(
+            state,
+            command_type=command.command_type,
+            outcome="REJECTED_UNKNOWN_TARGET",
+            target_position=target,
+            resolved_route=(),
+        )
+
+    try:
+        route = route_to_known_target(state, target)
+    except SrsMovementError:
+        return _rejected_command_result(
+            state,
+            command_type=command.command_type,
+            outcome="REJECTED_NO_PATH",
+            target_position=target,
+            resolved_route=(),
+        )
+
+    result = apply_srs_command(
+        state,
+        SrsCommand(command_type="MOVE_ROUTE", route=route),
+        contracts=contracts,
+    )
+    movement_event = _override_move_to_event(
+        result.events[0],
+        target_position=target,
+        resolved_route=route,
+    )
+    return SrsCommandResult(
+        state=result.state,
+        events=(movement_event, *result.events[1:]),
+    )
+
+
 def _rejected_command_result(
     state: SrsGameState,
     *,
     command_type: str,
     outcome: str,
+    target_position: Position | None = None,
+    resolved_route: Sequence[Direction] | None = None,
 ) -> SrsCommandResult:
     event = _movement_event(
         srs_turn=state.srs_turn,
@@ -422,6 +515,8 @@ def _rejected_command_result(
         movement_raw_cost=0,
         observation_updates=(),
         outcome=outcome,
+        target_position=target_position,
+        resolved_route=resolved_route,
     )
     return SrsCommandResult(state=state, events=(event,))
 
@@ -438,23 +533,29 @@ def _movement_event(
     movement_raw_cost: int,
     observation_updates: Sequence[Position],
     outcome: str,
+    target_position: Position | None = None,
+    resolved_route: Sequence[Direction] | None = None,
 ):
+    payload = {
+        "command_type": command_type,
+        "movement_rule": MovementRule.MOVEMENT_POINTS.value,
+        "cost_mode": CostMode.TURN_ONLY.value,
+        "start_position": _position_to_list(start_position),
+        "end_position": _position_to_list(end_position),
+        "entered_cells": [_position_to_list(position) for position in entered_cells],
+        "blocked_position": None if blocked_position is None else _position_to_list(blocked_position),
+        "movement_raw_cost": movement_raw_cost,
+        "fuel_delta": 0,
+        "observation_updates": [_position_to_list(position) for position in observation_updates],
+        "outcome": outcome,
+    }
+    if target_position is not None or resolved_route is not None:
+        payload["target_position"] = None if target_position is None else _position_to_list(target_position)
+        payload["resolved_route"] = [] if resolved_route is None else [direction.value for direction in resolved_route]
     return make_turn_event(
         srs_turn=srs_turn,
         event_type=event_type,
-        payload={
-            "command_type": command_type,
-            "movement_rule": MovementRule.MOVEMENT_POINTS.value,
-            "cost_mode": CostMode.TURN_ONLY.value,
-            "start_position": _position_to_list(start_position),
-            "end_position": _position_to_list(end_position),
-            "entered_cells": [_position_to_list(position) for position in entered_cells],
-            "blocked_position": None if blocked_position is None else _position_to_list(blocked_position),
-            "movement_raw_cost": movement_raw_cost,
-            "fuel_delta": 0,
-            "observation_updates": [_position_to_list(position) for position in observation_updates],
-            "outcome": outcome,
-        },
+        payload=payload,
     )
 
 
@@ -478,6 +579,24 @@ def _movement_turn_cost(contracts: SrsContracts) -> int:
     return turn_cost
 
 
+def _reconstruct_route(
+    came_from: Mapping[Position, tuple[Position, Direction] | None],
+    *,
+    start: Position,
+    target: Position,
+) -> tuple[Direction, ...]:
+    route: list[Direction] = []
+    current = target
+    while current != start:
+        previous = came_from.get(current)
+        if previous is None:
+            raise SrsMovementError(f"route reconstruction failed: {target}")
+        current, direction = previous
+        route.append(direction)
+    route.reverse()
+    return tuple(route)
+
+
 def _step_position(position: Position, direction: Direction) -> Position:
     deltas = {
         Direction.N: (0, -1),
@@ -491,3 +610,20 @@ def _step_position(position: Position, direction: Direction) -> Position:
 
 def _position_to_list(position: Position) -> list[int]:
     return [position.x, position.y]
+
+
+def _override_move_to_event(
+    event,
+    *,
+    target_position: Position,
+    resolved_route: Sequence[Direction],
+):
+    payload = dict(event.payload)
+    payload["command_type"] = "MOVE_TO"
+    payload["target_position"] = _position_to_list(target_position)
+    payload["resolved_route"] = [direction.value for direction in resolved_route]
+    return make_turn_event(
+        srs_turn=event.srs_turn,
+        event_type=event.event_type,
+        payload=payload,
+    )

--- a/experiments/galactic_exodus/srs/test_engine_movement.py
+++ b/experiments/galactic_exodus/srs/test_engine_movement.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import unittest
 from dataclasses import replace
 from pathlib import Path
+from typing import Iterable
 
 from experiments.galactic_exodus.srs.contracts import load_default_contracts
-from experiments.galactic_exodus.srs.engine import apply_srs_command, run_srs_commands
+from experiments.galactic_exodus.srs.engine import apply_srs_command, reveal_full_observation, run_srs_commands
 from experiments.galactic_exodus.srs.generate import create_sector
 from experiments.galactic_exodus.srs.log import (
     MOVE_ACCEPTED,
@@ -122,6 +123,33 @@ def _build_map(state: SrsGameState, rows: list[list[SrsCell]]) -> SrsActualMap:
         width=state.actual_map.width,
         height=state.actual_map.height,
         cells=tuple(tuple(row) for row in rows),
+    )
+
+
+def reveal_all_for_move_to(state: SrsGameState) -> SrsGameState:
+    return reveal_full_observation(state)
+
+
+def reveal_positions(
+    state: SrsGameState,
+    positions: Iterable[Position],
+) -> SrsGameState:
+    discovered_cells = frozenset(positions)
+    known_cells = {
+        position: state.actual_map.cell_at(position)
+        for position in discovered_cells
+    }
+    return replace(
+        state,
+        known_state=replace(
+            state.known_state,
+            discovered_cells=discovered_cells,
+            known_cells=known_cells,
+        ),
+        persistent_state=replace(
+            state.persistent_state,
+            discovered_cells=discovered_cells,
+        ),
     )
 
 
@@ -295,7 +323,7 @@ class SrsEngineMovementTests(unittest.TestCase):
         self.assertEqual(len(result.state.known_state.discovered_cells), 0)
         self.assertEqual([event.event_type for event in result.events], [MOVE_REJECTED])
 
-    def test_move_to_is_rejected_until_1114(self) -> None:
+    def test_move_to_rejects_unknown_target(self) -> None:
         state = make_state()
 
         result = apply_srs_command(
@@ -305,7 +333,147 @@ class SrsEngineMovementTests(unittest.TestCase):
         )
 
         self.assertEqual(result.events[0].event_type, MOVE_REJECTED)
-        self.assertEqual(result.events[0].payload["outcome"], "REJECTED_MOVE_TO_UNIMPLEMENTED")
+        self.assertEqual(result.events[0].payload["outcome"], "REJECTED_UNKNOWN_TARGET")
+        self.assertEqual(result.events[0].payload["target_position"], [4, 7])
+        self.assertEqual(result.events[0].payload["resolved_route"], [])
+        self.assertEqual(result.state, state)
+
+    def test_move_to_rejects_same_position(self) -> None:
+        state = make_state()
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(command_type="MOVE_TO", target=state.player_position),
+            contracts=self.contracts,
+        )
+
+        self.assertEqual(result.events[0].event_type, MOVE_REJECTED)
+        self.assertEqual(result.events[0].payload["outcome"], "REJECTED_SAME_POSITION")
+        self.assertEqual(result.events[0].payload["target_position"], [4, 8])
+        self.assertEqual(result.events[0].payload["resolved_route"], [])
+        self.assertEqual(result.state, state)
+
+    def test_move_to_rejects_out_of_bounds_target(self) -> None:
+        state = make_state()
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(command_type="MOVE_TO", target=Position(-1, 8)),
+            contracts=self.contracts,
+        )
+
+        self.assertEqual(result.events[0].event_type, MOVE_REJECTED)
+        self.assertEqual(result.events[0].payload["outcome"], "REJECTED_OUT_OF_BOUNDS")
+        self.assertEqual(result.events[0].payload["target_position"], [-1, 8])
+        self.assertEqual(result.events[0].payload["resolved_route"], [])
+        self.assertEqual(result.state, state)
+
+    def test_move_to_rejects_no_path(self) -> None:
+        target = Position(4, 6)
+        state = reveal_positions(make_state(), [target])
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(command_type="MOVE_TO", target=target),
+            contracts=self.contracts,
+        )
+
+        self.assertEqual(result.events[0].event_type, MOVE_REJECTED)
+        self.assertEqual(result.events[0].payload["outcome"], "REJECTED_NO_PATH")
+        self.assertEqual(result.events[0].payload["target_position"], [4, 6])
+        self.assertEqual(result.events[0].payload["resolved_route"], [])
+        self.assertEqual(result.state, state)
+
+    def test_move_to_uses_known_cells_bfs_neighbor_order(self) -> None:
+        target = Position(5, 7)
+        state = reveal_positions(
+            make_state(),
+            [
+                Position(4, 7),
+                Position(5, 8),
+                target,
+            ],
+        )
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(command_type="MOVE_TO", target=target),
+            contracts=self.contracts,
+        )
+
+        self.assertEqual(result.events[0].event_type, MOVE_ACCEPTED)
+        self.assertEqual(result.events[0].payload["resolved_route"], ["N", "E"])
+        self.assertEqual(result.events[0].payload["entered_cells"], [[4, 7], [5, 7]])
+
+    def test_move_to_executes_resolved_route(self) -> None:
+        state = reveal_all_for_move_to(make_state())
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(command_type="MOVE_TO", target=Position(4, 6)),
+            contracts=self.contracts,
+        )
+
+        self.assertEqual(result.state.player_position, Position(4, 6))
+        self.assertEqual(result.events[0].event_type, MOVE_ACCEPTED)
+        self.assertEqual(result.events[0].payload["entered_cells"], [[4, 7], [4, 6]])
+        self.assertEqual(result.events[0].payload["movement_raw_cost"], 20)
+
+    def test_move_to_observation_updates_entered_cells(self) -> None:
+        state = reveal_all_for_move_to(make_state())
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(command_type="MOVE_TO", target=Position(4, 6)),
+            contracts=self.contracts,
+        )
+
+        self.assertEqual(
+            [event.event_type for event in result.events],
+            [MOVE_ACCEPTED, OBSERVATION_UPDATED, OBSERVATION_UPDATED],
+        )
+        self.assertEqual(result.events[0].payload["observation_updates"], [[4, 7], [4, 6]])
+        self.assertEqual(result.state.known_state.visited_cells, frozenset({Position(4, 7), Position(4, 6)}))
+
+    def test_move_to_payload_contains_target_and_resolved_route(self) -> None:
+        state = reveal_all_for_move_to(make_state())
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(command_type="MOVE_TO", target=Position(5, 7)),
+            contracts=self.contracts,
+        )
+
+        self.assertEqual(result.events[0].payload["command_type"], "MOVE_TO")
+        self.assertEqual(result.events[0].payload["target_position"], [5, 7])
+        self.assertEqual(result.events[0].payload["resolved_route"], ["N", "E"])
+
+    def test_move_to_budget_stop_uses_resolved_route_prefix(self) -> None:
+        state = reveal_all_for_move_to(make_state())
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(command_type="MOVE_TO", target=Position(4, 3)),
+            contracts=self.contracts,
+        )
+
+        self.assertEqual(result.events[0].event_type, MOVE_ACCEPTED)
+        self.assertEqual(result.events[0].payload["outcome"], "BUDGET_EXHAUSTED")
+        self.assertEqual(result.events[0].payload["resolved_route"], ["N", "N", "N", "N", "N"])
+        self.assertEqual(result.events[0].payload["entered_cells"], [[4, 7], [4, 6], [4, 5], [4, 4]])
+        self.assertEqual(result.state.player_position, Position(4, 4))
+
+    def test_move_to_replaces_1107_unimplemented_reject(self) -> None:
+        state = reveal_all_for_move_to(make_state())
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(command_type="MOVE_TO", target=Position(4, 7)),
+            contracts=self.contracts,
+        )
+
+        self.assertEqual(result.events[0].event_type, MOVE_ACCEPTED)
+        self.assertNotEqual(result.events[0].payload["outcome"], "REJECTED_MOVE_TO_UNIMPLEMENTED")
 
     def test_impassable_star_blocks_movement(self) -> None:
         state = place_object(make_state(), Position(4, 7), SrsObjectType.STAR, "star-blocker")


### PR DESCRIPTION
Closes #1114
Refs #1080

## 概要

Phase 2B4bとして、SRSのMOVE_TO known BFSを実装します。

## 追加内容

- `engine.py`
  - `route_to_known_target(...)`
  - `apply_srs_command(...)` のMOVE_TO実行対応

- `test_engine_movement.py`
  - MOVE_TO unknown target reject
  - MOVE_TO same position reject
  - MOVE_TO out-of-bounds reject
  - MOVE_TO no path reject
  - known cells BFS neighbor order
  - resolved route実行
  - observation update
  - target_position / resolved_route payload
  - budget stop

## 仕様

- MOVE_TO targetはknown_state.discovered_cells内に限定する
- routeはknown cells上のBFSで解決する
- neighbor orderはN/E/S/W
- 解決したrouteは既存MOVE_ROUTE処理へ委譲する
- MOVE_TOもmovement_cost_budget_raw=40に従う
- 成功時はcommand_typeをMOVE_TOとしてevent payloadに記録する
- target_position / resolved_route をpayloadに含める
- reject時はturn/fuel/observation/known/persistentを変更しない

## 確認

```bash
python -m unittest experiments.galactic_exodus.srs.test_engine_movement
python -m unittest experiments.galactic_exodus.srs.test_log
python -m unittest experiments.galactic_exodus.srs.test_observation
python -m unittest experiments.galactic_exodus.srs.test_generate
python -m unittest experiments.galactic_exodus.srs.test_model
python -m unittest experiments.galactic_exodus.srs.test_contracts
```

## 非対象

- SHARED_FUEL
- VECTOR_COMMAND実行
- DIRECTIONAL_THRUST実行
- object interaction
- warp/exit実行
- render
