### PR TITLE
SRS reward flow: RESOURCE_CACHE / SALVAGE / BASEを実装

### DIFF
--- a/experiments/galactic_exodus/srs/engine.py
+++ b/experiments/galactic_exodus/srs/engine.py
@@ -24,6 +24,7 @@ from experiments.galactic_exodus.srs.log import (
     make_turn_event,
 )
 from experiments.galactic_exodus.srs.model import (
+    SrsBaseUpgrade,
     Direction,
     CostMode,
     MovementRule,
@@ -36,12 +37,14 @@ from experiments.galactic_exodus.srs.model import (
     SrsCommandResult,
     SrsEnemyCombatState,
     SrsEnemyReaction,
+    SrsEnemyTier,
     SrsGameState,
     SrsKnownState,
     SrsObjectType,
     SrsObjectState,
     SrsPlayerAttackAction,
     SrsPlayerCombatState,
+    SrsSalvageChoice,
     SrsPersistentState,
     SrsTerrainType,
     SrsWeaponType,
@@ -75,6 +78,54 @@ _ENEMY_PATH_TIEBREAK_DIRECTIONS = (
     Direction.E,
     Direction.S,
 )
+_RESOURCE_CACHE_FUEL_RESTORE = 3
+_SALVAGE_BASE_VALUE = 1
+_SALVAGE_BASE_RECOVERY = {
+    SrsSalvageChoice.RECOVER_DURABILITY: 8,
+    SrsSalvageChoice.RECOVER_ENERGY: 2,
+    SrsSalvageChoice.RECOVER_PHOTON_TORPEDO_AMMO: 1,
+    SrsSalvageChoice.STORE_ONLY: 0,
+}
+_SALVAGE_DROP_VALUES = {
+    SrsEnemyTier.TIER1: 1,
+    SrsEnemyTier.TIER2: 1,
+    SrsEnemyTier.TIER3: 2,
+    SrsEnemyTier.TIER4: 3,
+}
+_SALVAGE_DROP_RECOVERY = {
+    SrsEnemyTier.TIER1: {
+        SrsSalvageChoice.RECOVER_DURABILITY: 8,
+        SrsSalvageChoice.RECOVER_ENERGY: 2,
+        SrsSalvageChoice.RECOVER_PHOTON_TORPEDO_AMMO: 1,
+        SrsSalvageChoice.STORE_ONLY: 0,
+    },
+    SrsEnemyTier.TIER2: {
+        SrsSalvageChoice.RECOVER_DURABILITY: 8,
+        SrsSalvageChoice.RECOVER_ENERGY: 2,
+        SrsSalvageChoice.RECOVER_PHOTON_TORPEDO_AMMO: 1,
+        SrsSalvageChoice.STORE_ONLY: 0,
+    },
+    SrsEnemyTier.TIER3: {
+        SrsSalvageChoice.RECOVER_DURABILITY: 12,
+        SrsSalvageChoice.RECOVER_ENERGY: 3,
+        SrsSalvageChoice.RECOVER_PHOTON_TORPEDO_AMMO: 1,
+        SrsSalvageChoice.STORE_ONLY: 0,
+    },
+    SrsEnemyTier.TIER4: {
+        SrsSalvageChoice.RECOVER_DURABILITY: 16,
+        SrsSalvageChoice.RECOVER_ENERGY: 4,
+        SrsSalvageChoice.RECOVER_PHOTON_TORPEDO_AMMO: 2,
+        SrsSalvageChoice.STORE_ONLY: 0,
+    },
+}
+_BASE_UPGRADE_COSTS = {
+    SrsBaseUpgrade.PHASER_POWER: 4,
+    SrsBaseUpgrade.PHOTON_TORPEDO_POWER: 5,
+    SrsBaseUpgrade.ENERGY_CAPACITY: 3,
+    SrsBaseUpgrade.PHOTON_TORPEDO_AMMO_CAPACITY: 3,
+    SrsBaseUpgrade.DEFENSE: 4,
+    SrsBaseUpgrade.EVASION: 4,
+}
 
 
 def observation_size_for_terrain(
@@ -186,6 +237,25 @@ def snapshot_srs_state(
     return replace(
         state.persistent_state,
         discovered_cells=state.known_state.discovered_cells,
+    )
+
+
+def _current_player_state(state: SrsGameState) -> SrsPlayerCombatState:
+    if state.combat_state is not None:
+        return state.combat_state.player
+    return state.player_state
+
+
+def _replace_player_state(
+    state: SrsGameState,
+    player_state: SrsPlayerCombatState,
+) -> SrsGameState:
+    updated_state = replace(state, player_state=player_state)
+    if updated_state.combat_state is None:
+        return updated_state
+    return replace(
+        updated_state,
+        combat_state=replace(updated_state.combat_state, player=player_state),
     )
 
 
@@ -745,9 +815,19 @@ def _apply_interact(
     if object_state.object_type is SrsObjectType.RESOURCE_CACHE:
         return _apply_resource_cache_interaction(state, object_state, interaction_contract)
     if object_state.object_type is SrsObjectType.STATION:
-        return _apply_station_interaction(state, object_state, interaction_contract)
+        return _apply_station_interaction(
+            state,
+            object_state,
+            interaction_contract,
+            base_upgrade_choice=command.base_upgrade_choice,
+        )
     if object_state.object_type is SrsObjectType.SALVAGE:
-        return _apply_salvage_interaction(state, object_state, interaction_contract)
+        return _apply_salvage_interaction(
+            state,
+            object_state,
+            interaction_contract,
+            salvage_choice=command.salvage_choice,
+        )
 
     return _rejected_interaction_result(
         state,
@@ -927,6 +1007,7 @@ def _apply_combat_step(
 
     updated_state = replace(
         state,
+        player_state=player_after,
         combat_state=replace(
             combat_state,
             enemies=enemy_states,
@@ -1033,6 +1114,15 @@ def _resolve_player_attack_phase(
     if remaining_durability <= 0:
         del updated_enemies[target_enemy_id]
         payload["target_destroyed"] = True
+        if target_enemy.drop_salvage:
+            player, salvage_reward = _apply_salvage_reward_to_player(
+                player,
+                salvage_value=_SALVAGE_DROP_VALUES[target_enemy.tier],
+                choice=command.salvage_choice,
+                recovery_amounts=_SALVAGE_DROP_RECOVERY[target_enemy.tier],
+                source="ENEMY_DROP",
+            )
+            payload["salvage_reward"] = salvage_reward
     else:
         updated_enemies[target_enemy_id] = replace(target_enemy, durability=remaining_durability)
         payload["target_remaining_durability"] = remaining_durability
@@ -1349,9 +1439,8 @@ def _apply_resource_cache_interaction(
     object_state: SrsObjectState,
     interaction_contract: Mapping[str, Any],
 ) -> SrsCommandResult:
-    fuel_restore = _validated_fuel_restore(object_state)
     fuel_before = state.fuel
-    fuel_after = min(state.max_fuel, fuel_before + fuel_restore)
+    fuel_after = min(state.max_fuel, fuel_before + _RESOURCE_CACHE_FUEL_RESTORE)
     fuel_delta = fuel_after - fuel_before
     if fuel_delta == 0:
         return _rejected_interaction_result(
@@ -1386,7 +1475,7 @@ def _apply_resource_cache_interaction(
             payload={
                 "object_id": object_state.object_id,
                 "object_type": object_state.object_type.value,
-                "fuel_restore": fuel_restore,
+                "fuel_restore": _RESOURCE_CACHE_FUEL_RESTORE,
                 "fuel_before": fuel_before,
                 "fuel_after": fuel_after,
                 "fuel_delta": fuel_delta,
@@ -1401,17 +1490,40 @@ def _apply_station_interaction(
     state: SrsGameState,
     object_state: SrsObjectState,
     interaction_contract: Mapping[str, Any],
+    *,
+    base_upgrade_choice: SrsBaseUpgrade | None,
 ) -> SrsCommandResult:
+    player_before = _current_player_state(state)
     fuel_before = state.fuel
     fuel_after = state.max_fuel
     fuel_delta = fuel_after - fuel_before
-    if fuel_delta == 0:
-        return _rejected_interaction_result(
-            state,
-            object_id=object_state.object_id,
-            object_state=object_state,
-            outcome="REJECTED_NO_EFFECT",
-        )
+    available_upgrades = [
+        upgrade.value
+        for upgrade, cost in _BASE_UPGRADE_COSTS.items()
+        if player_before.salvage >= cost
+    ]
+    player_after_recovery = replace(
+        player_before,
+        durability=player_before.durability_capacity,
+        energy=player_before.energy_capacity,
+        photon_torpedo_ammo=player_before.photon_torpedo_ammo_capacity,
+    )
+    player_after_upgrade = player_after_recovery
+    applied_upgrade = None
+    salvage_spent = 0
+    if base_upgrade_choice is not None:
+        try:
+            player_after_upgrade, salvage_spent, applied_upgrade = _apply_base_upgrade_choice(
+                player_after_recovery,
+                upgrade=base_upgrade_choice,
+            )
+        except SrsInteractionError:
+            return _rejected_interaction_result(
+                state,
+                object_id=object_state.object_id,
+                object_state=object_state,
+                outcome="REJECTED_UPGRADE_UNAVAILABLE",
+            )
 
     next_turn = state.srs_turn + 1
     updated_state = _accepted_interaction_state(
@@ -1421,6 +1533,7 @@ def _apply_station_interaction(
         object_state=replace(object_state, activated=True),
         activated_object_id=object_state.object_id,
     )
+    updated_state = _replace_player_state(updated_state, player_after_upgrade)
     events = (
         _interaction_event(
             srs_turn=next_turn,
@@ -1431,6 +1544,14 @@ def _apply_station_interaction(
             fuel_after=fuel_after,
             fuel_delta=fuel_delta,
             outcome="ACCEPTED",
+            player_before=player_before,
+            player_after=player_after_upgrade,
+            extra_payload={
+                "available_upgrades": available_upgrades,
+                "selected_upgrade": None if base_upgrade_choice is None else base_upgrade_choice.value,
+                "applied_upgrade": applied_upgrade,
+                "salvage_spent": salvage_spent,
+            },
         ),
         make_turn_event(
             srs_turn=next_turn,
@@ -1443,6 +1564,18 @@ def _apply_station_interaction(
                 "fuel_delta": fuel_delta,
                 "activated": True,
                 "reusable": True,
+                "player_durability_before": player_before.durability,
+                "player_durability_after": player_after_upgrade.durability,
+                "player_energy_before": player_before.energy,
+                "player_energy_after": player_after_upgrade.energy,
+                "player_torpedo_ammo_before": player_before.photon_torpedo_ammo,
+                "player_torpedo_ammo_after": player_after_upgrade.photon_torpedo_ammo,
+                "salvage_before": player_before.salvage,
+                "salvage_after": player_after_upgrade.salvage,
+                "available_upgrades": available_upgrades,
+                "selected_upgrade": None if base_upgrade_choice is None else base_upgrade_choice.value,
+                "applied_upgrade": applied_upgrade,
+                "salvage_spent": salvage_spent,
             },
         ),
     )
@@ -1453,7 +1586,17 @@ def _apply_salvage_interaction(
     state: SrsGameState,
     object_state: SrsObjectState,
     interaction_contract: Mapping[str, Any],
+    *,
+    salvage_choice: SrsSalvageChoice | None,
 ) -> SrsCommandResult:
+    player_before = _current_player_state(state)
+    player_after, salvage_reward = _apply_salvage_reward_to_player(
+        player_before,
+        salvage_value=_SALVAGE_BASE_VALUE,
+        choice=salvage_choice,
+        recovery_amounts=_SALVAGE_BASE_RECOVERY,
+        source="MAP_PICKUP",
+    )
     next_turn = state.srs_turn + 1
     updated_state = _accepted_interaction_state(
         state,
@@ -1462,6 +1605,7 @@ def _apply_salvage_interaction(
         object_state=replace(object_state, consumed=True),
         consumed_object_id=object_state.object_id,
     )
+    updated_state = _replace_player_state(updated_state, player_after)
     events = (
         _interaction_event(
             srs_turn=next_turn,
@@ -1472,6 +1616,9 @@ def _apply_salvage_interaction(
             fuel_after=state.fuel,
             fuel_delta=0,
             outcome="ACCEPTED",
+            player_before=player_before,
+            player_after=player_after,
+            extra_payload=salvage_reward,
         ),
         make_turn_event(
             srs_turn=next_turn,
@@ -1481,10 +1628,98 @@ def _apply_salvage_interaction(
                 "object_type": object_state.object_type.value,
                 "consumed": True,
                 "outcome": "ACCEPTED",
+                **salvage_reward,
             },
         ),
     )
     return SrsCommandResult(state=updated_state, events=events)
+
+
+def _apply_salvage_reward_to_player(
+    player: SrsPlayerCombatState,
+    *,
+    salvage_value: int,
+    choice: SrsSalvageChoice | None,
+    recovery_amounts: Mapping[SrsSalvageChoice, int],
+    source: str,
+) -> tuple[SrsPlayerCombatState, Mapping[str, Any]]:
+    resolved_choice = SrsSalvageChoice.STORE_ONLY if choice is None else choice
+    recovery_amount = recovery_amounts[resolved_choice]
+    durability_before = player.durability
+    energy_before = player.energy
+    ammo_before = player.photon_torpedo_ammo
+
+    updated_player = player
+    if resolved_choice is SrsSalvageChoice.RECOVER_DURABILITY:
+        updated_player = replace(
+            updated_player,
+            durability=min(updated_player.durability_capacity, updated_player.durability + recovery_amount),
+        )
+    elif resolved_choice is SrsSalvageChoice.RECOVER_ENERGY:
+        updated_player = replace(
+            updated_player,
+            energy=min(updated_player.energy_capacity, updated_player.energy + recovery_amount),
+        )
+    elif resolved_choice is SrsSalvageChoice.RECOVER_PHOTON_TORPEDO_AMMO:
+        updated_player = replace(
+            updated_player,
+            photon_torpedo_ammo=min(
+                updated_player.photon_torpedo_ammo_capacity,
+                updated_player.photon_torpedo_ammo + recovery_amount,
+            ),
+        )
+
+    updated_player = replace(updated_player, salvage=updated_player.salvage + salvage_value)
+    return updated_player, {
+        "reward_source": source,
+        "salvage_value": salvage_value,
+        "salvage_before": player.salvage,
+        "salvage_after": updated_player.salvage,
+        "selected_salvage_choice": resolved_choice.value,
+        "durability_before": durability_before,
+        "durability_after": updated_player.durability,
+        "durability_delta": updated_player.durability - durability_before,
+        "energy_before": energy_before,
+        "energy_after": updated_player.energy,
+        "energy_delta": updated_player.energy - energy_before,
+        "photon_torpedo_ammo_before": ammo_before,
+        "photon_torpedo_ammo_after": updated_player.photon_torpedo_ammo,
+        "photon_torpedo_ammo_delta": updated_player.photon_torpedo_ammo - ammo_before,
+    }
+
+
+def _apply_base_upgrade_choice(
+    player: SrsPlayerCombatState,
+    *,
+    upgrade: SrsBaseUpgrade,
+) -> tuple[SrsPlayerCombatState, int, str]:
+    cost = _BASE_UPGRADE_COSTS[upgrade]
+    if player.salvage < cost:
+        raise SrsInteractionError(f"insufficient salvage for base upgrade: {upgrade.value}")
+
+    updated_player = replace(player, salvage=player.salvage - cost)
+    if upgrade is SrsBaseUpgrade.PHASER_POWER:
+        updated_player = replace(updated_player, phaser_power=updated_player.phaser_power + 1)
+    elif upgrade is SrsBaseUpgrade.PHOTON_TORPEDO_POWER:
+        updated_player = replace(updated_player, photon_torpedo_power=updated_player.photon_torpedo_power + 1)
+    elif upgrade is SrsBaseUpgrade.ENERGY_CAPACITY:
+        updated_player = replace(
+            updated_player,
+            energy_capacity=updated_player.energy_capacity + 1,
+            energy=updated_player.energy + 1,
+        )
+    elif upgrade is SrsBaseUpgrade.PHOTON_TORPEDO_AMMO_CAPACITY:
+        updated_player = replace(
+            updated_player,
+            photon_torpedo_ammo_capacity=updated_player.photon_torpedo_ammo_capacity + 1,
+            photon_torpedo_ammo=updated_player.photon_torpedo_ammo + 1,
+        )
+    elif upgrade is SrsBaseUpgrade.DEFENSE:
+        updated_player = replace(updated_player, defense=updated_player.defense + 1)
+    elif upgrade is SrsBaseUpgrade.EVASION:
+        updated_player = replace(updated_player, evasion=updated_player.evasion + 1)
+
+    return updated_player, cost, upgrade.value
 
 
 def _accepted_interaction_state(
@@ -1550,6 +1785,9 @@ def _interaction_event(
     fuel_delta: int,
     outcome: str,
     object_id: str | None = None,
+    player_before: SrsPlayerCombatState | None = None,
+    player_after: SrsPlayerCombatState | None = None,
+    extra_payload: Mapping[str, Any] | None = None,
 ) -> Any:
     resolved_object_id = object_id if object_id is not None else object_state.object_id
     payload = {
@@ -1564,6 +1802,19 @@ def _interaction_event(
         "fuel_delta": fuel_delta,
         "outcome": outcome,
     }
+    if player_before is not None and player_after is not None:
+        payload |= {
+            "player_durability_before": player_before.durability,
+            "player_durability_after": player_after.durability,
+            "player_energy_before": player_before.energy,
+            "player_energy_after": player_after.energy,
+            "player_torpedo_ammo_before": player_before.photon_torpedo_ammo,
+            "player_torpedo_ammo_after": player_after.photon_torpedo_ammo,
+            "salvage_before": player_before.salvage,
+            "salvage_after": player_after.salvage,
+        }
+    if extra_payload is not None:
+        payload |= dict(extra_payload)
     return make_turn_event(
         srs_turn=srs_turn,
         event_type=event_type,
@@ -1595,15 +1846,6 @@ def _is_valid_interaction_range(player_position: Position, object_position: Posi
 
 def _is_consumed_object(state: SrsGameState, object_state: SrsObjectState) -> bool:
     return object_state.consumed or object_state.object_id in state.persistent_state.consumed_object_ids
-
-
-def _validated_fuel_restore(object_state: SrsObjectState) -> int:
-    fuel_restore = object_state.metadata.get("fuel_restore")
-    if fuel_restore is None:
-        raise SrsInteractionError(f"{object_state.object_id} is missing fuel_restore metadata")
-    if not isinstance(fuel_restore, int) or isinstance(fuel_restore, bool) or fuel_restore <= 0:
-        raise SrsInteractionError(f"{object_state.object_id} fuel_restore must be a positive integer")
-    return fuel_restore
 
 
 def _apply_persistent_object_flags(

--- a/experiments/galactic_exodus/srs/evaluate_policies.py
+++ b/experiments/galactic_exodus/srs/evaluate_policies.py
@@ -458,6 +458,7 @@ def _known_interaction_positions_for_object(
 def _is_object_greedy_candidate(
     object_state: SrsObjectState,
     *,
+    state: SrsGameState,
     fuel: int,
     max_fuel: int,
     rejected_object_ids: frozenset[str],
@@ -467,7 +468,14 @@ def _is_object_greedy_candidate(
     if object_state.object_type is SrsObjectType.RESOURCE_CACHE:
         return not object_state.consumed and fuel != max_fuel
     if object_state.object_type is SrsObjectType.STATION:
-        return not object_state.activated and fuel != max_fuel
+        player = state.player_state if state.combat_state is None else state.combat_state.player
+        return not object_state.activated and (
+            fuel != max_fuel
+            or player.durability != player.durability_capacity
+            or player.energy != player.energy_capacity
+            or player.photon_torpedo_ammo != player.photon_torpedo_ammo_capacity
+            or player.salvage >= 3
+        )
     if object_state.object_type is SrsObjectType.SALVAGE:
         return not object_state.consumed
     return False
@@ -494,6 +502,7 @@ def build_object_greedy_candidates(
             continue
         if not _is_object_greedy_candidate(
             object_state,
+            state=state,
             fuel=state.fuel,
             max_fuel=state.max_fuel,
             rejected_object_ids=rejected,

--- a/experiments/galactic_exodus/srs/fixtures/base_upgrade_defense_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/base_upgrade_defense_9x9.json
@@ -1,6 +1,6 @@
 {
-  "fixture_id": "station_refuel_9x9",
-  "description": "BASE STATION interaction fully recovers fuel and combat resources.",
+  "fixture_id": "base_upgrade_defense_9x9",
+  "description": "BASE STATION interaction fully recovers and buys DEFENSE +1 for salvage 4.",
   "sector": {
     "sector_id": "base-2001",
     "sector_type": "BASE",
@@ -10,19 +10,25 @@
   },
   "initial": {
     "player_position": [3, 1],
-    "fuel": 2,
+    "fuel": 1,
     "max_fuel": 9,
     "player": {
-      "durability": 91,
+      "durability": 88,
       "energy": 2,
-      "photon_torpedo_ammo": 1
+      "photon_torpedo_ammo": 1,
+      "salvage": 4,
+      "defense": 1
     },
     "reveal": {
       "mode": "FULL"
     }
   },
   "commands": [
-    {"command_type": "INTERACT", "target_object_id": "station-1"}
+    {
+      "command_type": "INTERACT",
+      "target_object_id": "station-1",
+      "base_upgrade_choice": "DEFENSE"
+    }
   ],
   "expect": {
     "srs_turn": 1,
@@ -30,6 +36,8 @@
     "player_durability": 100,
     "player_energy": 6,
     "player_torpedo_ammo": 6,
+    "player_salvage": 0,
+    "player_defense": 2,
     "player_position": [3, 1],
     "event_types": ["INTERACT_ACCEPTED", "STATION_ACTIVATED"],
     "activated_object_ids": ["station-1"],

--- a/experiments/galactic_exodus/srs/fixtures/combat_salvage_drop_tier3_energy_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/combat_salvage_drop_tier3_energy_9x9.json
@@ -1,0 +1,52 @@
+{
+  "fixture_id": "combat_salvage_drop_tier3_energy_9x9",
+  "description": "A destroyed tier3 enemy with fixed salvage drop recovers energy and adds salvage.",
+  "sector": {
+    "sector_id": "normal-9120",
+    "sector_type": "NORMAL",
+    "sector_seed": 9120,
+    "entry_edge": "S",
+    "blocked_edges": []
+  },
+  "initial": {
+    "reveal": {"mode": "FULL"},
+    "player_position": [1, 4],
+    "player": {
+      "energy": 3,
+      "salvage": 1
+    },
+    "combat": {
+      "phase": "PLAYER_ATTACK",
+      "player": {
+        "energy": 3,
+        "salvage": 1
+      },
+      "enemies": [
+        {"enemy_id": "enemy-3", "tier": "TIER3", "position": [3, 4], "drop_salvage": true, "durability": 3}
+      ],
+      "player_attack_target_id": "enemy-3"
+    }
+  },
+  "commands": [
+    {
+      "command_type": "COMBAT_STEP",
+      "player_attack_action": "ATTACK",
+      "player_attack_weapon": "PHOTON_TORPEDO",
+      "salvage_choice": "RECOVER_ENERGY"
+    }
+  ],
+  "expect": {
+    "event_types": ["COMBAT_TRANSITIONED"],
+    "combat_phase": "ENEMY_ACTION",
+    "combat_turn": 0,
+    "enemy_presence": false,
+    "player_energy": 6,
+    "player_salvage": 3,
+    "combat_player_energy": 6,
+    "combat_player_torpedo_ammo": 5,
+    "combat_enemy_positions": {},
+    "combat_enemy_durabilities": {},
+    "enemy_actions": [],
+    "outcome": "ACCEPTED"
+  }
+}

--- a/experiments/galactic_exodus/srs/fixtures/combat_salvage_no_drop_tier1_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/combat_salvage_no_drop_tier1_9x9.json
@@ -1,0 +1,47 @@
+{
+  "fixture_id": "combat_salvage_no_drop_tier1_9x9",
+  "description": "A destroyed tier1 enemy without fixed salvage drop leaves salvage inventory unchanged.",
+  "sector": {
+    "sector_id": "normal-9121",
+    "sector_type": "NORMAL",
+    "sector_seed": 9121,
+    "entry_edge": "S",
+    "blocked_edges": []
+  },
+  "initial": {
+    "reveal": {"mode": "FULL"},
+    "player_position": [1, 4],
+    "player": {
+      "salvage": 2
+    },
+    "combat": {
+      "phase": "PLAYER_ATTACK",
+      "player": {
+        "salvage": 2
+      },
+      "enemies": [
+        {"enemy_id": "enemy-1", "tier": "TIER1", "position": [3, 4], "drop_salvage": false}
+      ],
+      "player_attack_target_id": "enemy-1"
+    }
+  },
+  "commands": [
+    {
+      "command_type": "COMBAT_STEP",
+      "player_attack_action": "ATTACK",
+      "player_attack_weapon": "PHOTON_TORPEDO"
+    }
+  ],
+  "expect": {
+    "event_types": ["COMBAT_TRANSITIONED"],
+    "combat_phase": "ENEMY_ACTION",
+    "combat_turn": 0,
+    "enemy_presence": false,
+    "player_salvage": 2,
+    "combat_player_torpedo_ammo": 5,
+    "combat_enemy_positions": {},
+    "combat_enemy_durabilities": {},
+    "enemy_actions": [],
+    "outcome": "ACCEPTED"
+  }
+}

--- a/experiments/galactic_exodus/srs/fixtures/phase2_reference.json
+++ b/experiments/galactic_exodus/srs/fixtures/phase2_reference.json
@@ -29,7 +29,7 @@
       "final_expect": {
         "cost_mode": "TURN_ONLY",
         "srs_turn": 1,
-        "fuel": 7,
+        "fuel": 5,
         "player_position": [2, 7],
         "event_types": ["INTERACT_ACCEPTED", "OBJECT_CONSUMED"],
         "consumed_object_ids": ["resource-cache-1"],

--- a/experiments/galactic_exodus/srs/fixtures/resource_cache_single_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/resource_cache_single_9x9.json
@@ -1,6 +1,6 @@
 {
   "fixture_id": "resource_cache_single_9x9",
-  "description": "RESOURCE_CACHE interaction consumes cache and restores fuel.",
+  "description": "RESOURCE_CACHE interaction consumes cache and restores fixed fuel +3.",
   "sector": {
     "sector_id": "resource-3001",
     "sector_type": "RESOURCE",
@@ -27,7 +27,7 @@
   "cost_mode": "TURN_ONLY",
   "expect": {
     "srs_turn": 1,
-    "fuel": 7,
+    "fuel": 5,
     "player_position": [2, 7],
     "event_types": ["INTERACT_ACCEPTED", "OBJECT_CONSUMED"],
     "consumed_object_ids": ["resource-cache-1"],

--- a/experiments/galactic_exodus/srs/fixtures/resource_minimal_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/resource_minimal_9x9.json
@@ -26,7 +26,7 @@
     },
     "object_metadata": {
       "resource-cache-1": {
-        "fuel_restore": 5
+        "fuel_restore": 3
       }
     },
     "known_discovered_count": 0

--- a/experiments/galactic_exodus/srs/fixtures/salvage_recover_durability_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/salvage_recover_durability_9x9.json
@@ -1,6 +1,6 @@
 {
-  "fixture_id": "salvage_placeholder_9x9",
-  "description": "SALVAGE interaction stores salvage without immediate recovery when no choice is supplied.",
+  "fixture_id": "salvage_recover_durability_9x9",
+  "description": "SALVAGE interaction recovers durability and still adds salvage inventory.",
   "sector": {
     "sector_id": "normal-1001",
     "sector_type": "NORMAL",
@@ -12,16 +12,24 @@
     "player_position": [4, 6],
     "fuel": 2,
     "max_fuel": 9,
+    "player": {
+      "durability": 92
+    },
     "reveal": {
       "mode": "FULL"
     }
   },
   "commands": [
-    {"command_type": "INTERACT", "target_object_id": "salvage-1"}
+    {
+      "command_type": "INTERACT",
+      "target_object_id": "salvage-1",
+      "salvage_choice": "RECOVER_DURABILITY"
+    }
   ],
   "expect": {
     "srs_turn": 1,
     "fuel": 2,
+    "player_durability": 100,
     "player_salvage": 1,
     "player_position": [4, 6],
     "event_types": ["INTERACT_ACCEPTED", "OBJECT_CONSUMED"],

--- a/experiments/galactic_exodus/srs/generate.py
+++ b/experiments/galactic_exodus/srs/generate.py
@@ -47,15 +47,7 @@ SECTOR_EXTRA_OBJECTS = {
 def resource_cache_restore_values(cache_count: int) -> tuple[int, ...]:
     if cache_count < 0:
         raise SrsGenerationError("resource cache count must be non-negative")
-    if cache_count == 0:
-        return ()
-    if cache_count == 1:
-        return (5,)
-    if cache_count == 2:
-        return (3, 2)
-    if cache_count == 3:
-        return (2, 2, 1)
-    raise SrsGenerationError("resource sectors support at most 3 resource caches")
+    return tuple(3 for _ in range(cache_count))
 
 
 def create_sector(

--- a/experiments/galactic_exodus/srs/model.py
+++ b/experiments/galactic_exodus/srs/model.py
@@ -80,6 +80,22 @@ class SrsEnemyReaction(str, Enum):
     DEFEND = "DEFEND"
 
 
+class SrsSalvageChoice(str, Enum):
+    RECOVER_DURABILITY = "RECOVER_DURABILITY"
+    RECOVER_ENERGY = "RECOVER_ENERGY"
+    RECOVER_PHOTON_TORPEDO_AMMO = "RECOVER_PHOTON_TORPEDO_AMMO"
+    STORE_ONLY = "STORE_ONLY"
+
+
+class SrsBaseUpgrade(str, Enum):
+    PHASER_POWER = "PHASER_POWER"
+    PHOTON_TORPEDO_POWER = "PHOTON_TORPEDO_POWER"
+    ENERGY_CAPACITY = "ENERGY_CAPACITY"
+    PHOTON_TORPEDO_AMMO_CAPACITY = "PHOTON_TORPEDO_AMMO_CAPACITY"
+    DEFENSE = "DEFENSE"
+    EVASION = "EVASION"
+
+
 class ResourceManagementMode(str, Enum):
     NONE = "NONE"
 
@@ -166,19 +182,30 @@ class SrsWeaponProfile:
 @dataclass(frozen=True, slots=True)
 class SrsPlayerCombatState:
     durability: int = 100
+    durability_capacity: int = 100
     defense: int = 0
+    evasion: int = 0
     movement_power: int = 4
     photon_torpedo_ammo: int = 6
     photon_torpedo_ammo_capacity: int = 6
+    photon_torpedo_power: int = 0
     energy: int = 6
     energy_capacity: int = 6
+    phaser_power: int = 0
     energy_recovery: int = 1
+    salvage: int = 0
 
     def __post_init__(self) -> None:
         if self.durability < 0:
             raise SrsModelError("player durability must be non-negative")
+        if self.durability_capacity <= 0:
+            raise SrsModelError("player durability_capacity must be positive")
+        if self.durability > self.durability_capacity:
+            raise SrsModelError("player durability must not exceed durability_capacity")
         if self.defense < 0:
             raise SrsModelError("player defense must be non-negative")
+        if self.evasion < 0:
+            raise SrsModelError("player evasion must be non-negative")
         if self.movement_power <= 0:
             raise SrsModelError("player movement_power must be positive")
         if self.photon_torpedo_ammo < 0:
@@ -187,14 +214,20 @@ class SrsPlayerCombatState:
             raise SrsModelError("player photon_torpedo_ammo_capacity must be positive")
         if self.photon_torpedo_ammo > self.photon_torpedo_ammo_capacity:
             raise SrsModelError("player photon_torpedo_ammo must not exceed capacity")
+        if self.photon_torpedo_power < 0:
+            raise SrsModelError("player photon_torpedo_power must be non-negative")
         if self.energy < 0:
             raise SrsModelError("player energy must be non-negative")
         if self.energy_capacity <= 0:
             raise SrsModelError("player energy_capacity must be positive")
         if self.energy > self.energy_capacity:
             raise SrsModelError("player energy must not exceed capacity")
+        if self.phaser_power < 0:
+            raise SrsModelError("player phaser_power must be non-negative")
         if self.energy_recovery < 0:
             raise SrsModelError("player energy_recovery must be non-negative")
+        if self.salvage < 0:
+            raise SrsModelError("player salvage must be non-negative")
 
 
 @dataclass(frozen=True, slots=True)
@@ -205,6 +238,7 @@ class SrsEnemyCombatState:
     durability: int
     attack_damage: int
     movement_power: int
+    drop_salvage: bool = False
 
     def __post_init__(self) -> None:
         if self.enemy_id == "":
@@ -259,6 +293,7 @@ def create_enemy_combat_state(
     enemy_id: str,
     tier: SrsEnemyTier,
     position: Position,
+    drop_salvage: bool = False,
 ) -> SrsEnemyCombatState:
     durability, attack_damage, movement_power = enemy_tier_defaults(tier)
     return SrsEnemyCombatState(
@@ -268,6 +303,7 @@ def create_enemy_combat_state(
         durability=durability,
         attack_damage=attack_damage,
         movement_power=movement_power,
+        drop_salvage=drop_salvage,
     )
 
 
@@ -414,6 +450,7 @@ class SrsGameState:
     known_state: SrsKnownState
     persistent_state: SrsPersistentState
     player_position: Position
+    player_state: SrsPlayerCombatState = field(default_factory=SrsPlayerCombatState)
     objects: Mapping[str, SrsObjectState] = field(default_factory=dict)
     combat_state: SrsCombatState | None = None
     srs_turn: int = 0
@@ -470,6 +507,8 @@ class SrsCommand:
     player_attack_action: SrsPlayerAttackAction | None = None
     player_attack_weapon: SrsWeaponType | None = None
     enemy_reactions: Mapping[str, SrsEnemyReaction] = field(default_factory=dict)
+    salvage_choice: SrsSalvageChoice | None = None
+    base_upgrade_choice: SrsBaseUpgrade | None = None
 
     def __post_init__(self) -> None:
         command_type = str(self.command_type)
@@ -497,6 +536,22 @@ class SrsCommand:
             )
         except ValueError as exc:
             raise SrsModelError("player_attack_weapon must be a SrsWeaponType value") from exc
+        try:
+            salvage_choice = (
+                None
+                if self.salvage_choice is None
+                else SrsSalvageChoice(self.salvage_choice)
+            )
+        except ValueError as exc:
+            raise SrsModelError("salvage_choice must be a SrsSalvageChoice value") from exc
+        try:
+            base_upgrade_choice = (
+                None
+                if self.base_upgrade_choice is None
+                else SrsBaseUpgrade(self.base_upgrade_choice)
+            )
+        except ValueError as exc:
+            raise SrsModelError("base_upgrade_choice must be a SrsBaseUpgrade value") from exc
         if player_attack_weapon is SrsWeaponType.ENEMY_WEAPON:
             raise SrsModelError("player_attack_weapon must be PHOTON_TORPEDO or PHASER")
         if not isinstance(self.enemy_reactions, Mapping):
@@ -525,6 +580,10 @@ class SrsCommand:
             or enemy_reactions
         ):
             raise SrsModelError("combat action fields require COMBAT_STEP")
+        if salvage_choice is not None and command_type not in {"INTERACT", "COMBAT_STEP"}:
+            raise SrsModelError("salvage_choice requires INTERACT or COMBAT_STEP")
+        if base_upgrade_choice is not None and command_type != "INTERACT":
+            raise SrsModelError("base_upgrade_choice requires INTERACT")
         if player_attack_action is SrsPlayerAttackAction.ATTACK and player_attack_weapon is None:
             raise SrsModelError("ATTACK requires a player_attack_weapon")
         if player_attack_action is not SrsPlayerAttackAction.ATTACK and player_attack_weapon is not None:
@@ -536,6 +595,8 @@ class SrsCommand:
         object.__setattr__(self, "player_attack_action", player_attack_action)
         object.__setattr__(self, "player_attack_weapon", player_attack_weapon)
         object.__setattr__(self, "enemy_reactions", enemy_reactions)
+        object.__setattr__(self, "salvage_choice", salvage_choice)
+        object.__setattr__(self, "base_upgrade_choice", base_upgrade_choice)
 
     def __hash__(self) -> int:
         return hash(
@@ -548,6 +609,8 @@ class SrsCommand:
                 self.player_attack_action,
                 self.player_attack_weapon,
                 tuple(sorted(self.enemy_reactions.items())),
+                self.salvage_choice,
+                self.base_upgrade_choice,
             )
         )
 

--- a/experiments/galactic_exodus/srs/run_fixture.py
+++ b/experiments/galactic_exodus/srs/run_fixture.py
@@ -17,6 +17,7 @@ from experiments.galactic_exodus.srs.engine import apply_srs_command, restore_sr
 from experiments.galactic_exodus.srs.generate import create_sector
 from experiments.galactic_exodus.srs.log import build_srs_log
 from experiments.galactic_exodus.srs.model import (
+    SrsBaseUpgrade,
     CostMode,
     Direction,
     ObservationMode,
@@ -33,6 +34,7 @@ from experiments.galactic_exodus.srs.model import (
     SrsCommand,
     SrsGameLog,
     SrsGameState,
+    SrsSalvageChoice,
     SrsPlayerCombatState,
     SrsPersistentState,
     SrsTerrainType,
@@ -55,6 +57,8 @@ _ALLOWED_COMMAND_KEYS = frozenset(
         "player_attack_action",
         "player_attack_weapon",
         "enemy_reactions",
+        "salvage_choice",
+        "base_upgrade_choice",
         "encounter_roll",
     }
 )
@@ -114,6 +118,8 @@ def command_from_json(data: Mapping[str, Any]) -> SrsCommand:
     player_attack_action: SrsPlayerAttackAction | None = None
     player_attack_weapon: SrsWeaponType | None = None
     enemy_reactions: Mapping[str, SrsEnemyReaction] = {}
+    salvage_choice: SrsSalvageChoice | None = None
+    base_upgrade_choice: SrsBaseUpgrade | None = None
 
     if "route" in data:
         route_value = data["route"]
@@ -150,6 +156,16 @@ def command_from_json(data: Mapping[str, Any]) -> SrsCommand:
                 enemy_reactions[enemy_id] = SrsEnemyReaction(reaction)
             except ValueError as exc:
                 raise SrsFixtureError(f"invalid enemy reaction: {reaction}") from exc
+    if "salvage_choice" in data:
+        try:
+            salvage_choice = SrsSalvageChoice(_required_str(data, "salvage_choice"))
+        except ValueError as exc:
+            raise SrsFixtureError(f"invalid salvage_choice: {data['salvage_choice']}") from exc
+    if "base_upgrade_choice" in data:
+        try:
+            base_upgrade_choice = SrsBaseUpgrade(_required_str(data, "base_upgrade_choice"))
+        except ValueError as exc:
+            raise SrsFixtureError(f"invalid base_upgrade_choice: {data['base_upgrade_choice']}") from exc
 
     try:
         return SrsCommand(
@@ -161,6 +177,8 @@ def command_from_json(data: Mapping[str, Any]) -> SrsCommand:
             player_attack_action=player_attack_action,
             player_attack_weapon=player_attack_weapon,
             enemy_reactions=enemy_reactions,
+            salvage_choice=salvage_choice,
+            base_upgrade_choice=base_upgrade_choice,
         )
     except ValueError as exc:
         raise SrsFixtureError(str(exc)) from exc
@@ -194,6 +212,7 @@ def state_from_fixture(data: Mapping[str, Any], *, contracts: SrsContracts) -> S
     fuel = _optional_int(initial, "fuel", default=state.fuel)
     max_fuel = _optional_int(initial, "max_fuel", default=state.max_fuel)
     srs_turn = _optional_int(initial, "srs_turn", default=state.srs_turn)
+    player_state = _player_state(initial.get("player"))
 
     persistent = initial.get("persistent")
     if persistent is not None:
@@ -207,9 +226,9 @@ def state_from_fixture(data: Mapping[str, Any], *, contracts: SrsContracts) -> S
 
     combat = initial.get("combat")
     if combat is not None:
-        state = replace(state, combat_state=_combat_state(state, combat))
+        state = replace(state, player_state=player_state, combat_state=_combat_state(state, combat, player_state=player_state))
 
-    return replace(state, fuel=fuel, max_fuel=max_fuel, srs_turn=srs_turn)
+    return replace(state, fuel=fuel, max_fuel=max_fuel, srs_turn=srs_turn, player_state=player_state)
 
 
 def run_fixture(path: Path, *, contracts: SrsContracts | None = None) -> SrsFixtureRunResult:
@@ -288,6 +307,16 @@ def fixture_result_to_jsonable(result: SrsFixtureRunResult) -> Mapping[str, Any]
             "fuel": final_state.fuel,
             "max_fuel": final_state.max_fuel,
             "player_position": _position_to_list(final_state.player_position),
+            "player_durability": final_state.player_state.durability,
+            "player_energy": final_state.player_state.energy,
+            "player_torpedo_ammo": final_state.player_state.photon_torpedo_ammo,
+            "player_salvage": final_state.player_state.salvage,
+            "player_energy_capacity": final_state.player_state.energy_capacity,
+            "player_torpedo_ammo_capacity": final_state.player_state.photon_torpedo_ammo_capacity,
+            "player_phaser_power": final_state.player_state.phaser_power,
+            "player_photon_torpedo_power": final_state.player_state.photon_torpedo_power,
+            "player_defense": final_state.player_state.defense,
+            "player_evasion": final_state.player_state.evasion,
             "consumed_object_ids": sorted(final_state.persistent_state.consumed_object_ids),
             "activated_object_ids": sorted(final_state.persistent_state.activated_object_ids),
             "discovered_count": len(final_state.known_state.discovered_cells),
@@ -426,7 +455,7 @@ def _apply_persistent_overrides(
     )
 
 
-def _combat_state(state: SrsGameState, data: Any) -> SrsCombatState:
+def _combat_state(state: SrsGameState, data: Any, *, player_state: SrsPlayerCombatState) -> SrsCombatState:
     if not isinstance(data, Mapping):
         raise SrsFixtureError("initial.combat must be an object")
 
@@ -437,22 +466,7 @@ def _combat_state(state: SrsGameState, data: Any) -> SrsCombatState:
         raise SrsFixtureError(f"invalid combat phase: {raw_phase}") from exc
 
     combat_turn = _optional_int(data, "combat_turn", default=0)
-    player_data = data.get("player", {})
-    if player_data is None:
-        player_data = {}
-    if not isinstance(player_data, Mapping):
-        raise SrsFixtureError("initial.combat.player must be an object")
-
-    player = SrsPlayerCombatState(
-        durability=_optional_int(player_data, "durability", default=100),
-        defense=_optional_int(player_data, "defense", default=0),
-        movement_power=_optional_int(player_data, "movement_power", default=4),
-        photon_torpedo_ammo=_optional_int(player_data, "photon_torpedo_ammo", default=6),
-        photon_torpedo_ammo_capacity=_optional_int(player_data, "photon_torpedo_ammo_capacity", default=6),
-        energy=_optional_int(player_data, "energy", default=6),
-        energy_capacity=_optional_int(player_data, "energy_capacity", default=6),
-        energy_recovery=_optional_int(player_data, "energy_recovery", default=1),
-    )
+    player = _player_state(data.get("player"), default=player_state)
 
     player_attack_target_id = data.get("player_attack_target_id")
     if player_attack_target_id is not None and not isinstance(player_attack_target_id, str):
@@ -494,10 +508,20 @@ def _combat_enemies(data: Mapping[str, Any]) -> Mapping[str, Any]:
             tier = SrsEnemyTier(raw_tier)
         except ValueError as exc:
             raise SrsFixtureError(f"invalid enemy tier: {raw_tier}") from exc
-        enemies[enemy_id] = create_enemy_combat_state(
+        enemy = create_enemy_combat_state(
             enemy_id=enemy_id,
             tier=tier,
             position=_position(raw_enemy.get("position"), field_name=f"initial.combat.enemies[{index}].position"),
+            drop_salvage=_optional_bool(raw_enemy, "drop_salvage", default=False),
+        )
+        durability = _optional_int(raw_enemy, "durability", default=enemy.durability)
+        attack_damage = _optional_int(raw_enemy, "attack_damage", default=enemy.attack_damage)
+        movement_power = _optional_int(raw_enemy, "movement_power", default=enemy.movement_power)
+        enemies[enemy_id] = replace(
+            enemy,
+            durability=durability,
+            attack_damage=attack_damage,
+            movement_power=movement_power,
         )
     return enemies
 
@@ -594,6 +618,16 @@ def _build_summary(
         "fuel": final_state.fuel,
         "max_fuel": final_state.max_fuel,
         "player_position": _position_to_list(final_state.player_position),
+        "player_durability": final_state.player_state.durability,
+        "player_energy": final_state.player_state.energy,
+        "player_torpedo_ammo": final_state.player_state.photon_torpedo_ammo,
+        "player_salvage": final_state.player_state.salvage,
+        "player_energy_capacity": final_state.player_state.energy_capacity,
+        "player_torpedo_ammo_capacity": final_state.player_state.photon_torpedo_ammo_capacity,
+        "player_phaser_power": final_state.player_state.phaser_power,
+        "player_photon_torpedo_power": final_state.player_state.photon_torpedo_power,
+        "player_defense": final_state.player_state.defense,
+        "player_evasion": final_state.player_state.evasion,
         "event_types": [event.event_type for event in log.events],
         "event_count": len(log.events),
         "consumed_object_ids": sorted(final_state.persistent_state.consumed_object_ids),
@@ -631,6 +665,16 @@ def _validate_expectations(expect: Any, result: SrsFixtureRunResult) -> None:
         ("srs_turn", final_state.srs_turn),
         ("fuel", final_state.fuel),
         ("player_position", _position_to_list(final_state.player_position)),
+        ("player_durability", final_state.player_state.durability),
+        ("player_energy", final_state.player_state.energy),
+        ("player_torpedo_ammo", final_state.player_state.photon_torpedo_ammo),
+        ("player_salvage", final_state.player_state.salvage),
+        ("player_energy_capacity", final_state.player_state.energy_capacity),
+        ("player_torpedo_ammo_capacity", final_state.player_state.photon_torpedo_ammo_capacity),
+        ("player_phaser_power", final_state.player_state.phaser_power),
+        ("player_photon_torpedo_power", final_state.player_state.photon_torpedo_power),
+        ("player_defense", final_state.player_state.defense),
+        ("player_evasion", final_state.player_state.evasion),
         ("event_types", event_types),
         ("consumed_object_ids", sorted(final_state.persistent_state.consumed_object_ids)),
         ("activated_object_ids", sorted(final_state.persistent_state.activated_object_ids)),
@@ -733,10 +777,46 @@ def _optional_int(mapping: Mapping[str, Any], field_name: str, *, default: int) 
     return value
 
 
+def _optional_bool(mapping: Mapping[str, Any], field_name: str, *, default: bool) -> bool:
+    if field_name not in mapping:
+        return default
+    value = mapping[field_name]
+    if not isinstance(value, bool):
+        raise SrsFixtureError(f"{field_name} must be a boolean")
+    return value
+
+
 def _optional_position(mapping: Mapping[str, Any], field_name: str) -> Position | None:
     if field_name not in mapping:
         return None
     return _position(mapping[field_name], field_name=field_name)
+
+
+def _player_state(data: Any, *, default: SrsPlayerCombatState | None = None) -> SrsPlayerCombatState:
+    defaults = SrsPlayerCombatState() if default is None else default
+    if data is None:
+        return defaults
+    if not isinstance(data, Mapping):
+        raise SrsFixtureError("player must be an object")
+    return SrsPlayerCombatState(
+        durability=_optional_int(data, "durability", default=defaults.durability),
+        durability_capacity=_optional_int(data, "durability_capacity", default=defaults.durability_capacity),
+        defense=_optional_int(data, "defense", default=defaults.defense),
+        evasion=_optional_int(data, "evasion", default=defaults.evasion),
+        movement_power=_optional_int(data, "movement_power", default=defaults.movement_power),
+        photon_torpedo_ammo=_optional_int(data, "photon_torpedo_ammo", default=defaults.photon_torpedo_ammo),
+        photon_torpedo_ammo_capacity=_optional_int(
+            data,
+            "photon_torpedo_ammo_capacity",
+            default=defaults.photon_torpedo_ammo_capacity,
+        ),
+        photon_torpedo_power=_optional_int(data, "photon_torpedo_power", default=defaults.photon_torpedo_power),
+        energy=_optional_int(data, "energy", default=defaults.energy),
+        energy_capacity=_optional_int(data, "energy_capacity", default=defaults.energy_capacity),
+        phaser_power=_optional_int(data, "phaser_power", default=defaults.phaser_power),
+        energy_recovery=_optional_int(data, "energy_recovery", default=defaults.energy_recovery),
+        salvage=_optional_int(data, "salvage", default=defaults.salvage),
+    )
 
 
 def _optional_str_list(mapping: Mapping[str, Any], field_name: str, *, default: list[str]) -> list[str]:

--- a/experiments/galactic_exodus/srs/test_engine_combat.py
+++ b/experiments/galactic_exodus/srs/test_engine_combat.py
@@ -17,10 +17,12 @@ from experiments.galactic_exodus.srs.log import COMBAT_TRANSITIONED, WARP_EXIT_R
 from experiments.galactic_exodus.srs.model import (
     Direction,
     Position,
+    SrsBaseUpgrade,
     SrsCombatPhase,
     SrsCombatState,
     SrsCommand,
     SrsEnemyTier,
+    SrsSalvageChoice,
     SrsTerrainType,
     SrsWeaponType,
     create_enemy_combat_state,
@@ -244,6 +246,74 @@ class SrsEngineCombatTests(unittest.TestCase):
                 "target_destroyed": True,
             },
         )
+
+    def test_destroyed_enemy_drop_adds_salvage_and_applies_choice(self) -> None:
+        state = replace(make_state(), player_position=Position(1, 4))
+        enemy = create_enemy_combat_state(
+            enemy_id="enemy-3",
+            tier=SrsEnemyTier.TIER3,
+            position=Position(3, 4),
+            drop_salvage=True,
+        )
+        enemy = replace(enemy, durability=3)
+        state = replace(
+            state,
+            player_state=replace(state.player_state, energy=3, salvage=1),
+            combat_state=SrsCombatState(
+                player=replace(state.player_state, energy=3, salvage=1),
+                enemies={"enemy-3": enemy},
+                phase=SrsCombatPhase.PLAYER_ATTACK,
+                player_attack_target_id="enemy-3",
+            ),
+        )
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(
+                command_type="COMBAT_STEP",
+                player_attack_action="ATTACK",
+                player_attack_weapon="PHOTON_TORPEDO",
+                salvage_choice=SrsSalvageChoice.RECOVER_ENERGY,
+            ),
+            contracts=self.contracts,
+        )
+
+        self.assertFalse(result.state.combat_state.enemy_presence)
+        self.assertEqual(result.state.player_state.energy, 6)
+        self.assertEqual(result.state.player_state.salvage, 3)
+        self.assertEqual(result.events[0].payload["player_action"]["salvage_reward"]["selected_salvage_choice"], "RECOVER_ENERGY")
+
+    def test_destroyed_enemy_without_drop_does_not_change_salvage(self) -> None:
+        state = replace(make_state(), player_position=Position(1, 4))
+        enemy = create_enemy_combat_state(
+            enemy_id="enemy-1",
+            tier=SrsEnemyTier.TIER1,
+            position=Position(3, 4),
+            drop_salvage=False,
+        )
+        state = replace(
+            state,
+            player_state=replace(state.player_state, salvage=2),
+            combat_state=SrsCombatState(
+                player=replace(state.player_state, salvage=2),
+                enemies={"enemy-1": enemy},
+                phase=SrsCombatPhase.PLAYER_ATTACK,
+                player_attack_target_id="enemy-1",
+            ),
+        )
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(
+                command_type="COMBAT_STEP",
+                player_attack_action="ATTACK",
+                player_attack_weapon="PHOTON_TORPEDO",
+            ),
+            contracts=self.contracts,
+        )
+
+        self.assertEqual(result.state.player_state.salvage, 2)
+        self.assertNotIn("salvage_reward", result.events[0].payload["player_action"])
 
     def test_player_attack_with_phaser_consumes_energy_and_applies_fixed_damage(self) -> None:
         state = replace(make_state(), player_position=Position(1, 4))

--- a/experiments/galactic_exodus/srs/test_engine_interaction.py
+++ b/experiments/galactic_exodus/srs/test_engine_interaction.py
@@ -5,7 +5,7 @@ from dataclasses import replace
 from pathlib import Path
 
 from experiments.galactic_exodus.srs.contracts import load_default_contracts
-from experiments.galactic_exodus.srs.engine import SrsInteractionError, apply_srs_command
+from experiments.galactic_exodus.srs.engine import apply_srs_command
 from experiments.galactic_exodus.srs.log import (
     INTERACT_ACCEPTED,
     INTERACT_REJECTED,
@@ -15,29 +15,15 @@ from experiments.galactic_exodus.srs.log import (
 from experiments.galactic_exodus.srs.model import (
     Direction,
     Position,
+    SrsBaseUpgrade,
     SrsCommand,
     SrsObjectType,
+    SrsSalvageChoice,
 )
 from experiments.galactic_exodus.srs.test_engine_movement import make_state, place_object
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
-
-
-def place_object_with_metadata(
-    object_type: SrsObjectType,
-    *,
-    position: Position,
-    object_id: str,
-    fuel_restore: int | None = None,
-):
-    state = place_object(make_state(fuel=2, max_fuel=9), position, object_type, object_id)
-    if fuel_restore is None:
-        return state
-    objects = dict(state.objects)
-    objects[object_id] = replace(objects[object_id], metadata={"fuel_restore": fuel_restore})
-    return replace(state, objects=objects)
-
 
 class SrsEngineInteractionTests(unittest.TestCase):
     @classmethod
@@ -45,12 +31,7 @@ class SrsEngineInteractionTests(unittest.TestCase):
         cls.contracts = load_default_contracts(REPO_ROOT)
 
     def test_resource_cache_refuels_and_consumes(self) -> None:
-        state = place_object_with_metadata(
-            SrsObjectType.RESOURCE_CACHE,
-            position=Position(4, 8),
-            object_id="resource-cache-1",
-            fuel_restore=5,
-        )
+        state = place_object(make_state(fuel=2, max_fuel=9), Position(4, 8), SrsObjectType.RESOURCE_CACHE, "resource-cache-1")
 
         result = apply_srs_command(
             state,
@@ -58,19 +39,14 @@ class SrsEngineInteractionTests(unittest.TestCase):
             contracts=self.contracts,
         )
 
-        self.assertEqual(result.state.fuel, 7)
+        self.assertEqual(result.state.fuel, 5)
         self.assertEqual(result.state.srs_turn, 1)
         self.assertTrue(result.state.objects["resource-cache-1"].consumed)
         self.assertIn("resource-cache-1", result.state.persistent_state.consumed_object_ids)
         self.assertEqual([event.event_type for event in result.events], [INTERACT_ACCEPTED, OBJECT_CONSUMED])
 
-    def test_resource_cache_reads_fuel_restore_metadata(self) -> None:
-        state = place_object_with_metadata(
-            SrsObjectType.RESOURCE_CACHE,
-            position=Position(4, 8),
-            object_id="resource-cache-1",
-            fuel_restore=3,
-        )
+    def test_resource_cache_uses_issue_fixed_restore_value(self) -> None:
+        state = place_object(make_state(fuel=2, max_fuel=9), Position(4, 8), SrsObjectType.RESOURCE_CACHE, "resource-cache-1")
 
         result = apply_srs_command(
             state,
@@ -81,13 +57,8 @@ class SrsEngineInteractionTests(unittest.TestCase):
         self.assertEqual(result.events[0].payload["fuel_delta"], 3)
         self.assertEqual(result.events[1].payload["fuel_restore"], 3)
 
-    def test_resource_cache_does_not_recompute_restore_from_cache_count(self) -> None:
-        state = place_object_with_metadata(
-            SrsObjectType.RESOURCE_CACHE,
-            position=Position(4, 8),
-            object_id="resource-cache-1",
-            fuel_restore=4,
-        )
+    def test_resource_cache_caps_at_max_fuel(self) -> None:
+        state = place_object(make_state(fuel=8, max_fuel=9), Position(4, 8), SrsObjectType.RESOURCE_CACHE, "resource-cache-1")
 
         result = apply_srs_command(
             state,
@@ -95,42 +66,11 @@ class SrsEngineInteractionTests(unittest.TestCase):
             contracts=self.contracts,
         )
 
-        self.assertEqual(result.state.fuel, 6)
-        self.assertEqual(result.events[1].payload["fuel_restore"], 4)
-
-    def test_resource_cache_missing_fuel_restore_raises(self) -> None:
-        state = place_object(make_state(fuel=2, max_fuel=9), Position(4, 8), SrsObjectType.RESOURCE_CACHE, "resource-cache-1")
-
-        with self.assertRaisesRegex(SrsInteractionError, "missing fuel_restore"):
-            apply_srs_command(
-                state,
-                SrsCommand(command_type="INTERACT", target_object_id="resource-cache-1"),
-                contracts=self.contracts,
-            )
-
-    def test_resource_cache_invalid_fuel_restore_raises(self) -> None:
-        state = place_object_with_metadata(
-            SrsObjectType.RESOURCE_CACHE,
-            position=Position(4, 8),
-            object_id="resource-cache-1",
-            fuel_restore=0,
-        )
-
-        with self.assertRaisesRegex(SrsInteractionError, "positive integer"):
-            apply_srs_command(
-                state,
-                SrsCommand(command_type="INTERACT", target_object_id="resource-cache-1"),
-                contracts=self.contracts,
-            )
+        self.assertEqual(result.state.fuel, 9)
+        self.assertEqual(result.events[0].payload["fuel_delta"], 1)
 
     def test_resource_cache_full_fuel_does_not_consume(self) -> None:
-        state = place_object_with_metadata(
-            SrsObjectType.RESOURCE_CACHE,
-            position=Position(4, 8),
-            object_id="resource-cache-1",
-            fuel_restore=5,
-        )
-        state = replace(state, fuel=9, max_fuel=9)
+        state = place_object(make_state(fuel=9, max_fuel=9), Position(4, 8), SrsObjectType.RESOURCE_CACHE, "resource-cache-1")
 
         result = apply_srs_command(
             state,
@@ -143,12 +83,7 @@ class SrsEngineInteractionTests(unittest.TestCase):
         self.assertEqual(result.state, state)
 
     def test_resource_cache_revisit_remains_consumed(self) -> None:
-        state = place_object_with_metadata(
-            SrsObjectType.RESOURCE_CACHE,
-            position=Position(4, 8),
-            object_id="resource-cache-1",
-            fuel_restore=5,
-        )
+        state = place_object(make_state(fuel=2, max_fuel=9), Position(4, 8), SrsObjectType.RESOURCE_CACHE, "resource-cache-1")
         consumed_state = replace(
             state,
             objects={
@@ -170,8 +105,17 @@ class SrsEngineInteractionTests(unittest.TestCase):
         self.assertEqual(result.events[0].payload["outcome"], "REJECTED_ALREADY_CONSUMED")
         self.assertEqual(result.state, consumed_state)
 
-    def test_station_refuels_to_max(self) -> None:
+    def test_station_recovers_all_resources_to_max(self) -> None:
         state = place_object(make_state(fuel=2, max_fuel=9), Position(4, 7), SrsObjectType.STATION, "station-1")
+        state = replace(
+            state,
+            player_state=replace(
+                state.player_state,
+                durability=91,
+                energy=2,
+                photon_torpedo_ammo=1,
+            ),
+        )
 
         result = apply_srs_command(
             state,
@@ -180,6 +124,9 @@ class SrsEngineInteractionTests(unittest.TestCase):
         )
 
         self.assertEqual(result.state.fuel, 9)
+        self.assertEqual(result.state.player_state.durability, 100)
+        self.assertEqual(result.state.player_state.energy, 6)
+        self.assertEqual(result.state.player_state.photon_torpedo_ammo, 6)
         self.assertEqual(result.state.srs_turn, 1)
         self.assertTrue(result.state.objects["station-1"].activated)
         self.assertIn("station-1", result.state.persistent_state.activated_object_ids)
@@ -221,19 +168,29 @@ class SrsEngineInteractionTests(unittest.TestCase):
         self.assertEqual(result.events[0].payload["outcome"], "REJECTED_WRONG_RANGE")
         self.assertEqual(result.state, state)
 
-    def test_station_full_fuel_rejected_no_effect(self) -> None:
+    def test_station_can_buy_base_upgrade(self) -> None:
         state = place_object(make_state(fuel=9, max_fuel=9), Position(4, 7), SrsObjectType.STATION, "station-1")
+        state = replace(
+            state,
+            player_state=replace(state.player_state, salvage=4, defense=1),
+        )
 
         result = apply_srs_command(
             state,
-            SrsCommand(command_type="INTERACT", target_object_id="station-1"),
+            SrsCommand(
+                command_type="INTERACT",
+                target_object_id="station-1",
+                base_upgrade_choice=SrsBaseUpgrade.DEFENSE,
+            ),
             contracts=self.contracts,
         )
 
-        self.assertEqual(result.events[0].payload["outcome"], "REJECTED_NO_EFFECT")
-        self.assertEqual(result.state, state)
+        self.assertEqual(result.events[0].payload["outcome"], "ACCEPTED")
+        self.assertEqual(result.state.player_state.salvage, 0)
+        self.assertEqual(result.state.player_state.defense, 2)
+        self.assertEqual(result.events[0].payload["selected_upgrade"], "DEFENSE")
 
-    def test_salvage_consumed_placeholder(self) -> None:
+    def test_salvage_store_only_adds_inventory(self) -> None:
         state = place_object(make_state(fuel=2, max_fuel=9), Position(4, 8), SrsObjectType.SALVAGE, "salvage-1")
 
         result = apply_srs_command(
@@ -246,9 +203,29 @@ class SrsEngineInteractionTests(unittest.TestCase):
         self.assertIn("salvage-1", result.state.persistent_state.consumed_object_ids)
         self.assertEqual(result.state.srs_turn, 1)
         self.assertEqual(result.events[0].payload["fuel_delta"], 0)
+        self.assertEqual(result.state.player_state.salvage, 1)
+        self.assertEqual(result.events[0].payload["selected_salvage_choice"], "STORE_ONLY")
+
+    def test_salvage_recover_energy_adds_inventory_and_caps_no_overflow(self) -> None:
+        state = place_object(make_state(fuel=2, max_fuel=9), Position(4, 8), SrsObjectType.SALVAGE, "salvage-1")
+        state = replace(state, player_state=replace(state.player_state, energy=5))
+
+        result = apply_srs_command(
+            state,
+            SrsCommand(
+                command_type="INTERACT",
+                target_object_id="salvage-1",
+                salvage_choice=SrsSalvageChoice.RECOVER_ENERGY,
+            ),
+            contracts=self.contracts,
+        )
+
+        self.assertEqual(result.state.player_state.energy, 6)
+        self.assertEqual(result.state.player_state.salvage, 1)
+        self.assertEqual(result.events[0].payload["energy_delta"], 1)
 
     def test_interact_rejected_does_not_consume_turn(self) -> None:
-        state = place_object(make_state(fuel=9, max_fuel=9), Position(4, 7), SrsObjectType.STATION, "station-1")
+        state = place_object(make_state(fuel=2, max_fuel=9), Position(4, 6), SrsObjectType.STATION, "station-1")
 
         result = apply_srs_command(
             state,
@@ -271,12 +248,7 @@ class SrsEngineInteractionTests(unittest.TestCase):
         self.assertEqual(result.state.srs_turn, 1)
 
     def test_interaction_log_fields(self) -> None:
-        state = place_object_with_metadata(
-            SrsObjectType.RESOURCE_CACHE,
-            position=Position(4, 8),
-            object_id="resource-cache-1",
-            fuel_restore=5,
-        )
+        state = place_object(make_state(fuel=2, max_fuel=9), Position(4, 8), SrsObjectType.RESOURCE_CACHE, "resource-cache-1")
 
         result = apply_srs_command(
             state,

--- a/experiments/galactic_exodus/srs/test_evaluate_policies.py
+++ b/experiments/galactic_exodus/srs/test_evaluate_policies.py
@@ -642,6 +642,19 @@ class ObjectGreedyPolicyTests(unittest.TestCase):
             SrsCommand(command_type="MOVE_ROUTE", route=(Direction.E,)),
         )
 
+    def test_station_is_candidate_for_upgrade_even_when_fuel_is_full(self) -> None:
+        state = place_object(make_state(fuel=9, max_fuel=9), Position(4, 7), SrsObjectType.STATION, "station-1")
+        state = replace(state, player_state=replace(state.player_state, salvage=4))
+        state = reveal_positions(state, [Position(4, 8), Position(4, 7)])
+
+        command = choose_object_greedy_command(
+            state,
+            contracts=self.contracts,
+            selected_exit_edge=Direction.N,
+        )
+
+        self.assertEqual(command, SrsCommand(command_type="INTERACT", target_object_id="station-1"))
+
     def test_known_unconsumed_salvage_is_a_candidate(self) -> None:
         state = place_object(make_state(fuel=2, max_fuel=9), Position(5, 8), SrsObjectType.SALVAGE, "salvage-1")
         state = reveal_positions(state, [Position(4, 8), Position(5, 8)])

--- a/experiments/galactic_exodus/srs/test_fixture_regression.py
+++ b/experiments/galactic_exodus/srs/test_fixture_regression.py
@@ -43,7 +43,7 @@ class SrsFixtureRegressionTests(unittest.TestCase):
         self.assertIn("INTERACT_ACCEPTED", event_types(result))
         self.assertIn("OBJECT_CONSUMED", event_types(result))
         self.assertEqual(primary_outcome(result), "ACCEPTED")
-        self.assertEqual(result.final_state.fuel, 7)
+        self.assertEqual(result.final_state.fuel, 5)
         self.assertIn("resource-cache-1", result.final_state.persistent_state.consumed_object_ids)
         self.assertTrue(result.final_state.objects["resource-cache-1"].consumed)
         self.assertIn(Position(2, 7), result.final_state.known_state.discovered_cells)
@@ -55,6 +55,9 @@ class SrsFixtureRegressionTests(unittest.TestCase):
         self.assertIn("STATION_ACTIVATED", event_types(result))
         self.assertEqual(primary_outcome(result), "ACCEPTED")
         self.assertEqual(result.final_state.fuel, result.final_state.max_fuel)
+        self.assertEqual(result.final_state.player_state.durability, 100)
+        self.assertEqual(result.final_state.player_state.energy, 6)
+        self.assertEqual(result.final_state.player_state.photon_torpedo_ammo, 6)
         self.assertIn("station-1", result.final_state.persistent_state.activated_object_ids)
         self.assertTrue(result.final_state.objects["station-1"].activated)
 
@@ -66,6 +69,19 @@ class SrsFixtureRegressionTests(unittest.TestCase):
         self.assertEqual(primary_outcome(result), "ACCEPTED")
         self.assertIn("salvage-1", result.final_state.persistent_state.consumed_object_ids)
         self.assertTrue(result.final_state.objects["salvage-1"].consumed)
+        self.assertEqual(result.final_state.player_state.salvage, 1)
+
+    def test_salvage_recover_durability(self) -> None:
+        result = run_named_fixture("salvage_recover_durability_9x9")
+
+        self.assertEqual(result.final_state.player_state.durability, 100)
+        self.assertEqual(result.final_state.player_state.salvage, 1)
+
+    def test_base_upgrade_defense(self) -> None:
+        result = run_named_fixture("base_upgrade_defense_9x9")
+
+        self.assertEqual(result.final_state.player_state.salvage, 0)
+        self.assertEqual(result.final_state.player_state.defense, 2)
 
     def test_warp_exit_s(self) -> None:
         result = run_named_fixture("warp_exit_s_9x9")
@@ -127,6 +143,21 @@ class SrsFixtureRegressionTests(unittest.TestCase):
 
         self.assertEqual(result.final_state.combat_state.player.energy, 5)
         self.assertEqual(result.final_state.combat_state.enemies["enemy-1"].durability, 4)
+
+    def test_combat_salvage_drop_tier3_energy(self) -> None:
+        result = run_named_fixture("combat_salvage_drop_tier3_energy_9x9")
+
+        self.assertEqual(result.final_state.player_state.energy, 6)
+        self.assertEqual(result.final_state.player_state.salvage, 3)
+        self.assertEqual(
+            result.log.events[0].payload["player_action"]["salvage_reward"]["selected_salvage_choice"],
+            "RECOVER_ENERGY",
+        )
+
+    def test_combat_salvage_no_drop_tier1(self) -> None:
+        result = run_named_fixture("combat_salvage_no_drop_tier1_9x9")
+
+        self.assertEqual(result.final_state.player_state.salvage, 2)
 
     def test_combat_enemy_defend(self) -> None:
         result = run_named_fixture("combat_enemy_defend_9x9")

--- a/experiments/galactic_exodus/srs/test_fixtures.py
+++ b/experiments/galactic_exodus/srs/test_fixtures.py
@@ -26,6 +26,8 @@ REQUIRED_FIXTURES = {
     "resource_cache_single_9x9.json",
     "station_refuel_9x9.json",
     "salvage_placeholder_9x9.json",
+    "salvage_recover_durability_9x9.json",
+    "base_upgrade_defense_9x9.json",
     "nebula_observation_3x3_9x9.json",
     "warp_exit_s_9x9.json",
     "warp_exit_rejected_no_flag_9x9.json",
@@ -41,6 +43,8 @@ REQUIRED_FIXTURES = {
     "combat_enemy_movement_tiebreak_9x9.json",
     "combat_torpedo_destroy_no_counterattack_9x9.json",
     "combat_phaser_attack_damage_9x9.json",
+    "combat_salvage_drop_tier3_energy_9x9.json",
+    "combat_salvage_no_drop_tier1_9x9.json",
     "combat_enemy_defend_9x9.json",
     "combat_enemy_counterattack_9x9.json",
     "combat_enemy_counterattack_fallback_energy_9x9.json",
@@ -98,7 +102,7 @@ class SrsFixtureTests(unittest.TestCase):
         payload = fixture_result_to_jsonable(result)
 
         self.assertEqual(payload["fixture_id"], "resource_cache_single_9x9")
-        self.assertEqual(payload["final_state"]["fuel"], 7)
+        self.assertEqual(payload["final_state"]["fuel"], 5)
         json.dumps(payload)
 
     def test_fixture_runner_validates_render_not_contains(self) -> None:

--- a/experiments/galactic_exodus/srs/test_generate.py
+++ b/experiments/galactic_exodus/srs/test_generate.py
@@ -235,16 +235,16 @@ class SrsGenerateTests(unittest.TestCase):
         )
 
         resource_cache = state.objects["resource-cache-1"]
-        self.assertEqual(resource_cache.metadata["fuel_restore"], 5)
+        self.assertEqual(resource_cache.metadata["fuel_restore"], 3)
 
-    def test_resource_cache_one_cache_restore_is_5(self) -> None:
-        self.assertEqual(resource_cache_restore_values(1), (5,))
+    def test_resource_cache_one_cache_restore_is_3(self) -> None:
+        self.assertEqual(resource_cache_restore_values(1), (3,))
 
-    def test_resource_cache_two_cache_restore_split_is_3_2(self) -> None:
-        self.assertEqual(resource_cache_restore_values(2), (3, 2))
+    def test_resource_cache_two_cache_restore_is_fixed_3(self) -> None:
+        self.assertEqual(resource_cache_restore_values(2), (3, 3))
 
-    def test_resource_cache_three_cache_restore_split_is_2_2_1(self) -> None:
-        self.assertEqual(resource_cache_restore_values(3), (2, 2, 1))
+    def test_resource_cache_three_cache_restore_is_fixed_3(self) -> None:
+        self.assertEqual(resource_cache_restore_values(3), (3, 3, 3))
 
     def test_resource_cache_restore_metadata_is_positive_int(self) -> None:
         state = create_sector(
@@ -259,9 +259,8 @@ class SrsGenerateTests(unittest.TestCase):
     def test_resource_cache_restore_values_zero_caches_returns_empty(self) -> None:
         self.assertEqual(resource_cache_restore_values(0), ())
 
-    def test_resource_cache_restore_values_rejects_more_than_three(self) -> None:
-        with self.assertRaisesRegex(SrsGenerationError, "at most 3"):
-            resource_cache_restore_values(4)
+    def test_resource_cache_restore_values_accepts_more_than_three(self) -> None:
+        self.assertEqual(resource_cache_restore_values(4), (3, 3, 3, 3))
 
     def test_rift_has_one_salvage(self) -> None:
         state = create_sector(

--- a/experiments/galactic_exodus/srs/test_model.py
+++ b/experiments/galactic_exodus/srs/test_model.py
@@ -9,6 +9,7 @@ from experiments.galactic_exodus.srs.model import (
     Position,
     SrsCombatPhase,
     SrsCombatState,
+    SrsBaseUpgrade,
     SrsEnemyTier,
     SrsEnemyReaction,
     SectorDescriptor,
@@ -24,6 +25,7 @@ from experiments.galactic_exodus.srs.model import (
     SrsPersistentState,
     SrsPlayerAttackAction,
     SrsTerrainType,
+    SrsSalvageChoice,
     SrsWeaponType,
     create_enemy_combat_state,
     default_weapon_profiles,
@@ -197,13 +199,18 @@ class SrsModelTests(unittest.TestCase):
         player = SrsPlayerCombatState()
 
         self.assertEqual(player.durability, 100)
+        self.assertEqual(player.durability_capacity, 100)
         self.assertEqual(player.defense, 0)
+        self.assertEqual(player.evasion, 0)
         self.assertEqual(player.movement_power, 4)
         self.assertEqual(player.photon_torpedo_ammo, 6)
         self.assertEqual(player.photon_torpedo_ammo_capacity, 6)
+        self.assertEqual(player.photon_torpedo_power, 0)
         self.assertEqual(player.energy, 6)
         self.assertEqual(player.energy_capacity, 6)
+        self.assertEqual(player.phaser_power, 0)
         self.assertEqual(player.energy_recovery, 1)
+        self.assertEqual(player.salvage, 0)
 
     def test_weapon_profiles_use_issue_1196_fixed_values(self) -> None:
         weapons = default_weapon_profiles()
@@ -354,6 +361,17 @@ class SrsModelTests(unittest.TestCase):
         self.assertEqual(command.player_attack_weapon, SrsWeaponType.PHOTON_TORPEDO)
         self.assertEqual(command.enemy_reactions["enemy-1"], SrsEnemyReaction.COUNTERATTACK)
 
+    def test_srs_command_normalizes_reward_choice_fields(self) -> None:
+        command = SrsCommand(
+            command_type="INTERACT",
+            target_object_id="salvage-1",
+            salvage_choice="RECOVER_ENERGY",
+            base_upgrade_choice="ENERGY_CAPACITY",
+        )
+
+        self.assertEqual(command.salvage_choice, SrsSalvageChoice.RECOVER_ENERGY)
+        self.assertEqual(command.base_upgrade_choice, SrsBaseUpgrade.ENERGY_CAPACITY)
+
     def test_srs_command_rejects_attack_without_weapon(self) -> None:
         with self.assertRaisesRegex(SrsModelError, "ATTACK requires a player_attack_weapon"):
             SrsCommand(command_type="COMBAT_STEP", player_attack_action="ATTACK")
@@ -361,6 +379,14 @@ class SrsModelTests(unittest.TestCase):
     def test_srs_command_rejects_combat_fields_for_non_combat_command(self) -> None:
         with self.assertRaisesRegex(SrsModelError, "combat action fields require COMBAT_STEP"):
             SrsCommand(command_type="MOVE_TO", target=Position(1, 1), player_attack_action="SKIP")
+
+    def test_srs_command_rejects_salvage_choice_for_non_reward_command(self) -> None:
+        with self.assertRaisesRegex(SrsModelError, "salvage_choice requires INTERACT or COMBAT_STEP"):
+            SrsCommand(command_type="MOVE_TO", target=Position(1, 1), salvage_choice="STORE_ONLY")
+
+    def test_srs_command_rejects_base_upgrade_choice_for_non_interact(self) -> None:
+        with self.assertRaisesRegex(SrsModelError, "base_upgrade_choice requires INTERACT"):
+            SrsCommand(command_type="COMBAT_STEP", base_upgrade_choice="DEFENSE")
 
     def test_player_combat_state_allows_zero_durability(self) -> None:
         player = SrsPlayerCombatState(durability=0)

--- a/experiments/galactic_exodus/srs/test_run_manual_eval.py
+++ b/experiments/galactic_exodus/srs/test_run_manual_eval.py
@@ -82,7 +82,7 @@ class SrsRunManualEvalTests(unittest.TestCase):
         self.assertEqual(
             lines[-2:],
             [
-                "turn 1: INTERACT_ACCEPTED RESOURCE_CACHE resource-cache-1 outcome=ACCEPTED fuel 2->7 restore=5 consumed=true",
+                "turn 1: INTERACT_ACCEPTED RESOURCE_CACHE resource-cache-1 outcome=ACCEPTED fuel 2->5 restore=3 consumed=true",
                 "turn 1: OBJECT_CONSUMED RESOURCE_CACHE resource-cache-1",
             ],
         )


### PR DESCRIPTION
## 概要

Closes #1203

- Issue: #1203 `#1178-19 SRS reward flow: RESOURCE_CACHE / SALVAGE / BASEを実装する`
- URL: https://github.com/kkismd/tbx/issues/1203

## Intended Scope

- SRS 内の `RESOURCE_CACHE` / `SALVAGE` / `BASE` reward flow を issue 本文の固定値・固定ルールで実装
- deterministic fixture で resource cache pickup、salvage choice、enemy salvage drop presence/absence、base upgrade choice を確認
- 既存の SRS policy / fixture / reference validation を新しい固定値へ追従

## Explicit Non-Scope

- encounter composition random selection
- combat hit probability
- advanced upgrade candidate randomization
- defense / evasion の未定義な戦闘意味づけ拡張

## Fixed Values / Fixed Rules

### RESOURCE_CACHE

- fuel recovery は固定 `+3`
- `fuel_capacity` で cap
- fuel recovery only

### SALVAGE

- map salvage の `salvage_value = 1`
- immediate effect choice:
  - durability `+8`
  - energy `+2`
  - photon_torpedo_ammo `+1`
  - store salvage only
- enemy drop salvage presence は fixture で固定
- enemy drop salvage_value:
  - tier1 `1`
  - tier2 `1`
  - tier3 `2`
  - tier4 `3`
- enemy drop immediate recovery:
  - tier1/tier2: durability `+8`, energy `+2`, photon_torpedo_ammo `+1`
  - tier3: durability `+12`, energy `+3`, photon_torpedo_ammo `+1`
  - tier4: durability `+16`, energy `+4`, photon_torpedo_ammo `+2`
- pickup 時は choice を適用したうえで salvage inventory を加算
- recovery target が full の場合も overflow / conversion bonus なしで salvage inventory のみ加算

### BASE

- STATION interaction を BASE reward flow として拡張
- durability / energy / photon_torpedo_ammo / fuel を max まで全回復
- upgrade は salvage cost の範囲で 1 interaction あたり 1 件購入
- no fixed count limit
- fixed costs:
  - `phaser_power +1`: salvage `4`
  - `photon_torpedo_power +1`: salvage `5`
  - `energy_capacity +1`: salvage `3`
  - `photon_torpedo_ammo_capacity +1`: salvage `3`
  - `defense +1`: salvage `4`
  - `evasion +1`: salvage `4`

## Changed Files

- `experiments/galactic_exodus/srs/model.py`
- `experiments/galactic_exodus/srs/engine.py`
- `experiments/galactic_exodus/srs/run_fixture.py`
- `experiments/galactic_exodus/srs/generate.py`
- `experiments/galactic_exodus/srs/evaluate_policies.py`
- `experiments/galactic_exodus/srs/fixtures/resource_cache_single_9x9.json`
- `experiments/galactic_exodus/srs/fixtures/station_refuel_9x9.json`
- `experiments/galactic_exodus/srs/fixtures/salvage_placeholder_9x9.json`
- `experiments/galactic_exodus/srs/fixtures/resource_minimal_9x9.json`
- `experiments/galactic_exodus/srs/fixtures/phase2_reference.json`
- `experiments/galactic_exodus/srs/fixtures/salvage_recover_durability_9x9.json`
- `experiments/galactic_exodus/srs/fixtures/base_upgrade_defense_9x9.json`
- `experiments/galactic_exodus/srs/fixtures/combat_salvage_drop_tier3_energy_9x9.json`
- `experiments/galactic_exodus/srs/fixtures/combat_salvage_no_drop_tier1_9x9.json`
- `experiments/galactic_exodus/srs/test_model.py`
- `experiments/galactic_exodus/srs/test_generate.py`
- `experiments/galactic_exodus/srs/test_engine_interaction.py`
- `experiments/galactic_exodus/srs/test_engine_combat.py`
- `experiments/galactic_exodus/srs/test_evaluate_policies.py`
- `experiments/galactic_exodus/srs/test_fixtures.py`
- `experiments/galactic_exodus/srs/test_fixture_regression.py`
- `experiments/galactic_exodus/srs/test_run_manual_eval.py`

## Verification

- `python3 -m unittest discover -s experiments/galactic_exodus/srs -p 'test_*.py'`
  - `Ran 460 tests in 1.508s`
  - `OK`
