### PR TITLE
SRS手動評価mapで足元記号と自機を両立表示

### DIFF
--- a/experiments/galactic_exodus/srs/run_manual_eval.py
+++ b/experiments/galactic_exodus/srs/run_manual_eval.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import argparse
 import re
+from dataclasses import replace
 from datetime import datetime
 from pathlib import Path
 from typing import Iterable, Mapping, Sequence
 
+from experiments.galactic_exodus.srs.model import Position, SrsGameState
 from experiments.galactic_exodus.srs.render import render_known_map_spaced
 from experiments.galactic_exodus.srs.run_fixture import FIXTURES_DIR, SrsFixtureRunResult, run_fixture
 
@@ -41,7 +43,7 @@ MAP_LEGEND = (
     ("r", "資源/消費済み"),
     ("$", "salvage/未回収"),
     ("s", "salvage/回収済み"),
-    ("@", "現在位置"),
+    ("@", "現在位置（重要記号と重なる場合は隣接空白へ表示）"),
     ("^", "北warp"),
     (">", "東warp"),
     ("v", "南warp"),
@@ -237,6 +239,59 @@ def _event_summary_text(result: SrsFixtureRunResult) -> str:
     return "\n".join(f"- {line}" for line in lines)
 
 
+def _render_known_map_spaced_for_manual_eval(state: SrsGameState) -> str:
+    render = render_known_map_spaced(state)
+    player = state.player_position
+    if not state.actual_map.contains(player):
+        return render
+
+    hidden_player_state = replace(state, player_position=Position(-1, -1))
+    underlay_rows = render_known_map_spaced(hidden_player_state).splitlines()
+    if not (0 <= player.y < len(underlay_rows)):
+        return render
+
+    player_row = underlay_rows[player.y]
+    player_cell_index = player.x * 2
+    if not (0 <= player_cell_index < len(player_row)):
+        return render
+
+    under_player = player_row[player_cell_index]
+    if under_player in {"?", "."}:
+        return render
+
+    row_chars = list(player_row)
+    if player.x < state.actual_map.width - 1:
+        row_chars[player_cell_index + 1] = "@"
+    elif player.x > 0:
+        row_chars[player_cell_index - 1] = "@"
+    else:
+        row_chars.append("@")
+
+    underlay_rows[player.y] = "".join(row_chars)
+    return "\n".join(underlay_rows)
+
+
+def _player_cell_text(state: SrsGameState) -> str:
+    player = state.player_position
+    if not state.actual_map.contains(player):
+        return f"- position=({player.x},{player.y}), out_of_bounds=True"
+
+    cell = state.actual_map.cell_at(player)
+    details = [f"position=({player.x},{player.y})", f"terrain={cell.terrain.value}"]
+
+    if cell.warp_flags:
+        warp = "".join(direction.value for direction in sorted(cell.warp_flags, key=lambda direction: direction.value))
+        details.append(f"warp={warp}")
+
+    if cell.object_id is not None:
+        object_state = state.objects[cell.object_id]
+        details.append(f"object={object_state.object_type.value}")
+        details.append(f"consumed={str(object_state.consumed).lower()}")
+        details.append(f"activated={str(object_state.activated).lower()}")
+
+    return "- " + ", ".join(details)
+
+
 def _print_case(result: SrsFixtureRunResult) -> None:
     print("\n" + "=" * 80)
     print(result.fixture_id)
@@ -248,8 +303,10 @@ def _print_case(result: SrsFixtureRunResult) -> None:
     print(_event_summary_text(result))
     print("\nmap legend:")
     print(_map_legend_text())
+    print("\nplayer cell:")
+    print(_player_cell_text(result.final_state))
     print("\nknown map:")
-    print(render_known_map_spaced(result.final_state))
+    print(_render_known_map_spaced_for_manual_eval(result.final_state))
     print("=" * 80)
 
 
@@ -265,8 +322,9 @@ def _write_header(path: Path, fixture_paths: tuple[Path, ...]) -> None:
         "# SRS Manual Evaluation",
         "",
         f"- created_at: {datetime.now().isoformat(timespec='seconds')}",
-        "- renderer: render_known_map_spaced",
+        "- renderer: manual-eval overlay over render_known_map_spaced",
         "- note: compact render / JSON API は fixture regression 用に維持する",
+        "- note: 重要記号と現在位置が重なる場合、足元記号を残して `@` を隣接空白へ表示する",
         "",
         "## 判定基準",
         "",
@@ -311,7 +369,7 @@ def _append_case_result(
     status: str,
     answers: Mapping[str, str],
 ) -> None:
-    render = render_known_map_spaced(result.final_state)
+    render = _render_known_map_spaced_for_manual_eval(result.final_state)
     section = f"""
 ## {result.fixture_id}
 
@@ -326,6 +384,10 @@ def _append_case_result(
 ### event summary
 
 {_event_summary_text(result)}
+
+### player cell
+
+{_player_cell_text(result.final_state)}
 
 ### known map
 

--- a/experiments/galactic_exodus/srs/test_run_manual_eval.py
+++ b/experiments/galactic_exodus/srs/test_run_manual_eval.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import unittest
+from dataclasses import replace
+
+from experiments.galactic_exodus.srs.model import Direction, Position, SrsObjectType, SrsTerrainType
+from experiments.galactic_exodus.srs.run_manual_eval import _player_cell_text, _render_known_map_spaced_for_manual_eval
+from experiments.galactic_exodus.srs.test_engine_movement import make_state, place_object, reveal_positions, replace_cell_terrain
+
+
+class SrsRunManualEvalTests(unittest.TestCase):
+    def test_manual_eval_render_keeps_player_on_floor_cell(self) -> None:
+        state = replace(make_state(), player_position=Position(4, 7))
+        state = reveal_positions(state, [Position(x, 7) for x in range(9)])
+
+        rendered = _render_known_map_spaced_for_manual_eval(state)
+
+        self.assertEqual(rendered.splitlines()[7], ". . . . @ . . . .")
+
+    def test_manual_eval_render_shows_player_beside_warp_symbol(self) -> None:
+        state = reveal_positions(make_state(), [Position(4, 8)])
+
+        rendered = _render_known_map_spaced_for_manual_eval(state)
+
+        self.assertEqual(rendered.splitlines()[8], "? ? ? ? v@? ? ? ?")
+
+    def test_manual_eval_render_shows_player_beside_salvage_symbol(self) -> None:
+        state = place_object(make_state(), Position(4, 6), SrsObjectType.SALVAGE, "salvage-a")
+        state = replace(state, player_position=Position(4, 6))
+        state = replace(
+            state,
+            objects={
+                **state.objects,
+                "salvage-a": replace(state.objects["salvage-a"], consumed=True),
+            },
+        )
+        state = reveal_positions(state, [Position(4, 6)])
+
+        rendered = _render_known_map_spaced_for_manual_eval(state)
+
+        self.assertEqual(rendered.splitlines()[6], "? ? ? ? s@? ? ? ?")
+
+    def test_manual_eval_render_uses_left_space_at_right_edge(self) -> None:
+        state = reveal_positions(make_state(entry_edge=Direction.E), [Position(8, 4)])
+
+        rendered = _render_known_map_spaced_for_manual_eval(state)
+
+        self.assertEqual(rendered.splitlines()[4], "? ? ? ? ? ? ? ?@>")
+
+    def test_player_cell_text_includes_object_and_warp_details(self) -> None:
+        state = place_object(make_state(), Position(4, 8), SrsObjectType.SALVAGE, "salvage-a")
+        state = replace(
+            state,
+            objects={
+                **state.objects,
+                "salvage-a": replace(state.objects["salvage-a"], consumed=True),
+            },
+        )
+        state = replace_cell_terrain(state, Position(4, 8), SrsTerrainType.RIFT_BARRIER)
+        state = reveal_positions(state, [Position(4, 8)])
+
+        text = _player_cell_text(state)
+
+        self.assertEqual(
+            text,
+            "- position=(4,8), terrain=RIFT_BARRIER, warp=S, object=SALVAGE, consumed=true, activated=false",
+        )


### PR DESCRIPTION
## 概要

Closes #1131

SRS 手動評価ランナーの `known map` 表示だけを調整し、重要記号と自機 `@` が同じマスにある場合でも足元記号を読めるようにしました。

## 変更内容

- `run_manual_eval.py` に手動評価専用の `known map` render helper を追加
- 足元が `.` / `?` のときは従来通りセル本体に `@` を表示
- 足元が warp / barrier / salvage / resource などの重要記号のときは、足元記号を残したまま隣接スペースへ `@` を重ねて表示
- コンソール出力と Markdown 出力の両方で同じ手動評価用 render を利用
- `player cell` 補足を追加し、現在位置の terrain / warp / object / consumed 状態をテキストでも確認できるようにした
- 既存の `render_known_map_spaced` / `render_known_map` 自体の仕様は変更していない
- 手動評価用 render の回帰テストを追加

## 確認

- `python3 -m unittest experiments.galactic_exodus.srs.test_run_manual_eval experiments.galactic_exodus.srs.test_render`
- `python3 -m unittest discover -s experiments/galactic_exodus/srs -p 'test_*.py'`
  - 既存失敗 2 件あり:
  - `test_validate_phase2_initial_model.Phase2InitialModelValidationTests.test_generation_rejects_legacy_token_outside_removed_contracts`
  - `test_validate_phase2_initial_model.Phase2InitialModelValidationTests.test_questions_reject_seven_by_seven_fixture`
