### PR TITLE
SRS手動評価のinteraction event summaryを詳細化

### DIFF
--- a/experiments/galactic_exodus/srs/run_manual_eval.py
+++ b/experiments/galactic_exodus/srs/run_manual_eval.py
@@ -155,6 +155,74 @@ def _format_position(value: object) -> str:
     return "-"
 
 
+def _format_bool(value: object) -> str:
+    if isinstance(value, bool):
+        return str(value).lower()
+    return str(value)
+
+
+def _summary_token(name: str, value: object) -> str | None:
+    if value is None:
+        return None
+    return f"{name}={_format_bool(value)}"
+
+
+def _interaction_subject_tokens(payload: Mapping[str, object]) -> list[str]:
+    return [
+        str(payload.get("object_type", "-") or "-"),
+        str(payload.get("object_id", "-") or "-"),
+    ]
+
+
+def _interaction_event_summary(prefix: str, payload: Mapping[str, object]) -> str:
+    object_type = str(payload.get("object_type", "-") or "-")
+    tokens: list[str] = [prefix, *_interaction_subject_tokens(payload)]
+
+    outcome = payload.get("outcome")
+    if outcome is not None:
+        tokens.append(f"outcome={outcome}")
+
+    fuel_before = payload.get("fuel_before")
+    fuel_after = payload.get("fuel_after")
+    if fuel_before is not None or fuel_after is not None:
+        tokens.append(f"fuel {fuel_before if fuel_before is not None else '-'}->{fuel_after if fuel_after is not None else '-'}")
+
+    if object_type == "RESOURCE_CACHE":
+        if prefix.endswith("INTERACT_ACCEPTED") or payload.get("fuel_restore") is not None:
+            restore = payload.get("fuel_restore", payload.get("fuel_delta"))
+            tokens.append(f"restore={restore if restore is not None else '-'}")
+        if payload.get("consumed") is not None:
+            tokens.append(f"consumed={_format_bool(payload.get('consumed'))}")
+        elif prefix.endswith("INTERACT_ACCEPTED") or outcome == "REJECTED_ALREADY_CONSUMED":
+            tokens.append("consumed=true")
+    elif object_type == "STATION":
+        if prefix.endswith("INTERACT_ACCEPTED"):
+            tokens.append("refuel_to_max=true")
+            tokens.append("activated=true")
+        else:
+            activated = _summary_token("activated", payload.get("activated"))
+            if activated is not None:
+                tokens.append(activated)
+    elif object_type == "SALVAGE":
+        if prefix.endswith("INTERACT_ACCEPTED"):
+            tokens.append("placeholder=true")
+            tokens.append("consumed=true")
+        else:
+            consumed = _summary_token("consumed", payload.get("consumed"))
+            if consumed is not None:
+                tokens.append(consumed)
+
+    if object_type not in {"RESOURCE_CACHE", "STATION", "SALVAGE"}:
+        consumed = _summary_token("consumed", payload.get("consumed"))
+        if consumed is not None:
+            tokens.append(consumed)
+        activated = _summary_token("activated", payload.get("activated"))
+        if activated is not None:
+            tokens.append(activated)
+
+    return " ".join(tokens)
+
+
 def _map_legend_items() -> list[str]:
     return [f"{symbol} {description}" for symbol, description in MAP_LEGEND]
 
@@ -225,6 +293,10 @@ def _event_summary_lines(result: SrsFixtureRunResult) -> list[str]:
                 f"new={payload.get('newly_discovered_count', '-')} "
                 f"total={payload.get('total_discovered_count', '-')}"
             )
+        elif event.event_type in {"INTERACT_ACCEPTED", "INTERACT_REJECTED"}:
+            lines.append(_interaction_event_summary(prefix, payload))
+        elif event.event_type in {"OBJECT_CONSUMED", "STATION_ACTIVATED"}:
+            lines.append(" ".join([prefix, *_interaction_subject_tokens(payload)]))
         elif "outcome" in payload:
             lines.append(f"{prefix} outcome={payload.get('outcome')}")
         else:

--- a/experiments/galactic_exodus/srs/test_run_manual_eval.py
+++ b/experiments/galactic_exodus/srs/test_run_manual_eval.py
@@ -2,13 +2,23 @@ from __future__ import annotations
 
 import unittest
 from dataclasses import replace
+from pathlib import Path
 
 from experiments.galactic_exodus.srs.model import Direction, Position, SrsObjectType, SrsTerrainType
-from experiments.galactic_exodus.srs.run_manual_eval import _player_cell_text, _render_known_map_spaced_for_manual_eval
+from experiments.galactic_exodus.srs.run_fixture import run_fixture
+from experiments.galactic_exodus.srs.run_manual_eval import (
+    _event_summary_lines,
+    _player_cell_text,
+    _render_known_map_spaced_for_manual_eval,
+)
 from experiments.galactic_exodus.srs.test_engine_movement import make_state, place_object, reveal_positions, replace_cell_terrain
 
 
 class SrsRunManualEvalTests(unittest.TestCase):
+    def _summary_lines_for_fixture(self, fixture_name: str) -> list[str]:
+        result = run_fixture(Path(__file__).resolve().parent / "fixtures" / fixture_name)
+        return _event_summary_lines(result)
+
     def test_manual_eval_render_keeps_player_on_floor_cell(self) -> None:
         state = replace(make_state(), player_position=Position(4, 7))
         state = reveal_positions(state, [Position(x, 7) for x in range(9)])
@@ -64,4 +74,45 @@ class SrsRunManualEvalTests(unittest.TestCase):
         self.assertEqual(
             text,
             "- position=(4,8), terrain=RIFT_BARRIER, warp=S, object=SALVAGE, consumed=true, activated=false",
+        )
+
+    def test_event_summary_resource_cache_includes_fuel_and_consumed_state(self) -> None:
+        lines = self._summary_lines_for_fixture("resource_cache_single_9x9.json")
+
+        self.assertEqual(
+            lines[-2:],
+            [
+                "turn 1: INTERACT_ACCEPTED RESOURCE_CACHE resource-cache-1 outcome=ACCEPTED fuel 2->7 restore=5 consumed=true",
+                "turn 1: OBJECT_CONSUMED RESOURCE_CACHE resource-cache-1",
+            ],
+        )
+
+    def test_event_summary_station_includes_refuel_and_activation(self) -> None:
+        lines = self._summary_lines_for_fixture("station_refuel_9x9.json")
+
+        self.assertEqual(
+            lines[-2:],
+            [
+                "turn 1: INTERACT_ACCEPTED STATION station-1 outcome=ACCEPTED fuel 2->9 refuel_to_max=true activated=true",
+                "turn 1: STATION_ACTIVATED STATION station-1",
+            ],
+        )
+
+    def test_event_summary_salvage_marks_placeholder_and_consumed(self) -> None:
+        lines = self._summary_lines_for_fixture("salvage_placeholder_9x9.json")
+
+        self.assertEqual(
+            lines[-2:],
+            [
+                "turn 1: INTERACT_ACCEPTED SALVAGE salvage-1 outcome=ACCEPTED fuel 2->2 placeholder=true consumed=true",
+                "turn 1: OBJECT_CONSUMED SALVAGE salvage-1",
+            ],
+        )
+
+    def test_event_summary_revisit_resource_reject_mentions_consumed_object(self) -> None:
+        lines = self._summary_lines_for_fixture("revisit_resource_consumed_9x9.json")
+
+        self.assertIn(
+            "turn 0: INTERACT_REJECTED RESOURCE_CACHE resource-cache-1 outcome=REJECTED_ALREADY_CONSUMED fuel 2->2 consumed=true",
+            lines,
         )


### PR DESCRIPTION
## 概要

Closes #1133

SRS 手動評価ランナーの `event summary` を interaction 系イベント向けに詳細化しました。

## 変更内容

- `INTERACT_ACCEPTED` / `INTERACT_REJECTED` に object type / object id / outcome / fuel 変化を表示
- `RESOURCE_CACHE` は回復量と consumed 状態、`STATION` は refuel to max / activated、`SALVAGE` は placeholder / consumed を短い 1 行 summary で表示
- `OBJECT_CONSUMED` / `STATION_ACTIVATED` に対象 object を表示
- fixture 実行ベースの回帰テストを追加し、resource cache / station / salvage / already consumed reject を検証

## 確認

- `python3 -m unittest experiments.galactic_exodus.srs.test_run_manual_eval`
- `python3 -m unittest experiments.galactic_exodus.srs.test_render`
- `python3 -m unittest discover -s experiments/galactic_exodus/srs -p 'test_*.py'`
  - 既存失敗:
    - `test_validate_phase2_initial_model.Phase2InitialModelValidationTests.test_generation_rejects_legacy_token_outside_removed_contracts`
    - `test_validate_phase2_initial_model.Phase2InitialModelValidationTests.test_questions_reject_seven_by_seven_fixture`
