### PR TITLE
SRS policy evaluation に known-state routing helper を追加

### DIFF
--- a/experiments/galactic_exodus/srs/evaluate_policies.py
+++ b/experiments/galactic_exodus/srs/evaluate_policies.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+from collections import deque
 from dataclasses import dataclass, replace
 from enum import Enum
 from types import MappingProxyType
-from typing import Any, Mapping
+from typing import Any, Iterable, Mapping
 
 from experiments.galactic_exodus.srs.contracts import SrsContracts
 from experiments.galactic_exodus.srs.engine import restore_srs_state, reveal_full_observation, reveal_observation
@@ -41,10 +42,113 @@ class RevisitMode(str, Enum):
 
 _DIRECTION_ORDER = (Direction.N, Direction.E, Direction.S, Direction.W)
 _REVISIT_CONSUMED_OBJECT_TYPES = frozenset({SrsObjectType.RESOURCE_CACHE, SrsObjectType.SALVAGE})
+_KNOWN_IMPASSABLE_TERRAINS = frozenset({SrsTerrainType.ASTEROID, SrsTerrainType.RIFT_BARRIER})
+_KNOWN_IMPASSABLE_OBJECT_TYPES = frozenset({SrsObjectType.STAR, SrsObjectType.PLANET, SrsObjectType.STATION})
 
 
 def _freeze_mapping(mapping: Mapping[str, Any]) -> Mapping[str, Any]:
     return MappingProxyType(dict(mapping))
+
+
+def iter_known_cardinal_neighbors(position: Position) -> tuple[tuple[Direction, Position], ...]:
+    return tuple(
+        (direction, _step_position(position, direction))
+        for direction in _DIRECTION_ORDER
+    )
+
+
+def is_known_passable_cell(
+    position: Position,
+    *,
+    known_cells: Mapping[Position, SrsCell],
+    objects: Mapping[str, Any],
+) -> bool:
+    cell = known_cells.get(position)
+    if cell is None:
+        return False
+    if cell.terrain in _KNOWN_IMPASSABLE_TERRAINS:
+        return False
+    if cell.object_id is None:
+        return True
+
+    object_state = objects.get(cell.object_id)
+    if object_state is None:
+        return False
+    return object_state.object_type not in _KNOWN_IMPASSABLE_OBJECT_TYPES
+
+
+def route_on_known_cells(
+    start: Position,
+    target: Position,
+    *,
+    known_cells: Mapping[Position, SrsCell],
+    objects: Mapping[str, Any],
+) -> tuple[Direction, ...] | None:
+    if not is_known_passable_cell(start, known_cells=known_cells, objects=objects):
+        return None
+    if not is_known_passable_cell(target, known_cells=known_cells, objects=objects):
+        return None
+    if start == target:
+        return ()
+
+    came_from: dict[Position, tuple[Position, Direction] | None] = {start: None}
+    frontier: deque[Position] = deque([start])
+
+    while frontier:
+        current = frontier.popleft()
+        for direction, next_position in iter_known_cardinal_neighbors(current):
+            if next_position in came_from:
+                continue
+            if not is_known_passable_cell(next_position, known_cells=known_cells, objects=objects):
+                continue
+            came_from[next_position] = (current, direction)
+            if next_position == target:
+                return _reconstruct_route(came_from, start=start, target=target)
+            frontier.append(next_position)
+
+    return None
+
+
+def first_known_route_step(
+    start: Position,
+    target: Position,
+    *,
+    known_cells: Mapping[Position, SrsCell],
+    objects: Mapping[str, Any],
+) -> Direction | None:
+    route = route_on_known_cells(start, target, known_cells=known_cells, objects=objects)
+    if route is None or not route:
+        return None
+    return route[0]
+
+
+def choose_known_target_step(
+    start: Position,
+    targets: Iterable[Position],
+    *,
+    known_cells: Mapping[Position, SrsCell],
+    objects: Mapping[str, Any],
+) -> tuple[Position, Direction] | None:
+    best_choice: tuple[int, int, int, int, Position, Direction] | None = None
+    for target in targets:
+        route = route_on_known_cells(start, target, known_cells=known_cells, objects=objects)
+        if route is None or not route:
+            continue
+        first_step = route[0]
+        choice = (
+            len(route),
+            target.y,
+            target.x,
+            _DIRECTION_ORDER.index(first_step),
+            target,
+            first_step,
+        )
+        if best_choice is None or choice < best_choice:
+            best_choice = choice
+
+    if best_choice is None:
+        return None
+    return best_choice[4], best_choice[5]
 
 
 @dataclass(frozen=True, slots=True)
@@ -363,3 +467,32 @@ def _replace_player_cell_terrain(
 
 def _sorted_directions(directions: frozenset[Direction]) -> tuple[Direction, ...]:
     return tuple(direction for direction in _DIRECTION_ORDER if direction in directions)
+
+
+def _reconstruct_route(
+    came_from: Mapping[Position, tuple[Position, Direction] | None],
+    *,
+    start: Position,
+    target: Position,
+) -> tuple[Direction, ...]:
+    route: list[Direction] = []
+    current = target
+    while current != start:
+        previous = came_from.get(current)
+        if previous is None:
+            raise EvaluationCaseError(f"known-state route reconstruction failed: {target}")
+        current, direction = previous
+        route.append(direction)
+    route.reverse()
+    return tuple(route)
+
+
+def _step_position(position: Position, direction: Direction) -> Position:
+    deltas = {
+        Direction.N: (0, -1),
+        Direction.E: (1, 0),
+        Direction.S: (0, 1),
+        Direction.W: (-1, 0),
+    }
+    dx, dy = deltas[direction]
+    return Position(position.x + dx, position.y + dy)

--- a/experiments/galactic_exodus/srs/test_evaluate_policies.py
+++ b/experiments/galactic_exodus/srs/test_evaluate_policies.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from experiments.galactic_exodus.srs.contracts import load_default_contracts
 from experiments.galactic_exodus.srs.evaluate_policies import (
@@ -11,8 +12,23 @@ from experiments.galactic_exodus.srs.evaluate_policies import (
     InitialRevealMode,
     RevisitMode,
     build_default_evaluation_cases,
+    choose_known_target_step,
+    first_known_route_step,
+    is_known_passable_cell,
+    iter_known_cardinal_neighbors,
+    route_on_known_cells,
 )
-from experiments.galactic_exodus.srs.model import CostMode, Direction, SectorDescriptor, SectorType, SrsGameState
+from experiments.galactic_exodus.srs.model import (
+    CostMode,
+    Direction,
+    Position,
+    SectorDescriptor,
+    SectorType,
+    SrsGameState,
+    SrsObjectType,
+    SrsTerrainType,
+)
+from experiments.galactic_exodus.srs.test_engine_movement import make_state, place_object, reveal_positions, replace_cell_terrain
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -166,6 +182,185 @@ class DefaultEvaluationCasesTests(unittest.TestCase):
 
         self.assertEqual(len(case_ids), len(set(case_ids)))
         self.assertEqual(case_ids, [case.metadata()["case_id"] for case in self.cases])
+
+
+class KnownStateRoutingHelperTests(unittest.TestCase):
+    def test_known_passable_cell_uses_known_cells_only(self) -> None:
+        state = reveal_positions(make_state(), [Position(4, 8), Position(4, 7)])
+
+        self.assertTrue(
+            is_known_passable_cell(
+                Position(4, 7),
+                known_cells=state.known_state.known_cells,
+                objects=state.objects,
+            )
+        )
+        self.assertFalse(
+            is_known_passable_cell(
+                Position(4, 6),
+                known_cells=state.known_state.known_cells,
+                objects=state.objects,
+            )
+        )
+
+    def test_known_passable_cell_rejects_impassable_terrain_and_celestial_objects(self) -> None:
+        state = replace_cell_terrain(make_state(), Position(4, 7), SrsTerrainType.ASTEROID)
+        state = reveal_positions(state, [Position(4, 7), Position(4, 6), Position(4, 5), Position(5, 7), Position(5, 6)])
+        state = place_object(state, Position(4, 6), SrsObjectType.STAR, "star-a")
+        state = place_object(state, Position(4, 5), SrsObjectType.PLANET, "planet-a")
+        state = place_object(state, Position(5, 7), SrsObjectType.STATION, "station-a")
+        state = place_object(state, Position(5, 6), SrsObjectType.RESOURCE_CACHE, "resource-a")
+        state = reveal_positions(state, [Position(4, 7), Position(4, 6), Position(4, 5), Position(5, 7), Position(5, 6)])
+
+        self.assertFalse(
+            is_known_passable_cell(
+                Position(4, 7),
+                known_cells=state.known_state.known_cells,
+                objects=state.objects,
+            )
+        )
+        self.assertFalse(
+            is_known_passable_cell(
+                Position(4, 6),
+                known_cells=state.known_state.known_cells,
+                objects=state.objects,
+            )
+        )
+        self.assertFalse(
+            is_known_passable_cell(
+                Position(4, 5),
+                known_cells=state.known_state.known_cells,
+                objects=state.objects,
+            )
+        )
+        self.assertFalse(
+            is_known_passable_cell(
+                Position(5, 7),
+                known_cells=state.known_state.known_cells,
+                objects=state.objects,
+            )
+        )
+        self.assertTrue(
+            is_known_passable_cell(
+                Position(5, 6),
+                known_cells=state.known_state.known_cells,
+                objects=state.objects,
+            )
+        )
+
+    def test_salvage_is_treated_as_known_passable(self) -> None:
+        state = place_object(make_state(), Position(4, 7), SrsObjectType.SALVAGE, "salvage-a")
+        state = reveal_positions(state, [Position(4, 8), Position(4, 7)])
+
+        self.assertTrue(
+            is_known_passable_cell(
+                Position(4, 7),
+                known_cells=state.known_state.known_cells,
+                objects=state.objects,
+            )
+        )
+
+    def test_route_on_known_cells_does_not_cross_undiscovered_cells(self) -> None:
+        state = reveal_positions(
+            make_state(),
+            [Position(4, 8), Position(5, 8), Position(5, 7), Position(5, 6)],
+        )
+
+        self.assertEqual(
+            route_on_known_cells(
+                Position(4, 8),
+                Position(5, 6),
+                known_cells=state.known_state.known_cells,
+                objects=state.objects,
+            ),
+            (Direction.E, Direction.N, Direction.N),
+        )
+        self.assertIsNone(
+            route_on_known_cells(
+                Position(4, 8),
+                Position(4, 6),
+                known_cells=state.known_state.known_cells,
+                objects=state.objects,
+            )
+        )
+
+    def test_first_known_route_step_uses_known_state_without_actual_map(self) -> None:
+        state = reveal_positions(
+            make_state(),
+            [Position(4, 8), Position(4, 7), Position(4, 6)],
+        )
+
+        with patch(
+            "experiments.galactic_exodus.srs.engine.route_to_known_target",
+            side_effect=AssertionError("engine.route_to_known_target must not be used"),
+        ):
+            self.assertEqual(
+                first_known_route_step(
+                    Position(4, 8),
+                    Position(4, 6),
+                    known_cells=state.known_state.known_cells,
+                    objects=state.objects,
+                ),
+                Direction.N,
+            )
+
+    def test_choose_known_target_step_applies_deterministic_tie_breaking(self) -> None:
+        state = reveal_positions(
+            make_state(),
+            [Position(4, 8), Position(4, 7), Position(5, 8), Position(3, 8)],
+        )
+
+        self.assertEqual(
+            choose_known_target_step(
+                Position(4, 8),
+                [Position(4, 7), Position(5, 8), Position(3, 8)],
+                known_cells=state.known_state.known_cells,
+                objects=state.objects,
+            ),
+            (Position(4, 7), Direction.N),
+        )
+        self.assertEqual(
+            choose_known_target_step(
+                Position(4, 8),
+                [Position(5, 8), Position(3, 8)],
+                known_cells=state.known_state.known_cells,
+                objects=state.objects,
+            ),
+            (Position(3, 8), Direction.W),
+        )
+
+    def test_iter_known_cardinal_neighbors_is_stable(self) -> None:
+        self.assertEqual(
+            iter_known_cardinal_neighbors(Position(4, 8)),
+            (
+                (Direction.N, Position(4, 7)),
+                (Direction.E, Position(5, 8)),
+                (Direction.S, Position(4, 9)),
+                (Direction.W, Position(3, 8)),
+            ),
+        )
+
+    def test_route_on_known_cells_is_deterministic_for_same_input(self) -> None:
+        state = reveal_positions(
+            make_state(),
+            [Position(4, 8), Position(4, 7), Position(5, 8), Position(5, 7)],
+        )
+
+        first = route_on_known_cells(
+            Position(4, 8),
+            Position(5, 7),
+            known_cells=state.known_state.known_cells,
+            objects=state.objects,
+        )
+        second = route_on_known_cells(
+            Position(4, 8),
+            Position(5, 7),
+            known_cells=state.known_state.known_cells,
+            objects=state.objects,
+        )
+
+        self.assertEqual(first, (Direction.N, Direction.E))
+        self.assertEqual(first, second)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 概要

Closes #1144

SRS policy evaluation 向けに、`known_state.known_cells` と既知 object 情報だけを使う routing helper を追加しました。

## 変更内容

- known cell の通行可否判定 helper を追加
- known passable cell 上だけを通る BFS routing helper を追加
- target への最初の 1 step を返す helper を追加
- frontier 判定などで再利用できる N/E/S/W 近傍列挙 helper を追加
- 複数 target 候補に対して、距離 → `y` → `x` → 方向順で deterministic に選ぶ helper を追加
- `actual_map` や `engine.route_to_known_target(...)` に依存しないことをテストで固定

## 確認

- `python3 -m unittest experiments.galactic_exodus.srs.test_evaluate_policies`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
