### PR TITLE
SRS policy evaluationのmetrics集計を追加

### DIFF
--- a/experiments/galactic_exodus/srs/evaluate_policies.py
+++ b/experiments/galactic_exodus/srs/evaluate_policies.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 from collections import deque
 from dataclasses import dataclass, replace
 from enum import Enum
+import statistics
 from types import MappingProxyType
 from typing import Any, Callable, Iterable, Mapping
 
+from experiments.galactic_exodus import metrics
 from experiments.galactic_exodus.srs.contracts import SrsContracts
 from experiments.galactic_exodus.srs.engine import (
     apply_srs_command,
@@ -70,6 +72,13 @@ _EXPLORE_THEN_EXIT_MIN_UNKNOWN_FRONTIER_COUNT = 1
 _EXPLORE_THEN_EXIT_MAX_EXPLORE_STEPS = 12
 DEFAULT_MAX_SRS_TURN = 50
 DEFAULT_MAX_COMMANDS = 50
+_VALUE_OBJECT_TYPES = frozenset(
+    {
+        SrsObjectType.RESOURCE_CACHE,
+        SrsObjectType.STATION,
+        SrsObjectType.SALVAGE,
+    }
+)
 
 
 def _freeze_mapping(mapping: Mapping[str, Any]) -> Mapping[str, Any]:
@@ -756,6 +765,237 @@ class PolicyRunResult:
     command_count: int
     event_log: tuple[SrsTurnEvent, ...]
     action_sequence: tuple[SrsCommand, ...]
+
+
+def summarize_policy_runs(policy_runs: Iterable[PolicyRunResult]) -> dict[str, Any]:
+    runs = tuple(policy_runs)
+    if not runs:
+        raise ValueError("policy_runs must not be empty")
+
+    turn_only_exit_rate = _exit_rate_for_cost_mode(runs, CostMode.TURN_ONLY)
+    shared_fuel_exit_rate = _exit_rate_for_cost_mode(runs, CostMode.SHARED_FUEL)
+
+    summary = _build_summary_metrics(runs)
+    summary["run_count_by_policy"] = _count_by_group(
+        runs,
+        key_fn=lambda run: run.policy_name,
+        preferred_keys=tuple(_POLICY_COMMAND_GENERATORS),
+    )
+    summary["run_count_by_cost_mode"] = _count_by_group(
+        runs,
+        key_fn=lambda run: run.evaluation_case.cost_mode.value,
+        preferred_keys=tuple(cost_mode.value for cost_mode in CostMode),
+    )
+    summary["run_count_by_sector_type"] = _count_by_group(
+        runs,
+        key_fn=lambda run: run.evaluation_case.sector_type.value,
+        preferred_keys=tuple(sector_type.value for sector_type in SectorType),
+    )
+    summary["run_count_by_outcome"] = _count_by_group(
+        runs,
+        key_fn=lambda run: run.outcome.value,
+        preferred_keys=tuple(outcome.value for outcome in PolicyRunOutcome),
+    )
+    summary["turn_only_exit_rate"] = turn_only_exit_rate
+    summary["shared_fuel_exit_rate"] = shared_fuel_exit_rate
+    summary["turn_only_vs_shared_fuel_failure_delta"] = _failure_rate_delta(
+        turn_only_exit_rate=turn_only_exit_rate,
+        shared_fuel_exit_rate=shared_fuel_exit_rate,
+    )
+    summary["by_policy"] = _summaries_by_group(
+        runs,
+        key_fn=lambda run: run.policy_name,
+        preferred_keys=tuple(_POLICY_COMMAND_GENERATORS),
+    )
+    summary["by_cost_mode"] = _summaries_by_group(
+        runs,
+        key_fn=lambda run: run.evaluation_case.cost_mode.value,
+        preferred_keys=tuple(cost_mode.value for cost_mode in CostMode),
+    )
+    summary["by_sector_type"] = _summaries_by_group(
+        runs,
+        key_fn=lambda run: run.evaluation_case.sector_type.value,
+        preferred_keys=tuple(sector_type.value for sector_type in SectorType),
+    )
+    summary["by_outcome"] = _summaries_by_group(
+        runs,
+        key_fn=lambda run: run.outcome.value,
+        preferred_keys=tuple(outcome.value for outcome in PolicyRunOutcome),
+    )
+    return summary
+
+
+def _build_summary_metrics(runs: tuple[PolicyRunResult, ...]) -> dict[str, Any]:
+    srs_turn_counts = sorted(
+        run.final_state.srs_turn
+        for run in runs
+        if run.final_state is not None
+    )
+    run_count = len(runs)
+    return {
+        "run_count": run_count,
+        "exit_rate": _rounded_ratio(_count_runs(runs, lambda run: run.outcome is PolicyRunOutcome.EXITED), run_count),
+        "median_srs_turn_count": _median_or_none(srs_turn_counts),
+        "p90_srs_turn_count": _p90_or_none(srs_turn_counts),
+        "object_discovery_rate": _rounded_ratio(_count_runs(runs, _has_discovered_value_object), run_count),
+        "object_acquisition_rate": _rounded_ratio(_count_runs(runs, _has_acquired_value_object), run_count),
+        "station_use_rate": _rounded_ratio(_count_runs(runs, _has_used_station), run_count),
+        "resource_use_rate": _rounded_ratio(_count_runs(runs, _has_used_resource_cache), run_count),
+        "salvage_acquisition_rate": _rounded_ratio(_count_runs(runs, _has_acquired_salvage), run_count),
+        "blocked_edge_attempt_rate": _rounded_ratio(_count_runs(runs, _attempted_blocked_edge), run_count),
+        "turn_limit_rate": _rounded_ratio(
+            _count_runs(runs, lambda run: run.outcome is PolicyRunOutcome.ABORTED_TURN_LIMIT),
+            run_count,
+        ),
+        "no_policy_action_rate": _rounded_ratio(
+            _count_runs(runs, lambda run: run.outcome is PolicyRunOutcome.ABORTED_NO_POLICY_ACTION),
+            run_count,
+        ),
+    }
+
+
+def _count_by_group(
+    runs: tuple[PolicyRunResult, ...],
+    *,
+    key_fn: Callable[[PolicyRunResult], str],
+    preferred_keys: tuple[str, ...],
+) -> dict[str, int]:
+    counts = {key: 0 for key in preferred_keys}
+    for run in runs:
+        key = key_fn(run)
+        counts[key] = counts.get(key, 0) + 1
+    ordered_keys = list(preferred_keys) + sorted(key for key in counts if key not in preferred_keys)
+    return {key: counts[key] for key in ordered_keys if counts.get(key, 0) > 0 or key in preferred_keys}
+
+
+def _summaries_by_group(
+    runs: tuple[PolicyRunResult, ...],
+    *,
+    key_fn: Callable[[PolicyRunResult], str],
+    preferred_keys: tuple[str, ...],
+) -> dict[str, dict[str, Any]]:
+    grouped: dict[str, list[PolicyRunResult]] = {}
+    for run in runs:
+        key = key_fn(run)
+        grouped.setdefault(key, []).append(run)
+
+    ordered_keys = [key for key in preferred_keys if key in grouped]
+    ordered_keys.extend(sorted(key for key in grouped if key not in preferred_keys))
+    return {
+        key: _build_summary_metrics(tuple(grouped[key]))
+        for key in ordered_keys
+    }
+
+
+def _count_runs(runs: Iterable[PolicyRunResult], predicate: Callable[[PolicyRunResult], bool]) -> int:
+    return sum(1 for run in runs if predicate(run))
+
+
+def _rounded_ratio(count: int, total: int) -> float:
+    if total == 0:
+        return 0.0
+    return round(count / total, 6)
+
+
+def _median_or_none(series: list[int]) -> float | int | None:
+    if not series:
+        return None
+    return statistics.median(series)
+
+
+def _p90_or_none(series: list[int]) -> int | None:
+    if not series:
+        return None
+    return metrics.percentile_nearest_rank(series, 0.90)
+
+
+def _exit_rate_for_cost_mode(
+    runs: tuple[PolicyRunResult, ...],
+    cost_mode: CostMode,
+) -> float | None:
+    matched_runs = tuple(run for run in runs if run.evaluation_case.cost_mode is cost_mode)
+    if not matched_runs:
+        return None
+    return _rounded_ratio(
+        _count_runs(matched_runs, lambda run: run.outcome is PolicyRunOutcome.EXITED),
+        len(matched_runs),
+    )
+
+
+def _failure_rate_delta(
+    *,
+    turn_only_exit_rate: float | None,
+    shared_fuel_exit_rate: float | None,
+) -> float | None:
+    if turn_only_exit_rate is None or shared_fuel_exit_rate is None:
+        return None
+    turn_only_failure_rate = 1.0 - turn_only_exit_rate
+    shared_fuel_failure_rate = 1.0 - shared_fuel_exit_rate
+    return round(turn_only_failure_rate - shared_fuel_failure_rate, 6)
+
+
+def _has_discovered_value_object(run: PolicyRunResult) -> bool:
+    final_state = run.final_state
+    if final_state is None:
+        return False
+    return any(
+        object_state is not None and object_state.object_type in _VALUE_OBJECT_TYPES
+        for cell in final_state.known_state.known_cells.values()
+        for object_state in [None if cell.object_id is None else final_state.objects.get(cell.object_id)]
+    )
+
+
+def _has_acquired_value_object(run: PolicyRunResult) -> bool:
+    return _has_used_station(run) or _has_used_resource_cache(run) or _has_acquired_salvage(run)
+
+
+def _has_used_station(run: PolicyRunResult) -> bool:
+    return _persistent_object_match(
+        run,
+        object_ids=run.final_state.persistent_state.activated_object_ids if run.final_state else (),
+        expected_type=SrsObjectType.STATION,
+    )
+
+
+def _has_used_resource_cache(run: PolicyRunResult) -> bool:
+    return _persistent_object_match(
+        run,
+        object_ids=run.final_state.persistent_state.consumed_object_ids if run.final_state else (),
+        expected_type=SrsObjectType.RESOURCE_CACHE,
+    )
+
+
+def _has_acquired_salvage(run: PolicyRunResult) -> bool:
+    return _persistent_object_match(
+        run,
+        object_ids=run.final_state.persistent_state.consumed_object_ids if run.final_state else (),
+        expected_type=SrsObjectType.SALVAGE,
+    )
+
+
+def _persistent_object_match(
+    run: PolicyRunResult,
+    *,
+    object_ids: Iterable[str],
+    expected_type: SrsObjectType | None,
+) -> bool:
+    final_state = run.final_state
+    if final_state is None:
+        return False
+    for object_id in object_ids:
+        object_state = final_state.objects.get(object_id)
+        if object_state is None:
+            continue
+        if expected_type is None or object_state.object_type is expected_type:
+            return True
+    return False
+
+
+def _attempted_blocked_edge(run: PolicyRunResult) -> bool:
+    return any(
+        event.event_type == WARP_EXIT_REJECTED and event.payload.get("outcome") == "REJECTED_BLOCKED_EDGE"
+        for event in run.event_log
+    )
 
 
 _POLICY_COMMAND_GENERATORS: Mapping[str, Callable[..., SrsCommand | None]] = MappingProxyType(

--- a/experiments/galactic_exodus/srs/test_evaluate_policies.py
+++ b/experiments/galactic_exodus/srs/test_evaluate_policies.py
@@ -14,6 +14,7 @@ from experiments.galactic_exodus.srs.evaluate_policies import (
     EXIT_GREEDY_POLICY_NAME,
     InitialRevealMode,
     OBJECT_GREEDY_POLICY_NAME,
+    PolicyRunResult,
     PolicyRunOutcome,
     RevisitMode,
     build_default_evaluation_cases,
@@ -27,8 +28,18 @@ from experiments.galactic_exodus.srs.evaluate_policies import (
     iter_known_cardinal_neighbors,
     route_on_known_cells,
     run_policy_evaluation_case,
+    summarize_policy_runs,
 )
-from experiments.galactic_exodus.srs.log import INTERACT_REJECTED, MOVE_REJECTED, WARP_EXIT_ACCEPTED, WARP_EXIT_REJECTED
+from experiments.galactic_exodus.srs.log import (
+    INTERACT_ACCEPTED,
+    INTERACT_REJECTED,
+    MOVE_REJECTED,
+    OBJECT_CONSUMED,
+    STATION_ACTIVATED,
+    WARP_EXIT_ACCEPTED,
+    WARP_EXIT_REJECTED,
+    make_turn_event,
+)
 from experiments.galactic_exodus.srs.model import (
     CostMode,
     Direction,
@@ -1185,6 +1196,237 @@ class PolicyRunLoopTests(unittest.TestCase):
             )
 
         self.assertEqual(first, second)
+
+
+class PolicyRunAggregationTests(unittest.TestCase):
+    def make_case(
+        self,
+        *,
+        case_id: str,
+        sector_type: SectorType,
+        cost_mode: CostMode,
+    ) -> EvaluationCase:
+        blocked_edges = frozenset({Direction.W}) if sector_type is SectorType.RIFT else frozenset()
+        return EvaluationCase(
+            case_id=case_id,
+            sector_id=f"{sector_type.value.lower()}-{case_id}",
+            sector_type=sector_type,
+            sector_seed=1000,
+            entry_edge=Direction.S,
+            blocked_edges=blocked_edges,
+            selected_exit_edge=Direction.N,
+            cost_mode=cost_mode,
+            initial_fuel=0,
+            max_fuel=9,
+            initial_reveal_mode=InitialRevealMode.NONE,
+            revisit_mode=RevisitMode.FIRST_VISIT,
+        )
+
+    def make_run_result(
+        self,
+        *,
+        case_id: str,
+        policy_name: str,
+        sector_type: SectorType,
+        cost_mode: CostMode,
+        outcome: PolicyRunOutcome,
+        srs_turn: int,
+        events=(),
+        consumed_object_ids=frozenset(),
+        activated_object_ids=frozenset(),
+        discovered_object_ids=(),
+    ) -> PolicyRunResult:
+        state = make_state()
+        if discovered_object_ids:
+            positions = [Position(4 + index, 4) for index, _ in enumerate(discovered_object_ids)]
+            for object_id, position in zip(discovered_object_ids, positions, strict=True):
+                object_type = {
+                    "resource-cache-1": SrsObjectType.RESOURCE_CACHE,
+                    "station-1": SrsObjectType.STATION,
+                    "salvage-1": SrsObjectType.SALVAGE,
+                }[object_id]
+                state = place_object(state, position, object_type, object_id)
+            state = reveal_positions(state, positions)
+        final_state = replace(
+            state,
+            descriptor=replace(state.descriptor, sector_type=sector_type),
+            srs_turn=srs_turn,
+            persistent_state=replace(
+                state.persistent_state,
+                consumed_object_ids=consumed_object_ids,
+                activated_object_ids=activated_object_ids,
+                sector_type=sector_type,
+            ),
+        )
+        return PolicyRunResult(
+            evaluation_case=self.make_case(case_id=case_id, sector_type=sector_type, cost_mode=cost_mode),
+            policy_name=policy_name,
+            outcome=outcome,
+            final_state=final_state,
+            command_count=len(events),
+            event_log=tuple(events),
+            action_sequence=(),
+        )
+
+    def test_summarizes_run_counts_rates_and_percentiles(self) -> None:
+        runs = [
+            self.make_run_result(
+                case_id="normal-turn-exit",
+                policy_name=EXIT_GREEDY_POLICY_NAME,
+                sector_type=SectorType.NORMAL,
+                cost_mode=CostMode.TURN_ONLY,
+                outcome=PolicyRunOutcome.EXITED,
+                srs_turn=4,
+                discovered_object_ids=("salvage-1",),
+                consumed_object_ids=frozenset({"salvage-1"}),
+                events=(
+                    make_turn_event(
+                        srs_turn=1,
+                        event_type=INTERACT_ACCEPTED,
+                        payload={"object_id": "salvage-1", "object_type": "SALVAGE", "outcome": "ACCEPTED"},
+                    ),
+                    make_turn_event(
+                        srs_turn=1,
+                        event_type=OBJECT_CONSUMED,
+                        payload={"object_id": "salvage-1", "object_type": "SALVAGE"},
+                    ),
+                    make_turn_event(
+                        srs_turn=4,
+                        event_type=WARP_EXIT_ACCEPTED,
+                        payload={"outcome": "ACCEPTED"},
+                    ),
+                ),
+            ),
+            self.make_run_result(
+                case_id="base-shared-exit",
+                policy_name=OBJECT_GREEDY_POLICY_NAME,
+                sector_type=SectorType.BASE,
+                cost_mode=CostMode.SHARED_FUEL,
+                outcome=PolicyRunOutcome.EXITED,
+                srs_turn=8,
+                discovered_object_ids=("station-1",),
+                activated_object_ids=frozenset({"station-1"}),
+                events=(
+                    make_turn_event(
+                        srs_turn=3,
+                        event_type=INTERACT_ACCEPTED,
+                        payload={"object_id": "station-1", "object_type": "STATION", "outcome": "ACCEPTED"},
+                    ),
+                    make_turn_event(
+                        srs_turn=3,
+                        event_type=STATION_ACTIVATED,
+                        payload={"object_id": "station-1", "object_type": "STATION"},
+                    ),
+                    make_turn_event(
+                        srs_turn=8,
+                        event_type=WARP_EXIT_ACCEPTED,
+                        payload={"outcome": "ACCEPTED"},
+                    ),
+                ),
+            ),
+            self.make_run_result(
+                case_id="resource-turn-limit",
+                policy_name=OBJECT_GREEDY_POLICY_NAME,
+                sector_type=SectorType.RESOURCE,
+                cost_mode=CostMode.TURN_ONLY,
+                outcome=PolicyRunOutcome.ABORTED_TURN_LIMIT,
+                srs_turn=6,
+                discovered_object_ids=("resource-cache-1",),
+                consumed_object_ids=frozenset({"resource-cache-1"}),
+                events=(
+                    make_turn_event(
+                        srs_turn=2,
+                        event_type=INTERACT_ACCEPTED,
+                        payload={"object_id": "resource-cache-1", "object_type": "RESOURCE_CACHE", "outcome": "ACCEPTED"},
+                    ),
+                    make_turn_event(
+                        srs_turn=2,
+                        event_type=OBJECT_CONSUMED,
+                        payload={"object_id": "resource-cache-1", "object_type": "RESOURCE_CACHE"},
+                    ),
+                ),
+            ),
+            self.make_run_result(
+                case_id="rift-no-policy",
+                policy_name=EXPLORE_THEN_EXIT_POLICY_NAME,
+                sector_type=SectorType.RIFT,
+                cost_mode=CostMode.SHARED_FUEL,
+                outcome=PolicyRunOutcome.ABORTED_NO_POLICY_ACTION,
+                srs_turn=10,
+                events=(
+                    make_turn_event(
+                        srs_turn=0,
+                        event_type=WARP_EXIT_REJECTED,
+                        payload={"outcome": "REJECTED_BLOCKED_EDGE"},
+                    ),
+                ),
+            ),
+        ]
+
+        summary = summarize_policy_runs(runs)
+
+        self.assertEqual(summary["run_count"], 4)
+        self.assertEqual(summary["run_count_by_policy"][EXIT_GREEDY_POLICY_NAME], 1)
+        self.assertEqual(summary["run_count_by_policy"][OBJECT_GREEDY_POLICY_NAME], 2)
+        self.assertEqual(summary["run_count_by_cost_mode"], {"TURN_ONLY": 2, "SHARED_FUEL": 2})
+        self.assertEqual(
+            summary["run_count_by_outcome"],
+            {
+                "EXITED": 2,
+                "ABORTED_TURN_LIMIT": 1,
+                "ABORTED_NO_POLICY_ACTION": 1,
+                "RESOURCE_DEPLETED": 0,
+                "GENERATION_ERROR": 0,
+            },
+        )
+        self.assertEqual(summary["run_count_by_sector_type"]["RIFT"], 1)
+        self.assertEqual(summary["exit_rate"], 0.5)
+        self.assertEqual(summary["median_srs_turn_count"], 7.0)
+        self.assertEqual(summary["p90_srs_turn_count"], 10)
+        self.assertEqual(summary["object_discovery_rate"], 0.75)
+        self.assertEqual(summary["object_acquisition_rate"], 0.75)
+        self.assertEqual(summary["station_use_rate"], 0.25)
+        self.assertEqual(summary["resource_use_rate"], 0.25)
+        self.assertEqual(summary["salvage_acquisition_rate"], 0.25)
+        self.assertEqual(summary["blocked_edge_attempt_rate"], 0.25)
+        self.assertEqual(summary["turn_limit_rate"], 0.25)
+        self.assertEqual(summary["no_policy_action_rate"], 0.25)
+        self.assertEqual(summary["turn_only_exit_rate"], 0.5)
+        self.assertEqual(summary["shared_fuel_exit_rate"], 0.5)
+        self.assertEqual(summary["turn_only_vs_shared_fuel_failure_delta"], 0.0)
+        self.assertEqual(summary["by_policy"][EXIT_GREEDY_POLICY_NAME]["exit_rate"], 1.0)
+        self.assertEqual(summary["by_cost_mode"]["TURN_ONLY"]["run_count"], 2)
+        self.assertEqual(summary["by_sector_type"]["RESOURCE"]["resource_use_rate"], 1.0)
+        self.assertEqual(summary["by_outcome"]["ABORTED_NO_POLICY_ACTION"]["run_count"], 1)
+
+    def test_same_run_list_returns_same_summary_regardless_of_input_order(self) -> None:
+        runs = [
+            self.make_run_result(
+                case_id="case-a",
+                policy_name=EXIT_GREEDY_POLICY_NAME,
+                sector_type=SectorType.NORMAL,
+                cost_mode=CostMode.TURN_ONLY,
+                outcome=PolicyRunOutcome.EXITED,
+                srs_turn=2,
+            ),
+            self.make_run_result(
+                case_id="case-b",
+                policy_name=OBJECT_GREEDY_POLICY_NAME,
+                sector_type=SectorType.BASE,
+                cost_mode=CostMode.SHARED_FUEL,
+                outcome=PolicyRunOutcome.ABORTED_NO_POLICY_ACTION,
+                srs_turn=3,
+            ),
+        ]
+
+        first = summarize_policy_runs(runs)
+        second = summarize_policy_runs(list(reversed(runs)))
+
+        self.assertEqual(first, second)
+        serialized = json.dumps(first, sort_keys=True)
+        self.assertNotIn(str(REPO_ROOT), serialized)
+        self.assertNotIn("generated_at", serialized)
+        self.assertNotIn("hostname", serialized)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 概要

Closes #1149

SRS policy evaluation の `PolicyRunResult` 群から、再現可能な summary metrics を集計する処理を追加しました。

## 変更内容

- `summarize_policy_runs(...)` を追加し、全 run の集計値を返すようにした
- `policy` / `cost_mode` / `sector_type` / `outcome` ごとの run count と group summary を生成するようにした
- `exit_rate`、`median_srs_turn_count`、nearest-rank 方式の `p90_srs_turn_count` を追加した
- `object_discovery_rate`、`object_acquisition_rate`、`station_use_rate`、`resource_use_rate`、`salvage_acquisition_rate` を run detail から計算するようにした
- `blocked_edge_attempt_rate`、`turn_limit_rate`、`no_policy_action_rate`、`turn_only_exit_rate`、`shared_fuel_exit_rate`、`turn_only_vs_shared_fuel_failure_delta` を追加した
- summary が入力順や環境依存値に影響されないことを確認するテストを追加した

## 確認

- `python3 -m unittest experiments.galactic_exodus.srs.test_evaluate_policies`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo fmt --check`
