### PR TITLE
SRS policy evaluationのrun loopとoutcome分類を追加

### DIFF
--- a/experiments/galactic_exodus/srs/evaluate_policies.py
+++ b/experiments/galactic_exodus/srs/evaluate_policies.py
@@ -4,11 +4,22 @@ from collections import deque
 from dataclasses import dataclass, replace
 from enum import Enum
 from types import MappingProxyType
-from typing import Any, Iterable, Mapping
+from typing import Any, Callable, Iterable, Mapping
 
 from experiments.galactic_exodus.srs.contracts import SrsContracts
-from experiments.galactic_exodus.srs.engine import restore_srs_state, reveal_full_observation, reveal_observation
+from experiments.galactic_exodus.srs.engine import (
+    apply_srs_command,
+    restore_srs_state,
+    reveal_full_observation,
+    reveal_observation,
+)
 from experiments.galactic_exodus.srs.generate import create_sector
+from experiments.galactic_exodus.srs.log import (
+    INTERACT_REJECTED,
+    MOVE_REJECTED,
+    WARP_EXIT_ACCEPTED,
+    WARP_EXIT_REJECTED,
+)
 from experiments.galactic_exodus.srs.model import (
     CostMode,
     Direction,
@@ -22,6 +33,7 @@ from experiments.galactic_exodus.srs.model import (
     SrsObjectState,
     SrsObjectType,
     SrsTerrainType,
+    SrsTurnEvent,
     validate_sector_descriptor,
 )
 
@@ -56,6 +68,8 @@ _OBJECT_GREEDY_PRIORITY = {
 }
 _EXPLORE_THEN_EXIT_MIN_UNKNOWN_FRONTIER_COUNT = 1
 _EXPLORE_THEN_EXIT_MAX_EXPLORE_STEPS = 12
+DEFAULT_MAX_SRS_TURN = 50
+DEFAULT_MAX_COMMANDS = 50
 
 
 def _freeze_mapping(mapping: Mapping[str, Any]) -> Mapping[str, Any]:
@@ -723,6 +737,196 @@ def build_default_evaluation_cases() -> tuple[EvaluationCase, ...]:
             initial_player_position=Position(4, 4),
         ),
     )
+
+
+class PolicyRunOutcome(str, Enum):
+    EXITED = "EXITED"
+    ABORTED_TURN_LIMIT = "ABORTED_TURN_LIMIT"
+    ABORTED_NO_POLICY_ACTION = "ABORTED_NO_POLICY_ACTION"
+    RESOURCE_DEPLETED = "RESOURCE_DEPLETED"
+    GENERATION_ERROR = "GENERATION_ERROR"
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyRunResult:
+    evaluation_case: EvaluationCase
+    policy_name: str
+    outcome: PolicyRunOutcome
+    final_state: SrsGameState | None
+    command_count: int
+    event_log: tuple[SrsTurnEvent, ...]
+    action_sequence: tuple[SrsCommand, ...]
+
+
+_POLICY_COMMAND_GENERATORS: Mapping[str, Callable[..., SrsCommand | None]] = MappingProxyType(
+    {
+        EXIT_GREEDY_POLICY_NAME: choose_exit_greedy_command,
+        EXPLORE_THEN_EXIT_POLICY_NAME: choose_explore_then_exit_command,
+        OBJECT_GREEDY_POLICY_NAME: choose_object_greedy_command,
+    }
+)
+_REJECTED_RUN_EVENT_TYPES = frozenset({MOVE_REJECTED, INTERACT_REJECTED, WARP_EXIT_REJECTED})
+
+
+def run_policy_evaluation_case(
+    evaluation_case: EvaluationCase,
+    policy_name: str,
+    *,
+    contracts: SrsContracts,
+    max_srs_turn: int = DEFAULT_MAX_SRS_TURN,
+    max_commands: int = DEFAULT_MAX_COMMANDS,
+) -> PolicyRunResult:
+    if max_srs_turn < 0:
+        raise ValueError("max_srs_turn must be non-negative")
+    if max_commands < 0:
+        raise ValueError("max_commands must be non-negative")
+
+    try:
+        current_state = evaluation_case.build_initial_state(contracts=contracts)
+    except (EvaluationCaseError, SrsModelError, ValueError):
+        return PolicyRunResult(
+            evaluation_case=evaluation_case,
+            policy_name=policy_name,
+            outcome=PolicyRunOutcome.GENERATION_ERROR,
+            final_state=None,
+            command_count=0,
+            event_log=(),
+            action_sequence=(),
+        )
+
+    events: list[SrsTurnEvent] = []
+    action_sequence: list[SrsCommand] = []
+    rejected_commands: set[SrsCommand] = set()
+    rejected_object_ids: set[str] = set()
+
+    while True:
+        if current_state.srs_turn >= max_srs_turn or len(action_sequence) >= max_commands:
+            return _build_policy_run_result(
+                evaluation_case=evaluation_case,
+                policy_name=policy_name,
+                outcome=PolicyRunOutcome.ABORTED_TURN_LIMIT,
+                final_state=current_state,
+                events=events,
+                action_sequence=action_sequence,
+            )
+
+        try:
+            command = choose_policy_command(
+                current_state,
+                policy_name=policy_name,
+                contracts=contracts,
+                selected_exit_edge=evaluation_case.selected_exit_edge,
+                rejected_object_ids=rejected_object_ids,
+            )
+        except (EvaluationCaseError, SrsModelError, ValueError):
+            return _build_policy_run_result(
+                evaluation_case=evaluation_case,
+                policy_name=policy_name,
+                outcome=PolicyRunOutcome.GENERATION_ERROR,
+                final_state=current_state,
+                events=events,
+                action_sequence=action_sequence,
+            )
+
+        if command is None or command in rejected_commands:
+            return _build_policy_run_result(
+                evaluation_case=evaluation_case,
+                policy_name=policy_name,
+                outcome=PolicyRunOutcome.ABORTED_NO_POLICY_ACTION,
+                final_state=current_state,
+                events=events,
+                action_sequence=action_sequence,
+            )
+
+        result = apply_srs_command(
+            current_state,
+            command,
+            contracts=contracts,
+            cost_mode=evaluation_case.cost_mode,
+        )
+        current_state = result.state
+        action_sequence.append(command)
+        events.extend(result.events)
+
+        outcome = _classify_run_outcome(result.events)
+        if outcome is not None:
+            return _build_policy_run_result(
+                evaluation_case=evaluation_case,
+                policy_name=policy_name,
+                outcome=outcome,
+                final_state=current_state,
+                events=events,
+                action_sequence=action_sequence,
+            )
+
+        if _command_was_rejected(result.events):
+            rejected_commands.add(command)
+            if command.command_type == "INTERACT" and command.target_object_id is not None:
+                rejected_object_ids.add(command.target_object_id)
+
+
+def choose_policy_command(
+    state: SrsGameState,
+    *,
+    policy_name: str,
+    contracts: SrsContracts,
+    selected_exit_edge: Direction,
+    rejected_object_ids: Iterable[str] = (),
+) -> SrsCommand | None:
+    generator = _POLICY_COMMAND_GENERATORS.get(policy_name)
+    if generator is None:
+        raise EvaluationCaseError(f"unsupported policy_name: {policy_name}")
+    if policy_name == OBJECT_GREEDY_POLICY_NAME:
+        return generator(
+            state,
+            contracts=contracts,
+            selected_exit_edge=selected_exit_edge,
+            rejected_object_ids=rejected_object_ids,
+        )
+    return generator(state, selected_exit_edge=selected_exit_edge)
+
+
+def _build_policy_run_result(
+    *,
+    evaluation_case: EvaluationCase,
+    policy_name: str,
+    outcome: PolicyRunOutcome,
+    final_state: SrsGameState | None,
+    events: Iterable[SrsTurnEvent],
+    action_sequence: Iterable[SrsCommand],
+) -> PolicyRunResult:
+    action_sequence = tuple(action_sequence)
+    return PolicyRunResult(
+        evaluation_case=evaluation_case,
+        policy_name=policy_name,
+        outcome=outcome,
+        final_state=final_state,
+        command_count=len(action_sequence),
+        event_log=tuple(events),
+        action_sequence=action_sequence,
+    )
+
+
+def _classify_run_outcome(events: Iterable[SrsTurnEvent]) -> PolicyRunOutcome | None:
+    event_types = {event.event_type for event in events}
+    if WARP_EXIT_ACCEPTED in event_types:
+        return PolicyRunOutcome.EXITED
+    if _contains_resource_depleted_event(events):
+        return PolicyRunOutcome.RESOURCE_DEPLETED
+    return None
+
+
+def _contains_resource_depleted_event(events: Iterable[SrsTurnEvent]) -> bool:
+    return any(
+        event.payload.get("outcome") == PolicyRunOutcome.RESOURCE_DEPLETED.value
+        for event in events
+    )
+
+
+def _command_was_rejected(events: Iterable[SrsTurnEvent]) -> bool:
+    for event in events:
+        return event.event_type in _REJECTED_RUN_EVENT_TYPES
+    return False
 
 
 def _apply_initial_reveal(

--- a/experiments/galactic_exodus/srs/test_evaluate_policies.py
+++ b/experiments/galactic_exodus/srs/test_evaluate_policies.py
@@ -11,7 +11,10 @@ from experiments.galactic_exodus.srs.evaluate_policies import (
     EvaluationCase,
     EvaluationCaseError,
     EXPLORE_THEN_EXIT_POLICY_NAME,
+    EXIT_GREEDY_POLICY_NAME,
     InitialRevealMode,
+    OBJECT_GREEDY_POLICY_NAME,
+    PolicyRunOutcome,
     RevisitMode,
     build_default_evaluation_cases,
     build_object_greedy_candidates,
@@ -19,13 +22,13 @@ from experiments.galactic_exodus.srs.evaluate_policies import (
     choose_exit_greedy_command,
     choose_known_target_step,
     choose_object_greedy_command,
-    EXIT_GREEDY_POLICY_NAME,
     first_known_route_step,
     is_known_passable_cell,
     iter_known_cardinal_neighbors,
-    OBJECT_GREEDY_POLICY_NAME,
     route_on_known_cells,
+    run_policy_evaluation_case,
 )
+from experiments.galactic_exodus.srs.log import INTERACT_REJECTED, MOVE_REJECTED, WARP_EXIT_ACCEPTED, WARP_EXIT_REJECTED
 from experiments.galactic_exodus.srs.model import (
     CostMode,
     Direction,
@@ -961,6 +964,226 @@ class ExploreThenExitPolicyTests(unittest.TestCase):
         second = choose_explore_then_exit_command(state, selected_exit_edge=Direction.N)
 
         self.assertEqual(first, SrsCommand(command_type="MOVE_ROUTE", route=(Direction.N,)))
+        self.assertEqual(first, second)
+
+
+class PolicyRunLoopTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.contracts = load_default_contracts(REPO_ROOT)
+
+    def make_case(self, *, selected_exit_edge: Direction = Direction.S) -> EvaluationCase:
+        return EvaluationCase(
+            case_id=f"run-loop-{selected_exit_edge.value.lower()}",
+            sector_id="normal-1001",
+            sector_type=SectorType.NORMAL,
+            sector_seed=1001,
+            entry_edge=Direction.S,
+            blocked_edges=frozenset(),
+            selected_exit_edge=selected_exit_edge,
+            cost_mode=CostMode.TURN_ONLY,
+            initial_fuel=0,
+            max_fuel=9,
+            initial_reveal_mode=InitialRevealMode.NONE,
+            revisit_mode=RevisitMode.FIRST_VISIT,
+        )
+
+    def make_exit_ready_state(self) -> SrsGameState:
+        return reveal_positions(make_state(entry_edge=Direction.S), [Position(4, 8)])
+
+    def test_classifies_warp_exit_accepted_as_exited(self) -> None:
+        case = self.make_case(selected_exit_edge=Direction.S)
+
+        with patch.object(EvaluationCase, "build_initial_state", return_value=self.make_exit_ready_state()):
+            result = run_policy_evaluation_case(
+                case,
+                EXIT_GREEDY_POLICY_NAME,
+                contracts=self.contracts,
+            )
+
+        self.assertEqual(result.outcome, PolicyRunOutcome.EXITED)
+        self.assertEqual(result.command_count, 1)
+        self.assertEqual(result.action_sequence, (SrsCommand(command_type="WARP_EXIT", exit_direction=Direction.S),))
+        self.assertEqual(result.event_log[0].event_type, WARP_EXIT_ACCEPTED)
+
+    def test_policy_returning_no_action_aborts_run(self) -> None:
+        case = self.make_case()
+
+        with patch.object(EvaluationCase, "build_initial_state", return_value=self.make_exit_ready_state()):
+            with patch(
+                "experiments.galactic_exodus.srs.evaluate_policies.choose_policy_command",
+                return_value=None,
+            ):
+                result = run_policy_evaluation_case(
+                    case,
+                    EXIT_GREEDY_POLICY_NAME,
+                    contracts=self.contracts,
+                )
+
+        self.assertEqual(result.outcome, PolicyRunOutcome.ABORTED_NO_POLICY_ACTION)
+        self.assertEqual(result.command_count, 0)
+        self.assertEqual(result.event_log, ())
+
+    def test_max_srs_turn_aborts_before_querying_policy(self) -> None:
+        case = self.make_case()
+        state = replace(self.make_exit_ready_state(), srs_turn=3)
+
+        with patch.object(EvaluationCase, "build_initial_state", return_value=state):
+            with patch(
+                "experiments.galactic_exodus.srs.evaluate_policies.choose_policy_command",
+                side_effect=AssertionError("policy should not be queried"),
+            ):
+                result = run_policy_evaluation_case(
+                    case,
+                    EXIT_GREEDY_POLICY_NAME,
+                    contracts=self.contracts,
+                    max_srs_turn=3,
+                )
+
+        self.assertEqual(result.outcome, PolicyRunOutcome.ABORTED_TURN_LIMIT)
+        self.assertEqual(result.command_count, 0)
+
+    def test_max_commands_aborts_after_reaching_command_limit(self) -> None:
+        case = self.make_case()
+        state = replace(make_state(), player_position=Position(4, 4))
+        state = reveal_positions(state, [Position(4, 4), Position(4, 3)])
+
+        with patch.object(EvaluationCase, "build_initial_state", return_value=state):
+            with patch(
+                "experiments.galactic_exodus.srs.evaluate_policies.choose_policy_command",
+                return_value=SrsCommand(command_type="MOVE_ROUTE", route=(Direction.N,)),
+            ):
+                result = run_policy_evaluation_case(
+                    case,
+                    EXIT_GREEDY_POLICY_NAME,
+                    contracts=self.contracts,
+                    max_commands=1,
+                )
+
+        self.assertEqual(result.outcome, PolicyRunOutcome.ABORTED_TURN_LIMIT)
+        self.assertEqual(result.command_count, 1)
+        self.assertEqual(result.action_sequence, (SrsCommand(command_type="MOVE_ROUTE", route=(Direction.N,)),))
+
+    def test_warp_exit_rejected_does_not_end_run(self) -> None:
+        case = self.make_case(selected_exit_edge=Direction.S)
+
+        with patch.object(EvaluationCase, "build_initial_state", return_value=self.make_exit_ready_state()):
+            with patch(
+                "experiments.galactic_exodus.srs.evaluate_policies.choose_policy_command",
+                side_effect=[
+                    SrsCommand(command_type="WARP_EXIT", exit_direction=Direction.N),
+                    SrsCommand(command_type="WARP_EXIT", exit_direction=Direction.S),
+                ],
+            ):
+                result = run_policy_evaluation_case(
+                    case,
+                    EXIT_GREEDY_POLICY_NAME,
+                    contracts=self.contracts,
+                )
+
+        self.assertEqual(result.outcome, PolicyRunOutcome.EXITED)
+        self.assertEqual(result.command_count, 2)
+        self.assertEqual(result.event_log[0].event_type, WARP_EXIT_REJECTED)
+        self.assertEqual(result.event_log[-1].event_type, WARP_EXIT_ACCEPTED)
+
+    def test_move_rejected_does_not_end_run(self) -> None:
+        case = self.make_case(selected_exit_edge=Direction.S)
+
+        with patch.object(EvaluationCase, "build_initial_state", return_value=self.make_exit_ready_state()):
+            with patch(
+                "experiments.galactic_exodus.srs.evaluate_policies.choose_policy_command",
+                side_effect=[
+                    SrsCommand(command_type="MOVE_TO", target=Position(0, 0)),
+                    SrsCommand(command_type="WARP_EXIT", exit_direction=Direction.S),
+                ],
+            ):
+                result = run_policy_evaluation_case(
+                    case,
+                    EXIT_GREEDY_POLICY_NAME,
+                    contracts=self.contracts,
+                )
+
+        self.assertEqual(result.outcome, PolicyRunOutcome.EXITED)
+        self.assertEqual(result.event_log[0].event_type, MOVE_REJECTED)
+        self.assertEqual(result.event_log[-1].event_type, WARP_EXIT_ACCEPTED)
+
+    def test_interact_rejected_does_not_end_run(self) -> None:
+        case = self.make_case(selected_exit_edge=Direction.S)
+
+        with patch.object(EvaluationCase, "build_initial_state", return_value=self.make_exit_ready_state()):
+            with patch(
+                "experiments.galactic_exodus.srs.evaluate_policies.choose_policy_command",
+                side_effect=[
+                    SrsCommand(command_type="INTERACT", target_object_id="missing-object"),
+                    SrsCommand(command_type="WARP_EXIT", exit_direction=Direction.S),
+                ],
+            ):
+                result = run_policy_evaluation_case(
+                    case,
+                    EXIT_GREEDY_POLICY_NAME,
+                    contracts=self.contracts,
+                )
+
+        self.assertEqual(result.outcome, PolicyRunOutcome.EXITED)
+        self.assertEqual(result.event_log[0].event_type, INTERACT_REJECTED)
+        self.assertEqual(result.event_log[-1].event_type, WARP_EXIT_ACCEPTED)
+
+    def test_repeated_invalid_action_is_suppressed_as_no_policy_action(self) -> None:
+        case = self.make_case()
+        repeated_command = SrsCommand(command_type="MOVE_TO", target=Position(0, 0))
+
+        with patch.object(EvaluationCase, "build_initial_state", return_value=self.make_exit_ready_state()):
+            with patch(
+                "experiments.galactic_exodus.srs.evaluate_policies.choose_policy_command",
+                side_effect=[repeated_command, repeated_command],
+            ):
+                result = run_policy_evaluation_case(
+                    case,
+                    EXIT_GREEDY_POLICY_NAME,
+                    contracts=self.contracts,
+                )
+
+        self.assertEqual(result.outcome, PolicyRunOutcome.ABORTED_NO_POLICY_ACTION)
+        self.assertEqual(result.command_count, 1)
+        self.assertEqual(result.event_log[0].event_type, MOVE_REJECTED)
+        self.assertEqual(result.action_sequence, (repeated_command,))
+
+    def test_action_sequence_is_recorded_in_order(self) -> None:
+        case = self.make_case(selected_exit_edge=Direction.S)
+        first = SrsCommand(command_type="MOVE_TO", target=Position(0, 0))
+        second = SrsCommand(command_type="WARP_EXIT", exit_direction=Direction.S)
+
+        with patch.object(EvaluationCase, "build_initial_state", return_value=self.make_exit_ready_state()):
+            with patch(
+                "experiments.galactic_exodus.srs.evaluate_policies.choose_policy_command",
+                side_effect=[first, second],
+            ):
+                result = run_policy_evaluation_case(
+                    case,
+                    EXIT_GREEDY_POLICY_NAME,
+                    contracts=self.contracts,
+                )
+
+        self.assertEqual(result.action_sequence, (first, second))
+        self.assertEqual(result.command_count, 2)
+
+    def test_same_input_produces_same_run_result(self) -> None:
+        case = self.make_case(selected_exit_edge=Direction.S)
+        state = self.make_exit_ready_state()
+
+        with patch.object(EvaluationCase, "build_initial_state", return_value=state):
+            first = run_policy_evaluation_case(
+                case,
+                EXIT_GREEDY_POLICY_NAME,
+                contracts=self.contracts,
+            )
+        with patch.object(EvaluationCase, "build_initial_state", return_value=state):
+            second = run_policy_evaluation_case(
+                case,
+                EXIT_GREEDY_POLICY_NAME,
+                contracts=self.contracts,
+            )
+
         self.assertEqual(first, second)
 
 


### PR DESCRIPTION
## 概要

Closes #1148

SRS policy evaluation の 1 case / 1 policy 実行用 run loop を追加し、run outcome の分類と再試行抑止を実装しました。

## 変更内容

- `PolicyRunOutcome` / `PolicyRunResult` を追加
- `run_policy_evaluation_case(...)` を追加し、初期 state 生成から policy 実行、`apply_srs_command(...)` 適用、終了判定までを一貫して処理
- policy dispatch を `choose_policy_command(...)` として共通化
- `MOVE_REJECTED` / `INTERACT_REJECTED` / `WARP_EXIT_REJECTED` は即終了にせず継続しつつ、同一無効 action の再実行は `ABORTED_NO_POLICY_ACTION` に抑止
- `test_evaluate_policies.py` に run loop と outcome classification の回帰テストを追加

## 確認

- `python3 -m unittest experiments.galactic_exodus.srs.test_evaluate_policies`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
