### PR TITLE
Phase 2B4c: SRS SHARED_FUEL cost modeを実装

### DIFF
--- a/experiments/galactic_exodus/srs/engine.py
+++ b/experiments/galactic_exodus/srs/engine.py
@@ -294,15 +294,18 @@ def apply_srs_command(
     command: SrsCommand,
     *,
     contracts: SrsContracts,
+    cost_mode: CostMode | None = None,
 ) -> SrsCommandResult:
+    resolved_cost_mode = _normalize_cost_mode(cost_mode, contracts=contracts)
     if command.command_type == "MOVE_ROUTE":
-        return _apply_move_route(state, command, contracts=contracts)
+        return _apply_move_route(state, command, contracts=contracts, cost_mode=resolved_cost_mode)
     if command.command_type == "MOVE_TO":
-        return _apply_move_to(state, command, contracts=contracts)
+        return _apply_move_to(state, command, contracts=contracts, cost_mode=resolved_cost_mode)
     return _rejected_command_result(
         state,
         command_type=command.command_type,
         outcome="REJECTED_UNKNOWN_COMMAND",
+        cost_mode=resolved_cost_mode,
     )
 
 
@@ -311,11 +314,13 @@ def run_srs_commands(
     commands: Sequence[SrsCommand],
     *,
     contracts: SrsContracts,
+    cost_mode: CostMode | None = None,
 ) -> SrsCommandResult:
+    resolved_cost_mode = _normalize_cost_mode(cost_mode, contracts=contracts)
     current_state = state
     all_events: list[Any] = []
     for command in commands:
-        result = apply_srs_command(current_state, command, contracts=contracts)
+        result = apply_srs_command(current_state, command, contracts=contracts, cost_mode=resolved_cost_mode)
         current_state = result.state
         all_events.extend(result.events)
     return SrsCommandResult(state=current_state, events=tuple(all_events))
@@ -349,12 +354,14 @@ def _apply_move_route(
     command: SrsCommand,
     *,
     contracts: SrsContracts,
+    cost_mode: CostMode,
 ) -> SrsCommandResult:
     if not all(direction in contracts.movement.directions for direction in command.route):
         return _rejected_command_result(
             state,
             command_type=command.command_type,
             outcome="REJECTED_UNKNOWN_COMMAND",
+            cost_mode=cost_mode,
         )
 
     entered_cells, blocked_position, movement_raw_cost = resolve_move_route(
@@ -367,21 +374,33 @@ def _apply_move_route(
             state,
             command_type=command.command_type,
             outcome="REJECTED_ZERO_STEP",
+            cost_mode=cost_mode,
         )
 
     next_turn = state.srs_turn + _movement_turn_cost(contracts)
+    fuel_before = state.fuel
+    fuel_delta = fuel_delta_for_movement_raw_cost(
+        movement_raw_cost,
+        cost_mode=cost_mode,
+        contracts=contracts,
+    )
+    fuel_after = max(0, fuel_before + fuel_delta)
 
     if not entered_cells:
-        result_state = replace(state, srs_turn=next_turn)
+        result_state = replace(state, srs_turn=next_turn, fuel=fuel_after)
         event = _movement_event(
             srs_turn=next_turn,
             event_type=STOPPED_BEFORE_IMPASSABLE,
             command_type=command.command_type,
+            cost_mode=cost_mode,
             start_position=state.player_position,
             end_position=state.player_position,
             entered_cells=(),
             blocked_position=blocked_position,
             movement_raw_cost=0,
+            fuel_delta=fuel_delta,
+            fuel_before=fuel_before,
+            fuel_after=fuel_after,
             observation_updates=(),
             outcome="STOPPED_BEFORE_IMPASSABLE",
         )
@@ -391,6 +410,7 @@ def _apply_move_route(
         state,
         player_position=entered_cells[-1],
         srs_turn=next_turn,
+        fuel=fuel_after,
     )
     observation_updates: list[Position] = []
     observation_events = []
@@ -421,11 +441,15 @@ def _apply_move_route(
         srs_turn=next_turn,
         event_type=movement_event_type,
         command_type=command.command_type,
+        cost_mode=cost_mode,
         start_position=state.player_position,
         end_position=entered_cells[-1],
         entered_cells=entered_cells,
         blocked_position=blocked_position,
         movement_raw_cost=movement_raw_cost,
+        fuel_delta=fuel_delta,
+        fuel_before=fuel_before,
+        fuel_after=fuel_after,
         observation_updates=tuple(observation_updates),
         outcome=outcome,
     )
@@ -440,6 +464,7 @@ def _apply_move_to(
     command: SrsCommand,
     *,
     contracts: SrsContracts,
+    cost_mode: CostMode,
 ) -> SrsCommandResult:
     target = command.target
     if target is None:
@@ -449,6 +474,7 @@ def _apply_move_to(
             state,
             command_type=command.command_type,
             outcome="REJECTED_OUT_OF_BOUNDS",
+            cost_mode=cost_mode,
             target_position=target,
             resolved_route=(),
         )
@@ -457,6 +483,7 @@ def _apply_move_to(
             state,
             command_type=command.command_type,
             outcome="REJECTED_SAME_POSITION",
+            cost_mode=cost_mode,
             target_position=target,
             resolved_route=(),
         )
@@ -465,6 +492,7 @@ def _apply_move_to(
             state,
             command_type=command.command_type,
             outcome="REJECTED_UNKNOWN_TARGET",
+            cost_mode=cost_mode,
             target_position=target,
             resolved_route=(),
         )
@@ -476,6 +504,7 @@ def _apply_move_to(
             state,
             command_type=command.command_type,
             outcome="REJECTED_NO_PATH",
+            cost_mode=cost_mode,
             target_position=target,
             resolved_route=(),
         )
@@ -484,6 +513,7 @@ def _apply_move_to(
         state,
         SrsCommand(command_type="MOVE_ROUTE", route=route),
         contracts=contracts,
+        cost_mode=cost_mode,
     )
     movement_event = _override_move_to_event(
         result.events[0],
@@ -501,6 +531,7 @@ def _rejected_command_result(
     *,
     command_type: str,
     outcome: str,
+    cost_mode: CostMode,
     target_position: Position | None = None,
     resolved_route: Sequence[Direction] | None = None,
 ) -> SrsCommandResult:
@@ -508,11 +539,15 @@ def _rejected_command_result(
         srs_turn=state.srs_turn,
         event_type=MOVE_REJECTED,
         command_type=command_type,
+        cost_mode=cost_mode,
         start_position=state.player_position,
         end_position=state.player_position,
         entered_cells=(),
         blocked_position=None,
         movement_raw_cost=0,
+        fuel_delta=0,
+        fuel_before=state.fuel,
+        fuel_after=state.fuel,
         observation_updates=(),
         outcome=outcome,
         target_position=target_position,
@@ -526,11 +561,15 @@ def _movement_event(
     srs_turn: int,
     event_type: str,
     command_type: str,
+    cost_mode: CostMode,
     start_position: Position,
     end_position: Position,
     entered_cells: Sequence[Position],
     blocked_position: Position | None,
     movement_raw_cost: int,
+    fuel_delta: int,
+    fuel_before: int,
+    fuel_after: int,
     observation_updates: Sequence[Position],
     outcome: str,
     target_position: Position | None = None,
@@ -539,13 +578,15 @@ def _movement_event(
     payload = {
         "command_type": command_type,
         "movement_rule": MovementRule.MOVEMENT_POINTS.value,
-        "cost_mode": CostMode.TURN_ONLY.value,
+        "cost_mode": cost_mode.value,
         "start_position": _position_to_list(start_position),
         "end_position": _position_to_list(end_position),
         "entered_cells": [_position_to_list(position) for position in entered_cells],
         "blocked_position": None if blocked_position is None else _position_to_list(blocked_position),
         "movement_raw_cost": movement_raw_cost,
-        "fuel_delta": 0,
+        "fuel_delta": fuel_delta,
+        "fuel_before": fuel_before,
+        "fuel_after": fuel_after,
         "observation_updates": [_position_to_list(position) for position in observation_updates],
         "outcome": outcome,
     }
@@ -577,6 +618,47 @@ def _movement_turn_cost(contracts: SrsContracts) -> int:
     if not isinstance(turn_cost, int) or isinstance(turn_cost, bool) or turn_cost <= 0:
         raise SrsMovementError("movement_turn_cost must be a positive integer")
     return turn_cost
+
+
+def fuel_delta_for_movement_raw_cost(
+    movement_raw_cost: int,
+    *,
+    cost_mode: CostMode,
+    contracts: SrsContracts,
+) -> int:
+    if not isinstance(movement_raw_cost, int) or isinstance(movement_raw_cost, bool):
+        raise SrsMovementError("movement_raw_cost must be an integer")
+    if movement_raw_cost < 0:
+        raise SrsMovementError("movement_raw_cost must be non-negative")
+    if cost_mode is CostMode.TURN_ONLY or movement_raw_cost == 0:
+        return 0
+    if cost_mode is not CostMode.SHARED_FUEL:
+        raise SrsMovementError(f"unsupported cost mode: {cost_mode}")
+
+    denominator = _movement_raw_cost_denominator(contracts)
+    return -((movement_raw_cost + denominator - 1) // denominator)
+
+
+def _normalize_cost_mode(
+    cost_mode: CostMode | None,
+    *,
+    contracts: SrsContracts,
+) -> CostMode:
+    raw_cost_mode = contracts.movement.baseline_cost_mode if cost_mode is None else cost_mode
+    try:
+        normalized = CostMode(raw_cost_mode)
+    except ValueError as exc:
+        raise SrsMovementError(f"unsupported cost mode: {raw_cost_mode}") from exc
+    if normalized not in {CostMode.TURN_ONLY, CostMode.SHARED_FUEL}:
+        raise SrsMovementError(f"unsupported cost mode: {raw_cost_mode}")
+    return normalized
+
+
+def _movement_raw_cost_denominator(contracts: SrsContracts) -> int:
+    denominator = contracts.movement.orthogonal_raw_cost
+    if not isinstance(denominator, int) or isinstance(denominator, bool) or denominator <= 0:
+        raise SrsMovementError("raw_cost_denominator must be a positive integer")
+    return denominator
 
 
 def _reconstruct_route(

--- a/experiments/galactic_exodus/srs/test_engine_movement.py
+++ b/experiments/galactic_exodus/srs/test_engine_movement.py
@@ -6,7 +6,13 @@ from pathlib import Path
 from typing import Iterable
 
 from experiments.galactic_exodus.srs.contracts import load_default_contracts
-from experiments.galactic_exodus.srs.engine import apply_srs_command, reveal_full_observation, run_srs_commands
+from experiments.galactic_exodus.srs.engine import (
+    SrsMovementError,
+    apply_srs_command,
+    fuel_delta_for_movement_raw_cost,
+    reveal_full_observation,
+    run_srs_commands,
+)
 from experiments.galactic_exodus.srs.generate import create_sector
 from experiments.galactic_exodus.srs.log import (
     MOVE_ACCEPTED,
@@ -15,6 +21,7 @@ from experiments.galactic_exodus.srs.log import (
     STOPPED_BEFORE_IMPASSABLE,
 )
 from experiments.galactic_exodus.srs.model import (
+    CostMode,
     Direction,
     Position,
     SectorDescriptor,
@@ -180,6 +187,48 @@ class SrsEngineMovementTests(unittest.TestCase):
 
         self.assertEqual(result.state.fuel, 7)
         self.assertEqual(result.events[0].payload["fuel_delta"], 0)
+        self.assertEqual(result.events[0].payload["fuel_before"], 7)
+        self.assertEqual(result.events[0].payload["fuel_after"], 7)
+
+    def test_fuel_delta_for_turn_only_is_zero(self) -> None:
+        self.assertEqual(
+            fuel_delta_for_movement_raw_cost(
+                40,
+                cost_mode=CostMode.TURN_ONLY,
+                contracts=self.contracts,
+            ),
+            0,
+        )
+
+    def test_fuel_delta_for_shared_fuel_uses_ceil_raw_cost_div_denominator(self) -> None:
+        expectations = {
+            0: 0,
+            1: -1,
+            10: -1,
+            11: -2,
+            20: -2,
+            30: -3,
+            40: -4,
+        }
+
+        for movement_raw_cost, expected_delta in expectations.items():
+            with self.subTest(movement_raw_cost=movement_raw_cost):
+                self.assertEqual(
+                    fuel_delta_for_movement_raw_cost(
+                        movement_raw_cost,
+                        cost_mode=CostMode.SHARED_FUEL,
+                        contracts=self.contracts,
+                    ),
+                    expected_delta,
+                )
+
+    def test_fuel_delta_rejects_negative_raw_cost(self) -> None:
+        with self.assertRaisesRegex(SrsMovementError, "movement_raw_cost must be non-negative"):
+            fuel_delta_for_movement_raw_cost(
+                -1,
+                cost_mode=CostMode.SHARED_FUEL,
+                contracts=self.contracts,
+            )
 
     def test_move_route_executes_longest_prefix_within_budget(self) -> None:
         state = make_state()
@@ -251,6 +300,65 @@ class SrsEngineMovementTests(unittest.TestCase):
         self.assertEqual(result.events[0].payload["movement_raw_cost"], 0)
         self.assertEqual(result.events[0].payload["observation_updates"], [])
 
+    def test_turn_only_payload_contains_fuel_before_and_after(self) -> None:
+        state = make_state(fuel=2, max_fuel=9)
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(command_type="MOVE_ROUTE", route=(Direction.N, Direction.N, Direction.N, Direction.N)),
+            contracts=self.contracts,
+            cost_mode=CostMode.TURN_ONLY,
+        )
+
+        self.assertEqual(result.events[0].payload["cost_mode"], "TURN_ONLY")
+        self.assertEqual(result.events[0].payload["movement_raw_cost"], 40)
+        self.assertEqual(result.events[0].payload["fuel_delta"], 0)
+        self.assertEqual(result.events[0].payload["fuel_before"], 2)
+        self.assertEqual(result.events[0].payload["fuel_after"], 2)
+
+    def test_shared_fuel_consumes_ceil_raw_cost_div_10(self) -> None:
+        state = make_state(fuel=7, max_fuel=9)
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(command_type="MOVE_ROUTE", route=(Direction.N, Direction.N, Direction.N, Direction.N)),
+            contracts=self.contracts,
+            cost_mode=CostMode.SHARED_FUEL,
+        )
+
+        self.assertEqual(result.state.fuel, 3)
+        self.assertEqual(result.events[0].payload["cost_mode"], "SHARED_FUEL")
+        self.assertEqual(result.events[0].payload["movement_raw_cost"], 40)
+        self.assertEqual(result.events[0].payload["fuel_delta"], -4)
+        self.assertEqual(result.events[0].payload["fuel_before"], 7)
+        self.assertEqual(result.events[0].payload["fuel_after"], 3)
+
+    def test_shared_fuel_clamps_state_fuel_to_zero(self) -> None:
+        state = make_state(fuel=2, max_fuel=9)
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(command_type="MOVE_ROUTE", route=(Direction.N, Direction.N, Direction.N, Direction.N)),
+            contracts=self.contracts,
+            cost_mode=CostMode.SHARED_FUEL,
+        )
+
+        self.assertEqual(result.state.fuel, 0)
+
+    def test_shared_fuel_payload_keeps_rule_delta_even_when_clamped(self) -> None:
+        state = make_state(fuel=2, max_fuel=9)
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(command_type="MOVE_ROUTE", route=(Direction.N, Direction.N, Direction.N, Direction.N)),
+            contracts=self.contracts,
+            cost_mode=CostMode.SHARED_FUEL,
+        )
+
+        self.assertEqual(result.events[0].payload["fuel_before"], 2)
+        self.assertEqual(result.events[0].payload["fuel_delta"], -4)
+        self.assertEqual(result.events[0].payload["fuel_after"], 0)
+
     def test_stop_before_after_partial_movement(self) -> None:
         state = place_object(make_state(), Position(4, 5), SrsObjectType.STAR, "star-blocker")
 
@@ -268,6 +376,48 @@ class SrsEngineMovementTests(unittest.TestCase):
         self.assertEqual(result.events[0].payload["blocked_position"], [4, 5])
         self.assertEqual(result.events[0].payload["movement_raw_cost"], 20)
 
+    def test_shared_fuel_first_blocked_cell_costs_zero_fuel(self) -> None:
+        state = replace_cell_terrain(
+            make_state(
+                sector_type=SectorType.RIFT,
+                entry_edge=Direction.S,
+                blocked_edges=frozenset({Direction.N}),
+                fuel=5,
+                max_fuel=9,
+            ),
+            Position(4, 7),
+            SrsTerrainType.RIFT_BARRIER,
+        )
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(command_type="MOVE_ROUTE", route=(Direction.N,)),
+            contracts=self.contracts,
+            cost_mode=CostMode.SHARED_FUEL,
+        )
+
+        self.assertEqual(result.state.fuel, 5)
+        self.assertEqual(result.events[0].payload["movement_raw_cost"], 0)
+        self.assertEqual(result.events[0].payload["fuel_delta"], 0)
+        self.assertEqual(result.events[0].payload["fuel_before"], 5)
+        self.assertEqual(result.events[0].payload["fuel_after"], 5)
+
+    def test_shared_fuel_partial_blocked_counts_passable_cells_only(self) -> None:
+        state = place_object(make_state(fuel=5, max_fuel=9), Position(4, 5), SrsObjectType.STAR, "star-blocker")
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(command_type="MOVE_ROUTE", route=(Direction.N, Direction.N, Direction.N, Direction.N)),
+            contracts=self.contracts,
+            cost_mode=CostMode.SHARED_FUEL,
+        )
+
+        self.assertEqual(result.state.fuel, 3)
+        self.assertEqual(result.events[0].event_type, STOPPED_BEFORE_IMPASSABLE)
+        self.assertEqual(result.events[0].payload["movement_raw_cost"], 20)
+        self.assertEqual(result.events[0].payload["fuel_delta"], -2)
+        self.assertEqual(result.events[0].payload["fuel_after"], 3)
+
     def test_budget_stop_is_move_accepted_not_blocked(self) -> None:
         state = make_state()
 
@@ -283,6 +433,24 @@ class SrsEngineMovementTests(unittest.TestCase):
         self.assertEqual(result.events[0].event_type, MOVE_ACCEPTED)
         self.assertIsNone(result.events[0].payload["blocked_position"])
         self.assertEqual(result.events[0].payload["outcome"], "BUDGET_EXHAUSTED")
+
+    def test_shared_fuel_budget_stop_counts_executed_prefix_only(self) -> None:
+        state = make_state(fuel=6, max_fuel=9)
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(
+                command_type="MOVE_ROUTE",
+                route=(Direction.N, Direction.N, Direction.N, Direction.N, Direction.W),
+            ),
+            contracts=self.contracts,
+            cost_mode=CostMode.SHARED_FUEL,
+        )
+
+        self.assertEqual(result.state.fuel, 2)
+        self.assertEqual(result.events[0].payload["movement_raw_cost"], 40)
+        self.assertEqual(result.events[0].payload["fuel_delta"], -4)
+        self.assertEqual(result.events[0].payload["fuel_after"], 2)
 
     def test_successful_steps_update_observation(self) -> None:
         state = make_state()
@@ -322,6 +490,22 @@ class SrsEngineMovementTests(unittest.TestCase):
         self.assertEqual(result.state, state)
         self.assertEqual(len(result.state.known_state.discovered_cells), 0)
         self.assertEqual([event.event_type for event in result.events], [MOVE_REJECTED])
+
+    def test_shared_fuel_rejected_command_does_not_change_fuel(self) -> None:
+        state = make_state(fuel=5, max_fuel=9)
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(command_type="INTERACT"),
+            contracts=self.contracts,
+            cost_mode=CostMode.SHARED_FUEL,
+        )
+
+        self.assertEqual(result.state.fuel, 5)
+        self.assertEqual(result.events[0].payload["cost_mode"], "SHARED_FUEL")
+        self.assertEqual(result.events[0].payload["fuel_delta"], 0)
+        self.assertEqual(result.events[0].payload["fuel_before"], 5)
+        self.assertEqual(result.events[0].payload["fuel_after"], 5)
 
     def test_move_to_rejects_unknown_target(self) -> None:
         state = make_state()
@@ -419,6 +603,23 @@ class SrsEngineMovementTests(unittest.TestCase):
         self.assertEqual(result.events[0].payload["entered_cells"], [[4, 7], [4, 6]])
         self.assertEqual(result.events[0].payload["movement_raw_cost"], 20)
 
+    def test_shared_fuel_move_to_uses_resolved_route_cost(self) -> None:
+        state = reveal_all_for_move_to(make_state(fuel=6, max_fuel=9))
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(command_type="MOVE_TO", target=Position(4, 6)),
+            contracts=self.contracts,
+            cost_mode=CostMode.SHARED_FUEL,
+        )
+
+        self.assertEqual(result.state.fuel, 4)
+        self.assertEqual(result.events[0].payload["command_type"], "MOVE_TO")
+        self.assertEqual(result.events[0].payload["resolved_route"], ["N", "N"])
+        self.assertEqual(result.events[0].payload["movement_raw_cost"], 20)
+        self.assertEqual(result.events[0].payload["fuel_delta"], -2)
+        self.assertEqual(result.events[0].payload["fuel_after"], 4)
+
     def test_move_to_observation_updates_entered_cells(self) -> None:
         state = reveal_all_for_move_to(make_state())
 
@@ -504,6 +705,26 @@ class SrsEngineMovementTests(unittest.TestCase):
             [event.event_type for event in result.events],
             [MOVE_ACCEPTED, OBSERVATION_UPDATED, MOVE_REJECTED],
         )
+
+    def test_run_srs_commands_passes_shared_fuel_to_each_command(self) -> None:
+        state = make_state(fuel=8, max_fuel=9)
+
+        result = run_srs_commands(
+            state,
+            (
+                SrsCommand(command_type="MOVE_ROUTE", route=(Direction.N, Direction.N)),
+                SrsCommand(command_type="INTERACT"),
+            ),
+            contracts=self.contracts,
+            cost_mode=CostMode.SHARED_FUEL,
+        )
+
+        self.assertEqual(result.state.fuel, 6)
+        self.assertEqual(result.events[0].payload["cost_mode"], "SHARED_FUEL")
+        self.assertEqual(result.events[0].payload["fuel_delta"], -2)
+        self.assertEqual(result.events[-1].payload["cost_mode"], "SHARED_FUEL")
+        self.assertEqual(result.events[-1].payload["fuel_before"], 6)
+        self.assertEqual(result.events[-1].payload["fuel_after"], 6)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #1115
Refs #1080

## 概要

Phase 2B4cとして、SRSのSHARED_FUEL cost modeを実装します。

## 追加内容

- `engine.py`
  - `fuel_delta_for_movement_raw_cost(...)`
  - `apply_srs_command(..., cost_mode=...)`
  - `run_srs_commands(..., cost_mode=...)`
  - movement result payloadの `fuel_before` / `fuel_after`

- `test_engine_movement.py`
  - TURN_ONLY互換
  - SHARED_FUEL fuel delta
  - fuel clamp
  - first blocked / partial blocked / budget stop
  - rejected command
  - MOVE_ROUTE / MOVE_TO
  - run_srs_commands

## 仕様

- cost_mode未指定時はbaseline cost modeを使う
- TURN_ONLYはfuelを消費しない
- SHARED_FUELはceil(movement_raw_cost / 10)を消費する
- state.fuelは0未満にしない
- payloadのfuel_deltaはclamp前のルールdeltaを保持する
- MOVE_ROUTE / MOVE_TO の両方でSHARED_FUELを適用する
- rejected commandではfuelを変更しない
- movement result payloadにfuel_before / fuel_afterを含める

## 確認

```bash
python -m unittest experiments.galactic_exodus.srs.test_engine_movement
python -m unittest experiments.galactic_exodus.srs.test_log
python -m unittest experiments.galactic_exodus.srs.test_observation
python -m unittest experiments.galactic_exodus.srs.test_generate
python -m unittest experiments.galactic_exodus.srs.test_model
python -m unittest experiments.galactic_exodus.srs.test_contracts
```

## 非対象

- VECTOR_COMMAND実行
- DIRECTIONAL_THRUST実行
- object interaction
- warp/exit実行
- render
