### PR TITLE
#1147 SRS policy evaluationにEXPLORE_THEN_EXIT方策を追加

### DIFF
--- a/experiments/galactic_exodus/srs/evaluate_policies.py
+++ b/experiments/galactic_exodus/srs/evaluate_policies.py
@@ -47,12 +47,15 @@ _REVISIT_CONSUMED_OBJECT_TYPES = frozenset({SrsObjectType.RESOURCE_CACHE, SrsObj
 _KNOWN_IMPASSABLE_TERRAINS = frozenset({SrsTerrainType.ASTEROID, SrsTerrainType.RIFT_BARRIER})
 _KNOWN_IMPASSABLE_OBJECT_TYPES = frozenset({SrsObjectType.STAR, SrsObjectType.PLANET, SrsObjectType.STATION})
 EXIT_GREEDY_POLICY_NAME = "EXIT_GREEDY"
+EXPLORE_THEN_EXIT_POLICY_NAME = "EXPLORE_THEN_EXIT"
 OBJECT_GREEDY_POLICY_NAME = "OBJECT_GREEDY"
 _OBJECT_GREEDY_PRIORITY = {
     SrsObjectType.RESOURCE_CACHE: 0,
     SrsObjectType.STATION: 1,
     SrsObjectType.SALVAGE: 2,
 }
+_EXPLORE_THEN_EXIT_MIN_UNKNOWN_FRONTIER_COUNT = 1
+_EXPLORE_THEN_EXIT_MAX_EXPLORE_STEPS = 12
 
 
 def _freeze_mapping(mapping: Mapping[str, Any]) -> Mapping[str, Any]:
@@ -213,6 +216,134 @@ def choose_exit_greedy_command(
         command_type="MOVE_ROUTE",
         route=(first_step,),
     )
+
+
+def choose_explore_then_exit_command(
+    state: SrsGameState,
+    *,
+    selected_exit_edge: Direction,
+) -> SrsCommand | None:
+    selected_exit_edge = Direction(selected_exit_edge)
+    frontier_candidates = _build_unknown_frontier_candidates(state)
+    if (
+        state.srs_turn >= _EXPLORE_THEN_EXIT_MAX_EXPLORE_STEPS
+        or len(frontier_candidates) < _EXPLORE_THEN_EXIT_MIN_UNKNOWN_FRONTIER_COUNT
+    ):
+        return choose_exit_greedy_command(state, selected_exit_edge=selected_exit_edge)
+
+    if state.player_position in {candidate[0] for candidate in frontier_candidates}:
+        direction = _choose_unknown_frontier_step(
+            state.player_position,
+            known_cells=state.known_state.known_cells,
+            map_width=state.actual_map.width,
+            map_height=state.actual_map.height,
+            selected_exit_edge=selected_exit_edge,
+        )
+        if direction is not None:
+            return SrsCommand(command_type="MOVE_ROUTE", route=(direction,))
+        return choose_exit_greedy_command(state, selected_exit_edge=selected_exit_edge)
+
+    best_choice: tuple[int, int, int, int, tuple[Direction, ...]] | None = None
+    for position, unknown_neighbor_count in frontier_candidates:
+        route = route_on_known_cells(
+            state.player_position,
+            position,
+            known_cells=state.known_state.known_cells,
+            objects=state.objects,
+        )
+        if route is None or not route:
+            continue
+        choice = (
+            -unknown_neighbor_count,
+            len(route),
+            position.y,
+            position.x,
+            route,
+        )
+        if best_choice is None or choice < best_choice:
+            best_choice = choice
+
+    if best_choice is None:
+        return choose_exit_greedy_command(state, selected_exit_edge=selected_exit_edge)
+
+    return SrsCommand(command_type="MOVE_ROUTE", route=(best_choice[4][0],))
+
+
+def _build_unknown_frontier_candidates(
+    state: SrsGameState,
+) -> tuple[tuple[Position, int], ...]:
+    candidates: list[tuple[Position, int]] = []
+    known_cells = state.known_state.known_cells
+    for position in known_cells:
+        if not is_known_passable_cell(position, known_cells=known_cells, objects=state.objects):
+            continue
+        unknown_neighbor_count = _count_unknown_cardinal_neighbors(
+            position,
+            known_cells=known_cells,
+            map_width=state.actual_map.width,
+            map_height=state.actual_map.height,
+        )
+        if unknown_neighbor_count > 0:
+            candidates.append((position, unknown_neighbor_count))
+    candidates.sort(key=lambda candidate: (-candidate[1], candidate[0].y, candidate[0].x))
+    return tuple(candidates)
+
+
+def _count_unknown_cardinal_neighbors(
+    position: Position,
+    *,
+    known_cells: Mapping[Position, SrsCell],
+    map_width: int,
+    map_height: int,
+) -> int:
+    return sum(
+        1
+        for _, neighbor in iter_known_cardinal_neighbors(position)
+        if _is_within_map_bounds(neighbor, map_width=map_width, map_height=map_height) and neighbor not in known_cells
+    )
+
+
+def _choose_unknown_frontier_step(
+    position: Position,
+    *,
+    known_cells: Mapping[Position, SrsCell],
+    map_width: int,
+    map_height: int,
+    selected_exit_edge: Direction,
+) -> Direction | None:
+    preferred_direction = _selected_exit_preferred_direction(selected_exit_edge)
+    candidates = [
+        direction
+        for direction, neighbor in iter_known_cardinal_neighbors(position)
+        if _is_within_map_bounds(neighbor, map_width=map_width, map_height=map_height) and neighbor not in known_cells
+    ]
+    if not candidates:
+        return None
+    return min(
+        candidates,
+        key=lambda direction: (
+            0 if direction is preferred_direction else 1,
+            _DIRECTION_ORDER.index(direction),
+        ),
+    )
+
+
+def _selected_exit_preferred_direction(selected_exit_edge: Direction) -> Direction:
+    return {
+        Direction.N: Direction.N,
+        Direction.E: Direction.E,
+        Direction.S: Direction.S,
+        Direction.W: Direction.W,
+    }[selected_exit_edge]
+
+
+def _is_within_map_bounds(
+    position: Position,
+    *,
+    map_width: int,
+    map_height: int,
+) -> bool:
+    return 0 <= position.x < map_width and 0 <= position.y < map_height
 
 
 @dataclass(frozen=True, slots=True)

--- a/experiments/galactic_exodus/srs/test_evaluate_policies.py
+++ b/experiments/galactic_exodus/srs/test_evaluate_policies.py
@@ -10,10 +10,12 @@ from experiments.galactic_exodus.srs.contracts import load_default_contracts
 from experiments.galactic_exodus.srs.evaluate_policies import (
     EvaluationCase,
     EvaluationCaseError,
+    EXPLORE_THEN_EXIT_POLICY_NAME,
     InitialRevealMode,
     RevisitMode,
     build_default_evaluation_cases,
     build_object_greedy_candidates,
+    choose_explore_then_exit_command,
     choose_exit_greedy_command,
     choose_known_target_step,
     choose_object_greedy_command,
@@ -775,6 +777,191 @@ class ObjectGreedyPolicyTests(unittest.TestCase):
                 ),
                 SrsCommand(command_type="MOVE_ROUTE", route=(Direction.N,)),
             )
+
+
+class ExploreThenExitPolicyTests(unittest.TestCase):
+    def test_policy_name_is_stable(self) -> None:
+        self.assertEqual(EXPLORE_THEN_EXIT_POLICY_NAME, "EXPLORE_THEN_EXIT")
+
+    def test_returns_single_step_move_route_toward_selected_frontier(self) -> None:
+        state = replace(make_state(), player_position=Position(4, 4))
+        state = reveal_positions(
+            state,
+            [
+                Position(4, 4),
+                Position(4, 3),
+                Position(4, 5),
+                Position(3, 4),
+                Position(5, 4),
+                Position(4, 2),
+                Position(3, 3),
+                Position(5, 3),
+            ],
+        )
+        state = replace_cell_terrain(state, Position(3, 4), SrsTerrainType.ASTEROID)
+        state = replace_cell_terrain(state, Position(5, 4), SrsTerrainType.ASTEROID)
+        state = replace_cell_terrain(state, Position(4, 5), SrsTerrainType.ASTEROID)
+        state = reveal_positions(
+            state,
+            [
+                Position(4, 4),
+                Position(4, 3),
+                Position(4, 5),
+                Position(3, 4),
+                Position(5, 4),
+                Position(4, 2),
+                Position(3, 3),
+                Position(5, 3),
+            ],
+        )
+
+        command = choose_explore_then_exit_command(state, selected_exit_edge=Direction.N)
+
+        self.assertEqual(command, SrsCommand(command_type="MOVE_ROUTE", route=(Direction.N,)))
+
+    def test_steps_into_unknown_when_current_position_is_frontier(self) -> None:
+        state = replace(make_state(), player_position=Position(4, 4))
+        state = reveal_positions(
+            state,
+            [
+                Position(4, 4),
+                Position(4, 5),
+                Position(3, 4),
+                Position(5, 4),
+            ],
+        )
+
+        command = choose_explore_then_exit_command(state, selected_exit_edge=Direction.N)
+
+        self.assertEqual(command, SrsCommand(command_type="MOVE_ROUTE", route=(Direction.N,)))
+
+    def test_selected_exit_edge_breaks_unknown_direction_ties(self) -> None:
+        state = replace(make_state(), player_position=Position(4, 4))
+        state = reveal_positions(
+            state,
+            [
+                Position(4, 4),
+                Position(4, 5),
+                Position(3, 4),
+            ],
+        )
+
+        command = choose_explore_then_exit_command(state, selected_exit_edge=Direction.E)
+
+        self.assertEqual(command, SrsCommand(command_type="MOVE_ROUTE", route=(Direction.E,)))
+
+    def test_falls_back_to_exit_greedy_after_max_explore_steps(self) -> None:
+        state = replace(make_state(), player_position=Position(4, 4), srs_turn=12)
+        state = reveal_positions(
+            state,
+            [Position(x, y) for y in range(9) for x in range(9)],
+        )
+        state = replace_cell_warp_flags(state, Position(6, 4), frozenset({Direction.N}))
+
+        command = choose_explore_then_exit_command(state, selected_exit_edge=Direction.N)
+
+        self.assertEqual(command, SrsCommand(command_type="MOVE_ROUTE", route=(Direction.E,)))
+
+    def test_falls_back_to_exit_greedy_when_no_frontier_exists(self) -> None:
+        state = replace(make_state(), player_position=Position(4, 4))
+        state = reveal_positions(
+            state,
+            [Position(x, y) for y in range(9) for x in range(9)],
+        )
+        state = replace_cell_warp_flags(state, Position(6, 4), frozenset({Direction.N}))
+
+        command = choose_explore_then_exit_command(state, selected_exit_edge=Direction.N)
+
+        self.assertEqual(command, SrsCommand(command_type="MOVE_ROUTE", route=(Direction.E,)))
+
+    def test_returns_no_action_when_frontier_and_exit_are_unreachable(self) -> None:
+        state = replace(make_state(), player_position=Position(4, 4))
+        state = reveal_positions(
+            state,
+            [
+                Position(4, 4),
+                Position(4, 3),
+                Position(4, 5),
+                Position(3, 4),
+                Position(5, 4),
+                Position(6, 4),
+            ],
+        )
+        state = replace_cell_terrain(state, Position(4, 3), SrsTerrainType.ASTEROID)
+        state = replace_cell_terrain(state, Position(4, 5), SrsTerrainType.ASTEROID)
+        state = replace_cell_terrain(state, Position(3, 4), SrsTerrainType.ASTEROID)
+        state = replace_cell_terrain(state, Position(5, 4), SrsTerrainType.ASTEROID)
+        state = reveal_positions(
+            state,
+            [
+                Position(4, 4),
+                Position(4, 3),
+                Position(4, 5),
+                Position(3, 4),
+                Position(5, 4),
+                Position(6, 4),
+            ],
+        )
+
+        self.assertIsNone(
+            choose_explore_then_exit_command(state, selected_exit_edge=Direction.N)
+        )
+
+    def test_never_returns_interact_or_move_to(self) -> None:
+        state = replace(make_state(), player_position=Position(4, 4))
+        state = reveal_positions(
+            state,
+            [
+                Position(4, 4),
+                Position(4, 5),
+                Position(3, 4),
+                Position(5, 4),
+            ],
+        )
+
+        command = choose_explore_then_exit_command(state, selected_exit_edge=Direction.N)
+
+        self.assertIsNotNone(command)
+        self.assertNotIn(command.command_type, {"INTERACT", "MOVE_TO"})
+
+    def test_uses_known_state_without_reading_unknown_cell_contents(self) -> None:
+        state = replace(make_state(), player_position=Position(4, 4))
+        state = reveal_positions(
+            state,
+            [
+                Position(4, 4),
+                Position(4, 5),
+                Position(3, 4),
+                Position(5, 4),
+            ],
+        )
+
+        with patch(
+            "experiments.galactic_exodus.srs.model.SrsActualMap.cell_at",
+            side_effect=AssertionError("actual_map.cell_at must not be used"),
+        ):
+            self.assertEqual(
+                choose_explore_then_exit_command(state, selected_exit_edge=Direction.N),
+                SrsCommand(command_type="MOVE_ROUTE", route=(Direction.N,)),
+            )
+
+    def test_is_deterministic_for_same_input(self) -> None:
+        state = replace(make_state(), player_position=Position(4, 4))
+        state = reveal_positions(
+            state,
+            [
+                Position(4, 4),
+                Position(4, 5),
+                Position(3, 4),
+                Position(5, 4),
+            ],
+        )
+
+        first = choose_explore_then_exit_command(state, selected_exit_edge=Direction.N)
+        second = choose_explore_then_exit_command(state, selected_exit_edge=Direction.N)
+
+        self.assertEqual(first, SrsCommand(command_type="MOVE_ROUTE", route=(Direction.N,)))
+        self.assertEqual(first, second)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 概要

Closes #1147

SRS policy evaluation に `EXPLORE_THEN_EXIT` 方策を追加しました。
未知セルに隣接する frontier を known state のみで列挙し、探索条件を満たす間は frontier へ 1 step ずつ移動または未知隣接セルへ踏み込みます。探索条件を満たさない場合や到達不能時は `EXIT_GREEDY` に fallback します。

## 変更内容

- `experiments/galactic_exodus/srs/evaluate_policies.py` に `EXPLORE_THEN_EXIT` 定数と policy chooser を追加
- frontier cell 判定、unknown neighbor 数カウント、selected exit edge 優先の tie-break を known state 限定 helper として追加
- `MOVE_ROUTE` / `WARP_EXIT` 以外を返さない制約を維持しつつ、未発見セル内容を読まない実装にした
- `experiments/galactic_exodus/srs/test_evaluate_policies.py` に frontier 選択、frontier 上での未知セル踏み込み、fallback、determinism、unknown cell 非参照のテストを追加

## 確認

- `python3 -m unittest experiments.galactic_exodus.srs.test_evaluate_policies`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo fmt --check`
