### PR TITLE
SRS encounter spawn / danger composition / spawn capを実装

### DIFF
--- a/experiments/galactic_exodus/srs/encounter.py
+++ b/experiments/galactic_exodus/srs/encounter.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Mapping, Sequence
+
+from experiments.galactic_exodus.srs.model import (
+    Position,
+    SrsCombatState,
+    SrsEnemyCombatState,
+    SrsEnemyTier,
+    SrsGameState,
+    SrsObjectType,
+    SrsTerrainType,
+    create_enemy_combat_state,
+)
+
+
+class SrsEncounterError(ValueError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class EncounterCompositionOption:
+    weight_percent: int
+    tiers: tuple[SrsEnemyTier, ...]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "tiers", tuple(self.tiers))
+        if self.weight_percent <= 0:
+            raise SrsEncounterError("composition weight_percent must be positive")
+        if not self.tiers:
+            raise SrsEncounterError("composition tiers must not be empty")
+
+
+def _freeze_mapping(mapping: Mapping[object, object]) -> Mapping[object, object]:
+    return MappingProxyType(dict(mapping))
+
+
+_TIER_ORDER = {
+    SrsEnemyTier.TIER1: 1,
+    SrsEnemyTier.TIER2: 2,
+    SrsEnemyTier.TIER3: 3,
+    SrsEnemyTier.TIER4: 4,
+}
+
+ENEMY_GROUP_COSTS: Mapping[SrsEnemyTier, int] = _freeze_mapping(
+    {
+        SrsEnemyTier.TIER1: 1,
+        SrsEnemyTier.TIER2: 2,
+        SrsEnemyTier.TIER3: 3,
+        SrsEnemyTier.TIER4: 5,
+    }
+)
+
+ENCOUNTER_GROUP_BUDGETS: Mapping[int, tuple[int, int]] = _freeze_mapping(
+    {
+        0: (1, 1),
+        1: (1, 2),
+        2: (2, 3),
+        3: (3, 4),
+        4: (4, 5),
+    }
+)
+
+ENCOUNTER_COMPOSITION_TABLE: Mapping[int, tuple[EncounterCompositionOption, ...]] = _freeze_mapping(
+    {
+        0: (
+            EncounterCompositionOption(100, (SrsEnemyTier.TIER1,)),
+        ),
+        1: (
+            EncounterCompositionOption(70, (SrsEnemyTier.TIER1,)),
+            EncounterCompositionOption(30, (SrsEnemyTier.TIER1, SrsEnemyTier.TIER1)),
+        ),
+        2: (
+            EncounterCompositionOption(50, (SrsEnemyTier.TIER2,)),
+            EncounterCompositionOption(35, (SrsEnemyTier.TIER1, SrsEnemyTier.TIER1)),
+            EncounterCompositionOption(15, (SrsEnemyTier.TIER2, SrsEnemyTier.TIER1)),
+        ),
+        3: (
+            EncounterCompositionOption(45, (SrsEnemyTier.TIER2, SrsEnemyTier.TIER1)),
+            EncounterCompositionOption(30, (SrsEnemyTier.TIER3,)),
+            EncounterCompositionOption(20, (SrsEnemyTier.TIER1, SrsEnemyTier.TIER1, SrsEnemyTier.TIER1)),
+            EncounterCompositionOption(5, (SrsEnemyTier.TIER2, SrsEnemyTier.TIER2)),
+        ),
+        4: (
+            EncounterCompositionOption(40, (SrsEnemyTier.TIER3, SrsEnemyTier.TIER1)),
+            EncounterCompositionOption(25, (SrsEnemyTier.TIER2, SrsEnemyTier.TIER2)),
+            EncounterCompositionOption(20, (SrsEnemyTier.TIER2, SrsEnemyTier.TIER1, SrsEnemyTier.TIER1)),
+            EncounterCompositionOption(10, (SrsEnemyTier.TIER3, SrsEnemyTier.TIER2)),
+            EncounterCompositionOption(5, (SrsEnemyTier.TIER4,)),
+        ),
+    }
+)
+
+
+def enemy_group_cost(tier: SrsEnemyTier) -> int:
+    return ENEMY_GROUP_COSTS[tier]
+
+
+def encounter_group_budget_range(danger_score: int) -> tuple[int, int]:
+    return ENCOUNTER_GROUP_BUDGETS[_validated_danger_score(danger_score)]
+
+
+def encounter_composition_options(danger_score: int) -> tuple[EncounterCompositionOption, ...]:
+    return ENCOUNTER_COMPOSITION_TABLE[_validated_danger_score(danger_score)]
+
+
+def validate_fixed_encounter_composition(
+    *,
+    danger_score: int,
+    composition: Sequence[SrsEnemyTier],
+) -> tuple[SrsEnemyTier, ...]:
+    normalized = tuple(composition)
+    if not normalized:
+        raise SrsEncounterError("encounter composition must not be empty")
+    budget_min, budget_max = encounter_group_budget_range(danger_score)
+    budget = sum(enemy_group_cost(tier) for tier in normalized)
+    if budget < budget_min or budget > budget_max:
+        raise SrsEncounterError("encounter composition cost must fit the danger budget range")
+
+    requested_counts = Counter(normalized)
+    for option in encounter_composition_options(danger_score):
+        if Counter(option.tiers) == requested_counts:
+            return normalized
+    raise SrsEncounterError("encounter composition must match a fixed option for the danger score")
+
+
+def spawn_candidate_points(state: SrsGameState) -> tuple[Position, ...]:
+    player_position = state.player_position
+    candidates: list[Position] = []
+    for position in _warp_point_positions(state):
+        if abs(position.x - player_position.x) <= 1 and abs(position.y - player_position.y) <= 1:
+            continue
+        candidates.append(position)
+    return tuple(sorted(candidates, key=_position_sort_key))
+
+
+def apply_spawn_cap(planned_enemies: Sequence[SrsEnemyTier], spawn_cap: int) -> tuple[SrsEnemyTier, ...]:
+    if spawn_cap < 0:
+        raise SrsEncounterError("spawn_cap must be non-negative")
+    if spawn_cap == 0:
+        return ()
+
+    strongest_first = sorted(planned_enemies, key=_tier_desc_sort_key)
+    kept = strongest_first[:spawn_cap]
+    return tuple(sorted(kept, key=_tier_asc_sort_key))
+
+
+def spawn_enemies_for_encounter(
+    state: SrsGameState,
+    *,
+    danger_score: int,
+    composition: Sequence[SrsEnemyTier],
+) -> tuple[SrsEnemyCombatState, ...]:
+    planned_enemies = validate_fixed_encounter_composition(
+        danger_score=danger_score,
+        composition=composition,
+    )
+    candidates = spawn_candidate_points(state)
+    selected_tiers = apply_spawn_cap(planned_enemies, len(candidates))
+    return tuple(
+        create_enemy_combat_state(
+            enemy_id=f"enemy-{index}",
+            tier=tier,
+            position=position,
+        )
+        for index, (tier, position) in enumerate(zip(selected_tiers, candidates, strict=True), start=1)
+    )
+
+
+def combat_state_from_fixed_encounter(
+    state: SrsGameState,
+    *,
+    danger_score: int,
+    composition: Sequence[SrsEnemyTier],
+    player_attack_target_id: str | None = None,
+    base_combat_state: SrsCombatState | None = None,
+) -> SrsCombatState:
+    enemies = spawn_enemies_for_encounter(
+        state,
+        danger_score=danger_score,
+        composition=composition,
+    )
+    if base_combat_state is None:
+        return SrsCombatState(
+            enemies={enemy.enemy_id: enemy for enemy in enemies},
+            player_attack_target_id=player_attack_target_id,
+        )
+    return SrsCombatState(
+        player=base_combat_state.player,
+        enemies={enemy.enemy_id: enemy for enemy in enemies},
+        weapon_profiles=base_combat_state.weapon_profiles,
+        phase=base_combat_state.phase,
+        combat_turn=base_combat_state.combat_turn,
+        player_attack_target_id=player_attack_target_id,
+    )
+
+
+def _validated_danger_score(danger_score: int) -> int:
+    if danger_score not in ENCOUNTER_GROUP_BUDGETS:
+        raise SrsEncounterError("danger_score must be in range 0..4")
+    return danger_score
+
+
+def _warp_point_positions(state: SrsGameState) -> tuple[Position, ...]:
+    positions: list[Position] = []
+    for y, row in enumerate(state.actual_map.cells):
+        for x, cell in enumerate(row):
+            if not cell.warp_flags:
+                continue
+            if cell.terrain in {SrsTerrainType.ASTEROID, SrsTerrainType.RIFT_BARRIER}:
+                continue
+            if cell.object_id is not None:
+                object_type = state.objects[cell.object_id].object_type
+                if object_type in {SrsObjectType.STAR, SrsObjectType.PLANET, SrsObjectType.STATION}:
+                    continue
+            positions.append(Position(x, y))
+    return tuple(positions)
+
+
+def _position_sort_key(position: Position) -> tuple[int, int]:
+    return (position.y, position.x)
+
+
+def _tier_asc_sort_key(tier: SrsEnemyTier) -> int:
+    return _TIER_ORDER[tier]
+
+
+def _tier_desc_sort_key(tier: SrsEnemyTier) -> int:
+    return -_tier_asc_sort_key(tier)

--- a/experiments/galactic_exodus/srs/fixtures/combat_encounter_spawn_cap_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/combat_encounter_spawn_cap_9x9.json
@@ -1,0 +1,41 @@
+{
+  "fixture_id": "combat_encounter_spawn_cap_9x9",
+  "description": "A fixed danger-4 composition is truncated by spawn_cap, strongest enemies are kept, and the final enemies array is sorted by tier ascending.",
+  "sector": {
+    "sector_id": "rift-9202",
+    "sector_type": "RIFT",
+    "sector_seed": 9202,
+    "entry_edge": "S",
+    "blocked_edges": ["N", "W"]
+  },
+  "initial": {
+    "reveal": {"mode": "FULL"},
+    "player_position": [4, 4],
+    "combat": {
+      "phase": "PLAYER_MOVEMENT",
+      "encounter": {
+        "danger_score": 4,
+        "composition": ["TIER2", "TIER1", "TIER1"]
+      }
+    }
+  },
+  "commands": [],
+  "expect": {
+    "event_types": [],
+    "combat_phase": "PLAYER_MOVEMENT",
+    "combat_turn": 0,
+    "enemy_presence": true,
+    "combat_player_durability": 100,
+    "combat_player_energy": 6,
+    "combat_player_torpedo_ammo": 6,
+    "combat_enemy_positions": {
+      "enemy-1": [8, 4],
+      "enemy-2": [4, 8]
+    },
+    "combat_enemy_durabilities": {
+      "enemy-1": 3,
+      "enemy-2": 5
+    },
+    "outcome": null
+  }
+}

--- a/experiments/galactic_exodus/srs/run_fixture.py
+++ b/experiments/galactic_exodus/srs/run_fixture.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any, Mapping
 
 from experiments.galactic_exodus.srs.contracts import SrsContracts, load_default_contracts
+from experiments.galactic_exodus.srs.encounter import combat_state_from_fixed_encounter
 from experiments.galactic_exodus.srs.engine import restore_srs_state, reveal_full_observation, reveal_observation, run_srs_commands
 from experiments.galactic_exodus.srs.generate import create_sector
 from experiments.galactic_exodus.srs.log import build_srs_log
@@ -187,7 +188,7 @@ def state_from_fixture(data: Mapping[str, Any], *, contracts: SrsContracts) -> S
 
     combat = initial.get("combat")
     if combat is not None:
-        state = replace(state, combat_state=_combat_state(combat))
+        state = replace(state, combat_state=_combat_state(state, combat))
 
     return replace(state, fuel=fuel, max_fuel=max_fuel, srs_turn=srs_turn)
 
@@ -379,7 +380,7 @@ def _apply_persistent_overrides(
     )
 
 
-def _combat_state(data: Any) -> SrsCombatState:
+def _combat_state(state: SrsGameState, data: Any) -> SrsCombatState:
     if not isinstance(data, Mapping):
         raise SrsFixtureError("initial.combat must be an object")
 
@@ -407,6 +408,33 @@ def _combat_state(data: Any) -> SrsCombatState:
         energy_recovery=_optional_int(player_data, "energy_recovery", default=1),
     )
 
+    player_attack_target_id = data.get("player_attack_target_id")
+    if player_attack_target_id is not None and not isinstance(player_attack_target_id, str):
+        raise SrsFixtureError("initial.combat.player_attack_target_id must be a string")
+
+    try:
+        base_combat_state = SrsCombatState(
+            player=player,
+            phase=phase,
+            combat_turn=combat_turn,
+        )
+        if "encounter" in data:
+            return _combat_state_from_encounter_fixture(
+                state,
+                data["encounter"],
+                base_combat_state=base_combat_state,
+                player_attack_target_id=player_attack_target_id,
+            )
+        return replace(
+            base_combat_state,
+            enemies=_combat_enemies(data),
+            player_attack_target_id=player_attack_target_id,
+        )
+    except ValueError as exc:
+        raise SrsFixtureError(str(exc)) from exc
+
+
+def _combat_enemies(data: Mapping[str, Any]) -> Mapping[str, Any]:
     raw_enemies = data.get("enemies", [])
     if not isinstance(raw_enemies, list):
         raise SrsFixtureError("initial.combat.enemies must be a list")
@@ -425,18 +453,39 @@ def _combat_state(data: Any) -> SrsCombatState:
             tier=tier,
             position=_position(raw_enemy.get("position"), field_name=f"initial.combat.enemies[{index}].position"),
         )
+    return enemies
 
-    player_attack_target_id = data.get("player_attack_target_id")
-    if player_attack_target_id is not None and not isinstance(player_attack_target_id, str):
-        raise SrsFixtureError("initial.combat.player_attack_target_id must be a string")
+
+def _combat_state_from_encounter_fixture(
+    state: SrsGameState,
+    data: Any,
+    *,
+    base_combat_state: SrsCombatState,
+    player_attack_target_id: str | None,
+) -> SrsCombatState:
+    if not isinstance(data, Mapping):
+        raise SrsFixtureError("initial.combat.encounter must be an object")
+    danger_score = _required_int(data, "danger_score")
+    raw_composition = data.get("composition")
+    if not isinstance(raw_composition, list):
+        raise SrsFixtureError("initial.combat.encounter.composition must be a list")
+
+    composition: list[SrsEnemyTier] = []
+    for index, raw_tier in enumerate(raw_composition, 1):
+        if not isinstance(raw_tier, str):
+            raise SrsFixtureError(f"initial.combat.encounter.composition[{index}] must be a string")
+        try:
+            composition.append(SrsEnemyTier(raw_tier))
+        except ValueError as exc:
+            raise SrsFixtureError(f"invalid enemy tier: {raw_tier}") from exc
 
     try:
-        return SrsCombatState(
-            player=player,
-            enemies=enemies,
-            phase=phase,
-            combat_turn=combat_turn,
+        return combat_state_from_fixed_encounter(
+            state,
+            danger_score=danger_score,
+            composition=tuple(composition),
             player_attack_target_id=player_attack_target_id,
+            base_combat_state=base_combat_state,
         )
     except ValueError as exc:
         raise SrsFixtureError(str(exc)) from exc

--- a/experiments/galactic_exodus/srs/test_encounter.py
+++ b/experiments/galactic_exodus/srs/test_encounter.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import unittest
+from dataclasses import replace
+from pathlib import Path
+
+from experiments.galactic_exodus.srs.contracts import load_default_contracts
+from experiments.galactic_exodus.srs.encounter import (
+    encounter_composition_options,
+    encounter_group_budget_range,
+    enemy_group_cost,
+    spawn_candidate_points,
+    spawn_enemies_for_encounter,
+)
+from experiments.galactic_exodus.srs.model import Direction, Position, SectorDescriptor, SectorType, SrsEnemyTier
+from experiments.galactic_exodus.srs.run_fixture import FIXTURES_DIR, run_fixture
+from experiments.galactic_exodus.srs.test_engine_movement import make_state
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+class SrsEncounterTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.contracts = load_default_contracts(REPO_ROOT)
+
+    def test_group_costs_and_budget_ranges_use_issue_1201_fixed_values(self) -> None:
+        self.assertEqual(enemy_group_cost(SrsEnemyTier.TIER1), 1)
+        self.assertEqual(enemy_group_cost(SrsEnemyTier.TIER2), 2)
+        self.assertEqual(enemy_group_cost(SrsEnemyTier.TIER3), 3)
+        self.assertEqual(enemy_group_cost(SrsEnemyTier.TIER4), 5)
+        self.assertEqual(encounter_group_budget_range(0), (1, 1))
+        self.assertEqual(encounter_group_budget_range(1), (1, 2))
+        self.assertEqual(encounter_group_budget_range(2), (2, 3))
+        self.assertEqual(encounter_group_budget_range(3), (3, 4))
+        self.assertEqual(encounter_group_budget_range(4), (4, 5))
+
+    def test_composition_table_uses_issue_1201_fixed_values(self) -> None:
+        danger4 = encounter_composition_options(4)
+
+        self.assertEqual(
+            [(option.weight_percent, tuple(option.tiers)) for option in danger4],
+            [
+                (40, (SrsEnemyTier.TIER3, SrsEnemyTier.TIER1)),
+                (25, (SrsEnemyTier.TIER2, SrsEnemyTier.TIER2)),
+                (20, (SrsEnemyTier.TIER2, SrsEnemyTier.TIER1, SrsEnemyTier.TIER1)),
+                (10, (SrsEnemyTier.TIER3, SrsEnemyTier.TIER2)),
+                (5, (SrsEnemyTier.TIER4,)),
+            ],
+        )
+
+    def test_spawn_candidates_use_passable_warp_points_outside_player_neighbor_ring(self) -> None:
+        state = replace(make_state(), player_position=Position(4, 4))
+
+        self.assertEqual(
+            spawn_candidate_points(state),
+            (
+                Position(4, 0),
+                Position(0, 4),
+                Position(8, 4),
+                Position(4, 8),
+            ),
+        )
+
+    def test_spawn_candidates_exclude_player_cell_and_blocked_warp_points(self) -> None:
+        descriptor = SectorDescriptor(
+            sector_id="rift-9201",
+            sector_type=SectorType.RIFT,
+            sector_seed=9201,
+            entry_edge=Direction.S,
+            blocked_edges=frozenset({Direction.N, Direction.W}),
+        )
+        state = make_state(
+            sector_type=descriptor.sector_type,
+            sector_seed=descriptor.sector_seed,
+            entry_edge=descriptor.entry_edge,
+            blocked_edges=descriptor.blocked_edges,
+        )
+        state = replace(state, descriptor=descriptor, player_position=Position(4, 4))
+
+        self.assertEqual(
+            spawn_candidate_points(state),
+            (
+                Position(8, 4),
+                Position(4, 8),
+            ),
+        )
+
+    def test_spawn_cap_keeps_strongest_enemies_then_sorts_result_ascending(self) -> None:
+        descriptor = SectorDescriptor(
+            sector_id="rift-9202",
+            sector_type=SectorType.RIFT,
+            sector_seed=9202,
+            entry_edge=Direction.S,
+            blocked_edges=frozenset({Direction.N, Direction.W}),
+        )
+        state = make_state(
+            sector_type=descriptor.sector_type,
+            sector_seed=descriptor.sector_seed,
+            entry_edge=descriptor.entry_edge,
+            blocked_edges=descriptor.blocked_edges,
+        )
+        state = replace(state, descriptor=descriptor, player_position=Position(4, 4))
+
+        enemies = spawn_enemies_for_encounter(
+            state,
+            danger_score=4,
+            composition=(
+                SrsEnemyTier.TIER2,
+                SrsEnemyTier.TIER1,
+                SrsEnemyTier.TIER1,
+            ),
+        )
+
+        self.assertEqual(
+            [(enemy.enemy_id, enemy.tier, enemy.position) for enemy in enemies],
+            [
+                ("enemy-1", SrsEnemyTier.TIER1, Position(8, 4)),
+                ("enemy-2", SrsEnemyTier.TIER2, Position(4, 8)),
+            ],
+        )
+
+    def test_fixture_accepts_fixed_encounter_composition_input(self) -> None:
+        result = run_fixture(FIXTURES_DIR / "combat_encounter_spawn_cap_9x9.json", contracts=self.contracts)
+
+        self.assertEqual(tuple(result.final_state.combat_state.enemies), ("enemy-1", "enemy-2"))
+        self.assertEqual(
+            result.summary["combat_enemy_positions"],
+            {
+                "enemy-1": [8, 4],
+                "enemy-2": [4, 8],
+            },
+        )
+

--- a/experiments/galactic_exodus/srs/test_fixture_regression.py
+++ b/experiments/galactic_exodus/srs/test_fixture_regression.py
@@ -179,3 +179,22 @@ class SrsFixtureRegressionTests(unittest.TestCase):
             [action["reaction"]["resolved_reaction"] for action in result.log.events[4].payload["enemy_actions"]],
             ["COUNTERATTACK", "DEFEND", "DEFEND", "DEFEND"],
         )
+
+    def test_combat_encounter_spawn_cap(self) -> None:
+        result = run_named_fixture("combat_encounter_spawn_cap_9x9")
+
+        self.assertEqual(result.log.events, ())
+        self.assertEqual(
+            result.summary["combat_enemy_positions"],
+            {
+                "enemy-1": [8, 4],
+                "enemy-2": [4, 8],
+            },
+        )
+        self.assertEqual(
+            result.summary["combat_enemy_durabilities"],
+            {
+                "enemy-1": 3,
+                "enemy-2": 5,
+            },
+        )

--- a/experiments/galactic_exodus/srs/test_fixtures.py
+++ b/experiments/galactic_exodus/srs/test_fixtures.py
@@ -46,6 +46,7 @@ REQUIRED_FIXTURES = {
     "combat_enemy_counterattack_fallback_energy_9x9.json",
     "combat_energy_pressure_danger3_9x9.json",
     "combat_energy_pressure_danger4_9x9.json",
+    "combat_encounter_spawn_cap_9x9.json",
 }
 
 
@@ -239,6 +240,24 @@ class SrsFixtureTests(unittest.TestCase):
         self.assertEqual(danger4.log.events[1].payload["player_energy_after"], 2)
         self.assertEqual(danger4.log.events[4].payload["player_energy_after"], 1)
         self.assertTrue(danger4.log.events[4].payload["enemy_actions"][1]["reaction"]["fallback_to_defend"])
+
+    def test_encounter_spawn_fixture_accepts_fixed_composition_and_spawn_cap(self) -> None:
+        result = run_fixture(FIXTURES_DIR / "combat_encounter_spawn_cap_9x9.json", contracts=self.contracts)
+
+        self.assertEqual(
+            result.summary["combat_enemy_positions"],
+            {
+                "enemy-1": [8, 4],
+                "enemy-2": [4, 8],
+            },
+        )
+        self.assertEqual(
+            result.summary["combat_enemy_durabilities"],
+            {
+                "enemy-1": 3,
+                "enemy-2": 5,
+            },
+        )
 
     def test_custom_orthogonal_raw_cost_is_used_by_movement_and_enemy_pathfinding(self) -> None:
         custom_contracts = replace(


### PR DESCRIPTION
## 概要

Closes #1201

- Issue: #1201 `#1178-17 SRS encounter spawn / danger composition / spawn capを実装する`
- URL: https://github.com/kkismd/tbx/issues/1201
- Base branch: `integration/882-galactic-exodus`

## Intended Scope

- danger別の fixed composition table を保持する
- fixture で確率選択済み composition を固定入力できるようにする
- `spawn_candidate_points` を列挙する
- `spawn_cap` で強い enemy を優先して残す
- `enemies` 配列を tier 昇順で安定化する

## Non-Scope

- actual encounter roll probability
- terrain encounter modifier
- combat damage resolution の追加ルール
- SALVAGE drop

## Fixed Values And Rules

### enemy group cost

- `tier1 = 1`
- `tier2 = 2`
- `tier3 = 3`
- `tier4 = 5`

### encounter group budget

- `danger 0: 1`
- `danger 1: 1..2`
- `danger 2: 2..3`
- `danger 3: 3..4`
- `danger 4: 4..5`

### composition table

- `danger 0: tier1`
- `danger 1: tier1 / tier1+tier1`
- `danger 2: tier2 / tier1+tier1 / tier2+tier1`
- `danger 3: tier2+tier1 / tier3 / tier1+tier1+tier1 / tier2+tier2`
- `danger 4: tier3+tier1 / tier2+tier2 / tier2+tier1+tier1 / tier3+tier2 / tier4`

### spawn rules

- spawn candidates are passable warp points only
- exclude the player current cell
- exclude the 8 neighboring cells around the player
- `spawn_cap = count(spawn_candidate_points)`
- when planned enemies exceed `spawn_cap`, keep the strongest enemies first
- after truncation, sort the final enemy array by tier ascending
- fixture input uses a fixed selected composition and does not roll randomness

## Changed Files

- `experiments/galactic_exodus/srs/encounter.py`
- `experiments/galactic_exodus/srs/run_fixture.py`
- `experiments/galactic_exodus/srs/test_encounter.py`
- `experiments/galactic_exodus/srs/test_fixtures.py`
- `experiments/galactic_exodus/srs/test_fixture_regression.py`
- `experiments/galactic_exodus/srs/fixtures/combat_encounter_spawn_cap_9x9.json`

## Tests

- `python3 -m unittest experiments.galactic_exodus.srs.test_model experiments.galactic_exodus.srs.test_engine_combat experiments.galactic_exodus.srs.test_encounter experiments.galactic_exodus.srs.test_fixtures experiments.galactic_exodus.srs.test_fixture_regression`
- Result: `Ran 99 tests in 0.092s / OK`
