### PR TITLE
SRS手動評価fixtureの初期可視セルを調整

### DIFF
--- a/experiments/galactic_exodus/srs/fixtures/resource_cache_single_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/resource_cache_single_9x9.json
@@ -18,7 +18,7 @@
     "persistent": {
       "consumed_object_ids": [],
       "activated_object_ids": [],
-      "discovered_cells": []
+      "discovered_cells": [[2, 7], [2, 6], [3, 7], [1, 7]]
     }
   },
   "commands": [

--- a/experiments/galactic_exodus/srs/test_fixtures.py
+++ b/experiments/galactic_exodus/srs/test_fixtures.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from experiments.galactic_exodus.srs.contracts import load_default_contracts
 from experiments.galactic_exodus.srs.log import build_srs_log
+from experiments.galactic_exodus.srs.model import Position
 from experiments.galactic_exodus.srs.run_fixture import (
     FIXTURES_DIR,
     REPO_ROOT,
@@ -77,6 +78,36 @@ class SrsFixtureTests(unittest.TestCase):
         self.assertEqual(payload["fixture_id"], "resource_cache_single_9x9")
         self.assertEqual(payload["final_state"]["fuel"], 7)
         json.dumps(payload)
+
+    def test_resource_cache_fixture_restores_manual_eval_discovered_cells(self) -> None:
+        result = run_fixture(FIXTURES_DIR / "resource_cache_single_9x9.json", contracts=self.contracts)
+
+        self.assertEqual(
+            result.initial_state.known_state.discovered_cells,
+            frozenset(
+                {
+                    Position(2, 7),
+                    Position(2, 6),
+                    Position(3, 7),
+                    Position(1, 7),
+                }
+            ),
+        )
+
+    def test_revisit_resource_fixture_preserves_manual_eval_discovered_cells(self) -> None:
+        result = run_fixture(FIXTURES_DIR / "revisit_resource_consumed_9x9.json", contracts=self.contracts)
+
+        self.assertEqual(
+            result.initial_state.known_state.discovered_cells,
+            frozenset(
+                {
+                    Position(2, 7),
+                    Position(2, 6),
+                    Position(3, 7),
+                    Position(1, 7),
+                }
+            ),
+        )
 
     def test_game_log_json_serializable(self) -> None:
         result = run_fixture(FIXTURES_DIR / "move_route_basic_9x9.json", contracts=self.contracts)

--- a/experiments/galactic_exodus/srs/test_run_manual_eval.py
+++ b/experiments/galactic_exodus/srs/test_run_manual_eval.py
@@ -87,6 +87,18 @@ class SrsRunManualEvalTests(unittest.TestCase):
             ],
         )
 
+    def test_manual_eval_resource_cache_fixture_keeps_target_area_visible(self) -> None:
+        result = run_fixture(Path(__file__).resolve().parent / "fixtures" / "resource_cache_single_9x9.json")
+
+        self.assertEqual(
+            _player_cell_text(result.final_state),
+            "- position=(2,7), terrain=FLOOR, object=RESOURCE_CACHE, consumed=true, activated=false",
+        )
+        self.assertEqual(
+            _render_known_map_spaced_for_manual_eval(result.final_state).splitlines()[7],
+            "? . r@. ? ? ? ? ?",
+        )
+
     def test_event_summary_station_includes_refuel_and_activation(self) -> None:
         lines = self._summary_lines_for_fixture("station_refuel_9x9.json")
 
@@ -115,4 +127,12 @@ class SrsRunManualEvalTests(unittest.TestCase):
         self.assertIn(
             "turn 0: INTERACT_REJECTED RESOURCE_CACHE resource-cache-1 outcome=REJECTED_ALREADY_CONSUMED fuel 2->2 consumed=true",
             lines,
+        )
+
+    def test_manual_eval_revisit_resource_fixture_shows_consumed_player_cell(self) -> None:
+        result = run_fixture(Path(__file__).resolve().parent / "fixtures" / "revisit_resource_consumed_9x9.json")
+
+        self.assertEqual(
+            _player_cell_text(result.final_state),
+            "- position=(2,7), terrain=FLOOR, object=RESOURCE_CACHE, consumed=true, activated=false",
         )


### PR DESCRIPTION
## 概要

Closes #1135

SRS 手動評価 fixture の初期 discovered state を調整し、resource cache fixture で対象セルが `?` だらけにならないようにしました。

## 変更内容

- `resource_cache_single_9x9.json` の `initial.persistent.discovered_cells` を resource/player 周辺 4 セルに設定
- `resource_cache_single_9x9` / `revisit_resource_consumed_9x9` の初期 discovered cells を固定する fixture テストを追加
- manual eval 向けに、resource cache fixture で対象領域が可視であることと、再訪 fixture で消費済み player cell 情報が読めることを確認するテストを追加

## 確認

- `python3 -m unittest experiments.galactic_exodus.srs.test_fixtures experiments.galactic_exodus.srs.test_run_manual_eval`
- `python3 -m unittest experiments.galactic_exodus.srs.test_render`
- `python3 -m unittest discover -s experiments/galactic_exodus/srs -p 'test_*.py'`
  - 既存失敗 2 件あり
  - `test_validate_phase2_initial_model.Phase2InitialModelValidationTests.test_generation_rejects_legacy_token_outside_removed_contracts`
  - `test_validate_phase2_initial_model.Phase2InitialModelValidationTests.test_questions_reject_seven_by_seven_fixture`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo fmt --check`
