### PR TITLE
SRS戦闘の複数enemy行動順とenergy pressureを実装

### DIFF
--- a/experiments/galactic_exodus/srs/engine.py
+++ b/experiments/galactic_exodus/srs/engine.py
@@ -1141,7 +1141,7 @@ def _resolve_enemy_action_phase(
     player = combat_state.player
     actions = []
     attackable_positions = enemy_attackable_positions(state)
-    for enemy_id in sorted(tuple(updated_enemies)):
+    for enemy_id in tuple(updated_enemies):
         enemy = updated_enemies.get(enemy_id)
         if enemy is None:
             continue

--- a/experiments/galactic_exodus/srs/fixtures/combat_energy_pressure_danger3_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/combat_energy_pressure_danger3_9x9.json
@@ -1,0 +1,81 @@
+{
+  "fixture_id": "combat_energy_pressure_danger3_9x9",
+  "description": "Three enemies act in tier order, and repeated counterattacks exhaust the last counterattack on the second combat turn.",
+  "sector": {
+    "sector_id": "normal-9121",
+    "sector_type": "NORMAL",
+    "sector_seed": 9121,
+    "entry_edge": "S",
+    "blocked_edges": []
+  },
+  "initial": {
+    "reveal": {"mode": "FULL"},
+    "player_position": [1, 4],
+    "combat": {
+      "phase": "PLAYER_ATTACK",
+      "enemies": [
+        {"enemy_id": "enemy-4", "tier": "TIER4", "position": [2, 4]},
+        {"enemy_id": "enemy-2", "tier": "TIER2", "position": [1, 3]},
+        {"enemy_id": "enemy-1", "tier": "TIER1", "position": [0, 4]}
+      ],
+      "player_attack_target_id": "enemy-4"
+    }
+  },
+  "commands": [
+    {
+      "command_type": "COMBAT_STEP",
+      "player_attack_action": "ATTACK",
+      "player_attack_weapon": "PHASER"
+    },
+    {
+      "command_type": "COMBAT_STEP",
+      "enemy_reactions": {
+        "enemy-1": "COUNTERATTACK",
+        "enemy-2": "COUNTERATTACK",
+        "enemy-4": "COUNTERATTACK"
+      }
+    },
+    {
+      "command_type": "COMBAT_STEP"
+    },
+    {
+      "command_type": "COMBAT_STEP",
+      "player_attack_action": "ATTACK",
+      "player_attack_weapon": "PHASER"
+    },
+    {
+      "command_type": "COMBAT_STEP",
+      "enemy_reactions": {
+        "enemy-1": "COUNTERATTACK",
+        "enemy-2": "COUNTERATTACK",
+        "enemy-4": "COUNTERATTACK"
+      }
+    }
+  ],
+  "expect": {
+    "event_types": [
+      "COMBAT_TRANSITIONED",
+      "COMBAT_TRANSITIONED",
+      "COMBAT_TRANSITIONED",
+      "COMBAT_TRANSITIONED",
+      "COMBAT_TRANSITIONED"
+    ],
+    "combat_phase": "PLAYER_MOVEMENT",
+    "combat_turn": 2,
+    "enemy_presence": true,
+    "combat_player_durability": 59,
+    "combat_player_energy": 1,
+    "combat_player_torpedo_ammo": 6,
+    "combat_enemy_positions": {
+      "enemy-1": [0, 4],
+      "enemy-2": [1, 3],
+      "enemy-4": [2, 4]
+    },
+    "combat_enemy_durabilities": {
+      "enemy-1": 1,
+      "enemy-2": 3,
+      "enemy-4": 9
+    },
+    "outcome": "ACCEPTED"
+  }
+}

--- a/experiments/galactic_exodus/srs/fixtures/combat_energy_pressure_danger4_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/combat_energy_pressure_danger4_9x9.json
@@ -1,0 +1,86 @@
+{
+  "fixture_id": "combat_energy_pressure_danger4_9x9",
+  "description": "Four enemies keep the same tier order and force counterattack fallback after energy is depleted on the second combat turn.",
+  "sector": {
+    "sector_id": "normal-9122",
+    "sector_type": "NORMAL",
+    "sector_seed": 9122,
+    "entry_edge": "S",
+    "blocked_edges": []
+  },
+  "initial": {
+    "reveal": {"mode": "FULL"},
+    "player_position": [1, 4],
+    "combat": {
+      "phase": "PLAYER_ATTACK",
+      "enemies": [
+        {"enemy_id": "enemy-4", "tier": "TIER4", "position": [2, 4]},
+        {"enemy_id": "enemy-2", "tier": "TIER2", "position": [1, 3]},
+        {"enemy_id": "enemy-3", "tier": "TIER3", "position": [2, 3]},
+        {"enemy_id": "enemy-1", "tier": "TIER1", "position": [0, 4]}
+      ],
+      "player_attack_target_id": "enemy-4"
+    }
+  },
+  "commands": [
+    {
+      "command_type": "COMBAT_STEP",
+      "player_attack_action": "ATTACK",
+      "player_attack_weapon": "PHASER"
+    },
+    {
+      "command_type": "COMBAT_STEP",
+      "enemy_reactions": {
+        "enemy-1": "COUNTERATTACK",
+        "enemy-2": "COUNTERATTACK",
+        "enemy-3": "COUNTERATTACK",
+        "enemy-4": "COUNTERATTACK"
+      }
+    },
+    {
+      "command_type": "COMBAT_STEP"
+    },
+    {
+      "command_type": "COMBAT_STEP",
+      "player_attack_action": "ATTACK",
+      "player_attack_weapon": "PHASER"
+    },
+    {
+      "command_type": "COMBAT_STEP",
+      "enemy_reactions": {
+        "enemy-1": "COUNTERATTACK",
+        "enemy-2": "COUNTERATTACK",
+        "enemy-3": "COUNTERATTACK",
+        "enemy-4": "COUNTERATTACK"
+      }
+    }
+  ],
+  "expect": {
+    "event_types": [
+      "COMBAT_TRANSITIONED",
+      "COMBAT_TRANSITIONED",
+      "COMBAT_TRANSITIONED",
+      "COMBAT_TRANSITIONED",
+      "COMBAT_TRANSITIONED"
+    ],
+    "combat_phase": "PLAYER_MOVEMENT",
+    "combat_turn": 2,
+    "enemy_presence": true,
+    "combat_player_durability": 50,
+    "combat_player_energy": 1,
+    "combat_player_torpedo_ammo": 6,
+    "combat_enemy_positions": {
+      "enemy-1": [0, 4],
+      "enemy-2": [1, 3],
+      "enemy-3": [2, 3],
+      "enemy-4": [2, 4]
+    },
+    "combat_enemy_durabilities": {
+      "enemy-1": 1,
+      "enemy-2": 4,
+      "enemy-3": 7,
+      "enemy-4": 9
+    },
+    "outcome": "ACCEPTED"
+  }
+}

--- a/experiments/galactic_exodus/srs/model.py
+++ b/experiments/galactic_exodus/srs/model.py
@@ -113,6 +113,30 @@ def _freeze_mapping(mapping: Mapping[Any, Any]) -> Mapping[Any, Any]:
     return MappingProxyType(dict(mapping))
 
 
+def _enemy_tier_sort_key(tier: SrsEnemyTier) -> int:
+    order = {
+        SrsEnemyTier.TIER1: 1,
+        SrsEnemyTier.TIER2: 2,
+        SrsEnemyTier.TIER3: 3,
+        SrsEnemyTier.TIER4: 4,
+    }
+    return order[tier]
+
+
+def _freeze_enemy_mapping(
+    mapping: Mapping[str, "SrsEnemyCombatState"],
+) -> Mapping[str, "SrsEnemyCombatState"]:
+    return MappingProxyType(
+        {
+            enemy_id: enemy
+            for enemy_id, enemy in sorted(
+                mapping.items(),
+                key=lambda item: _enemy_tier_sort_key(item[1].tier),
+            )
+        }
+    )
+
+
 @dataclass(frozen=True, slots=True)
 class Position:
     x: int
@@ -257,7 +281,7 @@ class SrsCombatState:
     player_attack_target_id: str | None = None
 
     def __post_init__(self) -> None:
-        normalized_enemies = _freeze_mapping(self.enemies)
+        normalized_enemies = _freeze_enemy_mapping(self.enemies)
         normalized_weapons = _freeze_mapping(self.weapon_profiles)
 
         if any(enemy_id != state.enemy_id for enemy_id, state in normalized_enemies.items()):

--- a/experiments/galactic_exodus/srs/test_engine_combat.py
+++ b/experiments/galactic_exodus/srs/test_engine_combat.py
@@ -11,6 +11,7 @@ from experiments.galactic_exodus.srs.engine import (
     enemy_attackable_positions,
     has_clear_line_of_sight,
     is_attackable_position,
+    run_srs_commands,
 )
 from experiments.galactic_exodus.srs.log import COMBAT_TRANSITIONED, WARP_EXIT_REJECTED
 from experiments.galactic_exodus.srs.model import (
@@ -324,6 +325,154 @@ class SrsEngineCombatTests(unittest.TestCase):
         self.assertEqual(result.state.combat_state.phase, SrsCombatPhase.PLAYER_MOVEMENT)
         self.assertEqual(result.state.combat_state.combat_turn, 1)
         self.assertEqual(result.state.combat_state.player.energy, 6)
+
+    def test_combat_state_normalizes_enemy_order_by_tier(self) -> None:
+        enemy_t4 = create_enemy_combat_state(
+            enemy_id="enemy-4",
+            tier=SrsEnemyTier.TIER4,
+            position=Position(2, 4),
+        )
+        enemy_t2 = create_enemy_combat_state(
+            enemy_id="enemy-2",
+            tier=SrsEnemyTier.TIER2,
+            position=Position(1, 3),
+        )
+        enemy_t1 = create_enemy_combat_state(
+            enemy_id="enemy-1",
+            tier=SrsEnemyTier.TIER1,
+            position=Position(0, 4),
+        )
+
+        combat_state = SrsCombatState(
+            enemies={
+                "enemy-4": enemy_t4,
+                "enemy-2": enemy_t2,
+                "enemy-1": enemy_t1,
+            },
+        )
+
+        self.assertEqual(tuple(combat_state.enemies), ("enemy-1", "enemy-2", "enemy-4"))
+
+    def test_multiple_enemy_actions_follow_tier_ascending_order(self) -> None:
+        state = replace(make_state(), player_position=Position(1, 4))
+        enemy_t4 = create_enemy_combat_state(
+            enemy_id="enemy-4",
+            tier=SrsEnemyTier.TIER4,
+            position=Position(2, 4),
+        )
+        enemy_t2 = create_enemy_combat_state(
+            enemy_id="enemy-2",
+            tier=SrsEnemyTier.TIER2,
+            position=Position(1, 3),
+        )
+        enemy_t1 = create_enemy_combat_state(
+            enemy_id="enemy-1",
+            tier=SrsEnemyTier.TIER1,
+            position=Position(0, 4),
+        )
+        state = replace(
+            state,
+            combat_state=SrsCombatState(
+                enemies={
+                    "enemy-4": enemy_t4,
+                    "enemy-2": enemy_t2,
+                    "enemy-1": enemy_t1,
+                },
+                phase=SrsCombatPhase.ENEMY_ACTION,
+            ),
+        )
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(
+                command_type="COMBAT_STEP",
+                enemy_reactions={
+                    "enemy-1": "COUNTERATTACK",
+                    "enemy-2": "COUNTERATTACK",
+                    "enemy-4": "COUNTERATTACK",
+                },
+            ),
+            contracts=self.contracts,
+        )
+
+        enemy_actions = result.events[0].payload["enemy_actions"]
+        self.assertEqual(
+            [action["enemy_id"] for action in enemy_actions],
+            ["enemy-1", "enemy-2", "enemy-4"],
+        )
+        self.assertEqual(result.state.combat_state.player.energy, 4)
+        self.assertEqual(result.state.combat_state.enemies["enemy-1"].durability, 2)
+        self.assertEqual(result.state.combat_state.enemies["enemy-2"].durability, 4)
+        self.assertEqual(result.state.combat_state.enemies["enemy-4"].durability, 11)
+
+    def test_three_enemy_pressure_can_exhaust_counterattacks_on_second_turn(self) -> None:
+        state = replace(make_state(), player_position=Position(1, 4))
+        state = replace(
+            state,
+            combat_state=SrsCombatState(
+                enemies={
+                    "enemy-4": create_enemy_combat_state(
+                        enemy_id="enemy-4",
+                        tier=SrsEnemyTier.TIER4,
+                        position=Position(2, 4),
+                    ),
+                    "enemy-2": create_enemy_combat_state(
+                        enemy_id="enemy-2",
+                        tier=SrsEnemyTier.TIER2,
+                        position=Position(1, 3),
+                    ),
+                    "enemy-1": create_enemy_combat_state(
+                        enemy_id="enemy-1",
+                        tier=SrsEnemyTier.TIER1,
+                        position=Position(0, 4),
+                    ),
+                },
+                phase=SrsCombatPhase.PLAYER_ATTACK,
+                player_attack_target_id="enemy-4",
+            ),
+        )
+
+        result = run_srs_commands(
+            state,
+            (
+                SrsCommand(
+                    command_type="COMBAT_STEP",
+                    player_attack_action="ATTACK",
+                    player_attack_weapon="PHASER",
+                ),
+                SrsCommand(
+                    command_type="COMBAT_STEP",
+                    enemy_reactions={
+                        "enemy-1": "COUNTERATTACK",
+                        "enemy-2": "COUNTERATTACK",
+                        "enemy-4": "COUNTERATTACK",
+                    },
+                ),
+                SrsCommand(command_type="COMBAT_STEP"),
+                SrsCommand(
+                    command_type="COMBAT_STEP",
+                    player_attack_action="ATTACK",
+                    player_attack_weapon="PHASER",
+                ),
+                SrsCommand(
+                    command_type="COMBAT_STEP",
+                    enemy_reactions={
+                        "enemy-1": "COUNTERATTACK",
+                        "enemy-2": "COUNTERATTACK",
+                        "enemy-4": "COUNTERATTACK",
+                    },
+                ),
+            ),
+            contracts=self.contracts,
+        )
+
+        self.assertEqual(result.events[1].payload["player_energy_after"], 3)
+        self.assertEqual(result.events[4].payload["player_energy_after"], 1)
+        self.assertEqual(
+            [action["reaction"]["resolved_reaction"] for action in result.events[4].payload["enemy_actions"]],
+            ["COUNTERATTACK", "COUNTERATTACK", "DEFEND"],
+        )
+        self.assertTrue(result.events[4].payload["enemy_actions"][2]["reaction"]["fallback_to_defend"])
 
     def test_enemy_action_moves_to_lowest_total_movement_cost_attack_cell(self) -> None:
         state = replace(make_state(), player_position=Position(4, 4))

--- a/experiments/galactic_exodus/srs/test_fixture_regression.py
+++ b/experiments/galactic_exodus/srs/test_fixture_regression.py
@@ -147,3 +147,35 @@ class SrsFixtureRegressionTests(unittest.TestCase):
         self.assertEqual(result.final_state.combat_state.player.durability, 97)
         self.assertEqual(result.final_state.combat_state.player.energy, 1)
         self.assertTrue(result.summary["enemy_actions"][0]["reaction"]["fallback_to_defend"])
+
+    def test_combat_energy_pressure_danger3(self) -> None:
+        result = run_named_fixture("combat_energy_pressure_danger3_9x9")
+
+        self.assertEqual(result.final_state.combat_state.player.energy, 1)
+        self.assertEqual(result.final_state.combat_state.player.durability, 59)
+        self.assertEqual(
+            [action["enemy_id"] for action in result.log.events[1].payload["enemy_actions"]],
+            ["enemy-1", "enemy-2", "enemy-4"],
+        )
+        self.assertEqual(result.log.events[1].payload["player_energy_after"], 3)
+        self.assertEqual(result.log.events[4].payload["player_energy_after"], 1)
+        self.assertEqual(
+            [action["reaction"]["resolved_reaction"] for action in result.log.events[4].payload["enemy_actions"]],
+            ["COUNTERATTACK", "COUNTERATTACK", "DEFEND"],
+        )
+
+    def test_combat_energy_pressure_danger4(self) -> None:
+        result = run_named_fixture("combat_energy_pressure_danger4_9x9")
+
+        self.assertEqual(result.final_state.combat_state.player.energy, 1)
+        self.assertEqual(result.final_state.combat_state.player.durability, 50)
+        self.assertEqual(
+            [action["enemy_id"] for action in result.log.events[1].payload["enemy_actions"]],
+            ["enemy-1", "enemy-2", "enemy-3", "enemy-4"],
+        )
+        self.assertEqual(result.log.events[1].payload["player_energy_after"], 2)
+        self.assertEqual(result.log.events[4].payload["player_energy_after"], 1)
+        self.assertEqual(
+            [action["reaction"]["resolved_reaction"] for action in result.log.events[4].payload["enemy_actions"]],
+            ["COUNTERATTACK", "DEFEND", "DEFEND", "DEFEND"],
+        )

--- a/experiments/galactic_exodus/srs/test_fixtures.py
+++ b/experiments/galactic_exodus/srs/test_fixtures.py
@@ -44,6 +44,8 @@ REQUIRED_FIXTURES = {
     "combat_enemy_defend_9x9.json",
     "combat_enemy_counterattack_9x9.json",
     "combat_enemy_counterattack_fallback_energy_9x9.json",
+    "combat_energy_pressure_danger3_9x9.json",
+    "combat_energy_pressure_danger4_9x9.json",
 }
 
 
@@ -218,6 +220,25 @@ class SrsFixtureTests(unittest.TestCase):
         )
         self.assertTrue(fallback.summary["enemy_actions"][0]["reaction"]["fallback_to_defend"])
         self.assertEqual(fallback.final_state.combat_state.player.energy, 1)
+
+    def test_multi_enemy_pressure_fixtures_preserve_tier_order_and_energy_pressure(self) -> None:
+        danger3 = run_fixture(FIXTURES_DIR / "combat_energy_pressure_danger3_9x9.json", contracts=self.contracts)
+        danger4 = run_fixture(FIXTURES_DIR / "combat_energy_pressure_danger4_9x9.json", contracts=self.contracts)
+
+        self.assertEqual(
+            [action["enemy_id"] for action in danger3.log.events[1].payload["enemy_actions"]],
+            ["enemy-1", "enemy-2", "enemy-4"],
+        )
+        self.assertEqual(danger3.log.events[1].payload["player_energy_after"], 3)
+        self.assertEqual(danger3.log.events[4].payload["player_energy_after"], 1)
+        self.assertTrue(danger3.log.events[4].payload["enemy_actions"][2]["reaction"]["fallback_to_defend"])
+        self.assertEqual(
+            [action["enemy_id"] for action in danger4.log.events[1].payload["enemy_actions"]],
+            ["enemy-1", "enemy-2", "enemy-3", "enemy-4"],
+        )
+        self.assertEqual(danger4.log.events[1].payload["player_energy_after"], 2)
+        self.assertEqual(danger4.log.events[4].payload["player_energy_after"], 1)
+        self.assertTrue(danger4.log.events[4].payload["enemy_actions"][1]["reaction"]["fallback_to_defend"])
 
     def test_custom_orthogonal_raw_cost_is_used_by_movement_and_enemy_pathfinding(self) -> None:
         custom_contracts = replace(


### PR DESCRIPTION
## 概要

Closes #1200

- Implemented issue: #1200 `#1178-16 SRS multiple enemies / action order / energy pressureを実装する`
- Issue URL: https://github.com/kkismd/tbx/issues/1200
- Base branch: `integration/882-galactic-exodus`

## Intended Scope

- SRS combat の複数 enemy 行動順を固定する
- enemy action phase が tier 昇順の stable order で解決されるようにする
- phaser counterattack の energy pressure を複数 enemy fixture で固定化する
- danger 3 / danger 4 相当の deterministic fixture で energy depletion による fallback を確認できるようにする

## Explicit Non-Scope

- encounter composition random selection
- spawn_cap selection
- SALVAGE reward
- advanced hit probability

## Fixed Values And Rules

### Fixed values

- `energy_capacity = 6`
- `energy_recovery = 1 / SRS turn`
- `phaser energy_cost = 1`
- `phaser counterattack consumes 1 energy`
- enemy durability:
  - tier1 = 3
  - tier2 = 5
  - tier3 = 8
  - tier4 = 12

### Fixed rules

- enemies array:
  - sort by tier ascending
- turn order:
  - enemies array order
- each enemy action:
  - resolve only if the enemy is still alive
- no per-turn initiative roll
- no per-turn distance sort
- weaker tier acts first
- fixture は乱数を使わず、initial enemies list / selected player attacks / selected reactions / expected energy after each turn / expected enemy durability after each action を固定する

## Changed Files

- `experiments/galactic_exodus/srs/model.py`
- `experiments/galactic_exodus/srs/engine.py`
- `experiments/galactic_exodus/srs/test_engine_combat.py`
- `experiments/galactic_exodus/srs/test_fixtures.py`
- `experiments/galactic_exodus/srs/test_fixture_regression.py`
- `experiments/galactic_exodus/srs/fixtures/combat_energy_pressure_danger3_9x9.json`
- `experiments/galactic_exodus/srs/fixtures/combat_energy_pressure_danger4_9x9.json`

## What Changed

- `SrsCombatState` の enemy mapping を tier 昇順へ正規化し、equal tier は既存順を維持するようにした
- enemy action phase の反復を `enemy_id` ソートから state 上の stable order へ切り替えた
- 複数 enemy の tier order と counterattack energy pressure を直接検証する engine テストを追加した
- danger 3 / danger 4 相当の固定 fixture を追加し、2 combat turn 分の energy 推移と fallback-to-defend を固定した

## Test Commands And Results

- `python -m unittest experiments.galactic_exodus.srs.test_engine_combat experiments.galactic_exodus.srs.test_fixtures experiments.galactic_exodus.srs.test_fixture_regression -v` : passed
- `python -m unittest experiments.galactic_exodus.srs.test_validate_phase2_results -v` : passed
- `cargo clippy --all-targets -- -D warnings` : passed
- `cargo test` : passed
- `cargo fmt --check` : passed
