### PR TITLE
Phase 2B4d: RESOURCE_CACHE回復量metadataを生成時に確定

### DIFF
--- a/experiments/galactic_exodus/srs/fixtures/resource_minimal_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/resource_minimal_9x9.json
@@ -24,6 +24,11 @@
       "RESOURCE_CACHE": 1,
       "STAR": 1
     },
+    "object_metadata": {
+      "resource-cache-1": {
+        "fuel_restore": 5
+      }
+    },
     "known_discovered_count": 0
   }
 }

--- a/experiments/galactic_exodus/srs/generate.py
+++ b/experiments/galactic_exodus/srs/generate.py
@@ -44,6 +44,20 @@ SECTOR_EXTRA_OBJECTS = {
 }
 
 
+def resource_cache_restore_values(cache_count: int) -> tuple[int, ...]:
+    if cache_count < 0:
+        raise SrsGenerationError("resource cache count must be non-negative")
+    if cache_count == 0:
+        return ()
+    if cache_count == 1:
+        return (5,)
+    if cache_count == 2:
+        return (3, 2)
+    if cache_count == 3:
+        return (2, 2, 1)
+    raise SrsGenerationError("resource sectors support at most 3 resource caches")
+
+
 def create_sector(
     descriptor: SectorDescriptor,
     *,
@@ -173,7 +187,27 @@ def _place_objects(
             object_type=object_type,
             position=position,
         )
+    _assign_resource_cache_metadata(objects)
     return objects
+
+
+def _assign_resource_cache_metadata(objects: dict[str, SrsObjectState]) -> None:
+    resource_cache_ids = sorted(
+        object_id
+        for object_id, state in objects.items()
+        if state.object_type is SrsObjectType.RESOURCE_CACHE
+    )
+    restore_values = resource_cache_restore_values(len(resource_cache_ids))
+    for object_id, fuel_restore in zip(resource_cache_ids, restore_values, strict=True):
+        resource_cache = objects[object_id]
+        objects[object_id] = SrsObjectState(
+            object_id=resource_cache.object_id,
+            object_type=resource_cache.object_type,
+            position=resource_cache.position,
+            consumed=resource_cache.consumed,
+            activated=resource_cache.activated,
+            metadata={"fuel_restore": fuel_restore},
+        )
 
 
 def _collect_object_candidates(

--- a/experiments/galactic_exodus/srs/test_generate.py
+++ b/experiments/galactic_exodus/srs/test_generate.py
@@ -7,7 +7,12 @@ from pathlib import Path
 from typing import Any
 
 from experiments.galactic_exodus.srs.contracts import load_default_contracts
-from experiments.galactic_exodus.srs.generate import EDGE_POSITIONS, SrsGenerationError, create_sector
+from experiments.galactic_exodus.srs.generate import (
+    EDGE_POSITIONS,
+    SrsGenerationError,
+    create_sector,
+    resource_cache_restore_values,
+)
 from experiments.galactic_exodus.srs.model import (
     Direction,
     Position,
@@ -39,6 +44,11 @@ def summarize_state(state: SrsGameState) -> dict[str, Any]:
         object_id: [object_state.position.x, object_state.position.y]
         for object_id, object_state in sorted(state.objects.items())
     }
+    object_metadata = {
+        object_id: dict(object_state.metadata)
+        for object_id, object_state in sorted(state.objects.items())
+        if object_state.metadata
+    }
     return {
         "width": state.actual_map.width,
         "height": state.actual_map.height,
@@ -50,6 +60,7 @@ def summarize_state(state: SrsGameState) -> dict[str, Any]:
         "terrain_counts": dict(sorted(terrain_counts.items())),
         "object_counts": dict(sorted(object_counts.items())),
         "object_positions": object_positions,
+        "object_metadata": object_metadata,
         "blocked_warp_positions": [
             f"{position.x},{position.y}"
             for direction, position in sorted(
@@ -200,6 +211,41 @@ class SrsGenerateTests(unittest.TestCase):
         )
 
         self.assertEqual(summarize_state(state)["object_counts"]["RESOURCE_CACHE"], 1)
+
+    def test_resource_cache_has_fuel_restore_metadata(self) -> None:
+        state = create_sector(
+            SectorDescriptor("resource-1", SectorType.RESOURCE, 3001, Direction.S),
+            contracts=self.contracts,
+        )
+
+        resource_cache = state.objects["resource-cache-1"]
+        self.assertEqual(resource_cache.metadata["fuel_restore"], 5)
+
+    def test_resource_cache_one_cache_restore_is_5(self) -> None:
+        self.assertEqual(resource_cache_restore_values(1), (5,))
+
+    def test_resource_cache_two_cache_restore_split_is_3_2(self) -> None:
+        self.assertEqual(resource_cache_restore_values(2), (3, 2))
+
+    def test_resource_cache_three_cache_restore_split_is_2_2_1(self) -> None:
+        self.assertEqual(resource_cache_restore_values(3), (2, 2, 1))
+
+    def test_resource_cache_restore_metadata_is_positive_int(self) -> None:
+        state = create_sector(
+            SectorDescriptor("resource-1", SectorType.RESOURCE, 3001, Direction.S),
+            contracts=self.contracts,
+        )
+
+        fuel_restore = state.objects["resource-cache-1"].metadata["fuel_restore"]
+        self.assertIs(type(fuel_restore), int)
+        self.assertGreater(fuel_restore, 0)
+
+    def test_resource_cache_restore_values_zero_caches_returns_empty(self) -> None:
+        self.assertEqual(resource_cache_restore_values(0), ())
+
+    def test_resource_cache_restore_values_rejects_more_than_three(self) -> None:
+        with self.assertRaisesRegex(SrsGenerationError, "at most 3"):
+            resource_cache_restore_values(4)
 
     def test_rift_has_one_salvage(self) -> None:
         state = create_sector(

--- a/experiments/galactic_exodus/srs/test_model.py
+++ b/experiments/galactic_exodus/srs/test_model.py
@@ -183,6 +183,18 @@ class SrsModelTests(unittest.TestCase):
                 objects={},
             )
 
+    def test_object_state_freezes_metadata(self) -> None:
+        resource_cache = SrsObjectState(
+            object_id="resource-cache-1",
+            object_type=SrsObjectType.RESOURCE_CACHE,
+            position=Position(1, 2),
+            metadata={"fuel_restore": 5},
+        )
+
+        self.assertEqual(resource_cache.metadata["fuel_restore"], 5)
+        with self.assertRaises(TypeError):
+            resource_cache.metadata["fuel_restore"] = 4
+
     def test_known_state_freezes_known_cells(self) -> None:
         state = SrsKnownState(
             discovered_cells={Position(0, 0)},


### PR DESCRIPTION
Closes #1119
Refs #1080
Refs #1108

## 概要

- RESOURCE_CACHE の回復量分配 helper を追加し、生成時に `metadata["fuel_restore"]` を確定するようにした
- RESOURCE sector の fixture に `fuel_restore` metadata を追加した
- 生成ロジック、分配ルール、metadata freeze 契約をテストで補強した

## 確認

- `python -m unittest experiments.galactic_exodus.srs.test_generate`
- `python -m unittest experiments.galactic_exodus.srs.test_model`
- `python -m unittest experiments.galactic_exodus.srs.test_contracts`
