### PR TITLE
SRS enemy movement / Dijkstra pathfindingを実装

### DIFF
--- a/experiments/galactic_exodus/srs/engine.py
+++ b/experiments/galactic_exodus/srs/engine.py
@@ -225,11 +225,13 @@ def movement_raw_cost_for_step(
 ) -> int:
     if direction not in contracts.movement.directions:
         raise SrsMovementError(f"unsupported movement direction: {direction}")
-    return _orthogonal_step_raw_cost(destination)
+    return _orthogonal_step_raw_cost(destination, contracts=contracts)
 
 
 def _orthogonal_step_raw_cost(
     destination: SrsCell,
+    *,
+    contracts: SrsContracts,
 ) -> int:
     terrain_multipliers = {
         SrsTerrainType.FLOOR: 1,
@@ -243,7 +245,7 @@ def _orthogonal_step_raw_cost(
     multiplier = terrain_multipliers.get(destination.terrain)
     if multiplier is None:
         raise SrsMovementError(f"impassable terrain has no movement cost: {destination.terrain.value}")
-    return 10 * multiplier
+    return _movement_raw_cost_denominator(contracts) * multiplier
 
 
 def is_impassable_cell(
@@ -434,7 +436,7 @@ def apply_srs_command(
     if command.command_type == "INTERACT":
         return _apply_interact(state, command, contracts=contracts)
     if command.command_type == "COMBAT_STEP":
-        return _apply_combat_step(state, command)
+        return _apply_combat_step(state, command, contracts=contracts)
     if command.command_type == "WARP_EXIT":
         return _apply_warp_exit(state, command)
     return _rejected_movement_result(
@@ -838,6 +840,8 @@ def _apply_warp_exit(
 def _apply_combat_step(
     state: SrsGameState,
     command: SrsCommand,
+    *,
+    contracts: SrsContracts,
 ) -> SrsCommandResult:
     combat_state = state.combat_state
     if combat_state is None:
@@ -864,7 +868,7 @@ def _apply_combat_step(
     enemy_actions: tuple[Mapping[str, Any], ...] = ()
     enemy_states = combat_state.enemies
     if phase_from is SrsCombatPhase.ENEMY_ACTION:
-        enemy_states, enemy_actions = _resolve_enemy_action_phase(state)
+        enemy_states, enemy_actions = _resolve_enemy_action_phase(state, contracts=contracts)
         combat_turn_after += 1
         player_after = _recover_player_energy(player_before)
 
@@ -946,6 +950,8 @@ def _recover_player_energy(player: SrsPlayerCombatState) -> SrsPlayerCombatState
 
 def _resolve_enemy_action_phase(
     state: SrsGameState,
+    *,
+    contracts: SrsContracts,
 ) -> tuple[Mapping[str, Any], tuple[Mapping[str, Any], ...]]:
     combat_state = state.combat_state
     if combat_state is None:
@@ -960,6 +966,7 @@ def _resolve_enemy_action_phase(
             state,
             enemy=enemy,
             attackable_positions=attackable_positions,
+            contracts=contracts,
         )
         updated_enemies[enemy_id] = updated_enemy
         actions.append(action)
@@ -972,6 +979,7 @@ def _resolve_enemy_action(
     *,
     enemy: SrsEnemyCombatState,
     attackable_positions: Sequence[Position],
+    contracts: SrsContracts,
 ) -> tuple[SrsEnemyCombatState, Mapping[str, Any]]:
     can_attack_before_move = is_attackable_position(
         state,
@@ -998,6 +1006,7 @@ def _resolve_enemy_action(
         state,
         start=enemy.position,
         attackable_positions=attackable_positions,
+        contracts=contracts,
     )
     moved_path = planned_path[: enemy.movement_power]
     final_position = enemy.position if not moved_path else moved_path[-1]
@@ -1028,11 +1037,12 @@ def _select_enemy_path_to_attack_position(
     *,
     start: Position,
     attackable_positions: Sequence[Position],
+    contracts: SrsContracts,
 ) -> tuple[Position | None, tuple[Position, ...], int]:
     if not state.actual_map.contains(start):
         raise SrsCombatError(f"enemy position out of bounds: {start}")
 
-    best_paths = _dijkstra_enemy_paths(state, start=start)
+    best_paths = _dijkstra_enemy_paths(state, start=start, contracts=contracts)
     best_target: Position | None = None
     best_path: tuple[Position, ...] = ()
     best_cost: int | None = None
@@ -1059,6 +1069,7 @@ def _dijkstra_enemy_paths(
     state: SrsGameState,
     *,
     start: Position,
+    contracts: SrsContracts,
 ) -> Mapping[Position, tuple[int, tuple[Position, ...]]]:
     best_paths: dict[Position, tuple[int, tuple[tuple[int, int], ...], tuple[Position, ...]]] = {
         start: (0, (), ())
@@ -1080,7 +1091,10 @@ def _dijkstra_enemy_paths(
             if is_impassable_cell(state, next_position):
                 continue
 
-            step_cost = _orthogonal_step_raw_cost(state.actual_map.cell_at(next_position))
+            step_cost = _orthogonal_step_raw_cost(
+                state.actual_map.cell_at(next_position),
+                contracts=contracts,
+            )
             next_path = recorded_path + (next_position,)
             next_path_key = current_path_key + (_position_sort_key(next_position),)
             candidate = (current_cost + step_cost, next_path_key, next_path)

--- a/experiments/galactic_exodus/srs/engine.py
+++ b/experiments/galactic_exodus/srs/engine.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections import deque
 from dataclasses import replace
+from heapq import heappop, heappush
 from typing import Any, Mapping, Sequence
 
 from experiments.galactic_exodus.srs.contracts import SrsContracts
@@ -31,6 +32,7 @@ from experiments.galactic_exodus.srs.model import (
     SrsCombatPhase,
     SrsCommand,
     SrsCommandResult,
+    SrsEnemyCombatState,
     SrsGameState,
     SrsKnownState,
     SrsObjectType,
@@ -62,6 +64,12 @@ class SrsCombatError(ValueError):
 _PLAYER_ATTACK_WEAPONS = (
     SrsWeaponType.PHOTON_TORPEDO,
     SrsWeaponType.PHASER,
+)
+_ENEMY_PATH_TIEBREAK_DIRECTIONS = (
+    Direction.N,
+    Direction.W,
+    Direction.E,
+    Direction.S,
 )
 
 
@@ -217,7 +225,12 @@ def movement_raw_cost_for_step(
 ) -> int:
     if direction not in contracts.movement.directions:
         raise SrsMovementError(f"unsupported movement direction: {direction}")
+    return _orthogonal_step_raw_cost(destination)
 
+
+def _orthogonal_step_raw_cost(
+    destination: SrsCell,
+) -> int:
     terrain_multipliers = {
         SrsTerrainType.FLOOR: 1,
         SrsTerrainType.DEBRIS: 2,
@@ -230,7 +243,7 @@ def movement_raw_cost_for_step(
     multiplier = terrain_multipliers.get(destination.terrain)
     if multiplier is None:
         raise SrsMovementError(f"impassable terrain has no movement cost: {destination.terrain.value}")
-    return contracts.movement.orthogonal_raw_cost * multiplier
+    return 10 * multiplier
 
 
 def is_impassable_cell(
@@ -322,6 +335,26 @@ def is_attackable_position(
     if combat_range_distance(attacker, target) > weapon_profile.range:
         return False
     return has_clear_line_of_sight(state, attacker=attacker, target=target)
+
+
+def enemy_attackable_positions(
+    state: SrsGameState,
+) -> tuple[Position, ...]:
+    player_position = state.player_position
+    attackable_positions = []
+    for position in _iter_positions(state.actual_map):
+        if position == player_position:
+            continue
+        if is_impassable_cell(state, position):
+            continue
+        if is_attackable_position(
+            state,
+            attacker=position,
+            target=player_position,
+            weapon_type=SrsWeaponType.ENEMY_WEAPON,
+        ):
+            attackable_positions.append(position)
+    return tuple(sorted(attackable_positions, key=_position_sort_key))
 
 
 def resolve_move_route(
@@ -828,7 +861,10 @@ def _apply_combat_step(
     phase_to = _next_combat_phase(state, target_attackable=target_attackable)
     player_after = player_before
     combat_turn_after = combat_state.combat_turn
+    enemy_actions: tuple[Mapping[str, Any], ...] = ()
+    enemy_states = combat_state.enemies
     if phase_from is SrsCombatPhase.ENEMY_ACTION:
+        enemy_states, enemy_actions = _resolve_enemy_action_phase(state)
         combat_turn_after += 1
         player_after = _recover_player_energy(player_before)
 
@@ -836,6 +872,7 @@ def _apply_combat_step(
         state,
         combat_state=replace(
             combat_state,
+            enemies=enemy_states,
             player=player_after,
             phase=phase_to,
             combat_turn=combat_turn_after,
@@ -856,6 +893,7 @@ def _apply_combat_step(
                     "enemy_presence": combat_state.enemy_presence,
                     "target_available": combat_state.target_available,
                     "target_attackable": target_attackable,
+                    "enemy_actions": enemy_actions,
                     "player_energy_before": player_before.energy,
                     "player_energy_after": player_after.energy,
                     "outcome": "ACCEPTED",
@@ -904,6 +942,158 @@ def _recover_player_energy(player: SrsPlayerCombatState) -> SrsPlayerCombatState
         player,
         energy=min(player.energy_capacity, player.energy + player.energy_recovery),
     )
+
+
+def _resolve_enemy_action_phase(
+    state: SrsGameState,
+) -> tuple[Mapping[str, Any], tuple[Mapping[str, Any], ...]]:
+    combat_state = state.combat_state
+    if combat_state is None:
+        raise SrsCombatError("combat_state is required for enemy action resolution")
+
+    updated_enemies = dict(combat_state.enemies)
+    actions = []
+    attackable_positions = enemy_attackable_positions(state)
+    for enemy_id in sorted(updated_enemies):
+        enemy = updated_enemies[enemy_id]
+        updated_enemy, action = _resolve_enemy_action(
+            state,
+            enemy=enemy,
+            attackable_positions=attackable_positions,
+        )
+        updated_enemies[enemy_id] = updated_enemy
+        actions.append(action)
+
+    return updated_enemies, tuple(actions)
+
+
+def _resolve_enemy_action(
+    state: SrsGameState,
+    *,
+    enemy: SrsEnemyCombatState,
+    attackable_positions: Sequence[Position],
+) -> tuple[SrsEnemyCombatState, Mapping[str, Any]]:
+    can_attack_before_move = is_attackable_position(
+        state,
+        attacker=enemy.position,
+        target=state.player_position,
+        weapon_type=SrsWeaponType.ENEMY_WEAPON,
+    )
+    if can_attack_before_move:
+        return enemy, {
+            "enemy_id": enemy.enemy_id,
+            "start_position": _position_to_list(enemy.position),
+            "target_attackable_position": _position_to_list(enemy.position),
+            "planned_path": [],
+            "moved_path": [],
+            "final_position": _position_to_list(enemy.position),
+            "movement_power": enemy.movement_power,
+            "movement_cost": 0,
+            "attacked_player": True,
+            "can_attack_before_move": True,
+            "can_attack_after_move": True,
+        }
+
+    planned_target, planned_path, movement_cost = _select_enemy_path_to_attack_position(
+        state,
+        start=enemy.position,
+        attackable_positions=attackable_positions,
+    )
+    moved_path = planned_path[: enemy.movement_power]
+    final_position = enemy.position if not moved_path else moved_path[-1]
+    updated_enemy = replace(enemy, position=final_position)
+    can_attack_after_move = is_attackable_position(
+        state,
+        attacker=final_position,
+        target=state.player_position,
+        weapon_type=SrsWeaponType.ENEMY_WEAPON,
+    )
+    return updated_enemy, {
+        "enemy_id": enemy.enemy_id,
+        "start_position": _position_to_list(enemy.position),
+        "target_attackable_position": None if planned_target is None else _position_to_list(planned_target),
+        "planned_path": [_position_to_list(position) for position in planned_path],
+        "moved_path": [_position_to_list(position) for position in moved_path],
+        "final_position": _position_to_list(final_position),
+        "movement_power": enemy.movement_power,
+        "movement_cost": movement_cost,
+        "attacked_player": False,
+        "can_attack_before_move": False,
+        "can_attack_after_move": can_attack_after_move,
+    }
+
+
+def _select_enemy_path_to_attack_position(
+    state: SrsGameState,
+    *,
+    start: Position,
+    attackable_positions: Sequence[Position],
+) -> tuple[Position | None, tuple[Position, ...], int]:
+    if not state.actual_map.contains(start):
+        raise SrsCombatError(f"enemy position out of bounds: {start}")
+
+    best_paths = _dijkstra_enemy_paths(state, start=start)
+    best_target: Position | None = None
+    best_path: tuple[Position, ...] = ()
+    best_cost: int | None = None
+    for target in attackable_positions:
+        if target == start:
+            continue
+        candidate = best_paths.get(target)
+        if candidate is None:
+            continue
+        candidate_cost, candidate_path = candidate
+        target_key = _position_sort_key(target)
+        best_target_key = None if best_target is None else _position_sort_key(best_target)
+        if best_cost is None or (candidate_cost, target_key) < (best_cost, best_target_key):
+            best_target = target
+            best_path = candidate_path
+            best_cost = candidate_cost
+
+    if best_target is None or best_cost is None:
+        return None, (), 0
+    return best_target, best_path, best_cost
+
+
+def _dijkstra_enemy_paths(
+    state: SrsGameState,
+    *,
+    start: Position,
+) -> Mapping[Position, tuple[int, tuple[Position, ...]]]:
+    best_paths: dict[Position, tuple[int, tuple[tuple[int, int], ...], tuple[Position, ...]]] = {
+        start: (0, (), ())
+    }
+    frontier: list[tuple[int, tuple[tuple[int, int], ...], Position]] = [(0, (), start)]
+
+    while frontier:
+        current_cost, current_path_key, current_position = heappop(frontier)
+        recorded_cost, recorded_path_key, recorded_path = best_paths[current_position]
+        if (current_cost, current_path_key) != (recorded_cost, recorded_path_key):
+            continue
+
+        for direction in _ENEMY_PATH_TIEBREAK_DIRECTIONS:
+            next_position = _step_position(current_position, direction)
+            if next_position == state.player_position:
+                continue
+            if not state.actual_map.contains(next_position):
+                continue
+            if is_impassable_cell(state, next_position):
+                continue
+
+            step_cost = _orthogonal_step_raw_cost(state.actual_map.cell_at(next_position))
+            next_path = recorded_path + (next_position,)
+            next_path_key = current_path_key + (_position_sort_key(next_position),)
+            candidate = (current_cost + step_cost, next_path_key, next_path)
+            existing = best_paths.get(next_position)
+            if existing is not None and candidate[:2] >= existing[:2]:
+                continue
+            best_paths[next_position] = candidate
+            heappush(frontier, (candidate[0], candidate[1], next_position))
+
+    return {
+        position: (cost, path)
+        for position, (cost, _path_key, path) in best_paths.items()
+    }
 
 
 def _apply_resource_cache_interaction(
@@ -1339,6 +1529,10 @@ def _step_position(position: Position, direction: Direction) -> Position:
     }
     dx, dy = deltas[direction]
     return Position(position.x + dx, position.y + dy)
+
+
+def _position_sort_key(position: Position) -> tuple[int, int]:
+    return (position.y, position.x)
 
 
 def _position_to_list(position: Position) -> list[int]:

--- a/experiments/galactic_exodus/srs/fixtures/combat_enemy_movement_tiebreak_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/combat_enemy_movement_tiebreak_9x9.json
@@ -1,0 +1,56 @@
+{
+  "fixture_id": "combat_enemy_movement_tiebreak_9x9",
+  "description": "Enemy picks a deterministic equal-cost attackable cell and moves only three cells along that Dijkstra path.",
+  "sector": {
+    "sector_id": "normal-9105",
+    "sector_type": "NORMAL",
+    "sector_seed": 9105,
+    "entry_edge": "S",
+    "blocked_edges": []
+  },
+  "initial": {
+    "reveal": {"mode": "FULL"},
+    "player_position": [6, 4],
+    "cell_overrides": [
+      {"position": [1, 4], "terrain": "ASTEROID"},
+      {"position": [2, 4], "terrain": "ASTEROID"},
+      {"position": [3, 4], "terrain": "ASTEROID"},
+      {"position": [4, 4], "terrain": "ASTEROID"}
+    ],
+    "combat": {
+      "phase": "ENEMY_ACTION",
+      "enemies": [
+        {"enemy_id": "enemy-1", "tier": "TIER1", "position": [0, 4]}
+      ]
+    }
+  },
+  "commands": [
+    {"command_type": "COMBAT_STEP"}
+  ],
+  "expect": {
+    "event_types": ["COMBAT_TRANSITIONED"],
+    "combat_phase": "PLAYER_MOVEMENT",
+    "combat_turn": 1,
+    "enemy_presence": true,
+    "combat_player_energy": 6,
+    "combat_enemy_positions": {
+      "enemy-1": [2, 3]
+    },
+    "enemy_actions": [
+      {
+        "enemy_id": "enemy-1",
+        "start_position": [0, 4],
+        "target_attackable_position": [4, 3],
+        "planned_path": [[0, 3], [1, 3], [2, 3], [3, 3], [4, 3]],
+        "moved_path": [[0, 3], [1, 3], [2, 3]],
+        "final_position": [2, 3],
+        "movement_power": 3,
+        "movement_cost": 50,
+        "attacked_player": false,
+        "can_attack_before_move": false,
+        "can_attack_after_move": false
+      }
+    ],
+    "outcome": "ACCEPTED"
+  }
+}

--- a/experiments/galactic_exodus/srs/run_fixture.py
+++ b/experiments/galactic_exodus/srs/run_fixture.py
@@ -188,6 +188,8 @@ def run_fixture_data(data: Mapping[str, Any], *, contracts: SrsContracts) -> Srs
 
 def fixture_result_to_jsonable(result: SrsFixtureRunResult) -> Mapping[str, Any]:
     final_state = result.final_state
+    enemy_positions = _enemy_positions_payload(final_state)
+    enemy_actions = _flatten_enemy_actions(result.log)
     return {
         "fixture_id": result.fixture_id,
         "final_state": {
@@ -203,6 +205,7 @@ def fixture_result_to_jsonable(result: SrsFixtureRunResult) -> Mapping[str, Any]
             "combat_turn": final_state.combat_state.combat_turn if final_state.combat_state is not None else None,
             "enemy_presence": final_state.combat_state.enemy_presence if final_state.combat_state is not None else False,
             "combat_player_energy": final_state.combat_state.player.energy if final_state.combat_state is not None else None,
+            "combat_enemy_positions": enemy_positions,
         },
         "log": {
             "events": [
@@ -215,7 +218,7 @@ def fixture_result_to_jsonable(result: SrsFixtureRunResult) -> Mapping[str, Any]
             ]
         },
         "render": result.render,
-        "summary": dict(result.summary),
+        "summary": dict(result.summary) | {"enemy_actions": enemy_actions},
     }
 
 
@@ -406,6 +409,8 @@ def _build_summary(
     primary_outcome = None
     if log.events:
         primary_outcome = log.events[0].payload.get("outcome")
+    enemy_positions = _enemy_positions_payload(final_state)
+    enemy_actions = _flatten_enemy_actions(log)
     return {
         "fixture_id": fixture_id,
         "cost_mode": cost_mode.value,
@@ -422,6 +427,8 @@ def _build_summary(
         "combat_turn": final_state.combat_state.combat_turn if final_state.combat_state is not None else None,
         "enemy_presence": final_state.combat_state.enemy_presence if final_state.combat_state is not None else False,
         "combat_player_energy": final_state.combat_state.player.energy if final_state.combat_state is not None else None,
+        "combat_enemy_positions": enemy_positions,
+        "enemy_actions": enemy_actions,
         "outcome": primary_outcome,
         "render_line_count": len(render.splitlines()),
     }
@@ -435,6 +442,8 @@ def _validate_expectations(expect: Any, result: SrsFixtureRunResult) -> None:
 
     final_state = result.final_state
     event_types = [event.event_type for event in result.log.events]
+    enemy_positions = _enemy_positions_payload(final_state)
+    enemy_actions = _flatten_enemy_actions(result.log)
     comparisons = (
         ("srs_turn", final_state.srs_turn),
         ("fuel", final_state.fuel),
@@ -446,6 +455,8 @@ def _validate_expectations(expect: Any, result: SrsFixtureRunResult) -> None:
         ("combat_turn", final_state.combat_state.combat_turn if final_state.combat_state is not None else None),
         ("enemy_presence", final_state.combat_state.enemy_presence if final_state.combat_state is not None else False),
         ("combat_player_energy", final_state.combat_state.player.energy if final_state.combat_state is not None else None),
+        ("combat_enemy_positions", enemy_positions),
+        ("enemy_actions", enemy_actions),
         ("outcome", result.summary.get("outcome")),
     )
     for field_name, actual in comparisons:
@@ -457,6 +468,27 @@ def _validate_expectations(expect: Any, result: SrsFixtureRunResult) -> None:
         for needle in _normalize_expected_strings(render_contains, field_name="render_contains"):
             if needle not in result.render:
                 raise SrsFixtureError(f"expect mismatch for render_contains: missing {needle!r}")
+
+
+def _enemy_positions_payload(final_state: SrsGameState) -> Mapping[str, list[int]]:
+    if final_state.combat_state is None:
+        return {}
+    return {
+        enemy_id: _position_to_list(enemy.position)
+        for enemy_id, enemy in sorted(final_state.combat_state.enemies.items())
+    }
+
+
+def _flatten_enemy_actions(log: SrsGameLog) -> list[Mapping[str, Any]]:
+    actions = []
+    for event in log.events:
+        event_actions = event.payload.get("enemy_actions")
+        if not isinstance(event_actions, (list, tuple)):
+            continue
+        for action in event_actions:
+            if isinstance(action, Mapping):
+                actions.append(dict(action))
+    return actions
 
     render_not_contains = expect.get("render_not_contains")
     if render_not_contains is not None:

--- a/experiments/galactic_exodus/srs/run_fixture.py
+++ b/experiments/galactic_exodus/srs/run_fixture.py
@@ -469,6 +469,12 @@ def _validate_expectations(expect: Any, result: SrsFixtureRunResult) -> None:
             if needle not in result.render:
                 raise SrsFixtureError(f"expect mismatch for render_contains: missing {needle!r}")
 
+    render_not_contains = expect.get("render_not_contains")
+    if render_not_contains is not None:
+        for needle in _normalize_expected_strings(render_not_contains, field_name="render_not_contains"):
+            if needle in result.render:
+                raise SrsFixtureError(f"expect mismatch for render_not_contains: found {needle!r}")
+
 
 def _enemy_positions_payload(final_state: SrsGameState) -> Mapping[str, list[int]]:
     if final_state.combat_state is None:
@@ -489,12 +495,6 @@ def _flatten_enemy_actions(log: SrsGameLog) -> list[Mapping[str, Any]]:
             if isinstance(action, Mapping):
                 actions.append(dict(action))
     return actions
-
-    render_not_contains = expect.get("render_not_contains")
-    if render_not_contains is not None:
-        for needle in _normalize_expected_strings(render_not_contains, field_name="render_not_contains"):
-            if needle in result.render:
-                raise SrsFixtureError(f"expect mismatch for render_not_contains: found {needle!r}")
 
 
 def _normalize_expected_strings(value: Any, *, field_name: str) -> list[str]:

--- a/experiments/galactic_exodus/srs/test_engine_combat.py
+++ b/experiments/galactic_exodus/srs/test_engine_combat.py
@@ -8,6 +8,7 @@ from experiments.galactic_exodus.srs.contracts import load_default_contracts
 from experiments.galactic_exodus.srs.engine import (
     apply_srs_command,
     bresenham_line,
+    enemy_attackable_positions,
     has_clear_line_of_sight,
     is_attackable_position,
 )
@@ -116,6 +117,17 @@ class SrsEngineCombatTests(unittest.TestCase):
             )
         )
 
+    def test_enemy_attackable_positions_enumerates_clear_los_cells(self) -> None:
+        state = replace(make_state(), player_position=Position(4, 4))
+
+        positions = enemy_attackable_positions(state)
+
+        self.assertIn(Position(2, 4), positions)
+        self.assertIn(Position(4, 2), positions)
+        self.assertIn(Position(6, 6), positions)
+        self.assertNotIn(Position(4, 4), positions)
+        self.assertNotIn(Position(1, 4), positions)
+
     def test_combat_step_skips_attack_phase_without_target(self) -> None:
         state = make_state()
         enemy = create_enemy_combat_state(
@@ -211,6 +223,66 @@ class SrsEngineCombatTests(unittest.TestCase):
         self.assertEqual(result.state.combat_state.phase, SrsCombatPhase.PLAYER_MOVEMENT)
         self.assertEqual(result.state.combat_state.combat_turn, 1)
         self.assertEqual(result.state.combat_state.player.energy, 6)
+
+    def test_enemy_action_moves_to_lowest_total_movement_cost_attack_cell(self) -> None:
+        state = replace(make_state(), player_position=Position(4, 4))
+        for position in (Position(1, 4), Position(2, 4)):
+            state = replace_cell_terrain(state, position, SrsTerrainType.ASTEROID_FIELD)
+        enemy = create_enemy_combat_state(
+            enemy_id="enemy-1",
+            tier=SrsEnemyTier.TIER1,
+            position=Position(0, 4),
+        )
+        state = replace(
+            state,
+            combat_state=SrsCombatState(
+                enemies={"enemy-1": enemy},
+                phase=SrsCombatPhase.ENEMY_ACTION,
+            ),
+        )
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(command_type="COMBAT_STEP"),
+            contracts=self.contracts,
+        )
+
+        enemy_action = result.events[0].payload["enemy_actions"][0]
+        self.assertEqual(enemy_action["target_attackable_position"], [2, 3])
+        self.assertEqual(enemy_action["planned_path"], [[0, 3], [1, 3], [2, 3]])
+        self.assertEqual(result.state.combat_state.enemies["enemy-1"].position, Position(2, 3))
+
+    def test_enemy_action_uses_deterministic_cell_order_for_equal_cost_targets(self) -> None:
+        state = replace(make_state(), player_position=Position(6, 4))
+        for position in (Position(1, 4), Position(2, 4), Position(3, 4), Position(4, 4)):
+            state = replace_cell_terrain(state, position, SrsTerrainType.ASTEROID)
+        enemy = create_enemy_combat_state(
+            enemy_id="enemy-1",
+            tier=SrsEnemyTier.TIER1,
+            position=Position(0, 4),
+        )
+        state = replace(
+            state,
+            combat_state=SrsCombatState(
+                enemies={"enemy-1": enemy},
+                phase=SrsCombatPhase.ENEMY_ACTION,
+            ),
+        )
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(command_type="COMBAT_STEP"),
+            contracts=self.contracts,
+        )
+
+        enemy_action = result.events[0].payload["enemy_actions"][0]
+        self.assertEqual(enemy_action["target_attackable_position"], [4, 3])
+        self.assertEqual(
+            enemy_action["planned_path"],
+            [[0, 3], [1, 3], [2, 3], [3, 3], [4, 3]],
+        )
+        self.assertEqual(enemy_action["moved_path"], [[0, 3], [1, 3], [2, 3]])
+        self.assertEqual(result.state.combat_state.enemies["enemy-1"].position, Position(2, 3))
 
     def test_warp_exit_rejected_while_enemy_presence_true(self) -> None:
         state = make_state(entry_edge=Direction.S)

--- a/experiments/galactic_exodus/srs/test_fixture_regression.py
+++ b/experiments/galactic_exodus/srs/test_fixture_regression.py
@@ -102,3 +102,14 @@ class SrsFixtureRegressionTests(unittest.TestCase):
         self.assertIn("resource-cache-1", result.final_state.persistent_state.consumed_object_ids)
         self.assertTrue(result.final_state.objects["resource-cache-1"].consumed)
         self.assertIn(Position(2, 7), result.final_state.known_state.discovered_cells)
+
+    def test_combat_enemy_movement_tiebreak(self) -> None:
+        result = run_named_fixture("combat_enemy_movement_tiebreak_9x9")
+
+        self.assertIn("COMBAT_TRANSITIONED", event_types(result))
+        self.assertEqual(primary_outcome(result), "ACCEPTED")
+        self.assertEqual(result.final_state.combat_state.enemies["enemy-1"].position, Position(2, 3))
+        self.assertEqual(
+            result.summary["enemy_actions"][0]["target_attackable_position"],
+            [4, 3],
+        )

--- a/experiments/galactic_exodus/srs/test_fixtures.py
+++ b/experiments/galactic_exodus/srs/test_fixtures.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import json
 import unittest
+from dataclasses import replace
 from pathlib import Path
 
 from experiments.galactic_exodus.srs.contracts import load_default_contracts
+from experiments.galactic_exodus.srs.engine import apply_srs_command
 from experiments.galactic_exodus.srs.log import build_srs_log
-from experiments.galactic_exodus.srs.model import Position
+from experiments.galactic_exodus.srs.model import Direction, Position, SrsCombatPhase, SrsCombatState, SrsCommand, SrsEnemyTier, create_enemy_combat_state
 from experiments.galactic_exodus.srs.run_fixture import (
     FIXTURES_DIR,
     REPO_ROOT,
@@ -15,6 +17,7 @@ from experiments.galactic_exodus.srs.run_fixture import (
     load_fixture,
     run_fixture,
 )
+from experiments.galactic_exodus.srs.test_engine_movement import make_state
 
 
 REQUIRED_FIXTURES = {
@@ -87,6 +90,17 @@ class SrsFixtureTests(unittest.TestCase):
         self.assertEqual(payload["fixture_id"], "resource_cache_single_9x9")
         self.assertEqual(payload["final_state"]["fuel"], 7)
         json.dumps(payload)
+
+    def test_fixture_runner_validates_render_not_contains(self) -> None:
+        path = FIXTURES_DIR / "move_route_basic_9x9.json"
+        payload = dict(load_fixture(path))
+        payload["expect"] = dict(payload["expect"])
+        payload["expect"]["render_not_contains"] = "."
+
+        with self.assertRaisesRegex(SrsFixtureError, "expect mismatch for render_not_contains"):
+            from experiments.galactic_exodus.srs.run_fixture import run_fixture_data
+
+            run_fixture_data(payload, contracts=self.contracts)
 
     def test_resource_cache_fixture_restores_manual_eval_discovered_cells(self) -> None:
         result = run_fixture(FIXTURES_DIR / "resource_cache_single_9x9.json", contracts=self.contracts)
@@ -170,6 +184,45 @@ class SrsFixtureTests(unittest.TestCase):
                 }
             ],
         )
+
+    def test_custom_orthogonal_raw_cost_is_used_by_movement_and_enemy_pathfinding(self) -> None:
+        custom_contracts = replace(
+            self.contracts,
+            movement=replace(
+                self.contracts.movement,
+                orthogonal_raw_cost=7,
+                movement_cost_budget_raw=28,
+            ),
+        )
+
+        movement_state = make_state()
+        movement_result = apply_srs_command(
+            movement_state,
+            SrsCommand(command_type="MOVE_ROUTE", route=(Direction.N,)),
+            contracts=custom_contracts,
+        )
+        self.assertEqual(movement_result.events[0].payload["movement_raw_cost"], 7)
+
+        enemy_state = replace(make_state(), player_position=Position(4, 4))
+        enemy = create_enemy_combat_state(
+            enemy_id="enemy-1",
+            tier=SrsEnemyTier.TIER1,
+            position=Position(0, 4),
+        )
+        enemy_state = replace(
+            enemy_state,
+            combat_state=SrsCombatState(
+                enemies={"enemy-1": enemy},
+                phase=SrsCombatPhase.ENEMY_ACTION,
+            ),
+        )
+        enemy_result = apply_srs_command(
+            enemy_state,
+            SrsCommand(command_type="COMBAT_STEP"),
+            contracts=custom_contracts,
+        )
+
+        self.assertEqual(enemy_result.events[0].payload["enemy_actions"][0]["movement_cost"], 14)
 
     def test_required_fixture_set_exists(self) -> None:
         existing = {path.name for path in FIXTURES_DIR.glob("*.json")}

--- a/experiments/galactic_exodus/srs/test_fixtures.py
+++ b/experiments/galactic_exodus/srs/test_fixtures.py
@@ -35,6 +35,7 @@ REQUIRED_FIXTURES = {
     "combat_attack_clear_los_9x9.json",
     "combat_attack_blocked_los_9x9.json",
     "combat_attack_out_of_range_9x9.json",
+    "combat_enemy_movement_tiebreak_9x9.json",
 }
 
 
@@ -145,6 +146,30 @@ class SrsFixtureTests(unittest.TestCase):
         self.assertEqual(clear.final_state.combat_state.phase.value, "PLAYER_ATTACK")
         self.assertEqual(blocked.final_state.combat_state.phase.value, "ENEMY_ACTION")
         self.assertEqual(out_of_range.final_state.combat_state.phase.value, "ENEMY_ACTION")
+
+    def test_enemy_movement_fixture_keeps_target_path_and_final_position_deterministic(self) -> None:
+        result = run_fixture(FIXTURES_DIR / "combat_enemy_movement_tiebreak_9x9.json", contracts=self.contracts)
+
+        self.assertEqual(result.final_state.combat_state.phase.value, "PLAYER_MOVEMENT")
+        self.assertEqual(result.final_state.combat_state.enemies["enemy-1"].position, Position(2, 3))
+        self.assertEqual(
+            result.summary["enemy_actions"],
+            [
+                {
+                    "enemy_id": "enemy-1",
+                    "start_position": [0, 4],
+                    "target_attackable_position": [4, 3],
+                    "planned_path": [[0, 3], [1, 3], [2, 3], [3, 3], [4, 3]],
+                    "moved_path": [[0, 3], [1, 3], [2, 3]],
+                    "final_position": [2, 3],
+                    "movement_power": 3,
+                    "movement_cost": 50,
+                    "attacked_player": False,
+                    "can_attack_before_move": False,
+                    "can_attack_after_move": False,
+                }
+            ],
+        )
 
     def test_required_fixture_set_exists(self) -> None:
         existing = {path.name for path in FIXTURES_DIR.glob("*.json")}


### PR DESCRIPTION
## 概要

Closes #1198

SRS combat の enemy action phase に、攻撃可能位置の列挙と Dijkstra による最小移動コスト経路選択を追加しました。

## 変更内容

- enemy weapon の射程 2 と LOS から攻撃可能位置を列挙する helper を追加
- enemy が攻撃不能時に、決定的な cell order tie-break 付き Dijkstra で攻撃可能位置への経路を選択する処理を追加
- enemy の `movement_power = 3` に従って、選ばれた経路の先頭 3 マスまで移動する処理を追加
- fixture runner に enemy 最終位置と enemy action path の期待値比較を追加
- 最小移動コスト経路、同コスト tie-break、固定 fixture を確認する tests / fixture を追加

## 確認

- `python3 -m unittest experiments.galactic_exodus.srs.test_engine_combat experiments.galactic_exodus.srs.test_fixtures experiments.galactic_exodus.srs.test_fixture_regression`
- `python3 -m unittest discover -s experiments/galactic_exodus/srs -p 'test_*.py'`
