### PR TITLE
SRS combat の攻撃フェーズとreactionを実装

### DIFF
--- a/experiments/galactic_exodus/srs/engine.py
+++ b/experiments/galactic_exodus/srs/engine.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections import deque
 from dataclasses import replace
 from heapq import heappop, heappush
+from math import ceil
 from typing import Any, Mapping, Sequence
 
 from experiments.galactic_exodus.srs.contracts import SrsContracts
@@ -33,10 +34,12 @@ from experiments.galactic_exodus.srs.model import (
     SrsCommand,
     SrsCommandResult,
     SrsEnemyCombatState,
+    SrsEnemyReaction,
     SrsGameState,
     SrsKnownState,
     SrsObjectType,
     SrsObjectState,
+    SrsPlayerAttackAction,
     SrsPlayerCombatState,
     SrsPersistentState,
     SrsTerrainType,
@@ -864,13 +867,36 @@ def _apply_combat_step(
     target_attackable = _player_target_is_attackable(state)
     phase_to = _next_combat_phase(state, target_attackable=target_attackable)
     player_after = player_before
+    player_action: Mapping[str, Any] | None = None
     combat_turn_after = combat_state.combat_turn
     enemy_actions: tuple[Mapping[str, Any], ...] = ()
     enemy_states = combat_state.enemies
-    if phase_from is SrsCombatPhase.ENEMY_ACTION:
-        enemy_states, enemy_actions = _resolve_enemy_action_phase(state, contracts=contracts)
-        combat_turn_after += 1
-        player_after = _recover_player_energy(player_before)
+    player_attack_target_id = combat_state.player_attack_target_id
+
+    try:
+        if phase_from is SrsCombatPhase.PLAYER_ATTACK:
+            enemy_states, player_after, player_action = _resolve_player_attack_phase(state, command)
+            if player_attack_target_id not in enemy_states:
+                player_attack_target_id = None
+        elif phase_from is SrsCombatPhase.ENEMY_ACTION:
+            enemy_states, player_after, enemy_actions = _resolve_enemy_action_phase(state, command, contracts=contracts)
+            combat_turn_after += 1
+            player_after = _recover_player_energy(player_after)
+    except SrsCombatError as exc:
+        return SrsCommandResult(
+            state=state,
+            events=(
+                make_turn_event(
+                    srs_turn=state.srs_turn,
+                    event_type=COMBAT_REJECTED,
+                    payload={
+                        "command_type": command.command_type,
+                        "phase": phase_from.value,
+                        "outcome": str(exc),
+                    },
+                ),
+            ),
+        )
 
     updated_state = replace(
         state,
@@ -880,6 +906,7 @@ def _apply_combat_step(
             player=player_after,
             phase=phase_to,
             combat_turn=combat_turn_after,
+            player_attack_target_id=player_attack_target_id,
         ),
     )
     return SrsCommandResult(
@@ -897,14 +924,92 @@ def _apply_combat_step(
                     "enemy_presence": combat_state.enemy_presence,
                     "target_available": combat_state.target_available,
                     "target_attackable": target_attackable,
+                    "player_action": player_action,
                     "enemy_actions": enemy_actions,
+                    "player_durability_before": player_before.durability,
+                    "player_durability_after": player_after.durability,
                     "player_energy_before": player_before.energy,
                     "player_energy_after": player_after.energy,
+                    "player_torpedo_ammo_before": player_before.photon_torpedo_ammo,
+                    "player_torpedo_ammo_after": player_after.photon_torpedo_ammo,
                     "outcome": "ACCEPTED",
                 },
             ),
         ),
     )
+
+
+def _resolve_player_attack_phase(
+    state: SrsGameState,
+    command: SrsCommand,
+) -> tuple[Mapping[str, SrsEnemyCombatState], SrsPlayerCombatState, Mapping[str, Any]]:
+    combat_state = state.combat_state
+    if combat_state is None:
+        raise SrsCombatError("combat_state is required for player attack resolution")
+
+    action = command.player_attack_action or SrsPlayerAttackAction.SKIP
+    payload: dict[str, Any] = {
+        "selected_action": action.value,
+        "selected_weapon": None if command.player_attack_weapon is None else command.player_attack_weapon.value,
+        "target_enemy_id": combat_state.player_attack_target_id,
+        "attack_executed": False,
+        "damage_applied": 0,
+        "resource_cost": 0,
+        "resource_type": None,
+        "target_destroyed": False,
+    }
+    if action is SrsPlayerAttackAction.SKIP:
+        return combat_state.enemies, combat_state.player, payload
+    if not combat_state.target_available:
+        raise SrsCombatError("REJECTED_TARGET_UNAVAILABLE")
+    if command.player_attack_weapon is None:
+        raise SrsCombatError("REJECTED_ATTACK_WEAPON_REQUIRED")
+
+    weapon_profile = combat_state.weapon_profiles.get(command.player_attack_weapon)
+    if weapon_profile is None or weapon_profile.damage is None:
+        raise SrsCombatError("REJECTED_INVALID_ATTACK_WEAPON")
+
+    target_enemy_id = combat_state.player_attack_target_id
+    target_enemy = combat_state.enemies[target_enemy_id]
+    if not is_attackable_position(
+        state,
+        attacker=state.player_position,
+        target=target_enemy.position,
+        weapon_type=command.player_attack_weapon,
+    ):
+        raise SrsCombatError("REJECTED_TARGET_NOT_ATTACKABLE")
+
+    player = combat_state.player
+    if weapon_profile.ammo_cost > 0:
+        if player.photon_torpedo_ammo < weapon_profile.ammo_cost:
+            raise SrsCombatError("REJECTED_INSUFFICIENT_TORPEDO_AMMO")
+        player = replace(
+            player,
+            photon_torpedo_ammo=player.photon_torpedo_ammo - weapon_profile.ammo_cost,
+        )
+        payload["resource_cost"] = weapon_profile.ammo_cost
+        payload["resource_type"] = "PHOTON_TORPEDO_AMMO"
+    if weapon_profile.energy_cost > 0:
+        if player.energy < weapon_profile.energy_cost:
+            raise SrsCombatError("REJECTED_INSUFFICIENT_PHASER_ENERGY")
+        player = replace(
+            player,
+            energy=player.energy - weapon_profile.energy_cost,
+        )
+        payload["resource_cost"] = weapon_profile.energy_cost
+        payload["resource_type"] = "ENERGY"
+
+    updated_enemies = dict(combat_state.enemies)
+    remaining_durability = target_enemy.durability - weapon_profile.damage
+    payload["attack_executed"] = True
+    payload["damage_applied"] = weapon_profile.damage
+    if remaining_durability <= 0:
+        del updated_enemies[target_enemy_id]
+        payload["target_destroyed"] = True
+    else:
+        updated_enemies[target_enemy_id] = replace(target_enemy, durability=remaining_durability)
+        payload["target_remaining_durability"] = remaining_durability
+    return updated_enemies, player, payload
 
 
 def _player_target_is_attackable(state: SrsGameState) -> bool:
@@ -948,39 +1053,134 @@ def _recover_player_energy(player: SrsPlayerCombatState) -> SrsPlayerCombatState
     )
 
 
-def _resolve_enemy_action_phase(
+def _resolve_enemy_attack_reaction(
     state: SrsGameState,
     *,
+    command: SrsCommand,
+    enemy: SrsEnemyCombatState,
+) -> tuple[SrsPlayerCombatState, SrsEnemyCombatState | None, Mapping[str, Any]]:
+    combat_state = state.combat_state
+    if combat_state is None:
+        raise SrsCombatError("combat_state is required for enemy reaction resolution")
+
+    selected_reaction = command.enemy_reactions.get(enemy.enemy_id, SrsEnemyReaction.DEFEND)
+    counterattack_available = _counterattack_available(state, enemy=enemy)
+    resolved_reaction = selected_reaction
+    if selected_reaction is SrsEnemyReaction.COUNTERATTACK and not counterattack_available:
+        resolved_reaction = SrsEnemyReaction.DEFEND
+
+    damage_to_player = enemy.attack_damage
+    player = combat_state.player
+    updated_enemy: SrsEnemyCombatState | None = enemy
+    counterattack_damage = 0
+    if resolved_reaction is SrsEnemyReaction.DEFEND:
+        damage_to_player = ceil(enemy.attack_damage * 0.5)
+    else:
+        phaser_profile = combat_state.weapon_profiles[SrsWeaponType.PHASER]
+        player = replace(
+            player,
+            energy=player.energy - phaser_profile.energy_cost,
+        )
+        counterattack_damage = phaser_profile.damage or 0
+        remaining_enemy_durability = enemy.durability - counterattack_damage
+        if remaining_enemy_durability <= 0:
+            updated_enemy = None
+        else:
+            updated_enemy = replace(enemy, durability=remaining_enemy_durability)
+
+    player = replace(
+        player,
+        durability=max(0, player.durability - damage_to_player),
+    )
+    return player, updated_enemy, {
+        "selected_reaction": selected_reaction.value,
+        "resolved_reaction": resolved_reaction.value,
+        "counterattack_available": counterattack_available,
+        "fallback_to_defend": (
+            selected_reaction is SrsEnemyReaction.COUNTERATTACK
+            and resolved_reaction is SrsEnemyReaction.DEFEND
+        ),
+        "damage_to_player": damage_to_player,
+        "counterattack_damage": counterattack_damage,
+        "enemy_destroyed": updated_enemy is None,
+    }
+
+
+def _counterattack_available(
+    state: SrsGameState,
+    *,
+    enemy: SrsEnemyCombatState,
+) -> bool:
+    combat_state = state.combat_state
+    if combat_state is None:
+        raise SrsCombatError("combat_state is required for counterattack checks")
+    phaser_profile = combat_state.weapon_profiles.get(SrsWeaponType.PHASER)
+    if phaser_profile is None:
+        raise SrsCombatError("missing weapon profile: PHASER")
+    if combat_state.player.energy < phaser_profile.energy_cost:
+        return False
+    return is_attackable_position(
+        state,
+        attacker=state.player_position,
+        target=enemy.position,
+        weapon_type=SrsWeaponType.PHASER,
+    )
+
+
+def _resolve_enemy_action_phase(
+    state: SrsGameState,
+    command: SrsCommand,
+    *,
     contracts: SrsContracts,
-) -> tuple[Mapping[str, Any], tuple[Mapping[str, Any], ...]]:
+) -> tuple[Mapping[str, Any], SrsPlayerCombatState, tuple[Mapping[str, Any], ...]]:
     combat_state = state.combat_state
     if combat_state is None:
         raise SrsCombatError("combat_state is required for enemy action resolution")
 
     updated_enemies = dict(combat_state.enemies)
+    player = combat_state.player
     actions = []
     attackable_positions = enemy_attackable_positions(state)
-    for enemy_id in sorted(updated_enemies):
-        enemy = updated_enemies[enemy_id]
-        updated_enemy, action = _resolve_enemy_action(
+    for enemy_id in sorted(tuple(updated_enemies)):
+        enemy = updated_enemies.get(enemy_id)
+        if enemy is None:
+            continue
+        working_state = replace(
             state,
+            combat_state=replace(
+                combat_state,
+                enemies=updated_enemies,
+                player=player,
+            ),
+        )
+        updated_enemy, player, action = _resolve_enemy_action(
+            working_state,
+            command=command,
             enemy=enemy,
             attackable_positions=attackable_positions,
             contracts=contracts,
         )
-        updated_enemies[enemy_id] = updated_enemy
+        if updated_enemy is None:
+            del updated_enemies[enemy_id]
+        else:
+            updated_enemies[enemy_id] = updated_enemy
         actions.append(action)
 
-    return updated_enemies, tuple(actions)
+    return updated_enemies, player, tuple(actions)
 
 
 def _resolve_enemy_action(
     state: SrsGameState,
     *,
+    command: SrsCommand,
     enemy: SrsEnemyCombatState,
     attackable_positions: Sequence[Position],
     contracts: SrsContracts,
-) -> tuple[SrsEnemyCombatState, Mapping[str, Any]]:
+) -> tuple[SrsEnemyCombatState | None, SrsPlayerCombatState, Mapping[str, Any]]:
+    combat_state = state.combat_state
+    if combat_state is None:
+        raise SrsCombatError("combat_state is required for enemy action resolution")
+
     can_attack_before_move = is_attackable_position(
         state,
         attacker=enemy.position,
@@ -988,7 +1188,12 @@ def _resolve_enemy_action(
         weapon_type=SrsWeaponType.ENEMY_WEAPON,
     )
     if can_attack_before_move:
-        return enemy, {
+        player_after, enemy_after, reaction = _resolve_enemy_attack_reaction(
+            state,
+            command=command,
+            enemy=enemy,
+        )
+        return enemy_after, player_after, {
             "enemy_id": enemy.enemy_id,
             "start_position": _position_to_list(enemy.position),
             "target_attackable_position": _position_to_list(enemy.position),
@@ -1000,6 +1205,7 @@ def _resolve_enemy_action(
             "attacked_player": True,
             "can_attack_before_move": True,
             "can_attack_after_move": True,
+            "reaction": reaction,
         }
 
     planned_target, planned_path, movement_cost = _select_enemy_path_to_attack_position(
@@ -1017,7 +1223,7 @@ def _resolve_enemy_action(
         target=state.player_position,
         weapon_type=SrsWeaponType.ENEMY_WEAPON,
     )
-    return updated_enemy, {
+    return updated_enemy, combat_state.player, {
         "enemy_id": enemy.enemy_id,
         "start_position": _position_to_list(enemy.position),
         "target_attackable_position": None if planned_target is None else _position_to_list(planned_target),
@@ -1029,6 +1235,7 @@ def _resolve_enemy_action(
         "attacked_player": False,
         "can_attack_before_move": False,
         "can_attack_after_move": can_attack_after_move,
+        "reaction": None,
     }
 
 

--- a/experiments/galactic_exodus/srs/fixtures/combat_enemy_counterattack_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/combat_enemy_counterattack_9x9.json
@@ -1,0 +1,69 @@
+{
+  "fixture_id": "combat_enemy_counterattack_9x9",
+  "description": "A counterattack spends one phaser energy, deals one fixed damage, and the incoming enemy attack still hits.",
+  "sector": {
+    "sector_id": "normal-9113",
+    "sector_type": "NORMAL",
+    "sector_seed": 9113,
+    "entry_edge": "S",
+    "blocked_edges": []
+  },
+  "initial": {
+    "reveal": {"mode": "FULL"},
+    "player_position": [1, 4],
+    "combat": {
+      "phase": "ENEMY_ACTION",
+      "enemies": [
+        {"enemy_id": "enemy-1", "tier": "TIER1", "position": [2, 4]}
+      ]
+    }
+  },
+  "commands": [
+    {
+      "command_type": "COMBAT_STEP",
+      "enemy_reactions": {
+        "enemy-1": "COUNTERATTACK"
+      }
+    }
+  ],
+  "expect": {
+    "event_types": ["COMBAT_TRANSITIONED"],
+    "combat_phase": "PLAYER_MOVEMENT",
+    "combat_turn": 1,
+    "enemy_presence": true,
+    "combat_player_durability": 94,
+    "combat_player_energy": 6,
+    "combat_player_torpedo_ammo": 6,
+    "combat_enemy_positions": {
+      "enemy-1": [2, 4]
+    },
+    "combat_enemy_durabilities": {
+      "enemy-1": 2
+    },
+    "enemy_actions": [
+      {
+        "enemy_id": "enemy-1",
+        "start_position": [2, 4],
+        "target_attackable_position": [2, 4],
+        "planned_path": [],
+        "moved_path": [],
+        "final_position": [2, 4],
+        "movement_power": 3,
+        "movement_cost": 0,
+        "attacked_player": true,
+        "can_attack_before_move": true,
+        "can_attack_after_move": true,
+        "reaction": {
+          "selected_reaction": "COUNTERATTACK",
+          "resolved_reaction": "COUNTERATTACK",
+          "counterattack_available": true,
+          "fallback_to_defend": false,
+          "damage_to_player": 6,
+          "counterattack_damage": 1,
+          "enemy_destroyed": false
+        }
+      }
+    ],
+    "outcome": "ACCEPTED"
+  }
+}

--- a/experiments/galactic_exodus/srs/fixtures/combat_enemy_counterattack_fallback_energy_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/combat_enemy_counterattack_fallback_energy_9x9.json
@@ -1,0 +1,72 @@
+{
+  "fixture_id": "combat_enemy_counterattack_fallback_energy_9x9",
+  "description": "A selected counterattack falls back to defend when phaser energy is insufficient.",
+  "sector": {
+    "sector_id": "normal-9114",
+    "sector_type": "NORMAL",
+    "sector_seed": 9114,
+    "entry_edge": "S",
+    "blocked_edges": []
+  },
+  "initial": {
+    "reveal": {"mode": "FULL"},
+    "player_position": [1, 4],
+    "combat": {
+      "phase": "ENEMY_ACTION",
+      "player": {
+        "energy": 0
+      },
+      "enemies": [
+        {"enemy_id": "enemy-1", "tier": "TIER1", "position": [2, 4]}
+      ]
+    }
+  },
+  "commands": [
+    {
+      "command_type": "COMBAT_STEP",
+      "enemy_reactions": {
+        "enemy-1": "COUNTERATTACK"
+      }
+    }
+  ],
+  "expect": {
+    "event_types": ["COMBAT_TRANSITIONED"],
+    "combat_phase": "PLAYER_MOVEMENT",
+    "combat_turn": 1,
+    "enemy_presence": true,
+    "combat_player_durability": 97,
+    "combat_player_energy": 1,
+    "combat_player_torpedo_ammo": 6,
+    "combat_enemy_positions": {
+      "enemy-1": [2, 4]
+    },
+    "combat_enemy_durabilities": {
+      "enemy-1": 3
+    },
+    "enemy_actions": [
+      {
+        "enemy_id": "enemy-1",
+        "start_position": [2, 4],
+        "target_attackable_position": [2, 4],
+        "planned_path": [],
+        "moved_path": [],
+        "final_position": [2, 4],
+        "movement_power": 3,
+        "movement_cost": 0,
+        "attacked_player": true,
+        "can_attack_before_move": true,
+        "can_attack_after_move": true,
+        "reaction": {
+          "selected_reaction": "COUNTERATTACK",
+          "resolved_reaction": "DEFEND",
+          "counterattack_available": false,
+          "fallback_to_defend": true,
+          "damage_to_player": 3,
+          "counterattack_damage": 0,
+          "enemy_destroyed": false
+        }
+      }
+    ],
+    "outcome": "ACCEPTED"
+  }
+}

--- a/experiments/galactic_exodus/srs/fixtures/combat_enemy_defend_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/combat_enemy_defend_9x9.json
@@ -1,0 +1,69 @@
+{
+  "fixture_id": "combat_enemy_defend_9x9",
+  "description": "A defend reaction halves incoming tier2 damage and rounds the final damage up.",
+  "sector": {
+    "sector_id": "normal-9112",
+    "sector_type": "NORMAL",
+    "sector_seed": 9112,
+    "entry_edge": "S",
+    "blocked_edges": []
+  },
+  "initial": {
+    "reveal": {"mode": "FULL"},
+    "player_position": [4, 4],
+    "combat": {
+      "phase": "ENEMY_ACTION",
+      "enemies": [
+        {"enemy_id": "enemy-1", "tier": "TIER2", "position": [4, 5]}
+      ]
+    }
+  },
+  "commands": [
+    {
+      "command_type": "COMBAT_STEP",
+      "enemy_reactions": {
+        "enemy-1": "DEFEND"
+      }
+    }
+  ],
+  "expect": {
+    "event_types": ["COMBAT_TRANSITIONED"],
+    "combat_phase": "PLAYER_MOVEMENT",
+    "combat_turn": 1,
+    "enemy_presence": true,
+    "combat_player_durability": 96,
+    "combat_player_energy": 6,
+    "combat_player_torpedo_ammo": 6,
+    "combat_enemy_positions": {
+      "enemy-1": [4, 5]
+    },
+    "combat_enemy_durabilities": {
+      "enemy-1": 5
+    },
+    "enemy_actions": [
+      {
+        "enemy_id": "enemy-1",
+        "start_position": [4, 5],
+        "target_attackable_position": [4, 5],
+        "planned_path": [],
+        "moved_path": [],
+        "final_position": [4, 5],
+        "movement_power": 3,
+        "movement_cost": 0,
+        "attacked_player": true,
+        "can_attack_before_move": true,
+        "can_attack_after_move": true,
+        "reaction": {
+          "selected_reaction": "DEFEND",
+          "resolved_reaction": "DEFEND",
+          "counterattack_available": true,
+          "fallback_to_defend": false,
+          "damage_to_player": 4,
+          "counterattack_damage": 0,
+          "enemy_destroyed": false
+        }
+      }
+    ],
+    "outcome": "ACCEPTED"
+  }
+}

--- a/experiments/galactic_exodus/srs/fixtures/combat_enemy_movement_tiebreak_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/combat_enemy_movement_tiebreak_9x9.json
@@ -48,7 +48,8 @@
         "movement_cost": 50,
         "attacked_player": false,
         "can_attack_before_move": false,
-        "can_attack_after_move": false
+        "can_attack_after_move": false,
+        "reaction": null
       }
     ],
     "outcome": "ACCEPTED"

--- a/experiments/galactic_exodus/srs/fixtures/combat_phaser_attack_damage_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/combat_phaser_attack_damage_9x9.json
@@ -1,0 +1,45 @@
+{
+  "fixture_id": "combat_phaser_attack_damage_9x9",
+  "description": "A phaser attack spends one energy and applies the fixed one-point damage to the selected enemy.",
+  "sector": {
+    "sector_id": "normal-9111",
+    "sector_type": "NORMAL",
+    "sector_seed": 9111,
+    "entry_edge": "S",
+    "blocked_edges": []
+  },
+  "initial": {
+    "reveal": {"mode": "FULL"},
+    "player_position": [1, 4],
+    "combat": {
+      "phase": "PLAYER_ATTACK",
+      "enemies": [
+        {"enemy_id": "enemy-1", "tier": "TIER2", "position": [2, 4]}
+      ],
+      "player_attack_target_id": "enemy-1"
+    }
+  },
+  "commands": [
+    {
+      "command_type": "COMBAT_STEP",
+      "player_attack_action": "ATTACK",
+      "player_attack_weapon": "PHASER"
+    }
+  ],
+  "expect": {
+    "event_types": ["COMBAT_TRANSITIONED"],
+    "combat_phase": "ENEMY_ACTION",
+    "combat_turn": 0,
+    "enemy_presence": true,
+    "combat_player_durability": 100,
+    "combat_player_energy": 5,
+    "combat_player_torpedo_ammo": 6,
+    "combat_enemy_positions": {
+      "enemy-1": [2, 4]
+    },
+    "combat_enemy_durabilities": {
+      "enemy-1": 4
+    },
+    "outcome": "ACCEPTED"
+  }
+}

--- a/experiments/galactic_exodus/srs/fixtures/combat_torpedo_destroy_no_counterattack_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/combat_torpedo_destroy_no_counterattack_9x9.json
@@ -1,0 +1,43 @@
+{
+  "fixture_id": "combat_torpedo_destroy_no_counterattack_9x9",
+  "description": "A photon torpedo spends one ammo, destroys the selected tier1 enemy, and leaves no enemy counterattack.",
+  "sector": {
+    "sector_id": "normal-9110",
+    "sector_type": "NORMAL",
+    "sector_seed": 9110,
+    "entry_edge": "S",
+    "blocked_edges": []
+  },
+  "initial": {
+    "reveal": {"mode": "FULL"},
+    "player_position": [1, 4],
+    "combat": {
+      "phase": "PLAYER_ATTACK",
+      "enemies": [
+        {"enemy_id": "enemy-1", "tier": "TIER1", "position": [3, 4]}
+      ],
+      "player_attack_target_id": "enemy-1"
+    }
+  },
+  "commands": [
+    {
+      "command_type": "COMBAT_STEP",
+      "player_attack_action": "ATTACK",
+      "player_attack_weapon": "PHOTON_TORPEDO"
+    },
+    {"command_type": "COMBAT_STEP"}
+  ],
+  "expect": {
+    "event_types": ["COMBAT_TRANSITIONED", "COMBAT_TRANSITIONED"],
+    "combat_phase": "PLAYER_MOVEMENT",
+    "combat_turn": 1,
+    "enemy_presence": false,
+    "combat_player_durability": 100,
+    "combat_player_energy": 6,
+    "combat_player_torpedo_ammo": 5,
+    "combat_enemy_positions": {},
+    "combat_enemy_durabilities": {},
+    "enemy_actions": [],
+    "outcome": "ACCEPTED"
+  }
+}

--- a/experiments/galactic_exodus/srs/model.py
+++ b/experiments/galactic_exodus/srs/model.py
@@ -70,6 +70,16 @@ class SrsCombatPhase(str, Enum):
     ENEMY_ACTION = "ENEMY_ACTION"
 
 
+class SrsPlayerAttackAction(str, Enum):
+    ATTACK = "ATTACK"
+    SKIP = "SKIP"
+
+
+class SrsEnemyReaction(str, Enum):
+    COUNTERATTACK = "COUNTERATTACK"
+    DEFEND = "DEFEND"
+
+
 class ResourceManagementMode(str, Enum):
     NONE = "NONE"
 
@@ -141,8 +151,8 @@ class SrsPlayerCombatState:
     energy_recovery: int = 1
 
     def __post_init__(self) -> None:
-        if self.durability <= 0:
-            raise SrsModelError("player durability must be positive")
+        if self.durability < 0:
+            raise SrsModelError("player durability must be non-negative")
         if self.defense < 0:
             raise SrsModelError("player defense must be non-negative")
         if self.movement_power <= 0:
@@ -433,6 +443,9 @@ class SrsCommand:
     target: Position | None = None
     target_object_id: str | None = None
     exit_direction: Direction | None = None
+    player_attack_action: SrsPlayerAttackAction | None = None
+    player_attack_weapon: SrsWeaponType | None = None
+    enemy_reactions: Mapping[str, SrsEnemyReaction] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         command_type = str(self.command_type)
@@ -444,6 +457,35 @@ class SrsCommand:
             exit_direction = None if self.exit_direction is None else Direction(self.exit_direction)
         except ValueError as exc:
             raise SrsModelError("exit_direction must be a Direction value") from exc
+        try:
+            player_attack_action = (
+                None
+                if self.player_attack_action is None
+                else SrsPlayerAttackAction(self.player_attack_action)
+            )
+        except ValueError as exc:
+            raise SrsModelError("player_attack_action must be ATTACK or SKIP") from exc
+        try:
+            player_attack_weapon = (
+                None
+                if self.player_attack_weapon is None
+                else SrsWeaponType(self.player_attack_weapon)
+            )
+        except ValueError as exc:
+            raise SrsModelError("player_attack_weapon must be a SrsWeaponType value") from exc
+        if player_attack_weapon is SrsWeaponType.ENEMY_WEAPON:
+            raise SrsModelError("player_attack_weapon must be PHOTON_TORPEDO or PHASER")
+        if not isinstance(self.enemy_reactions, Mapping):
+            raise SrsModelError("enemy_reactions must be a mapping")
+        try:
+            enemy_reactions = _freeze_mapping(
+                {
+                    str(enemy_id): SrsEnemyReaction(reaction)
+                    for enemy_id, reaction in self.enemy_reactions.items()
+                }
+            )
+        except ValueError as exc:
+            raise SrsModelError("enemy_reactions values must be COUNTERATTACK or DEFEND") from exc
 
         if command_type == "MOVE_ROUTE" and not route:
             raise SrsModelError("MOVE_ROUTE requires a non-empty route")
@@ -453,10 +495,37 @@ class SrsCommand:
             raise SrsModelError("INTERACT requires a target_object_id")
         if command_type == "WARP_EXIT" and exit_direction is None:
             raise SrsModelError("WARP_EXIT requires an exit_direction")
+        if command_type != "COMBAT_STEP" and (
+            player_attack_action is not None
+            or player_attack_weapon is not None
+            or enemy_reactions
+        ):
+            raise SrsModelError("combat action fields require COMBAT_STEP")
+        if player_attack_action is SrsPlayerAttackAction.ATTACK and player_attack_weapon is None:
+            raise SrsModelError("ATTACK requires a player_attack_weapon")
+        if player_attack_action is not SrsPlayerAttackAction.ATTACK and player_attack_weapon is not None:
+            raise SrsModelError("player_attack_weapon requires ATTACK")
 
         object.__setattr__(self, "command_type", command_type)
         object.__setattr__(self, "route", route)
         object.__setattr__(self, "exit_direction", exit_direction)
+        object.__setattr__(self, "player_attack_action", player_attack_action)
+        object.__setattr__(self, "player_attack_weapon", player_attack_weapon)
+        object.__setattr__(self, "enemy_reactions", enemy_reactions)
+
+    def __hash__(self) -> int:
+        return hash(
+            (
+                self.command_type,
+                self.route,
+                self.target,
+                self.target_object_id,
+                self.exit_direction,
+                self.player_attack_action,
+                self.player_attack_weapon,
+                tuple(sorted(self.enemy_reactions.items())),
+            )
+        )
 
 
 @dataclass(frozen=True, slots=True)

--- a/experiments/galactic_exodus/srs/run_fixture.py
+++ b/experiments/galactic_exodus/srs/run_fixture.py
@@ -17,8 +17,10 @@ from experiments.galactic_exodus.srs.model import (
     SrsCombatPhase,
     SrsCombatState,
     SrsEnemyTier,
+    SrsEnemyReaction,
     SrsActualMap,
     SrsCell,
+    SrsPlayerAttackAction,
     SectorDescriptor,
     SectorType,
     SrsCommand,
@@ -27,6 +29,7 @@ from experiments.galactic_exodus.srs.model import (
     SrsPlayerCombatState,
     SrsPersistentState,
     SrsTerrainType,
+    SrsWeaponType,
     create_enemy_combat_state,
 )
 from experiments.galactic_exodus.srs.render import render_known_map
@@ -35,7 +38,18 @@ from experiments.galactic_exodus.srs.render import render_known_map
 REPO_ROOT = Path(__file__).resolve().parents[3]
 FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
 
-_ALLOWED_COMMAND_KEYS = frozenset({"command_type", "route", "target", "target_object_id", "exit_direction"})
+_ALLOWED_COMMAND_KEYS = frozenset(
+    {
+        "command_type",
+        "route",
+        "target",
+        "target_object_id",
+        "exit_direction",
+        "player_attack_action",
+        "player_attack_weapon",
+        "enemy_reactions",
+    }
+)
 _ALLOWED_COMMAND_TYPES = frozenset({"MOVE_ROUTE", "MOVE_TO", "INTERACT", "WARP_EXIT", "COMBAT_STEP"})
 
 
@@ -83,6 +97,9 @@ def command_from_json(data: Mapping[str, Any]) -> SrsCommand:
     target: Position | None = None
     target_object_id: str | None = None
     exit_direction: Direction | None = None
+    player_attack_action: SrsPlayerAttackAction | None = None
+    player_attack_weapon: SrsWeaponType | None = None
+    enemy_reactions: Mapping[str, SrsEnemyReaction] = {}
 
     if "route" in data:
         route_value = data["route"]
@@ -95,6 +112,30 @@ def command_from_json(data: Mapping[str, Any]) -> SrsCommand:
         target_object_id = _required_str(data, "target_object_id")
     if "exit_direction" in data:
         exit_direction = _direction(data["exit_direction"])
+    if "player_attack_action" in data:
+        try:
+            player_attack_action = SrsPlayerAttackAction(_required_str(data, "player_attack_action"))
+        except ValueError as exc:
+            raise SrsFixtureError(f"invalid player_attack_action: {data['player_attack_action']}") from exc
+    if "player_attack_weapon" in data:
+        try:
+            player_attack_weapon = SrsWeaponType(_required_str(data, "player_attack_weapon"))
+        except ValueError as exc:
+            raise SrsFixtureError(f"invalid player_attack_weapon: {data['player_attack_weapon']}") from exc
+    if "enemy_reactions" in data:
+        raw_enemy_reactions = data["enemy_reactions"]
+        if not isinstance(raw_enemy_reactions, Mapping):
+            raise SrsFixtureError("enemy_reactions must be an object")
+        enemy_reactions = {}
+        for enemy_id, reaction in raw_enemy_reactions.items():
+            if not isinstance(enemy_id, str) or enemy_id == "":
+                raise SrsFixtureError("enemy_reactions keys must be non-empty strings")
+            if not isinstance(reaction, str):
+                raise SrsFixtureError("enemy_reactions values must be strings")
+            try:
+                enemy_reactions[enemy_id] = SrsEnemyReaction(reaction)
+            except ValueError as exc:
+                raise SrsFixtureError(f"invalid enemy reaction: {reaction}") from exc
 
     try:
         return SrsCommand(
@@ -103,6 +144,9 @@ def command_from_json(data: Mapping[str, Any]) -> SrsCommand:
             target=target,
             target_object_id=target_object_id,
             exit_direction=exit_direction,
+            player_attack_action=player_attack_action,
+            player_attack_weapon=player_attack_weapon,
+            enemy_reactions=enemy_reactions,
         )
     except ValueError as exc:
         raise SrsFixtureError(str(exc)) from exc
@@ -426,8 +470,15 @@ def _build_summary(
         "combat_phase": final_state.combat_state.phase.value if final_state.combat_state is not None else None,
         "combat_turn": final_state.combat_state.combat_turn if final_state.combat_state is not None else None,
         "enemy_presence": final_state.combat_state.enemy_presence if final_state.combat_state is not None else False,
+        "combat_player_durability": final_state.combat_state.player.durability if final_state.combat_state is not None else None,
         "combat_player_energy": final_state.combat_state.player.energy if final_state.combat_state is not None else None,
+        "combat_player_torpedo_ammo": (
+            final_state.combat_state.player.photon_torpedo_ammo
+            if final_state.combat_state is not None
+            else None
+        ),
         "combat_enemy_positions": enemy_positions,
+        "combat_enemy_durabilities": _enemy_durabilities_payload(final_state),
         "enemy_actions": enemy_actions,
         "outcome": primary_outcome,
         "render_line_count": len(render.splitlines()),
@@ -454,8 +505,14 @@ def _validate_expectations(expect: Any, result: SrsFixtureRunResult) -> None:
         ("combat_phase", final_state.combat_state.phase.value if final_state.combat_state is not None else None),
         ("combat_turn", final_state.combat_state.combat_turn if final_state.combat_state is not None else None),
         ("enemy_presence", final_state.combat_state.enemy_presence if final_state.combat_state is not None else False),
+        ("combat_player_durability", final_state.combat_state.player.durability if final_state.combat_state is not None else None),
         ("combat_player_energy", final_state.combat_state.player.energy if final_state.combat_state is not None else None),
+        (
+            "combat_player_torpedo_ammo",
+            final_state.combat_state.player.photon_torpedo_ammo if final_state.combat_state is not None else None,
+        ),
         ("combat_enemy_positions", enemy_positions),
+        ("combat_enemy_durabilities", _enemy_durabilities_payload(final_state)),
         ("enemy_actions", enemy_actions),
         ("outcome", result.summary.get("outcome")),
     )
@@ -481,6 +538,15 @@ def _enemy_positions_payload(final_state: SrsGameState) -> Mapping[str, list[int
         return {}
     return {
         enemy_id: _position_to_list(enemy.position)
+        for enemy_id, enemy in sorted(final_state.combat_state.enemies.items())
+    }
+
+
+def _enemy_durabilities_payload(final_state: SrsGameState) -> Mapping[str, int]:
+    if final_state.combat_state is None:
+        return {}
+    return {
+        enemy_id: enemy.durability
         for enemy_id, enemy in sorted(final_state.combat_state.enemies.items())
     }
 

--- a/experiments/galactic_exodus/srs/test_engine_combat.py
+++ b/experiments/galactic_exodus/srs/test_engine_combat.py
@@ -200,6 +200,107 @@ class SrsEngineCombatTests(unittest.TestCase):
         self.assertEqual(result.state.combat_state.phase, SrsCombatPhase.ENEMY_ACTION)
         self.assertFalse(result.events[0].payload["target_attackable"])
 
+    def test_player_attack_with_torpedo_consumes_ammo_and_removes_destroyed_enemy(self) -> None:
+        state = replace(make_state(), player_position=Position(1, 4))
+        enemy = create_enemy_combat_state(
+            enemy_id="enemy-1",
+            tier=SrsEnemyTier.TIER1,
+            position=Position(3, 4),
+        )
+        state = replace(
+            state,
+            combat_state=SrsCombatState(
+                enemies={"enemy-1": enemy},
+                phase=SrsCombatPhase.PLAYER_ATTACK,
+                player_attack_target_id="enemy-1",
+            ),
+        )
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(
+                command_type="COMBAT_STEP",
+                player_attack_action="ATTACK",
+                player_attack_weapon="PHOTON_TORPEDO",
+            ),
+            contracts=self.contracts,
+        )
+
+        self.assertEqual(result.state.combat_state.phase, SrsCombatPhase.ENEMY_ACTION)
+        self.assertEqual(result.state.combat_state.player.photon_torpedo_ammo, 5)
+        self.assertEqual(result.state.combat_state.enemies, {})
+        self.assertIsNone(result.state.combat_state.player_attack_target_id)
+        self.assertEqual(
+            result.events[0].payload["player_action"],
+            {
+                "selected_action": "ATTACK",
+                "selected_weapon": "PHOTON_TORPEDO",
+                "target_enemy_id": "enemy-1",
+                "attack_executed": True,
+                "damage_applied": 3,
+                "resource_cost": 1,
+                "resource_type": "PHOTON_TORPEDO_AMMO",
+                "target_destroyed": True,
+            },
+        )
+
+    def test_player_attack_with_phaser_consumes_energy_and_applies_fixed_damage(self) -> None:
+        state = replace(make_state(), player_position=Position(1, 4))
+        enemy = create_enemy_combat_state(
+            enemy_id="enemy-1",
+            tier=SrsEnemyTier.TIER2,
+            position=Position(2, 4),
+        )
+        state = replace(
+            state,
+            combat_state=SrsCombatState(
+                enemies={"enemy-1": enemy},
+                phase=SrsCombatPhase.PLAYER_ATTACK,
+                player_attack_target_id="enemy-1",
+            ),
+        )
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(
+                command_type="COMBAT_STEP",
+                player_attack_action="ATTACK",
+                player_attack_weapon="PHASER",
+            ),
+            contracts=self.contracts,
+        )
+
+        self.assertEqual(result.state.combat_state.player.energy, 5)
+        self.assertEqual(result.state.combat_state.enemies["enemy-1"].durability, 4)
+        self.assertEqual(result.events[0].payload["player_action"]["damage_applied"], 1)
+
+    def test_player_attack_can_skip_without_consuming_resources(self) -> None:
+        state = replace(make_state(), player_position=Position(1, 4))
+        enemy = create_enemy_combat_state(
+            enemy_id="enemy-1",
+            tier=SrsEnemyTier.TIER1,
+            position=Position(3, 4),
+        )
+        combat_state = SrsCombatState(
+            enemies={"enemy-1": enemy},
+            phase=SrsCombatPhase.PLAYER_ATTACK,
+            player_attack_target_id="enemy-1",
+        )
+        state = replace(state, combat_state=combat_state)
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(command_type="COMBAT_STEP", player_attack_action="SKIP"),
+            contracts=self.contracts,
+        )
+
+        self.assertEqual(result.state.combat_state.player.energy, combat_state.player.energy)
+        self.assertEqual(
+            result.state.combat_state.player.photon_torpedo_ammo,
+            combat_state.player.photon_torpedo_ammo,
+        )
+        self.assertEqual(result.events[0].payload["player_action"]["selected_action"], "SKIP")
+
     def test_enemy_action_advances_combat_turn_and_recovers_energy(self) -> None:
         state = make_state()
         enemy = create_enemy_combat_state(
@@ -283,6 +384,90 @@ class SrsEngineCombatTests(unittest.TestCase):
         )
         self.assertEqual(enemy_action["moved_path"], [[0, 3], [1, 3], [2, 3]])
         self.assertEqual(result.state.combat_state.enemies["enemy-1"].position, Position(2, 3))
+
+    def test_enemy_attack_defend_halves_damage_and_rounds_up(self) -> None:
+        state = make_state()
+        enemy = create_enemy_combat_state(
+            enemy_id="enemy-2",
+            tier=SrsEnemyTier.TIER2,
+            position=state.player_position,
+        )
+        state = replace(
+            state,
+            combat_state=SrsCombatState(
+                enemies={"enemy-2": enemy},
+                phase=SrsCombatPhase.ENEMY_ACTION,
+            ),
+        )
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(command_type="COMBAT_STEP", enemy_reactions={"enemy-2": "DEFEND"}),
+            contracts=self.contracts,
+        )
+
+        enemy_action = result.events[0].payload["enemy_actions"][0]
+        self.assertEqual(enemy_action["reaction"]["resolved_reaction"], "DEFEND")
+        self.assertEqual(enemy_action["reaction"]["damage_to_player"], 4)
+        self.assertEqual(result.state.combat_state.player.durability, 96)
+
+    def test_enemy_attack_counterattack_uses_phaser_and_full_enemy_damage(self) -> None:
+        state = make_state()
+        enemy = create_enemy_combat_state(
+            enemy_id="enemy-1",
+            tier=SrsEnemyTier.TIER1,
+            position=Position(2, 4),
+        )
+        state = replace(
+            state,
+            player_position=Position(1, 4),
+            combat_state=SrsCombatState(
+                enemies={"enemy-1": enemy},
+                phase=SrsCombatPhase.ENEMY_ACTION,
+            ),
+        )
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(command_type="COMBAT_STEP", enemy_reactions={"enemy-1": "COUNTERATTACK"}),
+            contracts=self.contracts,
+        )
+
+        enemy_action = result.events[0].payload["enemy_actions"][0]
+        self.assertEqual(enemy_action["reaction"]["resolved_reaction"], "COUNTERATTACK")
+        self.assertEqual(enemy_action["reaction"]["counterattack_damage"], 1)
+        self.assertEqual(enemy_action["reaction"]["damage_to_player"], 6)
+        self.assertEqual(result.state.combat_state.player.durability, 94)
+        self.assertEqual(result.state.combat_state.player.energy, 6)
+        self.assertEqual(result.state.combat_state.enemies["enemy-1"].durability, 2)
+
+    def test_enemy_attack_counterattack_falls_back_to_defend_when_energy_is_insufficient(self) -> None:
+        state = make_state()
+        enemy = create_enemy_combat_state(
+            enemy_id="enemy-1",
+            tier=SrsEnemyTier.TIER1,
+            position=Position(2, 4),
+        )
+        combat_state = SrsCombatState(
+            enemies={"enemy-1": enemy},
+            phase=SrsCombatPhase.ENEMY_ACTION,
+        )
+        combat_state = replace(combat_state, player=replace(combat_state.player, energy=0))
+        state = replace(
+            state,
+            player_position=Position(1, 4),
+            combat_state=combat_state,
+        )
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(command_type="COMBAT_STEP", enemy_reactions={"enemy-1": "COUNTERATTACK"}),
+            contracts=self.contracts,
+        )
+
+        self.assertEqual(result.events[0].payload["enemy_actions"][0]["reaction"]["resolved_reaction"], "DEFEND")
+        self.assertEqual(result.state.combat_state.player.energy, 1)
+        self.assertEqual(result.state.combat_state.player.durability, 97)
 
     def test_warp_exit_rejected_while_enemy_presence_true(self) -> None:
         state = make_state(entry_edge=Direction.S)

--- a/experiments/galactic_exodus/srs/test_fixture_regression.py
+++ b/experiments/galactic_exodus/srs/test_fixture_regression.py
@@ -113,3 +113,37 @@ class SrsFixtureRegressionTests(unittest.TestCase):
             result.summary["enemy_actions"][0]["target_attackable_position"],
             [4, 3],
         )
+        self.assertIsNone(result.summary["enemy_actions"][0]["reaction"])
+
+    def test_combat_torpedo_destroy_no_counterattack(self) -> None:
+        result = run_named_fixture("combat_torpedo_destroy_no_counterattack_9x9")
+
+        self.assertEqual(result.final_state.combat_state.player.photon_torpedo_ammo, 5)
+        self.assertFalse(result.final_state.combat_state.enemy_presence)
+        self.assertEqual(result.summary["enemy_actions"], [])
+
+    def test_combat_phaser_attack_damage(self) -> None:
+        result = run_named_fixture("combat_phaser_attack_damage_9x9")
+
+        self.assertEqual(result.final_state.combat_state.player.energy, 5)
+        self.assertEqual(result.final_state.combat_state.enemies["enemy-1"].durability, 4)
+
+    def test_combat_enemy_defend(self) -> None:
+        result = run_named_fixture("combat_enemy_defend_9x9")
+
+        self.assertEqual(result.final_state.combat_state.player.durability, 96)
+        self.assertEqual(result.summary["enemy_actions"][0]["reaction"]["resolved_reaction"], "DEFEND")
+
+    def test_combat_enemy_counterattack(self) -> None:
+        result = run_named_fixture("combat_enemy_counterattack_9x9")
+
+        self.assertEqual(result.final_state.combat_state.player.durability, 94)
+        self.assertEqual(result.final_state.combat_state.enemies["enemy-1"].durability, 2)
+        self.assertEqual(result.summary["enemy_actions"][0]["reaction"]["resolved_reaction"], "COUNTERATTACK")
+
+    def test_combat_enemy_counterattack_fallback_energy(self) -> None:
+        result = run_named_fixture("combat_enemy_counterattack_fallback_energy_9x9")
+
+        self.assertEqual(result.final_state.combat_state.player.durability, 97)
+        self.assertEqual(result.final_state.combat_state.player.energy, 1)
+        self.assertTrue(result.summary["enemy_actions"][0]["reaction"]["fallback_to_defend"])

--- a/experiments/galactic_exodus/srs/test_fixtures.py
+++ b/experiments/galactic_exodus/srs/test_fixtures.py
@@ -39,6 +39,11 @@ REQUIRED_FIXTURES = {
     "combat_attack_blocked_los_9x9.json",
     "combat_attack_out_of_range_9x9.json",
     "combat_enemy_movement_tiebreak_9x9.json",
+    "combat_torpedo_destroy_no_counterattack_9x9.json",
+    "combat_phaser_attack_damage_9x9.json",
+    "combat_enemy_defend_9x9.json",
+    "combat_enemy_counterattack_9x9.json",
+    "combat_enemy_counterattack_fallback_energy_9x9.json",
 }
 
 
@@ -181,9 +186,38 @@ class SrsFixtureTests(unittest.TestCase):
                     "attacked_player": False,
                     "can_attack_before_move": False,
                     "can_attack_after_move": False,
+                    "reaction": None,
                 }
             ],
         )
+
+    def test_combat_resolution_fixtures_cover_attack_and_reaction_outcomes(self) -> None:
+        torpedo = run_fixture(FIXTURES_DIR / "combat_torpedo_destroy_no_counterattack_9x9.json", contracts=self.contracts)
+        phaser = run_fixture(FIXTURES_DIR / "combat_phaser_attack_damage_9x9.json", contracts=self.contracts)
+        defend = run_fixture(FIXTURES_DIR / "combat_enemy_defend_9x9.json", contracts=self.contracts)
+        counterattack = run_fixture(FIXTURES_DIR / "combat_enemy_counterattack_9x9.json", contracts=self.contracts)
+        fallback = run_fixture(
+            FIXTURES_DIR / "combat_enemy_counterattack_fallback_energy_9x9.json",
+            contracts=self.contracts,
+        )
+
+        self.assertFalse(torpedo.final_state.combat_state.enemy_presence)
+        self.assertEqual(torpedo.final_state.combat_state.player.photon_torpedo_ammo, 5)
+        self.assertEqual(phaser.final_state.combat_state.enemies["enemy-1"].durability, 4)
+        self.assertEqual(phaser.final_state.combat_state.player.energy, 5)
+        self.assertEqual(defend.final_state.combat_state.player.durability, 96)
+        self.assertEqual(
+            defend.summary["enemy_actions"][0]["reaction"]["resolved_reaction"],
+            "DEFEND",
+        )
+        self.assertEqual(counterattack.final_state.combat_state.player.durability, 94)
+        self.assertEqual(counterattack.final_state.combat_state.enemies["enemy-1"].durability, 2)
+        self.assertEqual(
+            counterattack.summary["enemy_actions"][0]["reaction"]["resolved_reaction"],
+            "COUNTERATTACK",
+        )
+        self.assertTrue(fallback.summary["enemy_actions"][0]["reaction"]["fallback_to_defend"])
+        self.assertEqual(fallback.final_state.combat_state.player.energy, 1)
 
     def test_custom_orthogonal_raw_cost_is_used_by_movement_and_enemy_pathfinding(self) -> None:
         custom_contracts = replace(

--- a/experiments/galactic_exodus/srs/test_model.py
+++ b/experiments/galactic_exodus/srs/test_model.py
@@ -10,6 +10,7 @@ from experiments.galactic_exodus.srs.model import (
     SrsCombatPhase,
     SrsCombatState,
     SrsEnemyTier,
+    SrsEnemyReaction,
     SectorDescriptor,
     SectorType,
     SrsActualMap,
@@ -21,6 +22,7 @@ from experiments.galactic_exodus.srs.model import (
     SrsObjectState,
     SrsObjectType,
     SrsPersistentState,
+    SrsPlayerAttackAction,
     SrsTerrainType,
     SrsWeaponType,
     create_enemy_combat_state,
@@ -339,6 +341,31 @@ class SrsModelTests(unittest.TestCase):
     def test_srs_command_normalizes_exit_direction(self) -> None:
         command = SrsCommand(command_type="WARP_EXIT", exit_direction="N")
         self.assertEqual(command.exit_direction, Direction.N)
+
+    def test_srs_command_normalizes_combat_action_fields(self) -> None:
+        command = SrsCommand(
+            command_type="COMBAT_STEP",
+            player_attack_action="ATTACK",
+            player_attack_weapon="PHOTON_TORPEDO",
+            enemy_reactions={"enemy-1": "COUNTERATTACK"},
+        )
+
+        self.assertEqual(command.player_attack_action, SrsPlayerAttackAction.ATTACK)
+        self.assertEqual(command.player_attack_weapon, SrsWeaponType.PHOTON_TORPEDO)
+        self.assertEqual(command.enemy_reactions["enemy-1"], SrsEnemyReaction.COUNTERATTACK)
+
+    def test_srs_command_rejects_attack_without_weapon(self) -> None:
+        with self.assertRaisesRegex(SrsModelError, "ATTACK requires a player_attack_weapon"):
+            SrsCommand(command_type="COMBAT_STEP", player_attack_action="ATTACK")
+
+    def test_srs_command_rejects_combat_fields_for_non_combat_command(self) -> None:
+        with self.assertRaisesRegex(SrsModelError, "combat action fields require COMBAT_STEP"):
+            SrsCommand(command_type="MOVE_TO", target=Position(1, 1), player_attack_action="SKIP")
+
+    def test_player_combat_state_allows_zero_durability(self) -> None:
+        player = SrsPlayerCombatState(durability=0)
+
+        self.assertEqual(player.durability, 0)
 
     def test_srs_command_rejects_invalid_exit_direction(self) -> None:
         with self.assertRaisesRegex(SrsModelError, "exit_direction must be a Direction value"):


### PR DESCRIPTION
## 対応Issue

- #1199 `#1178-15 SRS player attack / enemy action / reactionを実装する`
- URL: https://github.com/kkismd/tbx/issues/1199
- Closes #1199

## Intended Scope

- `COMBAT_STEP` に player attack phase の `ATTACK` / `SKIP` を追加
- photon torpedo / phaser の固定 damage・固定 resource cost を適用
- enemy action phase の incoming attack に対する `COUNTERATTACK` / `DEFEND` reaction を追加
- counterattack 不可時の `DEFEND` fallback を実装
- deterministic fixture / unit test で damage / resource / enemy removal / reaction 結果を固定確認

## Explicit Non-Scope

- multiple enemy ordering の仕様拡張
- encounter spawn
- SALVAGE reward
- advanced hit / evasion / defense probability
- photon torpedo counterattack

## Fixed Values / Fixed Rules

- `photon_torpedo`: damage `3`, ammo_cost `1`, range `3`
- `phaser`: damage `1`, energy_cost `1`, range `2`
- `defend`: incoming damage multiplier `0.5`, final damage `ceil(base_damage * 0.5)`
- enemy attack damage:
  - tier1 `6`
  - tier2 `7`
  - tier3 `8`
  - tier4 `10`
- player attack phase:
  - `ATTACK`
  - or `SKIP`
- target:
  - visible / located enemy only
- if player attack destroys enemy:
  - destroyed enemy does not counterattack
- on each incoming enemy attack:
  - player chooses `COUNTERATTACK` or `DEFEND`
- counterattack unavailable when:
  - target is out of range
  - line of sight is blocked
  - phaser energy is insufficient
- if counterattack is unavailable:
  - fallback to `DEFEND`
- counterattack weapon:
  - phaser only
- hit calculation:
  - none
  - all attacks hit

## Changed Files

- `experiments/galactic_exodus/srs/model.py`
- `experiments/galactic_exodus/srs/engine.py`
- `experiments/galactic_exodus/srs/run_fixture.py`
- `experiments/galactic_exodus/srs/test_model.py`
- `experiments/galactic_exodus/srs/test_engine_combat.py`
- `experiments/galactic_exodus/srs/test_fixtures.py`
- `experiments/galactic_exodus/srs/test_fixture_regression.py`
- `experiments/galactic_exodus/srs/fixtures/combat_enemy_movement_tiebreak_9x9.json`
- `experiments/galactic_exodus/srs/fixtures/combat_torpedo_destroy_no_counterattack_9x9.json`
- `experiments/galactic_exodus/srs/fixtures/combat_phaser_attack_damage_9x9.json`
- `experiments/galactic_exodus/srs/fixtures/combat_enemy_defend_9x9.json`
- `experiments/galactic_exodus/srs/fixtures/combat_enemy_counterattack_9x9.json`
- `experiments/galactic_exodus/srs/fixtures/combat_enemy_counterattack_fallback_energy_9x9.json`

## Test Commands And Results

- `python3 -m unittest experiments.galactic_exodus.srs.test_model experiments.galactic_exodus.srs.test_engine_combat experiments.galactic_exodus.srs.test_fixtures experiments.galactic_exodus.srs.test_fixture_regression`
  - Passed
- `python3 -m unittest discover -s experiments/galactic_exodus/srs -p 'test_*.py'`
  - Passed
