### PR TITLE
SRS line of sight / range判定を実装

### DIFF
--- a/experiments/galactic_exodus/srs/engine.py
+++ b/experiments/galactic_exodus/srs/engine.py
@@ -38,6 +38,8 @@ from experiments.galactic_exodus.srs.model import (
     SrsPlayerCombatState,
     SrsPersistentState,
     SrsTerrainType,
+    SrsWeaponType,
+    default_weapon_profiles,
 )
 
 
@@ -51,6 +53,16 @@ class SrsMovementError(ValueError):
 
 class SrsInteractionError(ValueError):
     pass
+
+
+class SrsCombatError(ValueError):
+    pass
+
+
+_PLAYER_ATTACK_WEAPONS = (
+    SrsWeaponType.PHOTON_TORPEDO,
+    SrsWeaponType.PHASER,
+)
 
 
 def observation_size_for_terrain(
@@ -240,6 +252,76 @@ def is_impassable_cell(
         SrsObjectType.PLANET,
         SrsObjectType.STATION,
     }
+
+
+def bresenham_line(
+    start: Position,
+    end: Position,
+) -> tuple[Position, ...]:
+    x0 = start.x
+    y0 = start.y
+    x1 = end.x
+    y1 = end.y
+    dx = abs(x1 - x0)
+    dy = abs(y1 - y0)
+    sx = 1 if x0 < x1 else -1
+    sy = 1 if y0 < y1 else -1
+    err = dx - dy
+
+    line: list[Position] = []
+    while True:
+        line.append(Position(x0, y0))
+        if x0 == x1 and y0 == y1:
+            return tuple(line)
+
+        err_twice = err * 2
+        if err_twice > -dy:
+            err -= dy
+            x0 += sx
+        if err_twice < dx:
+            err += dx
+            y0 += sy
+
+
+def combat_range_distance(
+    attacker: Position,
+    target: Position,
+) -> int:
+    return max(abs(attacker.x - target.x), abs(attacker.y - target.y))
+
+
+def has_clear_line_of_sight(
+    state: SrsGameState,
+    *,
+    attacker: Position,
+    target: Position,
+) -> bool:
+    if not state.actual_map.contains(attacker):
+        raise SrsCombatError(f"attacker position out of bounds: {attacker}")
+    if not state.actual_map.contains(target):
+        raise SrsCombatError(f"target position out of bounds: {target}")
+
+    for position in bresenham_line(attacker, target)[1:-1]:
+        if is_impassable_cell(state, position):
+            return False
+    return True
+
+
+def is_attackable_position(
+    state: SrsGameState,
+    *,
+    attacker: Position,
+    target: Position,
+    weapon_type: SrsWeaponType,
+) -> bool:
+    weapon_profiles = default_weapon_profiles() if state.combat_state is None else state.combat_state.weapon_profiles
+    weapon_profile = weapon_profiles.get(weapon_type)
+    if weapon_profile is None:
+        raise SrsCombatError(f"missing weapon profile: {weapon_type.value}")
+
+    if combat_range_distance(attacker, target) > weapon_profile.range:
+        return False
+    return has_clear_line_of_sight(state, attacker=attacker, target=target)
 
 
 def resolve_move_route(
@@ -742,7 +824,8 @@ def _apply_combat_step(
 
     player_before = combat_state.player
     phase_from = combat_state.phase
-    phase_to = _next_combat_phase(combat_state)
+    target_attackable = _player_target_is_attackable(state)
+    phase_to = _next_combat_phase(state, target_attackable=target_attackable)
     player_after = player_before
     combat_turn_after = combat_state.combat_turn
     if phase_from is SrsCombatPhase.ENEMY_ACTION:
@@ -772,6 +855,7 @@ def _apply_combat_step(
                     "combat_turn_after": combat_turn_after,
                     "enemy_presence": combat_state.enemy_presence,
                     "target_available": combat_state.target_available,
+                    "target_attackable": target_attackable,
                     "player_energy_before": player_before.energy,
                     "player_energy_after": player_after.energy,
                     "outcome": "ACCEPTED",
@@ -781,9 +865,33 @@ def _apply_combat_step(
     )
 
 
-def _next_combat_phase(combat_state: Any) -> SrsCombatPhase:
+def _player_target_is_attackable(state: SrsGameState) -> bool:
+    combat_state = state.combat_state
+    if combat_state is None or not combat_state.target_available:
+        return False
+
+    enemy = combat_state.enemies[combat_state.player_attack_target_id]
+    return any(
+        is_attackable_position(
+            state,
+            attacker=state.player_position,
+            target=enemy.position,
+            weapon_type=weapon_type,
+        )
+        for weapon_type in _PLAYER_ATTACK_WEAPONS
+    )
+
+
+def _next_combat_phase(
+    state: SrsGameState,
+    *,
+    target_attackable: bool,
+) -> SrsCombatPhase:
+    combat_state = state.combat_state
+    if combat_state is None:
+        raise SrsCombatError("combat_state is required for combat phase transitions")
     if combat_state.phase is SrsCombatPhase.PLAYER_MOVEMENT:
-        if combat_state.enemy_presence and combat_state.target_available:
+        if combat_state.enemy_presence and target_attackable:
             return SrsCombatPhase.PLAYER_ATTACK
         return SrsCombatPhase.ENEMY_ACTION
     if combat_state.phase is SrsCombatPhase.PLAYER_ATTACK:

--- a/experiments/galactic_exodus/srs/fixtures/combat_attack_blocked_los_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/combat_attack_blocked_los_9x9.json
@@ -1,0 +1,35 @@
+{
+  "fixture_id": "combat_attack_blocked_los_9x9",
+  "description": "Selected target skips PLAYER_ATTACK when an impassable intermediate cell blocks line of sight.",
+  "sector": {
+    "sector_id": "normal-9103",
+    "sector_type": "NORMAL",
+    "sector_seed": 9103,
+    "entry_edge": "S",
+    "blocked_edges": []
+  },
+  "initial": {
+    "cell_overrides": [
+      {"position": [2, 4], "terrain": "ASTEROID"}
+    ],
+    "reveal": {"mode": "FULL"},
+    "player_position": [1, 4],
+    "combat": {
+      "phase": "PLAYER_MOVEMENT",
+      "enemies": [
+        {"enemy_id": "enemy-1", "tier": "TIER1", "position": [3, 4]}
+      ],
+      "player_attack_target_id": "enemy-1"
+    }
+  },
+  "commands": [
+    {"command_type": "COMBAT_STEP"}
+  ],
+  "expect": {
+    "event_types": ["COMBAT_TRANSITIONED"],
+    "combat_phase": "ENEMY_ACTION",
+    "combat_turn": 0,
+    "enemy_presence": true,
+    "outcome": "ACCEPTED"
+  }
+}

--- a/experiments/galactic_exodus/srs/fixtures/combat_attack_clear_los_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/combat_attack_clear_los_9x9.json
@@ -1,0 +1,32 @@
+{
+  "fixture_id": "combat_attack_clear_los_9x9",
+  "description": "Selected target enters PLAYER_ATTACK when it is within range and line of sight is clear.",
+  "sector": {
+    "sector_id": "normal-9102",
+    "sector_type": "NORMAL",
+    "sector_seed": 9102,
+    "entry_edge": "S",
+    "blocked_edges": []
+  },
+  "initial": {
+    "reveal": {"mode": "FULL"},
+    "player_position": [1, 4],
+    "combat": {
+      "phase": "PLAYER_MOVEMENT",
+      "enemies": [
+        {"enemy_id": "enemy-1", "tier": "TIER1", "position": [3, 4]}
+      ],
+      "player_attack_target_id": "enemy-1"
+    }
+  },
+  "commands": [
+    {"command_type": "COMBAT_STEP"}
+  ],
+  "expect": {
+    "event_types": ["COMBAT_TRANSITIONED"],
+    "combat_phase": "PLAYER_ATTACK",
+    "combat_turn": 0,
+    "enemy_presence": true,
+    "outcome": "ACCEPTED"
+  }
+}

--- a/experiments/galactic_exodus/srs/fixtures/combat_attack_out_of_range_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/combat_attack_out_of_range_9x9.json
@@ -1,0 +1,32 @@
+{
+  "fixture_id": "combat_attack_out_of_range_9x9",
+  "description": "Selected target skips PLAYER_ATTACK when it is outside all player weapon ranges even with clear line of sight.",
+  "sector": {
+    "sector_id": "normal-9104",
+    "sector_type": "NORMAL",
+    "sector_seed": 9104,
+    "entry_edge": "S",
+    "blocked_edges": []
+  },
+  "initial": {
+    "reveal": {"mode": "FULL"},
+    "player_position": [1, 4],
+    "combat": {
+      "phase": "PLAYER_MOVEMENT",
+      "enemies": [
+        {"enemy_id": "enemy-1", "tier": "TIER1", "position": [5, 4]}
+      ],
+      "player_attack_target_id": "enemy-1"
+    }
+  },
+  "commands": [
+    {"command_type": "COMBAT_STEP"}
+  ],
+  "expect": {
+    "event_types": ["COMBAT_TRANSITIONED"],
+    "combat_phase": "ENEMY_ACTION",
+    "combat_turn": 0,
+    "enemy_presence": true,
+    "outcome": "ACCEPTED"
+  }
+}

--- a/experiments/galactic_exodus/srs/test_engine_combat.py
+++ b/experiments/galactic_exodus/srs/test_engine_combat.py
@@ -5,17 +5,25 @@ from dataclasses import replace
 from pathlib import Path
 
 from experiments.galactic_exodus.srs.contracts import load_default_contracts
-from experiments.galactic_exodus.srs.engine import apply_srs_command
+from experiments.galactic_exodus.srs.engine import (
+    apply_srs_command,
+    bresenham_line,
+    has_clear_line_of_sight,
+    is_attackable_position,
+)
 from experiments.galactic_exodus.srs.log import COMBAT_TRANSITIONED, WARP_EXIT_REJECTED
 from experiments.galactic_exodus.srs.model import (
     Direction,
+    Position,
     SrsCombatPhase,
     SrsCombatState,
     SrsCommand,
     SrsEnemyTier,
+    SrsTerrainType,
+    SrsWeaponType,
     create_enemy_combat_state,
 )
-from experiments.galactic_exodus.srs.test_engine_movement import make_state
+from experiments.galactic_exodus.srs.test_engine_movement import make_state, replace_cell_terrain
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -51,6 +59,63 @@ class SrsEngineCombatTests(unittest.TestCase):
         self.assertEqual(result.state.combat_state.phase, SrsCombatPhase.PLAYER_ATTACK)
         self.assertEqual(result.state.combat_state.combat_turn, 0)
 
+    def test_bresenham_line_returns_expected_cells(self) -> None:
+        line = bresenham_line(Position(1, 1), Position(4, 3))
+
+        self.assertEqual(
+            line,
+            (
+                Position(1, 1),
+                Position(2, 2),
+                Position(3, 2),
+                Position(4, 3),
+            ),
+        )
+
+    def test_line_of_sight_is_blocked_by_impassable_intermediate_cell(self) -> None:
+        state = replace_cell_terrain(make_state(), Position(2, 4), SrsTerrainType.ASTEROID)
+
+        self.assertFalse(
+            has_clear_line_of_sight(
+                state,
+                attacker=Position(1, 4),
+                target=Position(3, 4),
+            )
+        )
+
+    def test_line_of_sight_ignores_attacker_and_target_cells_for_blocking(self) -> None:
+        state = make_state()
+        state = replace_cell_terrain(state, Position(1, 4), SrsTerrainType.ASTEROID)
+        state = replace_cell_terrain(state, Position(3, 4), SrsTerrainType.ASTEROID)
+
+        self.assertTrue(
+            has_clear_line_of_sight(
+                state,
+                attacker=Position(1, 4),
+                target=Position(3, 4),
+            )
+        )
+
+    def test_attackable_position_uses_fixed_weapon_range(self) -> None:
+        state = make_state()
+
+        self.assertTrue(
+            is_attackable_position(
+                state,
+                attacker=Position(1, 4),
+                target=Position(4, 4),
+                weapon_type=SrsWeaponType.PHOTON_TORPEDO,
+            )
+        )
+        self.assertFalse(
+            is_attackable_position(
+                state,
+                attacker=Position(1, 4),
+                target=Position(4, 4),
+                weapon_type=SrsWeaponType.PHASER,
+            )
+        )
+
     def test_combat_step_skips_attack_phase_without_target(self) -> None:
         state = make_state()
         enemy = create_enemy_combat_state(
@@ -72,6 +137,56 @@ class SrsEngineCombatTests(unittest.TestCase):
         )
 
         self.assertEqual(result.state.combat_state.phase, SrsCombatPhase.ENEMY_ACTION)
+
+    def test_combat_step_skips_attack_phase_when_line_of_sight_is_blocked(self) -> None:
+        state = replace_cell_terrain(make_state(), Position(2, 4), SrsTerrainType.ASTEROID)
+        enemy = create_enemy_combat_state(
+            enemy_id="enemy-1",
+            tier=SrsEnemyTier.TIER1,
+            position=Position(3, 4),
+        )
+        state = replace(
+            state,
+            player_position=Position(1, 4),
+            combat_state=SrsCombatState(
+                enemies={"enemy-1": enemy},
+                player_attack_target_id="enemy-1",
+            ),
+        )
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(command_type="COMBAT_STEP"),
+            contracts=self.contracts,
+        )
+
+        self.assertEqual(result.state.combat_state.phase, SrsCombatPhase.ENEMY_ACTION)
+        self.assertFalse(result.events[0].payload["target_attackable"])
+
+    def test_combat_step_skips_attack_phase_when_target_is_out_of_range(self) -> None:
+        state = make_state()
+        enemy = create_enemy_combat_state(
+            enemy_id="enemy-1",
+            tier=SrsEnemyTier.TIER1,
+            position=Position(5, 4),
+        )
+        state = replace(
+            state,
+            player_position=Position(1, 4),
+            combat_state=SrsCombatState(
+                enemies={"enemy-1": enemy},
+                player_attack_target_id="enemy-1",
+            ),
+        )
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(command_type="COMBAT_STEP"),
+            contracts=self.contracts,
+        )
+
+        self.assertEqual(result.state.combat_state.phase, SrsCombatPhase.ENEMY_ACTION)
+        self.assertFalse(result.events[0].payload["target_attackable"])
 
     def test_enemy_action_advances_combat_turn_and_recovers_energy(self) -> None:
         state = make_state()

--- a/experiments/galactic_exodus/srs/test_fixtures.py
+++ b/experiments/galactic_exodus/srs/test_fixtures.py
@@ -32,6 +32,9 @@ REQUIRED_FIXTURES = {
     "revisit_resource_consumed_9x9.json",
     "discovered_cells_restore_9x9.json",
     "combat_core_state_9x9.json",
+    "combat_attack_clear_los_9x9.json",
+    "combat_attack_blocked_los_9x9.json",
+    "combat_attack_out_of_range_9x9.json",
 }
 
 
@@ -133,6 +136,15 @@ class SrsFixtureTests(unittest.TestCase):
         self.assertEqual(result.final_state.combat_state.combat_turn, 1)
         self.assertTrue(result.final_state.combat_state.enemy_presence)
         self.assertEqual(result.final_state.combat_state.player.energy, 6)
+
+    def test_combat_attackability_fixtures_cover_allow_and_reject_cases(self) -> None:
+        clear = run_fixture(FIXTURES_DIR / "combat_attack_clear_los_9x9.json", contracts=self.contracts)
+        blocked = run_fixture(FIXTURES_DIR / "combat_attack_blocked_los_9x9.json", contracts=self.contracts)
+        out_of_range = run_fixture(FIXTURES_DIR / "combat_attack_out_of_range_9x9.json", contracts=self.contracts)
+
+        self.assertEqual(clear.final_state.combat_state.phase.value, "PLAYER_ATTACK")
+        self.assertEqual(blocked.final_state.combat_state.phase.value, "ENEMY_ACTION")
+        self.assertEqual(out_of_range.final_state.combat_state.phase.value, "ENEMY_ACTION")
 
     def test_required_fixture_set_exists(self) -> None:
         existing = {path.name for path in FIXTURES_DIR.glob("*.json")}


### PR DESCRIPTION
## 概要

Closes #1197

SRS combat の攻撃可否判定として、固定 weapon range と Bresenham line による LOS 判定を追加しました。

- `bresenham_line` / `has_clear_line_of_sight` / `is_attackable_position` を追加
- `COMBAT_STEP` の `PLAYER_MOVEMENT -> PLAYER_ATTACK` 遷移を、選択 target が実際に攻撃可能かどうかで判定
- 中間セルの `passable = false` を LOS block として扱い、attacker / target cell 自体は block 判定から除外
- 固定 fixture で clear LOS / blocked LOS / out of range の許可・拒否ケースを追加

## 確認

- `python3 -m unittest experiments.galactic_exodus.srs.test_engine_combat experiments.galactic_exodus.srs.test_fixtures experiments.galactic_exodus.srs.test_model`
- `python3 -m unittest discover -s experiments/galactic_exodus/srs -p 'test_*.py'`
