### PR TITLE
Phase 2参照fixtureとvalidatorを追加

### DIFF
--- a/experiments/galactic_exodus/srs/fixtures/discovered_cells_restore_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/discovered_cells_restore_9x9.json
@@ -1,0 +1,28 @@
+{
+  "fixture_id": "discovered_cells_restore_9x9",
+  "description": "Persistent discovered_cells restore the known map on revisit without leaking undiscovered cells.",
+  "sector": {
+    "sector_id": "normal-1001",
+    "sector_type": "NORMAL",
+    "sector_seed": 1001,
+    "entry_edge": "S",
+    "blocked_edges": []
+  },
+  "initial": {
+    "player_position": [4, 7],
+    "persistent": {
+      "consumed_object_ids": [],
+      "activated_object_ids": [],
+      "discovered_cells": [[3, 6], [4, 6], [5, 6], [4, 7]]
+    }
+  },
+  "commands": [],
+  "expect": {
+    "srs_turn": 0,
+    "fuel": 0,
+    "player_position": [4, 7],
+    "event_types": [],
+    "consumed_object_ids": [],
+    "activated_object_ids": []
+  }
+}

--- a/experiments/galactic_exodus/srs/fixtures/nebula_observation_3x3_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/nebula_observation_3x3_9x9.json
@@ -1,0 +1,32 @@
+{
+  "fixture_id": "nebula_observation_3x3_9x9",
+  "description": "A move onto a NEBULA cell reveals only a 3x3 observation area.",
+  "sector": {
+    "sector_id": "nebula-5001",
+    "sector_type": "NEBULA",
+    "sector_seed": 5001,
+    "entry_edge": "S",
+    "blocked_edges": []
+  },
+  "initial": {
+    "cell_overrides": [
+      {
+        "position": [4, 7],
+        "terrain": "NEBULA"
+      }
+    ]
+  },
+  "commands": [
+    {
+      "command_type": "MOVE_ROUTE",
+      "route": ["N"]
+    }
+  ],
+  "expect": {
+    "srs_turn": 1,
+    "fuel": 0,
+    "player_position": [4, 7],
+    "event_types": ["MOVE_ACCEPTED", "OBSERVATION_UPDATED"],
+    "outcome": "ACCEPTED"
+  }
+}

--- a/experiments/galactic_exodus/srs/fixtures/phase2_reference.json
+++ b/experiments/galactic_exodus/srs/fixtures/phase2_reference.json
@@ -7,7 +7,7 @@
   "cases": [
     {
       "case_id": "normal_first_visit",
-      "fixture_path": "fixtures/move_route_basic_9x9.json",
+      "fixture_path": "move_route_basic_9x9.json",
       "coverage_tags": ["NORMAL_FIRST_VISIT"],
       "final_expect": {
         "cost_mode": "TURN_ONLY",
@@ -21,7 +21,7 @@
     },
     {
       "case_id": "resource_cache_interaction",
-      "fixture_path": "fixtures/resource_cache_single_9x9.json",
+      "fixture_path": "resource_cache_single_9x9.json",
       "coverage_tags": ["RESOURCE_CACHE_INTERACTION"],
       "initial_expect": {
         "discovered_count": 4
@@ -39,7 +39,7 @@
     },
     {
       "case_id": "resource_cache_consumed_revisit",
-      "fixture_path": "fixtures/revisit_resource_consumed_9x9.json",
+      "fixture_path": "revisit_resource_consumed_9x9.json",
       "coverage_tags": ["RESOURCE_CACHE_CONSUMED_REVISIT", "REVISIT_PERSISTENT_STATE"],
       "initial_expect": {
         "discovered_count": 4,
@@ -58,7 +58,7 @@
     },
     {
       "case_id": "base_station_interaction",
-      "fixture_path": "fixtures/station_refuel_9x9.json",
+      "fixture_path": "station_refuel_9x9.json",
       "coverage_tags": ["BASE_STATION_INTERACTION"],
       "final_expect": {
         "cost_mode": "TURN_ONLY",
@@ -73,7 +73,7 @@
     },
     {
       "case_id": "salvage_placeholder_interaction",
-      "fixture_path": "fixtures/salvage_placeholder_9x9.json",
+      "fixture_path": "salvage_placeholder_9x9.json",
       "coverage_tags": ["SALVAGE_PLACEHOLDER_INTERACTION"],
       "final_expect": {
         "cost_mode": "TURN_ONLY",
@@ -88,7 +88,7 @@
     },
     {
       "case_id": "nebula_3x3_observation",
-      "fixture_path": "fixtures/nebula_observation_3x3_9x9.json",
+      "fixture_path": "nebula_observation_3x3_9x9.json",
       "coverage_tags": ["NEBULA_3X3_OBSERVATION"],
       "final_expect": {
         "cost_mode": "TURN_ONLY",
@@ -102,7 +102,7 @@
     },
     {
       "case_id": "rift_blocked_edge",
-      "fixture_path": "fixtures/rift_blocked_n_9x9.json",
+      "fixture_path": "rift_blocked_n_9x9.json",
       "coverage_tags": ["RIFT_BLOCKED_EDGE"],
       "final_expect": {
         "cost_mode": "TURN_ONLY",
@@ -116,7 +116,7 @@
     },
     {
       "case_id": "warp_exit_accepted",
-      "fixture_path": "fixtures/warp_exit_s_9x9.json",
+      "fixture_path": "warp_exit_s_9x9.json",
       "coverage_tags": ["WARP_EXIT_ACCEPTED"],
       "final_expect": {
         "cost_mode": "TURN_ONLY",
@@ -130,7 +130,7 @@
     },
     {
       "case_id": "warp_exit_rejected",
-      "fixture_path": "fixtures/warp_exit_rejected_no_flag_9x9.json",
+      "fixture_path": "warp_exit_rejected_no_flag_9x9.json",
       "coverage_tags": ["WARP_EXIT_REJECTED"],
       "final_expect": {
         "cost_mode": "TURN_ONLY",
@@ -144,7 +144,7 @@
     },
     {
       "case_id": "turn_only_route",
-      "fixture_path": "fixtures/turn_only_cost_9x9.json",
+      "fixture_path": "turn_only_cost_9x9.json",
       "coverage_tags": ["TURN_ONLY"],
       "final_expect": {
         "cost_mode": "TURN_ONLY",
@@ -158,7 +158,7 @@
     },
     {
       "case_id": "shared_fuel_route",
-      "fixture_path": "fixtures/shared_fuel_cost_9x9.json",
+      "fixture_path": "shared_fuel_cost_9x9.json",
       "coverage_tags": ["SHARED_FUEL"],
       "final_expect": {
         "cost_mode": "SHARED_FUEL",
@@ -172,7 +172,7 @@
     },
     {
       "case_id": "persistent_discovered_cells_restore",
-      "fixture_path": "fixtures/discovered_cells_restore_9x9.json",
+      "fixture_path": "discovered_cells_restore_9x9.json",
       "coverage_tags": ["PERSISTENT_DISCOVERED_CELLS_RESTORE"],
       "initial_expect": {
         "discovered_count": 4

--- a/experiments/galactic_exodus/srs/fixtures/turn_only_cost_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/turn_only_cost_9x9.json
@@ -1,0 +1,32 @@
+{
+  "fixture_id": "turn_only_cost_9x9",
+  "description": "TURN_ONLY keeps fuel unchanged for the same two-step route used by SHARED_FUEL.",
+  "sector": {
+    "sector_id": "normal-1001",
+    "sector_type": "NORMAL",
+    "sector_seed": 1001,
+    "entry_edge": "S",
+    "blocked_edges": []
+  },
+  "initial": {
+    "fuel": 9,
+    "max_fuel": 9,
+    "reveal": {
+      "mode": "FULL"
+    }
+  },
+  "commands": [
+    {
+      "command_type": "MOVE_ROUTE",
+      "route": ["N", "N"]
+    }
+  ],
+  "cost_mode": "TURN_ONLY",
+  "expect": {
+    "srs_turn": 1,
+    "fuel": 9,
+    "player_position": [4, 6],
+    "event_types": ["MOVE_ACCEPTED", "OBSERVATION_UPDATED", "OBSERVATION_UPDATED"],
+    "outcome": "ACCEPTED"
+  }
+}

--- a/experiments/galactic_exodus/srs/fixtures/warp_exit_rejected_no_flag_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/warp_exit_rejected_no_flag_9x9.json
@@ -1,0 +1,30 @@
+{
+  "fixture_id": "warp_exit_rejected_no_flag_9x9",
+  "description": "WARP_EXIT rejects when the current cell lacks the requested warp flag.",
+  "sector": {
+    "sector_id": "normal-1001",
+    "sector_type": "NORMAL",
+    "sector_seed": 1001,
+    "entry_edge": "S",
+    "blocked_edges": []
+  },
+  "initial": {
+    "player_position": [4, 7],
+    "reveal": {
+      "mode": "FULL"
+    }
+  },
+  "commands": [
+    {
+      "command_type": "WARP_EXIT",
+      "exit_direction": "N"
+    }
+  ],
+  "expect": {
+    "srs_turn": 0,
+    "fuel": 0,
+    "player_position": [4, 7],
+    "event_types": ["WARP_EXIT_REJECTED"],
+    "outcome": "REJECTED_NO_WARP_FLAG"
+  }
+}

--- a/experiments/galactic_exodus/srs/phase2_reference.json
+++ b/experiments/galactic_exodus/srs/phase2_reference.json
@@ -1,0 +1,199 @@
+{
+  "reference_schema_version": 1,
+  "spec_refs": [
+    "experiments/galactic_exodus/srs/phase2_srs_spec.md",
+    "experiments/galactic_exodus/srs/phase2_decisions.csv"
+  ],
+  "cases": [
+    {
+      "case_id": "normal_first_visit",
+      "fixture_path": "fixtures/move_route_basic_9x9.json",
+      "coverage_tags": ["NORMAL_FIRST_VISIT"],
+      "final_expect": {
+        "cost_mode": "TURN_ONLY",
+        "srs_turn": 1,
+        "fuel": 0,
+        "player_position": [4, 7],
+        "event_types": ["MOVE_ACCEPTED", "OBSERVATION_UPDATED"],
+        "outcome": "ACCEPTED",
+        "discovered_count": 20
+      }
+    },
+    {
+      "case_id": "resource_cache_interaction",
+      "fixture_path": "fixtures/resource_cache_single_9x9.json",
+      "coverage_tags": ["RESOURCE_CACHE_INTERACTION"],
+      "initial_expect": {
+        "discovered_count": 4
+      },
+      "final_expect": {
+        "cost_mode": "TURN_ONLY",
+        "srs_turn": 1,
+        "fuel": 7,
+        "player_position": [2, 7],
+        "event_types": ["INTERACT_ACCEPTED", "OBJECT_CONSUMED"],
+        "consumed_object_ids": ["resource-cache-1"],
+        "outcome": "ACCEPTED",
+        "discovered_count": 4
+      }
+    },
+    {
+      "case_id": "resource_cache_consumed_revisit",
+      "fixture_path": "fixtures/revisit_resource_consumed_9x9.json",
+      "coverage_tags": ["RESOURCE_CACHE_CONSUMED_REVISIT", "REVISIT_PERSISTENT_STATE"],
+      "initial_expect": {
+        "discovered_count": 4,
+        "consumed_object_ids": ["resource-cache-1"]
+      },
+      "final_expect": {
+        "cost_mode": "TURN_ONLY",
+        "srs_turn": 0,
+        "fuel": 2,
+        "player_position": [2, 7],
+        "event_types": ["INTERACT_REJECTED"],
+        "consumed_object_ids": ["resource-cache-1"],
+        "outcome": "REJECTED_ALREADY_CONSUMED",
+        "discovered_count": 4
+      }
+    },
+    {
+      "case_id": "base_station_interaction",
+      "fixture_path": "fixtures/station_refuel_9x9.json",
+      "coverage_tags": ["BASE_STATION_INTERACTION"],
+      "final_expect": {
+        "cost_mode": "TURN_ONLY",
+        "srs_turn": 1,
+        "fuel": 9,
+        "player_position": [3, 1],
+        "event_types": ["INTERACT_ACCEPTED", "STATION_ACTIVATED"],
+        "activated_object_ids": ["station-1"],
+        "outcome": "ACCEPTED",
+        "discovered_count": 81
+      }
+    },
+    {
+      "case_id": "salvage_placeholder_interaction",
+      "fixture_path": "fixtures/salvage_placeholder_9x9.json",
+      "coverage_tags": ["SALVAGE_PLACEHOLDER_INTERACTION"],
+      "final_expect": {
+        "cost_mode": "TURN_ONLY",
+        "srs_turn": 1,
+        "fuel": 2,
+        "player_position": [4, 6],
+        "event_types": ["INTERACT_ACCEPTED", "OBJECT_CONSUMED"],
+        "consumed_object_ids": ["salvage-1"],
+        "outcome": "ACCEPTED",
+        "discovered_count": 81
+      }
+    },
+    {
+      "case_id": "nebula_3x3_observation",
+      "fixture_path": "fixtures/nebula_observation_3x3_9x9.json",
+      "coverage_tags": ["NEBULA_3X3_OBSERVATION"],
+      "final_expect": {
+        "cost_mode": "TURN_ONLY",
+        "srs_turn": 1,
+        "fuel": 0,
+        "player_position": [4, 7],
+        "event_types": ["MOVE_ACCEPTED", "OBSERVATION_UPDATED"],
+        "outcome": "ACCEPTED",
+        "discovered_count": 9
+      }
+    },
+    {
+      "case_id": "rift_blocked_edge",
+      "fixture_path": "fixtures/rift_blocked_n_9x9.json",
+      "coverage_tags": ["RIFT_BLOCKED_EDGE"],
+      "final_expect": {
+        "cost_mode": "TURN_ONLY",
+        "srs_turn": 0,
+        "fuel": 0,
+        "player_position": [4, 0],
+        "event_types": ["WARP_EXIT_REJECTED"],
+        "outcome": "REJECTED_BLOCKED_EDGE",
+        "discovered_count": 81
+      }
+    },
+    {
+      "case_id": "warp_exit_accepted",
+      "fixture_path": "fixtures/warp_exit_s_9x9.json",
+      "coverage_tags": ["WARP_EXIT_ACCEPTED"],
+      "final_expect": {
+        "cost_mode": "TURN_ONLY",
+        "srs_turn": 1,
+        "fuel": 0,
+        "player_position": [4, 8],
+        "event_types": ["WARP_EXIT_ACCEPTED"],
+        "outcome": "ACCEPTED",
+        "discovered_count": 81
+      }
+    },
+    {
+      "case_id": "warp_exit_rejected",
+      "fixture_path": "fixtures/warp_exit_rejected_no_flag_9x9.json",
+      "coverage_tags": ["WARP_EXIT_REJECTED"],
+      "final_expect": {
+        "cost_mode": "TURN_ONLY",
+        "srs_turn": 0,
+        "fuel": 0,
+        "player_position": [4, 7],
+        "event_types": ["WARP_EXIT_REJECTED"],
+        "outcome": "REJECTED_NO_WARP_FLAG",
+        "discovered_count": 81
+      }
+    },
+    {
+      "case_id": "turn_only_route",
+      "fixture_path": "fixtures/turn_only_cost_9x9.json",
+      "coverage_tags": ["TURN_ONLY"],
+      "final_expect": {
+        "cost_mode": "TURN_ONLY",
+        "srs_turn": 1,
+        "fuel": 9,
+        "player_position": [4, 6],
+        "event_types": ["MOVE_ACCEPTED", "OBSERVATION_UPDATED", "OBSERVATION_UPDATED"],
+        "outcome": "ACCEPTED",
+        "discovered_count": 81
+      }
+    },
+    {
+      "case_id": "shared_fuel_route",
+      "fixture_path": "fixtures/shared_fuel_cost_9x9.json",
+      "coverage_tags": ["SHARED_FUEL"],
+      "final_expect": {
+        "cost_mode": "SHARED_FUEL",
+        "srs_turn": 1,
+        "fuel": 7,
+        "player_position": [4, 6],
+        "event_types": ["MOVE_ACCEPTED", "OBSERVATION_UPDATED", "OBSERVATION_UPDATED"],
+        "outcome": "ACCEPTED",
+        "discovered_count": 81
+      }
+    },
+    {
+      "case_id": "persistent_discovered_cells_restore",
+      "fixture_path": "fixtures/discovered_cells_restore_9x9.json",
+      "coverage_tags": ["PERSISTENT_DISCOVERED_CELLS_RESTORE"],
+      "initial_expect": {
+        "discovered_count": 4
+      },
+      "final_expect": {
+        "cost_mode": "TURN_ONLY",
+        "srs_turn": 0,
+        "fuel": 0,
+        "player_position": [4, 7],
+        "event_types": [],
+        "consumed_object_ids": [],
+        "activated_object_ids": [],
+        "discovered_count": 4
+      }
+    }
+  ],
+  "comparisons": {
+    "turn_only_vs_shared_fuel": {
+      "turn_only_case_id": "turn_only_route",
+      "shared_fuel_case_id": "shared_fuel_route",
+      "expected_fuel_delta": 2
+    }
+  }
+}

--- a/experiments/galactic_exodus/srs/run_fixture.py
+++ b/experiments/galactic_exodus/srs/run_fixture.py
@@ -14,12 +14,15 @@ from experiments.galactic_exodus.srs.model import (
     Direction,
     ObservationMode,
     Position,
+    SrsActualMap,
+    SrsCell,
     SectorDescriptor,
     SectorType,
     SrsCommand,
     SrsGameLog,
     SrsGameState,
     SrsPersistentState,
+    SrsTerrainType,
 )
 from experiments.galactic_exodus.srs.render import render_known_map
 
@@ -109,6 +112,10 @@ def state_from_fixture(data: Mapping[str, Any], *, contracts: SrsContracts) -> S
         initial = {}
     if not isinstance(initial, Mapping):
         raise SrsFixtureError("initial must be an object")
+
+    cell_overrides = initial.get("cell_overrides")
+    if cell_overrides is not None:
+        state = _apply_cell_overrides(state, overrides=cell_overrides)
 
     reveal = initial.get("reveal")
     if reveal is not None:
@@ -237,6 +244,34 @@ def _apply_reveal(state: SrsGameState, *, reveal: Any, contracts: SrsContracts) 
     if mode == ObservationMode.LOCAL_MOVEMENT.value:
         return reveal_observation(state, center=state.player_position, contracts=contracts)
     raise SrsFixtureError(f"invalid reveal mode: {mode}")
+
+
+def _apply_cell_overrides(state: SrsGameState, *, overrides: Any) -> SrsGameState:
+    if not isinstance(overrides, list):
+        raise SrsFixtureError("initial.cell_overrides must be a list")
+
+    rows = [list(row) for row in state.actual_map.cells]
+    for index, override in enumerate(overrides, 1):
+        if not isinstance(override, Mapping):
+            raise SrsFixtureError(f"initial.cell_overrides[{index}] must be an object")
+        position = _position(override.get("position"), field_name=f"initial.cell_overrides[{index}].position")
+        if not state.actual_map.contains(position):
+            raise SrsFixtureError(f"initial.cell_overrides[{index}].position out of bounds: {position}")
+        terrain = _terrain_type(override.get("terrain"), field_name=f"initial.cell_overrides[{index}].terrain")
+        cell = rows[position.y][position.x]
+        rows[position.y][position.x] = SrsCell(
+            terrain=terrain,
+            object_id=cell.object_id,
+            actor_id=cell.actor_id,
+            warp_flags=cell.warp_flags,
+        )
+
+    actual_map = SrsActualMap(
+        width=state.actual_map.width,
+        height=state.actual_map.height,
+        cells=tuple(tuple(row) for row in rows),
+    )
+    return replace(state, actual_map=actual_map)
 
 
 def _apply_persistent_overrides(
@@ -433,6 +468,13 @@ def _sector_type(value: Any) -> SectorType:
         return SectorType(value)
     except ValueError as exc:
         raise SrsFixtureError(f"invalid sector_type: {value}") from exc
+
+
+def _terrain_type(value: Any, *, field_name: str) -> SrsTerrainType:
+    try:
+        return SrsTerrainType(value)
+    except ValueError as exc:
+        raise SrsFixtureError(f"invalid {field_name}: {value}") from exc
 
 
 def _print_cli_result(result: SrsFixtureRunResult) -> None:

--- a/experiments/galactic_exodus/srs/test_fixtures.py
+++ b/experiments/galactic_exodus/srs/test_fixtures.py
@@ -23,10 +23,14 @@ REQUIRED_FIXTURES = {
     "resource_cache_single_9x9.json",
     "station_refuel_9x9.json",
     "salvage_placeholder_9x9.json",
+    "nebula_observation_3x3_9x9.json",
     "warp_exit_s_9x9.json",
+    "warp_exit_rejected_no_flag_9x9.json",
     "rift_blocked_n_9x9.json",
+    "turn_only_cost_9x9.json",
     "shared_fuel_cost_9x9.json",
     "revisit_resource_consumed_9x9.json",
+    "discovered_cells_restore_9x9.json",
 }
 
 
@@ -108,6 +112,12 @@ class SrsFixtureTests(unittest.TestCase):
                 }
             ),
         )
+
+    def test_nebula_fixture_applies_cell_override_before_observation(self) -> None:
+        result = run_fixture(FIXTURES_DIR / "nebula_observation_3x3_9x9.json", contracts=self.contracts)
+
+        self.assertEqual(len(result.final_state.known_state.discovered_cells), 9)
+        self.assertEqual(result.final_state.actual_map.cell_at(Position(4, 7)).terrain.value, "NEBULA")
 
     def test_game_log_json_serializable(self) -> None:
         result = run_fixture(FIXTURES_DIR / "move_route_basic_9x9.json", contracts=self.contracts)

--- a/experiments/galactic_exodus/srs/test_validate_phase2_results.py
+++ b/experiments/galactic_exodus/srs/test_validate_phase2_results.py
@@ -16,7 +16,7 @@ class Phase2ReferenceValidationTests(unittest.TestCase):
         self.tmp_root.mkdir(exist_ok=True)
         self.tempdir = tempfile.TemporaryDirectory(dir=self.tmp_root)
         self.path = Path(self.tempdir.name) / "phase2_reference.json"
-        source = Path(__file__).with_name("phase2_reference.json")
+        source = Path(__file__).parent / "fixtures" / "phase2_reference.json"
         self.source_dir = source.parent
         self.payload = json.loads(source.read_text(encoding="utf-8"))
         for case in self.payload["cases"]:
@@ -66,7 +66,7 @@ class Phase2ReferenceValidationTests(unittest.TestCase):
             [
                 "python",
                 "experiments/galactic_exodus/srs/validate_phase2_results.py",
-                "experiments/galactic_exodus/srs/phase2_reference.json",
+                "experiments/galactic_exodus/srs/fixtures/phase2_reference.json",
             ],
             cwd=self.repo_root,
             capture_output=True,

--- a/experiments/galactic_exodus/srs/test_validate_phase2_results.py
+++ b/experiments/galactic_exodus/srs/test_validate_phase2_results.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-import csv
+import json
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -8,89 +9,89 @@ from pathlib import Path
 from experiments.galactic_exodus.srs import validate_phase2_results as validator
 
 
-class Phase2ResultsValidationTests(unittest.TestCase):
+class Phase2ReferenceValidationTests(unittest.TestCase):
     def setUp(self) -> None:
-        self.tempdir = tempfile.TemporaryDirectory()
-        self.root = Path(self.tempdir.name)
-        self.playtest = self.root / "phase2_playtest.md"
-        self.findings = self.root / "phase2_findings.csv"
-        self.write_valid_artifacts()
+        self.repo_root = Path(__file__).resolve().parents[3]
+        self.tmp_root = self.repo_root / ".tmp"
+        self.tmp_root.mkdir(exist_ok=True)
+        self.tempdir = tempfile.TemporaryDirectory(dir=self.tmp_root)
+        self.path = Path(self.tempdir.name) / "phase2_reference.json"
+        source = Path(__file__).with_name("phase2_reference.json")
+        self.source_dir = source.parent
+        self.payload = json.loads(source.read_text(encoding="utf-8"))
+        for case in self.payload["cases"]:
+            case["fixture_path"] = str((self.source_dir / case["fixture_path"]).resolve())
+        self.write()
 
     def tearDown(self) -> None:
         self.tempdir.cleanup()
 
-    def write_valid_artifacts(self) -> None:
-        self.playtest.write_text(
-            "\n".join(
-                [
-                    "# title",
-                    "## 2. 手動評価の要約",
-                    "## 3. 自動評価の要約",
-                    "policy 別の特徴",
-                    "TURN_ONLY / SHARED_FUEL",
-                    "RESOURCE_CACHE",
-                    "STATION",
-                    "SALVAGE placeholder",
-                    "NEBULA 3x3",
-                    "Q1.",
-                    "Q10.",
-                ]
-            )
-            + "\n",
-            encoding="utf-8",
+    def write(self) -> None:
+        self.path.write_text(json.dumps(self.payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def assert_invalid(self, pattern: str) -> None:
+        self.write()
+        with self.assertRaisesRegex(validator.ValidationError, pattern):
+            validator.validate(self.path)
+
+    def test_valid_reference_is_accepted(self) -> None:
+        summary = validator.validate(self.path)
+        self.assertEqual(summary["case_count"], 12)
+
+    def test_missing_required_case_is_rejected(self) -> None:
+        self.payload["cases"] = [case for case in self.payload["cases"] if case["case_id"] != "shared_fuel_route"]
+        self.assert_invalid("missing required cases")
+
+    def test_missing_fixture_file_is_rejected(self) -> None:
+        self.payload["cases"][0]["fixture_path"] = "fixtures/does_not_exist.json"
+        self.assert_invalid("fixture file not found")
+
+    def test_final_expect_unknown_field_is_rejected(self) -> None:
+        self.payload["cases"][0]["final_expect"]["bad_field"] = True
+        self.assert_invalid("unknown field")
+
+    def test_nebula_discovered_count_mismatch_is_rejected(self) -> None:
+        for case in self.payload["cases"]:
+            if case["case_id"] == "nebula_3x3_observation":
+                case["final_expect"]["discovered_count"] = 10
+                break
+        self.assert_invalid("discovered_count expected 10")
+
+    def test_turn_only_vs_shared_fuel_delta_mismatch_is_rejected(self) -> None:
+        self.payload["comparisons"]["turn_only_vs_shared_fuel"]["expected_fuel_delta"] = 3
+        self.assert_invalid("fuel delta expected 3")
+
+    def test_cli_reports_ok_for_valid_reference(self) -> None:
+        result = subprocess.run(
+            [
+                "python",
+                "experiments/galactic_exodus/srs/validate_phase2_results.py",
+                "experiments/galactic_exodus/srs/phase2_reference.json",
+            ],
+            cwd=self.repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
         )
-        with self.findings.open("w", encoding="utf-8", newline="") as file:
-            writer = csv.DictWriter(file, fieldnames=validator.FINDING_FIELDS)
-            writer.writeheader()
-            for index in range(1, 11):
-                writer.writerow(
-                    {
-                        "finding_id": f"P2SRS-{index:03d}",
-                        "question_id": f"Q{index}",
-                        "category": "CATEGORY",
-                        "candidate_classification": "NO_CHANGE",
-                        "summary": "summary",
-                        "evidence_type": "manual+automated",
-                        "evidence_ref": "ref",
-                        "case_id": "case",
-                        "policy": "policy",
-                        "cost_mode": "TURN_ONLY",
-                        "impact": "impact",
-                        "suggested_next_action": "next",
-                        "notes": "notes",
-                    }
-                )
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("Phase 2 SRS reference fixture: OK", result.stdout)
 
-    def test_validate_all_accepts_valid_artifacts(self) -> None:
-        counts = validator.validate_all(self.playtest, self.findings)
-        self.assertEqual(counts["NO_CHANGE"], 10)
-
-    def test_validate_playtest_requires_expected_sections(self) -> None:
-        self.playtest.write_text("# title\n", encoding="utf-8")
-        with self.assertRaisesRegex(validator.ValidationError, "missing required section text"):
-            validator.validate_playtest(self.playtest)
-
-    def test_validate_findings_requires_question_coverage(self) -> None:
-        with self.findings.open(encoding="utf-8", newline="") as file:
-            rows = list(csv.DictReader(file))
-        rows[-1]["question_id"] = "Q9"
-        with self.findings.open("w", encoding="utf-8", newline="") as file:
-            writer = csv.DictWriter(file, fieldnames=validator.FINDING_FIELDS)
-            writer.writeheader()
-            writer.writerows(rows)
-        with self.assertRaisesRegex(validator.ValidationError, "missing question coverage"):
-            validator.validate_findings(self.findings)
-
-    def test_validate_findings_rejects_unknown_classification(self) -> None:
-        with self.findings.open(encoding="utf-8", newline="") as file:
-            rows = list(csv.DictReader(file))
-        rows[0]["candidate_classification"] = "UNKNOWN"
-        with self.findings.open("w", encoding="utf-8", newline="") as file:
-            writer = csv.DictWriter(file, fieldnames=validator.FINDING_FIELDS)
-            writer.writeheader()
-            writer.writerows(rows)
-        with self.assertRaisesRegex(validator.ValidationError, "candidate_classification"):
-            validator.validate_findings(self.findings)
+    def test_cli_returns_nonzero_for_invalid_reference(self) -> None:
+        self.payload["reference_schema_version"] = 2
+        self.write()
+        result = subprocess.run(
+            [
+                "python",
+                "experiments/galactic_exodus/srs/validate_phase2_results.py",
+                str(self.path),
+            ],
+            cwd=self.repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("error:", result.stderr)
 
 
 if __name__ == "__main__":

--- a/experiments/galactic_exodus/srs/validate_phase2_results.py
+++ b/experiments/galactic_exodus/srs/validate_phase2_results.py
@@ -65,7 +65,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "reference",
         type=Path,
         nargs="?",
-        default=Path("experiments/galactic_exodus/srs/phase2_reference.json"),
+        default=Path("experiments/galactic_exodus/srs/fixtures/phase2_reference.json"),
     )
     return parser.parse_args(argv)
 

--- a/experiments/galactic_exodus/srs/validate_phase2_results.py
+++ b/experiments/galactic_exodus/srs/validate_phase2_results.py
@@ -1,137 +1,308 @@
 #!/usr/bin/env python3
-"""Validate Phase 2 SRS integrated evaluation artifacts."""
+"""Validate the Phase 2 SRS reference fixture and its replayable contracts."""
 
 from __future__ import annotations
 
 import argparse
-import csv
+import json
 import sys
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
-FINDING_FIELDS = [
-    "finding_id",
-    "question_id",
-    "category",
-    "candidate_classification",
-    "summary",
-    "evidence_type",
-    "evidence_ref",
-    "case_id",
-    "policy",
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from experiments.galactic_exodus.srs.model import Position
+from experiments.galactic_exodus.srs.run_fixture import FIXTURES_DIR, REPO_ROOT, SrsFixtureRunResult, run_fixture
+
+
+EXPECTED_SCHEMA_VERSION = 1
+REQUIRED_CASE_IDS = {
+    "normal_first_visit",
+    "resource_cache_interaction",
+    "resource_cache_consumed_revisit",
+    "base_station_interaction",
+    "salvage_placeholder_interaction",
+    "nebula_3x3_observation",
+    "rift_blocked_edge",
+    "warp_exit_accepted",
+    "warp_exit_rejected",
+    "turn_only_route",
+    "shared_fuel_route",
+    "persistent_discovered_cells_restore",
+}
+ALLOWED_EXPECT_FIELDS = {
     "cost_mode",
-    "impact",
-    "suggested_next_action",
-    "notes",
-]
-CLASSIFICATIONS = {"BLOCKER", "ADJUSTMENT", "PHASE_LATER", "NO_CHANGE"}
-QUESTION_IDS = {f"Q{index}" for index in range(1, 11)}
-REQUIRED_PLAYTEST_SNIPPETS = (
-    "## 2. 手動評価の要約",
-    "## 3. 自動評価の要約",
-    "policy 別の特徴",
-    "TURN_ONLY / SHARED_FUEL",
-    "RESOURCE_CACHE",
-    "STATION",
-    "SALVAGE placeholder",
-    "NEBULA 3x3",
-    "Q1.",
-    "Q10.",
-)
+    "srs_turn",
+    "fuel",
+    "max_fuel",
+    "player_position",
+    "event_types",
+    "consumed_object_ids",
+    "activated_object_ids",
+    "outcome",
+    "discovered_count",
+}
 
 
 class ValidationError(ValueError):
-    """Raised when a Phase 2 artifact violates its contract."""
+    """Raised when a Phase 2 reference artifact violates its contract."""
+
+
+@dataclass(frozen=True, slots=True)
+class ReferenceCase:
+    case_id: str
+    fixture_path: Path
+    coverage_tags: tuple[str, ...]
+    initial_expect: dict[str, Any]
+    final_expect: dict[str, Any]
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--playtest", type=Path, required=True)
-    parser.add_argument("--findings", type=Path, required=True)
+    parser.add_argument(
+        "reference",
+        type=Path,
+        nargs="?",
+        default=Path("experiments/galactic_exodus/srs/phase2_reference.json"),
+    )
     return parser.parse_args(argv)
 
 
-def load_csv(path: Path) -> tuple[list[str], list[dict[str, str]]]:
+def load_reference(path: Path) -> dict[str, Any]:
     try:
-        with path.open(encoding="utf-8", newline="") as file:
-            reader = csv.DictReader(file)
-            if reader.fieldnames is None:
-                raise ValidationError(f"{path}: missing CSV header")
-            return reader.fieldnames, list(reader)
+        payload = json.loads(path.read_text(encoding="utf-8"))
     except FileNotFoundError as exc:
         raise ValidationError(f"missing file: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValidationError(f"{path}: invalid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValidationError(f"{path}: root must be an object")
+    return payload
 
 
-def validate_playtest(path: Path) -> None:
-    try:
-        text = path.read_text(encoding="utf-8")
-    except FileNotFoundError as exc:
-        raise ValidationError(f"missing file: {path}") from exc
-    for snippet in REQUIRED_PLAYTEST_SNIPPETS:
-        if snippet not in text:
-            raise ValidationError(f"{path}: missing required section text: {snippet}")
+def validate(reference_path: Path) -> dict[str, Any]:
+    payload = load_reference(reference_path)
+    cases, comparison = _parse_reference(reference_path, payload)
+    results = {case.case_id: run_fixture(case.fixture_path) for case in cases}
+
+    for case in cases:
+        _validate_case_expectations(case, results[case.case_id])
+        _validate_known_map_secrecy(case.case_id, results[case.case_id])
+
+    _validate_turn_only_vs_shared_fuel(results, comparison)
+    _validate_nebula_observation(results["nebula_3x3_observation"])
+    _validate_persistent_restore(results["persistent_discovered_cells_restore"])
+    _validate_revisit_persistent_state(results["resource_cache_consumed_revisit"])
+    return {
+        "case_count": len(cases),
+        "fixture_dir": str(FIXTURES_DIR.relative_to(REPO_ROOT)),
+    }
 
 
-def _split_semicolon(raw: str) -> list[str]:
-    return [part.strip() for part in raw.split(";") if part.strip()]
+def _parse_reference(reference_path: Path, payload: dict[str, Any]) -> tuple[tuple[ReferenceCase, ...], dict[str, Any]]:
+    schema_version = payload.get("reference_schema_version")
+    if schema_version != EXPECTED_SCHEMA_VERSION:
+        raise ValidationError(f"{reference_path}: reference_schema_version must be {EXPECTED_SCHEMA_VERSION}")
 
+    spec_refs = payload.get("spec_refs")
+    if not isinstance(spec_refs, list) or not spec_refs:
+        raise ValidationError(f"{reference_path}: spec_refs must be a non-empty list")
+    if any(not isinstance(item, str) or item == "" for item in spec_refs):
+        raise ValidationError(f"{reference_path}: spec_refs must contain only non-empty strings")
 
-def validate_findings(path: Path) -> dict[str, int]:
-    fields, rows = load_csv(path)
-    if fields != FINDING_FIELDS:
-        raise ValidationError(f"{path}: columns must exactly match {FINDING_FIELDS}")
-    if len(rows) < 10:
-        raise ValidationError(f"{path}: expected at least 10 rows, got {len(rows)}")
+    raw_cases = payload.get("cases")
+    if not isinstance(raw_cases, list) or not raw_cases:
+        raise ValidationError(f"{reference_path}: cases must be a non-empty list")
+    cases = tuple(_parse_case(reference_path, raw_case) for raw_case in raw_cases)
 
-    seen_ids: set[str] = set()
-    covered_questions: set[str] = set()
-    counts = {classification: 0 for classification in CLASSIFICATIONS}
-    for index, row in enumerate(rows, 1):
-        label = f"finding row {index}"
-        for field in FINDING_FIELDS:
-            if not row.get(field, "").strip():
-                raise ValidationError(f"{label}.{field} must not be blank")
-        if row["finding_id"] in seen_ids:
-            raise ValidationError(f"{path}: duplicate finding_id {row['finding_id']}")
-        seen_ids.add(row["finding_id"])
-        if not row["finding_id"].startswith("P2SRS-"):
-            raise ValidationError(f"{label}.finding_id must start with P2SRS-")
-        classification = row["candidate_classification"]
-        if classification not in CLASSIFICATIONS:
-            raise ValidationError(
-                f"{label}.candidate_classification must be one of {sorted(CLASSIFICATIONS)}"
-            )
-        counts[classification] += 1
-        questions = _split_semicolon(row["question_id"])
-        if not questions:
-            raise ValidationError(f"{label}.question_id must not be empty")
-        for question_id in questions:
-            if question_id not in QUESTION_IDS:
-                raise ValidationError(f"{label}.question_id has unknown value {question_id}")
-            covered_questions.add(question_id)
-
-    missing = QUESTION_IDS - covered_questions
+    case_ids = {case.case_id for case in cases}
+    if len(case_ids) != len(cases):
+        raise ValidationError(f"{reference_path}: duplicate case_id detected")
+    missing = REQUIRED_CASE_IDS - case_ids
     if missing:
-        raise ValidationError(f"{path}: missing question coverage for {sorted(missing)}")
-    return counts
+        raise ValidationError(f"{reference_path}: missing required cases: {sorted(missing)}")
+
+    comparisons = payload.get("comparisons")
+    if not isinstance(comparisons, dict):
+        raise ValidationError(f"{reference_path}: comparisons must be an object")
+    comparison = comparisons.get("turn_only_vs_shared_fuel")
+    if not isinstance(comparison, dict):
+        raise ValidationError(f"{reference_path}: comparisons.turn_only_vs_shared_fuel must be an object")
+    return cases, comparison
 
 
-def validate_all(playtest: Path, findings: Path) -> dict[str, int]:
-    validate_playtest(playtest)
-    return validate_findings(findings)
+def _parse_case(reference_path: Path, raw_case: Any) -> ReferenceCase:
+    if not isinstance(raw_case, dict):
+        raise ValidationError(f"{reference_path}: each case must be an object")
+
+    case_id = _require_str(raw_case, "case_id", reference_path)
+    fixture_rel = _require_str(raw_case, "fixture_path", reference_path)
+    coverage_tags = raw_case.get("coverage_tags")
+    if not isinstance(coverage_tags, list) or not coverage_tags:
+        raise ValidationError(f"{reference_path}: case {case_id} coverage_tags must be a non-empty list")
+    if any(not isinstance(tag, str) or tag == "" for tag in coverage_tags):
+        raise ValidationError(f"{reference_path}: case {case_id} coverage_tags must contain only strings")
+
+    fixture_path = reference_path.parent / fixture_rel
+    if not fixture_path.is_file():
+        raise ValidationError(f"{reference_path}: case {case_id} fixture file not found: {fixture_rel}")
+
+    initial_expect = _parse_expect(raw_case.get("initial_expect", {}), case_id=case_id, field_name="initial_expect", reference_path=reference_path)
+    final_expect = _parse_expect(raw_case.get("final_expect", {}), case_id=case_id, field_name="final_expect", reference_path=reference_path)
+    if not final_expect:
+        raise ValidationError(f"{reference_path}: case {case_id} final_expect must not be empty")
+
+    return ReferenceCase(
+        case_id=case_id,
+        fixture_path=fixture_path,
+        coverage_tags=tuple(coverage_tags),
+        initial_expect=initial_expect,
+        final_expect=final_expect,
+    )
+
+
+def _parse_expect(raw_expect: Any, *, case_id: str, field_name: str, reference_path: Path) -> dict[str, Any]:
+    if not isinstance(raw_expect, dict):
+        raise ValidationError(f"{reference_path}: case {case_id} {field_name} must be an object")
+    unknown = sorted(set(raw_expect) - ALLOWED_EXPECT_FIELDS)
+    if unknown:
+        raise ValidationError(f"{reference_path}: case {case_id} {field_name} has unknown field {unknown[0]}")
+    return dict(raw_expect)
+
+
+def _validate_case_expectations(case: ReferenceCase, result: SrsFixtureRunResult) -> None:
+    _compare_expectations(case.case_id, "initial_expect", case.initial_expect, _snapshot(result.initial_state, result, use_final=False))
+    _compare_expectations(case.case_id, "final_expect", case.final_expect, _snapshot(result.final_state, result, use_final=True))
+
+
+def _snapshot(state: Any, result: SrsFixtureRunResult, *, use_final: bool) -> dict[str, Any]:
+    summary = result.summary if use_final else {"cost_mode": result.summary["cost_mode"], "outcome": None}
+    return {
+        "cost_mode": summary["cost_mode"],
+        "srs_turn": state.srs_turn,
+        "fuel": state.fuel,
+        "max_fuel": state.max_fuel,
+        "player_position": [state.player_position.x, state.player_position.y],
+        "event_types": [event.event_type for event in result.log.events] if use_final else [],
+        "consumed_object_ids": sorted(state.persistent_state.consumed_object_ids),
+        "activated_object_ids": sorted(state.persistent_state.activated_object_ids),
+        "outcome": summary["outcome"],
+        "discovered_count": len(state.known_state.discovered_cells),
+    }
+
+
+def _compare_expectations(case_id: str, phase: str, expected: dict[str, Any], actual: dict[str, Any]) -> None:
+    for field_name, expected_value in expected.items():
+        actual_value = actual[field_name]
+        if actual_value != expected_value:
+            raise ValidationError(f"{case_id}: {phase}.{field_name} expected {expected_value!r}, got {actual_value!r}")
+
+
+def _validate_known_map_secrecy(case_id: str, result: SrsFixtureRunResult) -> None:
+    state = result.final_state
+    discovered = state.known_state.discovered_cells
+    known_positions = set(state.known_state.known_cells)
+    if known_positions != set(discovered):
+        raise ValidationError(f"{case_id}: known_cells keys must exactly match discovered_cells")
+
+    rows = result.render.splitlines()
+    if len(rows) != state.actual_map.height:
+        raise ValidationError(f"{case_id}: render height mismatch")
+    if any(len(row) != state.actual_map.width for row in rows):
+        raise ValidationError(f"{case_id}: render width mismatch")
+
+    for y in range(state.actual_map.height):
+        for x in range(state.actual_map.width):
+            position = Position(x, y)
+            rendered = rows[y][x]
+            if position in discovered:
+                if rendered == "?":
+                    raise ValidationError(f"{case_id}: discovered cell rendered as unknown at {position}")
+                if state.known_state.known_cells[position] != state.actual_map.cell_at(position):
+                    raise ValidationError(f"{case_id}: known cell differs from actual cell at {position}")
+            elif rendered != "?":
+                raise ValidationError(f"{case_id}: undiscovered cell leaked into render at {position}")
+
+
+def _validate_turn_only_vs_shared_fuel(results: dict[str, SrsFixtureRunResult], comparison: dict[str, Any]) -> None:
+    turn_only_case_id = comparison.get("turn_only_case_id")
+    shared_fuel_case_id = comparison.get("shared_fuel_case_id")
+    expected_fuel_delta = comparison.get("expected_fuel_delta")
+    if not isinstance(turn_only_case_id, str) or not isinstance(shared_fuel_case_id, str):
+        raise ValidationError("comparisons.turn_only_vs_shared_fuel case ids must be strings")
+    if not isinstance(expected_fuel_delta, int) or expected_fuel_delta <= 0:
+        raise ValidationError("comparisons.turn_only_vs_shared_fuel expected_fuel_delta must be a positive integer")
+
+    turn_only = results[turn_only_case_id]
+    shared_fuel = results[shared_fuel_case_id]
+    if turn_only.final_state.player_position != shared_fuel.final_state.player_position:
+        raise ValidationError("TURN_ONLY and SHARED_FUEL comparison routes must end at the same position")
+    if turn_only.final_state.srs_turn != shared_fuel.final_state.srs_turn:
+        raise ValidationError("TURN_ONLY and SHARED_FUEL comparison routes must consume the same turns")
+    if [event.event_type for event in turn_only.log.events] != [event.event_type for event in shared_fuel.log.events]:
+        raise ValidationError("TURN_ONLY and SHARED_FUEL comparison routes must emit the same event types")
+    if turn_only.final_state.fuel != turn_only.initial_state.fuel:
+        raise ValidationError("TURN_ONLY comparison case must not consume fuel")
+    actual_delta = turn_only.final_state.fuel - shared_fuel.final_state.fuel
+    if actual_delta != expected_fuel_delta:
+        raise ValidationError(f"TURN_ONLY vs SHARED_FUEL fuel delta expected {expected_fuel_delta}, got {actual_delta}")
+
+
+def _validate_nebula_observation(result: SrsFixtureRunResult) -> None:
+    discovered = result.final_state.known_state.discovered_cells
+    if len(discovered) != 9:
+        raise ValidationError("nebula_3x3_observation: discovered_count must be 9")
+    center = result.final_state.player_position
+    expected = {
+        Position(x, y)
+        for y in range(center.y - 1, center.y + 2)
+        for x in range(center.x - 1, center.x + 2)
+    }
+    if discovered != expected:
+        raise ValidationError("nebula_3x3_observation: discovered cells must match the 3x3 neighborhood")
+
+
+def _validate_persistent_restore(result: SrsFixtureRunResult) -> None:
+    initial = result.initial_state.known_state.discovered_cells
+    final = result.final_state.known_state.discovered_cells
+    if initial != final:
+        raise ValidationError("persistent_discovered_cells_restore: discovered cells must be stable across no-op replay")
+    if result.final_state.persistent_state.discovered_cells != final:
+        raise ValidationError("persistent_discovered_cells_restore: persistent discovered cells must match known state")
+    if result.log.events:
+        raise ValidationError("persistent_discovered_cells_restore: no commands should yield no events")
+
+
+def _validate_revisit_persistent_state(result: SrsFixtureRunResult) -> None:
+    if "resource-cache-1" not in result.final_state.persistent_state.consumed_object_ids:
+        raise ValidationError("resource_cache_consumed_revisit: consumed resource cache must stay persistent")
+    if not result.final_state.objects["resource-cache-1"].consumed:
+        raise ValidationError("resource_cache_consumed_revisit: object state must stay consumed")
+
+
+def _require_str(mapping: dict[str, Any], field_name: str, path: Path) -> str:
+    value = mapping.get(field_name)
+    if not isinstance(value, str) or value == "":
+        raise ValidationError(f"{path}: {field_name} must be a non-empty string")
+    return value
+
+
+def validate_all(reference: Path) -> dict[str, Any]:
+    return validate(reference)
 
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     try:
-        counts = validate_all(args.playtest, args.findings)
+        summary = validate_all(args.reference)
     except ValidationError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
-    print("Phase 2 SRS integrated results: OK")
-    print(
-        "classifications:",
-        ", ".join(f"{key}={counts[key]}" for key in sorted(CLASSIFICATIONS)),
-    )
+    print("Phase 2 SRS reference fixture: OK")
+    print(f"cases: {summary['case_count']}")
+    print(f"fixture_dir: {summary['fixture_dir']}")
     return 0
 
 


### PR DESCRIPTION
## 概要

Closes #1165

Phase 2 SRS の代表ケースを集約した `phase2_reference.json` を追加し、Python fixture runner で再生して契約を検証する validator を実装しました。

- `experiments/galactic_exodus/srs/phase2_reference.json` を追加
- `experiments/galactic_exodus/srs/validate_phase2_results.py` を reference fixture validator に更新
- `NEBULA 3x3 observation`、`WARP_EXIT rejected`、`TURN_ONLY`、`persistent discovered_cells restore` の追加 fixture を作成
- `run_fixture.py` に `initial.cell_overrides` を追加して代表ケースを generic に再現
- validator / fixture runner のテストを更新

## 確認

- `python experiments/galactic_exodus/srs/validate_phase2_results.py experiments/galactic_exodus/srs/phase2_reference.json`
- `python -m unittest experiments.galactic_exodus.srs.test_fixture_regression experiments.galactic_exodus.srs.test_fixtures experiments.galactic_exodus.srs.test_validate_phase2_results`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
