### PR TITLE
SRS policy evaluationのCSV/JSON writerを追加

### DIFF
--- a/experiments/galactic_exodus/srs/evaluate_policies.py
+++ b/experiments/galactic_exodus/srs/evaluate_policies.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import csv
+import json
 from collections import deque
 from dataclasses import dataclass, replace
 from enum import Enum
 import statistics
+from pathlib import Path
 from types import MappingProxyType
 from typing import Any, Callable, Iterable, Mapping
 
@@ -19,6 +22,7 @@ from experiments.galactic_exodus.srs.generate import create_sector
 from experiments.galactic_exodus.srs.log import (
     INTERACT_REJECTED,
     MOVE_REJECTED,
+    OBSERVATION_UPDATED,
     WARP_EXIT_ACCEPTED,
     WARP_EXIT_REJECTED,
 )
@@ -78,6 +82,48 @@ _VALUE_OBJECT_TYPES = frozenset(
         SrsObjectType.STATION,
         SrsObjectType.SALVAGE,
     }
+)
+POLICY_RUNS_CSV_FIELDNAMES = [
+    "case_id",
+    "policy",
+    "sector_type",
+    "sector_seed",
+    "entry_edge",
+    "selected_exit_edge",
+    "cost_mode",
+    "outcome",
+    "srs_turn_count",
+    "command_count",
+    "final_fuel",
+    "max_fuel",
+    "objects_discovered",
+    "objects_acquired",
+    "station_used",
+    "resource_used",
+    "salvage_acquired",
+    "blocked_edge_attempt_count",
+    "observation_5x5_count",
+    "observation_3x3_count",
+]
+_POLICY_SUMMARY_METRIC_KEYS = (
+    "run_count_by_policy",
+    "run_count_by_cost_mode",
+    "run_count_by_sector_type",
+    "run_count_by_outcome",
+    "exit_rate",
+    "median_srs_turn_count",
+    "p90_srs_turn_count",
+    "object_discovery_rate",
+    "object_acquisition_rate",
+    "station_use_rate",
+    "resource_use_rate",
+    "salvage_acquisition_rate",
+    "blocked_edge_attempt_rate",
+    "turn_limit_rate",
+    "no_policy_action_rate",
+    "turn_only_exit_rate",
+    "shared_fuel_exit_rate",
+    "turn_only_vs_shared_fuel_failure_delta",
 )
 
 
@@ -825,6 +871,78 @@ def summarize_policy_runs(policy_runs: Iterable[PolicyRunResult]) -> dict[str, A
     return summary
 
 
+def build_policy_summary_document(policy_runs: Iterable[PolicyRunResult]) -> dict[str, Any]:
+    summary = summarize_policy_runs(policy_runs)
+    return {
+        "run_count": summary["run_count"],
+        "policies": summary["by_policy"],
+        "conditions": {
+            "cost_modes": summary["by_cost_mode"],
+            "sector_types": summary["by_sector_type"],
+            "outcomes": summary["by_outcome"],
+        },
+        "metrics": {
+            key: summary[key]
+            for key in _POLICY_SUMMARY_METRIC_KEYS
+        },
+    }
+
+
+def write_policy_runs_csv(output_path: Path, policy_runs: Iterable[PolicyRunResult]) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    ordered_runs = sorted(policy_runs, key=_policy_run_csv_sort_key)
+    with output_path.open("w", encoding="utf-8", newline="") as file:
+        writer = csv.DictWriter(file, fieldnames=POLICY_RUNS_CSV_FIELDNAMES)
+        writer.writeheader()
+        writer.writerows(_policy_run_csv_row(run) for run in ordered_runs)
+
+
+def write_policy_summary_json(summary_path: Path, policy_runs: Iterable[PolicyRunResult]) -> None:
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = build_policy_summary_document(policy_runs)
+    summary_path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+
+
+def _policy_run_csv_sort_key(run: PolicyRunResult) -> tuple[Any, ...]:
+    return (
+        run.evaluation_case.case_id,
+        run.policy_name,
+        run.evaluation_case.cost_mode.value,
+        run.evaluation_case.sector_seed,
+        run.outcome.value,
+        run.command_count,
+    )
+
+
+def _policy_run_csv_row(run: PolicyRunResult) -> dict[str, Any]:
+    final_state = run.final_state
+    objects_discovered = _discovered_value_object_ids(run)
+    objects_acquired = _acquired_value_object_ids(run)
+    observation_counts = _observation_counts(run)
+    return {
+        "case_id": run.evaluation_case.case_id,
+        "policy": run.policy_name,
+        "sector_type": run.evaluation_case.sector_type.value,
+        "sector_seed": run.evaluation_case.sector_seed,
+        "entry_edge": run.evaluation_case.entry_edge.value,
+        "selected_exit_edge": run.evaluation_case.selected_exit_edge.value,
+        "cost_mode": run.evaluation_case.cost_mode.value,
+        "outcome": run.outcome.value,
+        "srs_turn_count": None if final_state is None else final_state.srs_turn,
+        "command_count": run.command_count,
+        "final_fuel": None if final_state is None else final_state.fuel,
+        "max_fuel": None if final_state is None else final_state.max_fuel,
+        "objects_discovered": len(objects_discovered),
+        "objects_acquired": len(objects_acquired),
+        "station_used": int(_has_used_station(run)),
+        "resource_used": int(_has_used_resource_cache(run)),
+        "salvage_acquired": int(_has_acquired_salvage(run)),
+        "blocked_edge_attempt_count": _blocked_edge_attempt_count(run),
+        "observation_5x5_count": observation_counts[5],
+        "observation_3x3_count": observation_counts[3],
+    }
+
+
 def _build_summary_metrics(runs: tuple[PolicyRunResult, ...]) -> dict[str, Any]:
     srs_turn_counts = sorted(
         run.final_state.srs_turn
@@ -935,18 +1053,81 @@ def _failure_rate_delta(
 
 
 def _has_discovered_value_object(run: PolicyRunResult) -> bool:
+    return bool(_discovered_value_object_ids(run))
+
+
+def _discovered_value_object_ids(run: PolicyRunResult) -> tuple[str, ...]:
     final_state = run.final_state
     if final_state is None:
-        return False
-    return any(
-        object_state is not None and object_state.object_type in _VALUE_OBJECT_TYPES
-        for cell in final_state.known_state.known_cells.values()
-        for object_state in [None if cell.object_id is None else final_state.objects.get(cell.object_id)]
+        return ()
+    return tuple(
+        sorted(
+            {
+                object_state.object_id
+                for cell in final_state.known_state.known_cells.values()
+                for object_state in [None if cell.object_id is None else final_state.objects.get(cell.object_id)]
+                if object_state is not None and object_state.object_type in _VALUE_OBJECT_TYPES
+            }
+        )
     )
 
 
+def _acquired_value_object_ids(run: PolicyRunResult) -> tuple[str, ...]:
+    final_state = run.final_state
+    if final_state is None:
+        return ()
+    return tuple(
+        sorted(
+            {
+                object_id
+                for object_id in (
+                    *final_state.persistent_state.consumed_object_ids,
+                    *final_state.persistent_state.activated_object_ids,
+                )
+                if _object_matches_type(final_state, object_id, expected_types=_VALUE_OBJECT_TYPES)
+            }
+        )
+    )
+
+
+def _observation_counts(run: PolicyRunResult) -> dict[int, int]:
+    counts = {3: 0, 5: 0}
+    final_state = run.final_state
+    if final_state is None:
+        return counts
+    for event in run.event_log:
+        if event.event_type != OBSERVATION_UPDATED:
+            continue
+        center = event.payload.get("center")
+        if not isinstance(center, list) or len(center) != 2:
+            continue
+        position = Position(center[0], center[1])
+        terrain = final_state.actual_map.cell_at(position).terrain
+        size = 3 if terrain is SrsTerrainType.NEBULA else 5
+        counts[size] += 1
+    return counts
+
+
+def _blocked_edge_attempt_count(run: PolicyRunResult) -> int:
+    return sum(
+        1
+        for event in run.event_log
+        if event.event_type == WARP_EXIT_REJECTED and event.payload.get("outcome") == "REJECTED_BLOCKED_EDGE"
+    )
+
+
+def _object_matches_type(
+    final_state: SrsGameState,
+    object_id: str,
+    *,
+    expected_types: frozenset[SrsObjectType],
+) -> bool:
+    object_state = final_state.objects.get(object_id)
+    return object_state is not None and object_state.object_type in expected_types
+
+
 def _has_acquired_value_object(run: PolicyRunResult) -> bool:
-    return _has_used_station(run) or _has_used_resource_cache(run) or _has_acquired_salvage(run)
+    return bool(_acquired_value_object_ids(run))
 
 
 def _has_used_station(run: PolicyRunResult) -> bool:
@@ -992,10 +1173,7 @@ def _persistent_object_match(
 
 
 def _attempted_blocked_edge(run: PolicyRunResult) -> bool:
-    return any(
-        event.event_type == WARP_EXIT_REJECTED and event.payload.get("outcome") == "REJECTED_BLOCKED_EDGE"
-        for event in run.event_log
-    )
+    return _blocked_edge_attempt_count(run) > 0
 
 
 _POLICY_COMMAND_GENERATORS: Mapping[str, Callable[..., SrsCommand | None]] = MappingProxyType(

--- a/experiments/galactic_exodus/srs/test_evaluate_policies.py
+++ b/experiments/galactic_exodus/srs/test_evaluate_policies.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import csv
 import json
+import tempfile
 import unittest
 from dataclasses import replace
 from pathlib import Path
@@ -17,6 +19,7 @@ from experiments.galactic_exodus.srs.evaluate_policies import (
     PolicyRunResult,
     PolicyRunOutcome,
     RevisitMode,
+    build_policy_summary_document,
     build_default_evaluation_cases,
     build_object_greedy_candidates,
     choose_explore_then_exit_command,
@@ -29,11 +32,14 @@ from experiments.galactic_exodus.srs.evaluate_policies import (
     route_on_known_cells,
     run_policy_evaluation_case,
     summarize_policy_runs,
+    write_policy_runs_csv,
+    write_policy_summary_json,
 )
 from experiments.galactic_exodus.srs.log import (
     INTERACT_ACCEPTED,
     INTERACT_REJECTED,
     MOVE_REJECTED,
+    OBSERVATION_UPDATED,
     OBJECT_CONSUMED,
     STATION_ACTIVATED,
     WARP_EXIT_ACCEPTED,
@@ -1237,6 +1243,14 @@ class PolicyRunAggregationTests(unittest.TestCase):
         discovered_object_ids=(),
     ) -> PolicyRunResult:
         state = make_state()
+        if sector_type is SectorType.NEBULA:
+            nebula_positions = [state.player_position]
+            for event in events:
+                center = event.payload.get("center")
+                if isinstance(center, list) and len(center) == 2:
+                    nebula_positions.append(Position(center[0], center[1]))
+            for position in nebula_positions:
+                state = replace_cell_terrain(state, position, SrsTerrainType.NEBULA)
         if discovered_object_ids:
             positions = [Position(4 + index, 4) for index, _ in enumerate(discovered_object_ids)]
             for object_id, position in zip(discovered_object_ids, positions, strict=True):
@@ -1427,6 +1441,173 @@ class PolicyRunAggregationTests(unittest.TestCase):
         self.assertNotIn(str(REPO_ROOT), serialized)
         self.assertNotIn("generated_at", serialized)
         self.assertNotIn("hostname", serialized)
+
+
+class PolicyRunWriterTests(PolicyRunAggregationTests):
+    def test_csv_writer_preserves_column_order_and_stable_sort(self) -> None:
+        runs = [
+            self.make_run_result(
+                case_id="case-b",
+                policy_name=OBJECT_GREEDY_POLICY_NAME,
+                sector_type=SectorType.NEBULA,
+                cost_mode=CostMode.SHARED_FUEL,
+                outcome=PolicyRunOutcome.ABORTED_NO_POLICY_ACTION,
+                srs_turn=7,
+                discovered_object_ids=("salvage-1",),
+                consumed_object_ids=frozenset({"salvage-1"}),
+                events=(
+                    make_turn_event(
+                        srs_turn=1,
+                        event_type=OBSERVATION_UPDATED,
+                        payload={"center": [4, 4], "newly_discovered_count": 3, "total_discovered_count": 9},
+                    ),
+                    make_turn_event(
+                        srs_turn=2,
+                        event_type=WARP_EXIT_REJECTED,
+                        payload={"outcome": "REJECTED_BLOCKED_EDGE"},
+                    ),
+                ),
+            ),
+            self.make_run_result(
+                case_id="case-a",
+                policy_name=EXIT_GREEDY_POLICY_NAME,
+                sector_type=SectorType.NORMAL,
+                cost_mode=CostMode.TURN_ONLY,
+                outcome=PolicyRunOutcome.EXITED,
+                srs_turn=5,
+                discovered_object_ids=("resource-cache-1", "station-1"),
+                consumed_object_ids=frozenset({"resource-cache-1"}),
+                activated_object_ids=frozenset({"station-1"}),
+                events=(
+                    make_turn_event(
+                        srs_turn=1,
+                        event_type=OBSERVATION_UPDATED,
+                        payload={"center": [4, 4], "newly_discovered_count": 5, "total_discovered_count": 25},
+                    ),
+                    make_turn_event(
+                        srs_turn=2,
+                        event_type=OBSERVATION_UPDATED,
+                        payload={"center": [5, 4], "newly_discovered_count": 4, "total_discovered_count": 29},
+                    ),
+                ),
+            ),
+        ]
+
+        with tempfile.TemporaryDirectory(dir=".tmp") as tmp_dir:
+            output_path = Path(tmp_dir) / "nested" / "policy_runs.csv"
+            write_policy_runs_csv(output_path, runs)
+            with output_path.open(encoding="utf-8", newline="") as file:
+                rows = list(csv.DictReader(file))
+                fieldnames = list(rows[0].keys())
+
+        self.assertEqual(
+            fieldnames,
+            [
+                "case_id",
+                "policy",
+                "sector_type",
+                "sector_seed",
+                "entry_edge",
+                "selected_exit_edge",
+                "cost_mode",
+                "outcome",
+                "srs_turn_count",
+                "command_count",
+                "final_fuel",
+                "max_fuel",
+                "objects_discovered",
+                "objects_acquired",
+                "station_used",
+                "resource_used",
+                "salvage_acquired",
+                "blocked_edge_attempt_count",
+                "observation_5x5_count",
+                "observation_3x3_count",
+            ],
+        )
+        self.assertEqual([row["case_id"] for row in rows], ["case-a", "case-b"])
+        self.assertEqual(rows[0]["station_used"], "1")
+        self.assertEqual(rows[0]["resource_used"], "1")
+        self.assertEqual(rows[0]["objects_discovered"], "2")
+        self.assertEqual(rows[0]["objects_acquired"], "2")
+        self.assertEqual(rows[0]["observation_5x5_count"], "2")
+        self.assertEqual(rows[0]["observation_3x3_count"], "0")
+        self.assertEqual(rows[1]["salvage_acquired"], "1")
+        self.assertEqual(rows[1]["blocked_edge_attempt_count"], "1")
+        self.assertEqual(rows[1]["observation_3x3_count"], "1")
+
+    def test_json_summary_writer_uses_fixed_top_level_keys_and_indent(self) -> None:
+        runs = [
+            self.make_run_result(
+                case_id="case-a",
+                policy_name=EXIT_GREEDY_POLICY_NAME,
+                sector_type=SectorType.NORMAL,
+                cost_mode=CostMode.TURN_ONLY,
+                outcome=PolicyRunOutcome.EXITED,
+                srs_turn=2,
+            ),
+            self.make_run_result(
+                case_id="case-b",
+                policy_name=OBJECT_GREEDY_POLICY_NAME,
+                sector_type=SectorType.BASE,
+                cost_mode=CostMode.SHARED_FUEL,
+                outcome=PolicyRunOutcome.ABORTED_NO_POLICY_ACTION,
+                srs_turn=3,
+            ),
+        ]
+
+        with tempfile.TemporaryDirectory(dir=".tmp") as tmp_dir:
+            summary_path = Path(tmp_dir) / "nested" / "policy_summary.json"
+            write_policy_summary_json(summary_path, runs)
+            text = summary_path.read_text(encoding="utf-8")
+            payload = json.loads(text)
+
+        self.assertEqual(list(payload.keys()), ["run_count", "policies", "conditions", "metrics"])
+        self.assertTrue(text.startswith('{\n  "run_count": 2,\n  "policies": {\n'))
+        self.assertEqual(list(payload["conditions"].keys()), ["cost_modes", "sector_types", "outcomes"])
+        self.assertNotIn("generated_at", text)
+        self.assertNotIn(str(REPO_ROOT), text)
+        self.assertNotIn("PosixPath", text)
+
+    def test_same_input_produces_same_csv_and_json(self) -> None:
+        runs = [
+            self.make_run_result(
+                case_id="case-b",
+                policy_name=OBJECT_GREEDY_POLICY_NAME,
+                sector_type=SectorType.BASE,
+                cost_mode=CostMode.SHARED_FUEL,
+                outcome=PolicyRunOutcome.EXITED,
+                srs_turn=4,
+            ),
+            self.make_run_result(
+                case_id="case-a",
+                policy_name=EXIT_GREEDY_POLICY_NAME,
+                sector_type=SectorType.NORMAL,
+                cost_mode=CostMode.TURN_ONLY,
+                outcome=PolicyRunOutcome.ABORTED_TURN_LIMIT,
+                srs_turn=6,
+            ),
+        ]
+
+        with tempfile.TemporaryDirectory(dir=".tmp") as first_tmp_dir:
+            first_csv_path = Path(first_tmp_dir) / "policy_runs.csv"
+            first_json_path = Path(first_tmp_dir) / "policy_summary.json"
+            write_policy_runs_csv(first_csv_path, runs)
+            write_policy_summary_json(first_json_path, runs)
+            first_csv = first_csv_path.read_text(encoding="utf-8")
+            first_json = first_json_path.read_text(encoding="utf-8")
+
+        with tempfile.TemporaryDirectory(dir=".tmp") as second_tmp_dir:
+            second_csv_path = Path(second_tmp_dir) / "policy_runs.csv"
+            second_json_path = Path(second_tmp_dir) / "policy_summary.json"
+            write_policy_runs_csv(second_csv_path, list(reversed(runs)))
+            write_policy_summary_json(second_json_path, list(reversed(runs)))
+            second_csv = second_csv_path.read_text(encoding="utf-8")
+            second_json = second_json_path.read_text(encoding="utf-8")
+
+        self.assertEqual(first_csv, second_csv)
+        self.assertEqual(first_json, second_json)
+        self.assertEqual(build_policy_summary_document(runs), build_policy_summary_document(list(reversed(runs))))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 概要

Closes #1150

SRS policy evaluation の run 結果と summary metrics を、再現可能な CSV / JSON として書き出す writer を追加しました。

## 変更内容

- `write_policy_runs_csv(...)` を追加し、`policy_runs.csv` の列順を固定した
- `case_id` / `policy` / `cost_mode` を先頭にした安定順で run を出力するようにした
- CSV 出力時に親ディレクトリを自動生成するようにした
- `build_policy_summary_document(...)` と `write_policy_summary_json(...)` を追加し、`run_count` / `policies` / `conditions` / `metrics` の固定 top-level key を持つ JSON を生成するようにした
- JSON は固定 indent で書き出し、`generated_at` や絶対パスなどの環境依存値を含めないようにした
- `PolicyRunResult` から writer 用の per-run 値を組み立てる helper を追加し、object discovery/acquisition、blocked edge attempt、observation 5x5/3x3 を CSV に出せるようにした
- CSV / JSON の列順、key 順、親ディレクトリ生成、再現性を検証するテストを追加した

## 確認

- `python3 -m unittest experiments.galactic_exodus.srs.test_evaluate_policies`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo fmt --check`
