### PR TITLE
SRS policy evaluationのCLI entrypointを追加

### DIFF
--- a/experiments/galactic_exodus/srs/evaluate_policies.py
+++ b/experiments/galactic_exodus/srs/evaluate_policies.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import csv
 import json
 from collections import deque
@@ -7,11 +8,12 @@ from dataclasses import dataclass, replace
 from enum import Enum
 import statistics
 from pathlib import Path
+import sys
 from types import MappingProxyType
 from typing import Any, Callable, Iterable, Mapping
 
 from experiments.galactic_exodus import metrics
-from experiments.galactic_exodus.srs.contracts import SrsContracts
+from experiments.galactic_exodus.srs.contracts import SrsContracts, load_default_contracts
 from experiments.galactic_exodus.srs.engine import (
     apply_srs_command,
     restore_srs_state,
@@ -125,6 +127,12 @@ _POLICY_SUMMARY_METRIC_KEYS = (
     "shared_fuel_exit_rate",
     "turn_only_vs_shared_fuel_failure_delta",
 )
+POLICY_NAME_ORDER = (
+    EXIT_GREEDY_POLICY_NAME,
+    EXPLORE_THEN_EXIT_POLICY_NAME,
+    OBJECT_GREEDY_POLICY_NAME,
+)
+REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
 def _freeze_mapping(mapping: Mapping[str, Any]) -> Mapping[str, Any]:
@@ -903,6 +911,49 @@ def write_policy_summary_json(summary_path: Path, policy_runs: Iterable[PolicyRu
     summary_path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
 
 
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output-runs",
+        type=Path,
+        required=True,
+        help="CSV file path for per-run policy evaluation results.",
+    )
+    parser.add_argument(
+        "--output-summary",
+        type=Path,
+        required=True,
+        help="JSON file path for aggregated policy evaluation results.",
+    )
+    return parser.parse_args(argv)
+
+
+def evaluate_default_policies(*, contracts: SrsContracts) -> tuple[PolicyRunResult, ...]:
+    runs: list[PolicyRunResult] = []
+    for evaluation_case in build_default_evaluation_cases():
+        for policy_name in POLICY_NAME_ORDER:
+            runs.append(
+                run_policy_evaluation_case(
+                    evaluation_case,
+                    policy_name,
+                    contracts=contracts,
+                )
+            )
+    return tuple(runs)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        policy_runs = evaluate_default_policies(contracts=load_default_contracts(REPO_ROOT))
+        write_policy_runs_csv(args.output_runs, policy_runs)
+        write_policy_summary_json(args.output_summary, policy_runs)
+    except (OSError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
 def _policy_run_csv_sort_key(run: PolicyRunResult) -> tuple[Any, ...]:
     return (
         run.evaluation_case.case_id,
@@ -1455,3 +1506,7 @@ def _step_position(position: Position, direction: Direction) -> Position:
     }
     dx, dy = deltas[direction]
     return Position(position.x + dx, position.y + dy)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/galactic_exodus/srs/test_evaluate_policies.py
+++ b/experiments/galactic_exodus/srs/test_evaluate_policies.py
@@ -2,13 +2,17 @@ from __future__ import annotations
 
 import csv
 import json
+import shutil
 import tempfile
 import unittest
+from contextlib import redirect_stderr, redirect_stdout
 from dataclasses import replace
+from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
 
 from experiments.galactic_exodus.srs.contracts import load_default_contracts
+from experiments.galactic_exodus.srs import evaluate_policies as evaluator
 from experiments.galactic_exodus.srs.evaluate_policies import (
     EvaluationCase,
     EvaluationCaseError,
@@ -26,9 +30,11 @@ from experiments.galactic_exodus.srs.evaluate_policies import (
     choose_exit_greedy_command,
     choose_known_target_step,
     choose_object_greedy_command,
+    evaluate_default_policies,
     first_known_route_step,
     is_known_passable_cell,
     iter_known_cardinal_neighbors,
+    parse_args,
     route_on_known_cells,
     run_policy_evaluation_case,
     summarize_policy_runs,
@@ -1608,6 +1614,138 @@ class PolicyRunWriterTests(PolicyRunAggregationTests):
         self.assertEqual(first_csv, second_csv)
         self.assertEqual(first_json, second_json)
         self.assertEqual(build_policy_summary_document(runs), build_policy_summary_document(list(reversed(runs))))
+
+
+class EvaluatePoliciesCliTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.root = Path(".tmp/evaluate_policies_cli_tests") / self._testMethodName
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.root, ignore_errors=True)
+
+    def run_main(self, *args: str) -> tuple[int, str, str]:
+        stdout = StringIO()
+        stderr = StringIO()
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            exit_code = evaluator.main(list(args))
+        return exit_code, stdout.getvalue(), stderr.getvalue()
+
+    def test_parse_args_accepts_required_output_paths(self) -> None:
+        args = parse_args(
+            [
+                "--output-runs",
+                str(self.root / "policy_runs.csv"),
+                "--output-summary",
+                str(self.root / "policy_summary.json"),
+            ]
+        )
+
+        self.assertEqual(args.output_runs, self.root / "policy_runs.csv")
+        self.assertEqual(args.output_summary, self.root / "policy_summary.json")
+
+    def test_main_writes_csv_and_json_to_requested_paths(self) -> None:
+        output_runs = self.root / "results" / "policy_runs.csv"
+        output_summary = self.root / "results" / "policy_summary.json"
+
+        exit_code, stdout, stderr = self.run_main(
+            "--output-runs",
+            str(output_runs),
+            "--output-summary",
+            str(output_summary),
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(stdout, "")
+        self.assertEqual(stderr, "")
+        self.assertTrue(output_runs.is_file())
+        self.assertTrue(output_summary.is_file())
+        with output_runs.open(encoding="utf-8", newline="") as file:
+            rows = list(csv.DictReader(file))
+        summary = json.loads(output_summary.read_text(encoding="utf-8"))
+        self.assertEqual(len(rows), len(build_default_evaluation_cases()) * 3)
+        self.assertEqual(summary["run_count"], len(rows))
+
+    def test_main_creates_missing_parent_directories(self) -> None:
+        output_runs = self.root / "deep" / "nested" / "policy_runs.csv"
+        output_summary = self.root / "deep" / "nested" / "policy_summary.json"
+
+        exit_code, _, stderr = self.run_main(
+            "--output-runs",
+            str(output_runs),
+            "--output-summary",
+            str(output_summary),
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(stderr, "")
+        self.assertTrue(output_runs.exists())
+        self.assertTrue(output_summary.exists())
+
+    def test_same_cli_equivalent_processing_is_fully_reproducible(self) -> None:
+        first_runs = self.root / "first" / "policy_runs.csv"
+        first_summary = self.root / "first" / "policy_summary.json"
+        second_runs = self.root / "second" / "policy_runs.csv"
+        second_summary = self.root / "second" / "policy_summary.json"
+
+        first_exit_code, _, first_stderr = self.run_main(
+            "--output-runs",
+            str(first_runs),
+            "--output-summary",
+            str(first_summary),
+        )
+        second_exit_code, _, second_stderr = self.run_main(
+            "--output-runs",
+            str(second_runs),
+            "--output-summary",
+            str(second_summary),
+        )
+
+        self.assertEqual(first_exit_code, 0)
+        self.assertEqual(second_exit_code, 0)
+        self.assertEqual(first_stderr, "")
+        self.assertEqual(second_stderr, "")
+        self.assertEqual(first_runs.read_text(encoding="utf-8"), second_runs.read_text(encoding="utf-8"))
+        self.assertEqual(first_summary.read_text(encoding="utf-8"), second_summary.read_text(encoding="utf-8"))
+
+    def test_main_returns_non_zero_on_write_failure(self) -> None:
+        blocked_parent = self.root / "blocked"
+        blocked_parent.write_text("not a directory", encoding="utf-8")
+
+        exit_code, stdout, stderr = self.run_main(
+            "--output-runs",
+            str(blocked_parent / "policy_runs.csv"),
+            "--output-summary",
+            str(self.root / "policy_summary.json"),
+        )
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(stdout, "")
+        self.assertIn("error:", stderr)
+
+    def test_missing_required_arguments_exit_non_zero(self) -> None:
+        with redirect_stderr(StringIO()):
+            with self.assertRaises(SystemExit) as cm:
+                evaluator.main(
+                    [
+                        "--output-runs",
+                        str(self.root / "policy_runs.csv"),
+                    ]
+                )
+        self.assertNotEqual(cm.exception.code, 0)
+
+    def test_evaluate_default_policies_runs_all_default_cases_and_policies(self) -> None:
+        runs = evaluate_default_policies(contracts=load_default_contracts(REPO_ROOT))
+
+        self.assertEqual(len(runs), len(build_default_evaluation_cases()) * 3)
+        self.assertEqual(
+            {run.policy_name for run in runs},
+            {
+                EXIT_GREEDY_POLICY_NAME,
+                EXPLORE_THEN_EXIT_POLICY_NAME,
+                OBJECT_GREEDY_POLICY_NAME,
+            },
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 概要

Closes #1151

`experiments.galactic_exodus.srs.evaluate_policies` に CLI entrypoint を追加し、default evaluation cases に対して 3 方策を実行して CSV / JSON を指定 path へ書き出せるようにしました。

## 変更内容

- `--output-runs` / `--output-summary` を受け取る `parse_args()` と `main()` を追加
- default evaluation cases × 3 方策を安定順で実行する `evaluate_default_policies()` を追加
- CLI から default contracts を読み込み、per-run CSV と summary JSON を writer 経由で出力
- 書き込み失敗時は `stderr` に error を出して exit code 1 を返すように追加
- CLI 引数受理、出力作成、親ディレクトリ自動作成、再現性、必須引数不足、書き込み失敗を検証するテストを追加

## 確認

- `python3 -m unittest experiments.galactic_exodus.srs.test_evaluate_policies`
- `python3 -m experiments.galactic_exodus.srs.evaluate_policies --output-runs .tmp/policy_runs_cli_1.csv --output-summary .tmp/policy_summary_cli_1.json`
- `python3 -m experiments.galactic_exodus.srs.evaluate_policies --output-runs .tmp/policy_runs_cli_2.csv --output-summary .tmp/policy_summary_cli_2.json`
- `diff -u .tmp/policy_runs_cli_1.csv .tmp/policy_runs_cli_2.csv`
- `diff -u .tmp/policy_summary_cli_1.json .tmp/policy_summary_cli_2.json`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo fmt --check`
