### PR TITLE
SRS known renderにspaced表示を追加

### DIFF
--- a/experiments/galactic_exodus/srs/__init__.py
+++ b/experiments/galactic_exodus/srs/__init__.py
@@ -5,16 +5,19 @@ __all__ = [
     "SrsFixtureRunResult",
     "fixture_result_to_jsonable",
     "render_known_map",
+    "render_known_map_spaced",
     "run_fixture",
     "run_fixture_data",
 ]
 
 
 def __getattr__(name: str):
-    if name == "render_known_map":
-        from experiments.galactic_exodus.srs.render import render_known_map
+    if name in {"render_known_map", "render_known_map_spaced"}:
+        from importlib import import_module
 
-        return render_known_map
+        render_module = import_module("experiments.galactic_exodus.srs.render")
+
+        return getattr(render_module, name)
     if name in {
         "SrsFixtureError",
         "SrsFixtureRunResult",

--- a/experiments/galactic_exodus/srs/render.py
+++ b/experiments/galactic_exodus/srs/render.py
@@ -39,13 +39,21 @@ _WARP_SYMBOLS = {
 
 
 def render_known_map(state: SrsGameState) -> str:
+    return _render_known_map(state, cell_separator="")
+
+
+def render_known_map_spaced(state: SrsGameState) -> str:
+    return _render_known_map(state, cell_separator=" ")
+
+
+def _render_known_map(state: SrsGameState, *, cell_separator: str) -> str:
     rows: list[str] = []
     for y in range(state.actual_map.height):
         chars: list[str] = []
         for x in range(state.actual_map.width):
             position = Position(x, y)
             chars.append(_render_position(state, position))
-        rows.append("".join(chars))
+        rows.append(cell_separator.join(chars))
     return "\n".join(rows)
 
 

--- a/experiments/galactic_exodus/srs/test_render.py
+++ b/experiments/galactic_exodus/srs/test_render.py
@@ -4,7 +4,7 @@ import unittest
 from dataclasses import replace
 
 from experiments.galactic_exodus.srs.model import Direction, Position, SrsCell, SrsObjectType, SrsTerrainType
-from experiments.galactic_exodus.srs.render import render_known_map
+from experiments.galactic_exodus.srs.render import render_known_map, render_known_map_spaced
 from experiments.galactic_exodus.srs.test_engine_movement import make_state, place_object, reveal_positions, replace_cell_terrain
 
 
@@ -106,3 +106,13 @@ class SrsRenderTests(unittest.TestCase):
         rendered = render_known_map(state)
 
         self.assertEqual([len(row) for row in rendered.splitlines()], [9] * 9)
+
+    def test_spaced_known_render_inserts_single_spaces_between_cells(self) -> None:
+        state = reveal_positions(make_state(), [Position(x, 8) for x in range(9)])
+
+        rendered = render_known_map_spaced(state)
+
+        lines = rendered.splitlines()
+        self.assertEqual(lines[0], "? ? ? ? ? ? ? ? ?")
+        self.assertEqual(lines[8], ". . . . @ . . . .")
+        self.assertEqual([len(row) for row in lines], [17] * 9)


### PR DESCRIPTION
## Summary

- Add `render_known_map_spaced(...)` for manual SRS evaluation.
- Keep existing `render_known_map(...)` compact output unchanged for fixture regression compatibility.
- Export the new renderer and add unit coverage for row width and spacing.

## Test

- Not run locally. Changes were made through GitHub connector only.

Related to #1081