### PR TITLE
SRS policy evaluationにOBJECT_GREEDY方策を追加

### DIFF
--- a/experiments/galactic_exodus/srs/evaluate_policies.py
+++ b/experiments/galactic_exodus/srs/evaluate_policies.py
@@ -19,6 +19,7 @@ from experiments.galactic_exodus.srs.model import (
     SrsCommand,
     SrsGameState,
     SrsModelError,
+    SrsObjectState,
     SrsObjectType,
     SrsTerrainType,
     validate_sector_descriptor,
@@ -46,6 +47,12 @@ _REVISIT_CONSUMED_OBJECT_TYPES = frozenset({SrsObjectType.RESOURCE_CACHE, SrsObj
 _KNOWN_IMPASSABLE_TERRAINS = frozenset({SrsTerrainType.ASTEROID, SrsTerrainType.RIFT_BARRIER})
 _KNOWN_IMPASSABLE_OBJECT_TYPES = frozenset({SrsObjectType.STAR, SrsObjectType.PLANET, SrsObjectType.STATION})
 EXIT_GREEDY_POLICY_NAME = "EXIT_GREEDY"
+OBJECT_GREEDY_POLICY_NAME = "OBJECT_GREEDY"
+_OBJECT_GREEDY_PRIORITY = {
+    SrsObjectType.RESOURCE_CACHE: 0,
+    SrsObjectType.STATION: 1,
+    SrsObjectType.SALVAGE: 2,
+}
 
 
 def _freeze_mapping(mapping: Mapping[str, Any]) -> Mapping[str, Any]:
@@ -131,26 +138,43 @@ def choose_known_target_step(
     known_cells: Mapping[Position, SrsCell],
     objects: Mapping[str, Any],
 ) -> tuple[Position, Direction] | None:
-    best_choice: tuple[int, int, int, int, Position, Direction] | None = None
+    choice = _choose_known_target_route(
+        start,
+        targets,
+        known_cells=known_cells,
+        objects=objects,
+    )
+    if choice is None:
+        return None
+    return choice[0], choice[2][0]
+
+
+def _choose_known_target_route(
+    start: Position,
+    targets: Iterable[Position],
+    *,
+    known_cells: Mapping[Position, SrsCell],
+    objects: Mapping[str, Any],
+) -> tuple[Position, int, tuple[Direction, ...]] | None:
+    best_choice: tuple[int, int, int, int, Position, tuple[Direction, ...]] | None = None
     for target in targets:
         route = route_on_known_cells(start, target, known_cells=known_cells, objects=objects)
         if route is None or not route:
             continue
-        first_step = route[0]
         choice = (
             len(route),
             target.y,
             target.x,
-            _DIRECTION_ORDER.index(first_step),
+            _DIRECTION_ORDER.index(route[0]),
             target,
-            first_step,
+            route,
         )
         if best_choice is None or choice < best_choice:
             best_choice = choice
 
     if best_choice is None:
         return None
-    return best_choice[4], best_choice[5]
+    return best_choice[4], best_choice[0], best_choice[5]
 
 
 def choose_exit_greedy_command(
@@ -189,6 +213,148 @@ def choose_exit_greedy_command(
         command_type="MOVE_ROUTE",
         route=(first_step,),
     )
+
+
+@dataclass(frozen=True, slots=True)
+class ObjectGreedyCandidate:
+    object_id: str
+    object_type: SrsObjectType
+    object_position: Position
+    interaction_positions: tuple[Position, ...]
+
+
+def _known_interaction_positions_for_object(
+    object_state: SrsObjectState,
+    *,
+    known_cells: Mapping[Position, SrsCell],
+    objects: Mapping[str, Any],
+    contracts: SrsContracts,
+) -> tuple[Position, ...]:
+    contract = contracts.movement.interaction.get(object_state.object_type.value)
+    if not isinstance(contract, Mapping):
+        raise EvaluationCaseError(f"interaction contract missing for {object_state.object_type.value}")
+    interaction_range = contract.get("range")
+    if interaction_range == "SAME_CELL":
+        if is_known_passable_cell(object_state.position, known_cells=known_cells, objects=objects):
+            return (object_state.position,)
+        return ()
+    if interaction_range == "ADJACENT":
+        return tuple(
+            position
+            for _, position in iter_known_cardinal_neighbors(object_state.position)
+            if is_known_passable_cell(position, known_cells=known_cells, objects=objects)
+        )
+    raise EvaluationCaseError(f"unsupported interaction range: {interaction_range}")
+
+
+def _is_object_greedy_candidate(
+    object_state: SrsObjectState,
+    *,
+    fuel: int,
+    max_fuel: int,
+    rejected_object_ids: frozenset[str],
+) -> bool:
+    if object_state.object_id in rejected_object_ids:
+        return False
+    if object_state.object_type is SrsObjectType.RESOURCE_CACHE:
+        return not object_state.consumed and fuel != max_fuel
+    if object_state.object_type is SrsObjectType.STATION:
+        return not object_state.activated and fuel != max_fuel
+    if object_state.object_type is SrsObjectType.SALVAGE:
+        return not object_state.consumed
+    return False
+
+
+def build_object_greedy_candidates(
+    state: SrsGameState,
+    *,
+    contracts: SrsContracts,
+    rejected_object_ids: Iterable[str] = (),
+) -> tuple[ObjectGreedyCandidate, ...]:
+    rejected = frozenset(rejected_object_ids)
+    candidates: list[ObjectGreedyCandidate] = []
+    for position, cell in state.known_state.known_cells.items():
+        object_id = cell.object_id
+        if object_id is None:
+            continue
+        object_state = state.objects.get(object_id)
+        if object_state is None:
+            continue
+        if position != object_state.position:
+            continue
+        if object_state.object_type not in _OBJECT_GREEDY_PRIORITY:
+            continue
+        if not _is_object_greedy_candidate(
+            object_state,
+            fuel=state.fuel,
+            max_fuel=state.max_fuel,
+            rejected_object_ids=rejected,
+        ):
+            continue
+        interaction_positions = _known_interaction_positions_for_object(
+            object_state,
+            known_cells=state.known_state.known_cells,
+            objects=state.objects,
+            contracts=contracts,
+        )
+        if not interaction_positions:
+            continue
+        candidates.append(
+            ObjectGreedyCandidate(
+                object_id=object_id,
+                object_type=object_state.object_type,
+                object_position=object_state.position,
+                interaction_positions=interaction_positions,
+            )
+        )
+    return tuple(candidates)
+
+
+def choose_object_greedy_command(
+    state: SrsGameState,
+    *,
+    contracts: SrsContracts,
+    selected_exit_edge: Direction,
+    rejected_object_ids: Iterable[str] = (),
+) -> SrsCommand | None:
+    best_choice: tuple[int, int, int, int, str, ObjectGreedyCandidate, tuple[Direction, ...]] | None = None
+    for candidate in build_object_greedy_candidates(
+        state,
+        contracts=contracts,
+        rejected_object_ids=rejected_object_ids,
+    ):
+        if state.player_position in candidate.interaction_positions:
+            route: tuple[Direction, ...] = ()
+        else:
+            route_choice = _choose_known_target_route(
+                state.player_position,
+                candidate.interaction_positions,
+                known_cells=state.known_state.known_cells,
+                objects=state.objects,
+            )
+            if route_choice is None:
+                continue
+            _, _, route = route_choice
+        choice = (
+            _OBJECT_GREEDY_PRIORITY[candidate.object_type],
+            len(route),
+            candidate.object_position.y,
+            candidate.object_position.x,
+            candidate.object_id,
+            candidate,
+            route,
+        )
+        if best_choice is None or choice < best_choice:
+            best_choice = choice
+
+    if best_choice is None:
+        return choose_exit_greedy_command(state, selected_exit_edge=selected_exit_edge)
+
+    candidate = best_choice[5]
+    route = best_choice[6]
+    if not route:
+        return SrsCommand(command_type="INTERACT", target_object_id=candidate.object_id)
+    return SrsCommand(command_type="MOVE_ROUTE", route=(route[0],))
 
 
 @dataclass(frozen=True, slots=True)

--- a/experiments/galactic_exodus/srs/test_evaluate_policies.py
+++ b/experiments/galactic_exodus/srs/test_evaluate_policies.py
@@ -13,12 +13,15 @@ from experiments.galactic_exodus.srs.evaluate_policies import (
     InitialRevealMode,
     RevisitMode,
     build_default_evaluation_cases,
+    build_object_greedy_candidates,
     choose_exit_greedy_command,
     choose_known_target_step,
+    choose_object_greedy_command,
     EXIT_GREEDY_POLICY_NAME,
     first_known_route_step,
     is_known_passable_cell,
     iter_known_cardinal_neighbors,
+    OBJECT_GREEDY_POLICY_NAME,
     route_on_known_cells,
 )
 from experiments.galactic_exodus.srs.model import (
@@ -70,6 +73,26 @@ def replace_cell_warp_flags(
                 for known_position, known_cell in state.known_state.known_cells.items()
             },
         ),
+    )
+
+
+def place_object_with_metadata(
+    state: SrsGameState,
+    position: Position,
+    object_type: SrsObjectType,
+    object_id: str,
+    *,
+    fuel_restore: int | None = None,
+) -> SrsGameState:
+    state = place_object(state, position, object_type, object_id)
+    if fuel_restore is None:
+        return state
+    return replace(
+        state,
+        objects={
+            **state.objects,
+            object_id: replace(state.objects[object_id], metadata={"fuel_restore": fuel_restore}),
+        },
     )
 
 
@@ -505,6 +528,252 @@ class ExitGreedyPolicyTests(unittest.TestCase):
             self.assertEqual(
                 choose_exit_greedy_command(state, selected_exit_edge=Direction.N),
                 SrsCommand(command_type="MOVE_ROUTE", route=(Direction.E,)),
+            )
+
+
+class ObjectGreedyPolicyTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.contracts = load_default_contracts(REPO_ROOT)
+
+    def test_policy_name_is_stable(self) -> None:
+        self.assertEqual(OBJECT_GREEDY_POLICY_NAME, "OBJECT_GREEDY")
+
+    def test_prioritizes_known_unconsumed_resource_cache(self) -> None:
+        state = place_object_with_metadata(
+            make_state(fuel=2, max_fuel=9),
+            Position(4, 8),
+            SrsObjectType.RESOURCE_CACHE,
+            "resource-cache-1",
+            fuel_restore=5,
+        )
+        state = place_object(state, Position(5, 8), SrsObjectType.SALVAGE, "salvage-1")
+        state = reveal_positions(state, [Position(4, 8), Position(5, 8)])
+
+        command = choose_object_greedy_command(
+            state,
+            contracts=self.contracts,
+            selected_exit_edge=Direction.N,
+        )
+
+        self.assertEqual(
+            command,
+            SrsCommand(command_type="INTERACT", target_object_id="resource-cache-1"),
+        )
+
+    def test_resource_cache_is_excluded_at_full_fuel(self) -> None:
+        state = place_object_with_metadata(
+            make_state(fuel=9, max_fuel=9),
+            Position(4, 8),
+            SrsObjectType.RESOURCE_CACHE,
+            "resource-cache-1",
+            fuel_restore=5,
+        )
+        state = reveal_positions(state, [Position(4, 8), Position(4, 7), Position(4, 6)])
+        state = replace_cell_warp_flags(state, Position(4, 6), frozenset({Direction.N}))
+
+        command = choose_object_greedy_command(
+            state,
+            contracts=self.contracts,
+            selected_exit_edge=Direction.N,
+        )
+
+        self.assertEqual(
+            command,
+            SrsCommand(command_type="MOVE_ROUTE", route=(Direction.N,)),
+        )
+
+    def test_known_unactivated_station_is_a_candidate(self) -> None:
+        state = place_object(make_state(fuel=2, max_fuel=9), Position(4, 7), SrsObjectType.STATION, "station-1")
+        state = reveal_positions(state, [Position(4, 8), Position(4, 7)])
+
+        command = choose_object_greedy_command(
+            state,
+            contracts=self.contracts,
+            selected_exit_edge=Direction.N,
+        )
+
+        self.assertEqual(
+            command,
+            SrsCommand(command_type="INTERACT", target_object_id="station-1"),
+        )
+
+    def test_station_is_excluded_at_full_fuel(self) -> None:
+        state = place_object(make_state(fuel=9, max_fuel=9), Position(4, 7), SrsObjectType.STATION, "station-1")
+        state = reveal_positions(state, [Position(4, 8), Position(4, 7), Position(5, 8)])
+        state = replace_cell_warp_flags(state, Position(5, 8), frozenset({Direction.N}))
+
+        command = choose_object_greedy_command(
+            state,
+            contracts=self.contracts,
+            selected_exit_edge=Direction.N,
+        )
+
+        self.assertEqual(
+            command,
+            SrsCommand(command_type="MOVE_ROUTE", route=(Direction.E,)),
+        )
+
+    def test_known_unconsumed_salvage_is_a_candidate(self) -> None:
+        state = place_object(make_state(fuel=2, max_fuel=9), Position(5, 8), SrsObjectType.SALVAGE, "salvage-1")
+        state = reveal_positions(state, [Position(4, 8), Position(5, 8)])
+
+        command = choose_object_greedy_command(
+            state,
+            contracts=self.contracts,
+            selected_exit_edge=Direction.N,
+        )
+
+        self.assertEqual(
+            command,
+            SrsCommand(command_type="MOVE_ROUTE", route=(Direction.E,)),
+        )
+
+    def test_returns_interact_when_in_interaction_range(self) -> None:
+        state = place_object(make_state(fuel=2, max_fuel=9), Position(4, 7), SrsObjectType.STATION, "station-1")
+        state = reveal_positions(state, [Position(4, 8), Position(4, 7), Position(5, 8)])
+
+        command = choose_object_greedy_command(
+            state,
+            contracts=self.contracts,
+            selected_exit_edge=Direction.N,
+        )
+
+        self.assertEqual(
+            command,
+            SrsCommand(command_type="INTERACT", target_object_id="station-1"),
+        )
+
+    def test_returns_single_step_move_route_when_out_of_range(self) -> None:
+        state = place_object_with_metadata(
+            make_state(fuel=2, max_fuel=9),
+            Position(4, 6),
+            SrsObjectType.RESOURCE_CACHE,
+            "resource-cache-1",
+            fuel_restore=5,
+        )
+        state = reveal_positions(state, [Position(4, 8), Position(4, 7), Position(4, 6)])
+
+        command = choose_object_greedy_command(
+            state,
+            contracts=self.contracts,
+            selected_exit_edge=Direction.N,
+        )
+
+        self.assertEqual(
+            command,
+            SrsCommand(command_type="MOVE_ROUTE", route=(Direction.N,)),
+        )
+        self.assertEqual(command.route, (Direction.N,))
+
+    def test_falls_back_to_exit_greedy_when_no_object_candidates_exist(self) -> None:
+        state = reveal_positions(make_state(), [Position(4, 8), Position(4, 7), Position(4, 6)])
+        state = replace_cell_warp_flags(state, Position(4, 6), frozenset({Direction.N}))
+
+        command = choose_object_greedy_command(
+            state,
+            contracts=self.contracts,
+            selected_exit_edge=Direction.N,
+        )
+
+        self.assertEqual(
+            command,
+            SrsCommand(command_type="MOVE_ROUTE", route=(Direction.N,)),
+        )
+
+    def test_rejected_object_is_not_retried(self) -> None:
+        state = place_object_with_metadata(
+            make_state(fuel=2, max_fuel=9),
+            Position(4, 8),
+            SrsObjectType.RESOURCE_CACHE,
+            "resource-cache-1",
+            fuel_restore=5,
+        )
+        state = place_object(state, Position(5, 8), SrsObjectType.SALVAGE, "salvage-1")
+        state = reveal_positions(state, [Position(4, 8), Position(5, 8)])
+
+        command = choose_object_greedy_command(
+            state,
+            contracts=self.contracts,
+            selected_exit_edge=Direction.N,
+            rejected_object_ids={"resource-cache-1"},
+        )
+
+        self.assertEqual(
+            command,
+            SrsCommand(command_type="MOVE_ROUTE", route=(Direction.E,)),
+        )
+
+    def test_build_candidates_uses_known_cells_only(self) -> None:
+        state = place_object_with_metadata(
+            make_state(fuel=2, max_fuel=9),
+            Position(4, 6),
+            SrsObjectType.RESOURCE_CACHE,
+            "resource-cache-1",
+            fuel_restore=5,
+        )
+        state = reveal_positions(state, [Position(4, 8), Position(4, 7)])
+
+        candidates = build_object_greedy_candidates(
+            state,
+            contracts=self.contracts,
+        )
+
+        self.assertEqual(candidates, ())
+
+    def test_never_returns_move_to(self) -> None:
+        state = place_object(make_state(fuel=2, max_fuel=9), Position(5, 8), SrsObjectType.SALVAGE, "salvage-1")
+        state = reveal_positions(state, [Position(4, 8), Position(5, 8)])
+
+        command = choose_object_greedy_command(
+            state,
+            contracts=self.contracts,
+            selected_exit_edge=Direction.N,
+        )
+
+        self.assertIsNotNone(command)
+        self.assertNotEqual(command.command_type, "MOVE_TO")
+
+    def test_is_deterministic_for_same_input(self) -> None:
+        state = place_object(make_state(fuel=2, max_fuel=9), Position(3, 8), SrsObjectType.SALVAGE, "salvage-a")
+        state = place_object(state, Position(5, 8), SrsObjectType.SALVAGE, "salvage-b")
+        state = reveal_positions(state, [Position(4, 8), Position(3, 8), Position(5, 8)])
+
+        first = choose_object_greedy_command(
+            state,
+            contracts=self.contracts,
+            selected_exit_edge=Direction.N,
+        )
+        second = choose_object_greedy_command(
+            state,
+            contracts=self.contracts,
+            selected_exit_edge=Direction.N,
+        )
+
+        self.assertEqual(first, SrsCommand(command_type="MOVE_ROUTE", route=(Direction.W,)))
+        self.assertEqual(first, second)
+
+    def test_uses_known_state_without_actual_map(self) -> None:
+        state = place_object_with_metadata(
+            make_state(fuel=2, max_fuel=9),
+            Position(4, 6),
+            SrsObjectType.RESOURCE_CACHE,
+            "resource-cache-1",
+            fuel_restore=5,
+        )
+        state = reveal_positions(state, [Position(4, 8), Position(4, 7), Position(4, 6)])
+
+        with patch(
+            "experiments.galactic_exodus.srs.model.SrsActualMap.cell_at",
+            side_effect=AssertionError("actual_map must not be used"),
+        ):
+            self.assertEqual(
+                choose_object_greedy_command(
+                    state,
+                    contracts=self.contracts,
+                    selected_exit_edge=Direction.N,
+                ),
+                SrsCommand(command_type="MOVE_ROUTE", route=(Direction.N,)),
             )
 
 


### PR DESCRIPTION
## 概要

Closes #1146

SRS policy evaluation に `OBJECT_GREEDY` 方策を追加しました。
known-state のみを使って `RESOURCE_CACHE` / `STATION` / `SALVAGE` を候補化し、対象がなければ `EXIT_GREEDY` にフォールバックします。

## 変更内容

- `OBJECT_GREEDY` 方策名と object 優先順位を追加
- known passable cell だけから interaction 可能位置を列挙する helper を追加
- `INTERACT` / 単一 step の `MOVE_ROUTE` / `EXIT_GREEDY` fallback を返す選択ロジックを追加
- `INTERACT_REJECTED` の再試行抑止用に `rejected_object_ids` 引数を追加
- full fuel 時の `RESOURCE_CACHE` / `STATION` 除外、未発見 object 非参照、`MOVE_TO` 非使用、deterministic 選択をテスト追加

## 確認

- `python3 -m unittest experiments.galactic_exodus.srs.test_evaluate_policies`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
