### PR TITLE
SRS座標系を1始まりへ統一

### DIFF
--- a/experiments/galactic_exodus/srs/encounter.py
+++ b/experiments/galactic_exodus/srs/encounter.py
@@ -351,8 +351,8 @@ def is_base_docked(state: SrsGameState) -> bool:
 
 def _warp_point_positions(state: SrsGameState) -> tuple[Position, ...]:
     positions: list[Position] = []
-    for y, row in enumerate(state.actual_map.cells):
-        for x, cell in enumerate(row):
+    for y, row in enumerate(state.actual_map.cells, start=1):
+        for x, cell in enumerate(row, start=1):
             if not cell.warp_flags:
                 continue
             if cell.terrain in {SrsTerrainType.ASTEROID, SrsTerrainType.RIFT_BARRIER}:

--- a/experiments/galactic_exodus/srs/engine.py
+++ b/experiments/galactic_exodus/srs/engine.py
@@ -157,7 +157,7 @@ def observation_area(
         Position(x, y)
         for y in range(center.y - radius, center.y + radius + 1)
         for x in range(center.x - radius, center.x + radius + 1)
-        if 0 <= x < actual_map.width and 0 <= y < actual_map.height
+        if 1 <= x <= actual_map.width and 1 <= y <= actual_map.height
     }
     return frozenset(positions)
 
@@ -547,8 +547,8 @@ def _validated_observation_size(value: object, *, field_name: str) -> int:
 
 
 def _iter_positions(actual_map: SrsActualMap):
-    for y, row in enumerate(actual_map.cells):
-        for x, _ in enumerate(row):
+    for y, row in enumerate(actual_map.cells, start=1):
+        for x, _ in enumerate(row, start=1):
             yield Position(x, y)
 
 

--- a/experiments/galactic_exodus/srs/evaluate_policies.py
+++ b/experiments/galactic_exodus/srs/evaluate_policies.py
@@ -1471,7 +1471,8 @@ def _replace_player_cell_terrain(
     rows = [list(row) for row in state.actual_map.cells]
     position = state.player_position
     current = state.actual_map.cell_at(position)
-    rows[position.y][position.x] = SrsCell(
+    row_idx, col_idx = state.actual_map.indices_for(position)
+    rows[row_idx][col_idx] = SrsCell(
         terrain=terrain,
         object_id=current.object_id,
         actor_id=current.actor_id,

--- a/experiments/galactic_exodus/srs/fixtures/base_minimal_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/base_minimal_9x9.json
@@ -9,12 +9,23 @@
   "expected": {
     "width": 9,
     "height": 9,
-    "player_position": [4, 8],
+    "player_position": [
+      5,
+      9
+    ],
     "warp_flags": {
-      "4,0": ["N"],
-      "8,4": ["E"],
-      "4,8": ["S"],
-      "0,4": ["W"]
+      "5,1": [
+        "N"
+      ],
+      "1,5": [
+        "W"
+      ],
+      "9,5": [
+        "E"
+      ],
+      "5,9": [
+        "S"
+      ]
     },
     "terrain_counts": {
       "FLOOR": 81

--- a/experiments/galactic_exodus/srs/fixtures/base_upgrade_defense_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/base_upgrade_defense_9x9.json
@@ -9,7 +9,10 @@
     "blocked_edges": []
   },
   "initial": {
-    "player_position": [3, 1],
+    "player_position": [
+      4,
+      2
+    ],
     "fuel": 1,
     "max_fuel": 9,
     "player": {
@@ -38,9 +41,17 @@
     "player_torpedo_ammo": 6,
     "player_salvage": 0,
     "player_defense": 2,
-    "player_position": [3, 1],
-    "event_types": ["INTERACT_ACCEPTED", "STATION_ACTIVATED"],
-    "activated_object_ids": ["station-1"],
+    "player_position": [
+      4,
+      2
+    ],
+    "event_types": [
+      "INTERACT_ACCEPTED",
+      "STATION_ACTIVATED"
+    ],
+    "activated_object_ids": [
+      "station-1"
+    ],
     "outcome": "ACCEPTED"
   }
 }

--- a/experiments/galactic_exodus/srs/fixtures/combat_attack_blocked_los_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/combat_attack_blocked_los_9x9.json
@@ -10,23 +10,45 @@
   },
   "initial": {
     "cell_overrides": [
-      {"position": [2, 4], "terrain": "ASTEROID"}
+      {
+        "position": [
+          3,
+          5
+        ],
+        "terrain": "ASTEROID"
+      }
     ],
-    "reveal": {"mode": "FULL"},
-    "player_position": [1, 4],
+    "reveal": {
+      "mode": "FULL"
+    },
+    "player_position": [
+      2,
+      5
+    ],
     "combat": {
       "phase": "PLAYER_MOVEMENT",
       "enemies": [
-        {"enemy_id": "enemy-1", "tier": "TIER1", "position": [3, 4]}
+        {
+          "enemy_id": "enemy-1",
+          "tier": "TIER1",
+          "position": [
+            4,
+            5
+          ]
+        }
       ],
       "player_attack_target_id": "enemy-1"
     }
   },
   "commands": [
-    {"command_type": "COMBAT_STEP"}
+    {
+      "command_type": "COMBAT_STEP"
+    }
   ],
   "expect": {
-    "event_types": ["COMBAT_TRANSITIONED"],
+    "event_types": [
+      "COMBAT_TRANSITIONED"
+    ],
     "combat_phase": "ENEMY_ACTION",
     "combat_turn": 0,
     "enemy_presence": true,

--- a/experiments/galactic_exodus/srs/fixtures/combat_attack_clear_los_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/combat_attack_clear_los_9x9.json
@@ -9,21 +9,37 @@
     "blocked_edges": []
   },
   "initial": {
-    "reveal": {"mode": "FULL"},
-    "player_position": [1, 4],
+    "reveal": {
+      "mode": "FULL"
+    },
+    "player_position": [
+      2,
+      5
+    ],
     "combat": {
       "phase": "PLAYER_MOVEMENT",
       "enemies": [
-        {"enemy_id": "enemy-1", "tier": "TIER1", "position": [3, 4]}
+        {
+          "enemy_id": "enemy-1",
+          "tier": "TIER1",
+          "position": [
+            4,
+            5
+          ]
+        }
       ],
       "player_attack_target_id": "enemy-1"
     }
   },
   "commands": [
-    {"command_type": "COMBAT_STEP"}
+    {
+      "command_type": "COMBAT_STEP"
+    }
   ],
   "expect": {
-    "event_types": ["COMBAT_TRANSITIONED"],
+    "event_types": [
+      "COMBAT_TRANSITIONED"
+    ],
     "combat_phase": "PLAYER_ATTACK",
     "combat_turn": 0,
     "enemy_presence": true,

--- a/experiments/galactic_exodus/srs/fixtures/combat_attack_out_of_range_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/combat_attack_out_of_range_9x9.json
@@ -9,21 +9,37 @@
     "blocked_edges": []
   },
   "initial": {
-    "reveal": {"mode": "FULL"},
-    "player_position": [1, 4],
+    "reveal": {
+      "mode": "FULL"
+    },
+    "player_position": [
+      2,
+      5
+    ],
     "combat": {
       "phase": "PLAYER_MOVEMENT",
       "enemies": [
-        {"enemy_id": "enemy-1", "tier": "TIER1", "position": [5, 4]}
+        {
+          "enemy_id": "enemy-1",
+          "tier": "TIER1",
+          "position": [
+            6,
+            5
+          ]
+        }
       ],
       "player_attack_target_id": "enemy-1"
     }
   },
   "commands": [
-    {"command_type": "COMBAT_STEP"}
+    {
+      "command_type": "COMBAT_STEP"
+    }
   ],
   "expect": {
-    "event_types": ["COMBAT_TRANSITIONED"],
+    "event_types": [
+      "COMBAT_TRANSITIONED"
+    ],
     "combat_phase": "ENEMY_ACTION",
     "combat_turn": 0,
     "enemy_presence": true,

--- a/experiments/galactic_exodus/srs/fixtures/combat_core_state_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/combat_core_state_9x9.json
@@ -9,23 +9,41 @@
     "blocked_edges": []
   },
   "initial": {
-    "reveal": {"mode": "LOCAL_MOVEMENT"},
+    "reveal": {
+      "mode": "LOCAL_MOVEMENT"
+    },
     "combat": {
       "phase": "PLAYER_MOVEMENT",
       "player": {
         "energy": 5
       },
       "enemies": [
-        {"enemy_id": "enemy-1", "tier": "TIER1", "position": [4, 8]}
+        {
+          "enemy_id": "enemy-1",
+          "tier": "TIER1",
+          "position": [
+            5,
+            9
+          ]
+        }
       ],
       "player_attack_target_id": "enemy-1"
     }
   },
   "commands": [
-    {"command_type": "WARP_EXIT", "exit_direction": "S"},
-    {"command_type": "COMBAT_STEP"},
-    {"command_type": "COMBAT_STEP"},
-    {"command_type": "COMBAT_STEP"}
+    {
+      "command_type": "WARP_EXIT",
+      "exit_direction": "S"
+    },
+    {
+      "command_type": "COMBAT_STEP"
+    },
+    {
+      "command_type": "COMBAT_STEP"
+    },
+    {
+      "command_type": "COMBAT_STEP"
+    }
   ],
   "expect": {
     "event_types": [

--- a/experiments/galactic_exodus/srs/fixtures/combat_encounter_spawn_cap_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/combat_encounter_spawn_cap_9x9.json
@@ -6,16 +6,28 @@
     "sector_type": "RIFT",
     "sector_seed": 9202,
     "entry_edge": "S",
-    "blocked_edges": ["N", "W"]
+    "blocked_edges": [
+      "N",
+      "W"
+    ]
   },
   "initial": {
-    "reveal": {"mode": "FULL"},
-    "player_position": [4, 4],
+    "reveal": {
+      "mode": "FULL"
+    },
+    "player_position": [
+      5,
+      5
+    ],
     "combat": {
       "phase": "PLAYER_MOVEMENT",
       "encounter": {
         "danger_score": 4,
-        "composition": ["TIER2", "TIER1", "TIER1"]
+        "composition": [
+          "TIER2",
+          "TIER1",
+          "TIER1"
+        ]
       }
     }
   },
@@ -29,8 +41,14 @@
     "combat_player_energy": 6,
     "combat_player_torpedo_ammo": 6,
     "combat_enemy_positions": {
-      "enemy-1": [8, 4],
-      "enemy-2": [4, 8]
+      "enemy-1": [
+        9,
+        5
+      ],
+      "enemy-2": [
+        5,
+        9
+      ]
     },
     "combat_enemy_durabilities": {
       "enemy-1": 3,

--- a/experiments/galactic_exodus/srs/fixtures/combat_encounter_wait_base_docked_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/combat_encounter_wait_base_docked_9x9.json
@@ -9,8 +9,13 @@
     "blocked_edges": []
   },
   "initial": {
-    "reveal": {"mode": "FULL"},
-    "player_position": [3, 1]
+    "reveal": {
+      "mode": "FULL"
+    },
+    "player_position": [
+      4,
+      2
+    ]
   },
   "commands": [
     {
@@ -19,7 +24,9 @@
   ],
   "expect": {
     "srs_turn": 1,
-    "event_types": ["WAIT_ACCEPTED"],
+    "event_types": [
+      "WAIT_ACCEPTED"
+    ],
     "enemy_presence": false,
     "outcome": "ACCEPTED"
   }

--- a/experiments/galactic_exodus/srs/fixtures/combat_encounter_wait_nebula_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/combat_encounter_wait_nebula_9x9.json
@@ -9,11 +9,19 @@
     "blocked_edges": []
   },
   "initial": {
-    "reveal": {"mode": "FULL"},
-    "player_position": [4, 7],
+    "reveal": {
+      "mode": "FULL"
+    },
+    "player_position": [
+      5,
+      8
+    ],
     "cell_overrides": [
       {
-        "position": [4, 7],
+        "position": [
+          5,
+          8
+        ],
         "terrain": "NEBULA"
       }
     ],
@@ -27,18 +35,26 @@
       "encounter_roll": {
         "roll_result": "success",
         "danger_score": 2,
-        "composition": ["TIER2"]
+        "composition": [
+          "TIER2"
+        ]
       }
     }
   ],
   "expect": {
     "srs_turn": 1,
-    "event_types": ["WAIT_ACCEPTED", "ENCOUNTER_ROLLED"],
+    "event_types": [
+      "WAIT_ACCEPTED",
+      "ENCOUNTER_ROLLED"
+    ],
     "combat_phase": "PLAYER_MOVEMENT",
     "combat_turn": 0,
     "enemy_presence": true,
     "combat_enemy_positions": {
-      "enemy-1": [4, 0]
+      "enemy-1": [
+        5,
+        1
+      ]
     },
     "combat_enemy_durabilities": {
       "enemy-1": 5

--- a/experiments/galactic_exodus/srs/fixtures/combat_enemy_counterattack_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/combat_enemy_counterattack_9x9.json
@@ -9,12 +9,24 @@
     "blocked_edges": []
   },
   "initial": {
-    "reveal": {"mode": "FULL"},
-    "player_position": [1, 4],
+    "reveal": {
+      "mode": "FULL"
+    },
+    "player_position": [
+      2,
+      5
+    ],
     "combat": {
       "phase": "ENEMY_ACTION",
       "enemies": [
-        {"enemy_id": "enemy-1", "tier": "TIER1", "position": [2, 4]}
+        {
+          "enemy_id": "enemy-1",
+          "tier": "TIER1",
+          "position": [
+            3,
+            5
+          ]
+        }
       ]
     }
   },
@@ -27,7 +39,9 @@
     }
   ],
   "expect": {
-    "event_types": ["COMBAT_TRANSITIONED"],
+    "event_types": [
+      "COMBAT_TRANSITIONED"
+    ],
     "combat_phase": "PLAYER_MOVEMENT",
     "combat_turn": 1,
     "enemy_presence": true,
@@ -35,7 +49,10 @@
     "combat_player_energy": 6,
     "combat_player_torpedo_ammo": 6,
     "combat_enemy_positions": {
-      "enemy-1": [2, 4]
+      "enemy-1": [
+        3,
+        5
+      ]
     },
     "combat_enemy_durabilities": {
       "enemy-1": 2
@@ -43,11 +60,20 @@
     "enemy_actions": [
       {
         "enemy_id": "enemy-1",
-        "start_position": [2, 4],
-        "target_attackable_position": [2, 4],
+        "start_position": [
+          3,
+          5
+        ],
+        "target_attackable_position": [
+          3,
+          5
+        ],
         "planned_path": [],
         "moved_path": [],
-        "final_position": [2, 4],
+        "final_position": [
+          3,
+          5
+        ],
         "movement_power": 3,
         "movement_cost": 0,
         "attacked_player": true,

--- a/experiments/galactic_exodus/srs/fixtures/combat_enemy_counterattack_fallback_energy_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/combat_enemy_counterattack_fallback_energy_9x9.json
@@ -9,15 +9,27 @@
     "blocked_edges": []
   },
   "initial": {
-    "reveal": {"mode": "FULL"},
-    "player_position": [1, 4],
+    "reveal": {
+      "mode": "FULL"
+    },
+    "player_position": [
+      2,
+      5
+    ],
     "combat": {
       "phase": "ENEMY_ACTION",
       "player": {
         "energy": 0
       },
       "enemies": [
-        {"enemy_id": "enemy-1", "tier": "TIER1", "position": [2, 4]}
+        {
+          "enemy_id": "enemy-1",
+          "tier": "TIER1",
+          "position": [
+            3,
+            5
+          ]
+        }
       ]
     }
   },
@@ -30,7 +42,9 @@
     }
   ],
   "expect": {
-    "event_types": ["COMBAT_TRANSITIONED"],
+    "event_types": [
+      "COMBAT_TRANSITIONED"
+    ],
     "combat_phase": "PLAYER_MOVEMENT",
     "combat_turn": 1,
     "enemy_presence": true,
@@ -38,7 +52,10 @@
     "combat_player_energy": 1,
     "combat_player_torpedo_ammo": 6,
     "combat_enemy_positions": {
-      "enemy-1": [2, 4]
+      "enemy-1": [
+        3,
+        5
+      ]
     },
     "combat_enemy_durabilities": {
       "enemy-1": 3
@@ -46,11 +63,20 @@
     "enemy_actions": [
       {
         "enemy_id": "enemy-1",
-        "start_position": [2, 4],
-        "target_attackable_position": [2, 4],
+        "start_position": [
+          3,
+          5
+        ],
+        "target_attackable_position": [
+          3,
+          5
+        ],
         "planned_path": [],
         "moved_path": [],
-        "final_position": [2, 4],
+        "final_position": [
+          3,
+          5
+        ],
         "movement_power": 3,
         "movement_cost": 0,
         "attacked_player": true,

--- a/experiments/galactic_exodus/srs/fixtures/combat_enemy_defend_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/combat_enemy_defend_9x9.json
@@ -9,12 +9,24 @@
     "blocked_edges": []
   },
   "initial": {
-    "reveal": {"mode": "FULL"},
-    "player_position": [4, 4],
+    "reveal": {
+      "mode": "FULL"
+    },
+    "player_position": [
+      5,
+      5
+    ],
     "combat": {
       "phase": "ENEMY_ACTION",
       "enemies": [
-        {"enemy_id": "enemy-1", "tier": "TIER2", "position": [4, 5]}
+        {
+          "enemy_id": "enemy-1",
+          "tier": "TIER2",
+          "position": [
+            5,
+            6
+          ]
+        }
       ]
     }
   },
@@ -27,7 +39,9 @@
     }
   ],
   "expect": {
-    "event_types": ["COMBAT_TRANSITIONED"],
+    "event_types": [
+      "COMBAT_TRANSITIONED"
+    ],
     "combat_phase": "PLAYER_MOVEMENT",
     "combat_turn": 1,
     "enemy_presence": true,
@@ -35,7 +49,10 @@
     "combat_player_energy": 6,
     "combat_player_torpedo_ammo": 6,
     "combat_enemy_positions": {
-      "enemy-1": [4, 5]
+      "enemy-1": [
+        5,
+        6
+      ]
     },
     "combat_enemy_durabilities": {
       "enemy-1": 5
@@ -43,11 +60,20 @@
     "enemy_actions": [
       {
         "enemy_id": "enemy-1",
-        "start_position": [4, 5],
-        "target_attackable_position": [4, 5],
+        "start_position": [
+          5,
+          6
+        ],
+        "target_attackable_position": [
+          5,
+          6
+        ],
         "planned_path": [],
         "moved_path": [],
-        "final_position": [4, 5],
+        "final_position": [
+          5,
+          6
+        ],
         "movement_power": 3,
         "movement_cost": 0,
         "attacked_player": true,

--- a/experiments/galactic_exodus/srs/fixtures/combat_enemy_movement_tiebreak_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/combat_enemy_movement_tiebreak_9x9.json
@@ -9,41 +9,127 @@
     "blocked_edges": []
   },
   "initial": {
-    "reveal": {"mode": "FULL"},
-    "player_position": [6, 4],
+    "reveal": {
+      "mode": "FULL"
+    },
+    "player_position": [
+      7,
+      5
+    ],
     "cell_overrides": [
-      {"position": [1, 4], "terrain": "ASTEROID"},
-      {"position": [2, 4], "terrain": "ASTEROID"},
-      {"position": [3, 4], "terrain": "ASTEROID"},
-      {"position": [4, 4], "terrain": "ASTEROID"}
+      {
+        "position": [
+          2,
+          5
+        ],
+        "terrain": "ASTEROID"
+      },
+      {
+        "position": [
+          3,
+          5
+        ],
+        "terrain": "ASTEROID"
+      },
+      {
+        "position": [
+          4,
+          5
+        ],
+        "terrain": "ASTEROID"
+      },
+      {
+        "position": [
+          5,
+          5
+        ],
+        "terrain": "ASTEROID"
+      }
     ],
     "combat": {
       "phase": "ENEMY_ACTION",
       "enemies": [
-        {"enemy_id": "enemy-1", "tier": "TIER1", "position": [0, 4]}
+        {
+          "enemy_id": "enemy-1",
+          "tier": "TIER1",
+          "position": [
+            1,
+            5
+          ]
+        }
       ]
     }
   },
   "commands": [
-    {"command_type": "COMBAT_STEP"}
+    {
+      "command_type": "COMBAT_STEP"
+    }
   ],
   "expect": {
-    "event_types": ["COMBAT_TRANSITIONED"],
+    "event_types": [
+      "COMBAT_TRANSITIONED"
+    ],
     "combat_phase": "PLAYER_MOVEMENT",
     "combat_turn": 1,
     "enemy_presence": true,
     "combat_player_energy": 6,
     "combat_enemy_positions": {
-      "enemy-1": [2, 3]
+      "enemy-1": [
+        3,
+        4
+      ]
     },
     "enemy_actions": [
       {
         "enemy_id": "enemy-1",
-        "start_position": [0, 4],
-        "target_attackable_position": [4, 3],
-        "planned_path": [[0, 3], [1, 3], [2, 3], [3, 3], [4, 3]],
-        "moved_path": [[0, 3], [1, 3], [2, 3]],
-        "final_position": [2, 3],
+        "start_position": [
+          1,
+          5
+        ],
+        "target_attackable_position": [
+          5,
+          4
+        ],
+        "planned_path": [
+          [
+            1,
+            4
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            4,
+            4
+          ],
+          [
+            5,
+            4
+          ]
+        ],
+        "moved_path": [
+          [
+            1,
+            4
+          ],
+          [
+            2,
+            4
+          ],
+          [
+            3,
+            4
+          ]
+        ],
+        "final_position": [
+          3,
+          4
+        ],
         "movement_power": 3,
         "movement_cost": 50,
         "attacked_player": false,

--- a/experiments/galactic_exodus/srs/fixtures/combat_energy_pressure_danger3_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/combat_energy_pressure_danger3_9x9.json
@@ -9,14 +9,40 @@
     "blocked_edges": []
   },
   "initial": {
-    "reveal": {"mode": "FULL"},
-    "player_position": [1, 4],
+    "reveal": {
+      "mode": "FULL"
+    },
+    "player_position": [
+      2,
+      5
+    ],
     "combat": {
       "phase": "PLAYER_ATTACK",
       "enemies": [
-        {"enemy_id": "enemy-4", "tier": "TIER4", "position": [2, 4]},
-        {"enemy_id": "enemy-2", "tier": "TIER2", "position": [1, 3]},
-        {"enemy_id": "enemy-1", "tier": "TIER1", "position": [0, 4]}
+        {
+          "enemy_id": "enemy-4",
+          "tier": "TIER4",
+          "position": [
+            3,
+            5
+          ]
+        },
+        {
+          "enemy_id": "enemy-2",
+          "tier": "TIER2",
+          "position": [
+            2,
+            4
+          ]
+        },
+        {
+          "enemy_id": "enemy-1",
+          "tier": "TIER1",
+          "position": [
+            1,
+            5
+          ]
+        }
       ],
       "player_attack_target_id": "enemy-4"
     }
@@ -67,9 +93,18 @@
     "combat_player_energy": 1,
     "combat_player_torpedo_ammo": 6,
     "combat_enemy_positions": {
-      "enemy-1": [0, 4],
-      "enemy-2": [1, 3],
-      "enemy-4": [2, 4]
+      "enemy-1": [
+        1,
+        5
+      ],
+      "enemy-2": [
+        2,
+        4
+      ],
+      "enemy-4": [
+        3,
+        5
+      ]
     },
     "combat_enemy_durabilities": {
       "enemy-1": 1,

--- a/experiments/galactic_exodus/srs/fixtures/combat_energy_pressure_danger4_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/combat_energy_pressure_danger4_9x9.json
@@ -9,15 +9,48 @@
     "blocked_edges": []
   },
   "initial": {
-    "reveal": {"mode": "FULL"},
-    "player_position": [1, 4],
+    "reveal": {
+      "mode": "FULL"
+    },
+    "player_position": [
+      2,
+      5
+    ],
     "combat": {
       "phase": "PLAYER_ATTACK",
       "enemies": [
-        {"enemy_id": "enemy-4", "tier": "TIER4", "position": [2, 4]},
-        {"enemy_id": "enemy-2", "tier": "TIER2", "position": [1, 3]},
-        {"enemy_id": "enemy-3", "tier": "TIER3", "position": [2, 3]},
-        {"enemy_id": "enemy-1", "tier": "TIER1", "position": [0, 4]}
+        {
+          "enemy_id": "enemy-4",
+          "tier": "TIER4",
+          "position": [
+            3,
+            5
+          ]
+        },
+        {
+          "enemy_id": "enemy-2",
+          "tier": "TIER2",
+          "position": [
+            2,
+            4
+          ]
+        },
+        {
+          "enemy_id": "enemy-3",
+          "tier": "TIER3",
+          "position": [
+            3,
+            4
+          ]
+        },
+        {
+          "enemy_id": "enemy-1",
+          "tier": "TIER1",
+          "position": [
+            1,
+            5
+          ]
+        }
       ],
       "player_attack_target_id": "enemy-4"
     }
@@ -70,10 +103,22 @@
     "combat_player_energy": 1,
     "combat_player_torpedo_ammo": 6,
     "combat_enemy_positions": {
-      "enemy-1": [0, 4],
-      "enemy-2": [1, 3],
-      "enemy-3": [2, 3],
-      "enemy-4": [2, 4]
+      "enemy-1": [
+        1,
+        5
+      ],
+      "enemy-2": [
+        2,
+        4
+      ],
+      "enemy-3": [
+        3,
+        4
+      ],
+      "enemy-4": [
+        3,
+        5
+      ]
     },
     "combat_enemy_durabilities": {
       "enemy-1": 1,

--- a/experiments/galactic_exodus/srs/fixtures/combat_phaser_attack_damage_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/combat_phaser_attack_damage_9x9.json
@@ -9,12 +9,24 @@
     "blocked_edges": []
   },
   "initial": {
-    "reveal": {"mode": "FULL"},
-    "player_position": [1, 4],
+    "reveal": {
+      "mode": "FULL"
+    },
+    "player_position": [
+      2,
+      5
+    ],
     "combat": {
       "phase": "PLAYER_ATTACK",
       "enemies": [
-        {"enemy_id": "enemy-1", "tier": "TIER2", "position": [2, 4]}
+        {
+          "enemy_id": "enemy-1",
+          "tier": "TIER2",
+          "position": [
+            3,
+            5
+          ]
+        }
       ],
       "player_attack_target_id": "enemy-1"
     }
@@ -27,7 +39,9 @@
     }
   ],
   "expect": {
-    "event_types": ["COMBAT_TRANSITIONED"],
+    "event_types": [
+      "COMBAT_TRANSITIONED"
+    ],
     "combat_phase": "ENEMY_ACTION",
     "combat_turn": 0,
     "enemy_presence": true,
@@ -35,7 +49,10 @@
     "combat_player_energy": 5,
     "combat_player_torpedo_ammo": 6,
     "combat_enemy_positions": {
-      "enemy-1": [2, 4]
+      "enemy-1": [
+        3,
+        5
+      ]
     },
     "combat_enemy_durabilities": {
       "enemy-1": 4

--- a/experiments/galactic_exodus/srs/fixtures/combat_salvage_drop_tier3_energy_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/combat_salvage_drop_tier3_energy_9x9.json
@@ -9,8 +9,13 @@
     "blocked_edges": []
   },
   "initial": {
-    "reveal": {"mode": "FULL"},
-    "player_position": [1, 4],
+    "reveal": {
+      "mode": "FULL"
+    },
+    "player_position": [
+      2,
+      5
+    ],
     "player": {
       "energy": 3,
       "salvage": 1
@@ -22,7 +27,16 @@
         "salvage": 1
       },
       "enemies": [
-        {"enemy_id": "enemy-3", "tier": "TIER3", "position": [3, 4], "drop_salvage": true, "durability": 3}
+        {
+          "enemy_id": "enemy-3",
+          "tier": "TIER3",
+          "position": [
+            4,
+            5
+          ],
+          "drop_salvage": true,
+          "durability": 3
+        }
       ],
       "player_attack_target_id": "enemy-3"
     }
@@ -36,7 +50,9 @@
     }
   ],
   "expect": {
-    "event_types": ["COMBAT_TRANSITIONED"],
+    "event_types": [
+      "COMBAT_TRANSITIONED"
+    ],
     "combat_phase": "ENEMY_ACTION",
     "combat_turn": 0,
     "enemy_presence": false,

--- a/experiments/galactic_exodus/srs/fixtures/combat_salvage_no_drop_tier1_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/combat_salvage_no_drop_tier1_9x9.json
@@ -9,8 +9,13 @@
     "blocked_edges": []
   },
   "initial": {
-    "reveal": {"mode": "FULL"},
-    "player_position": [1, 4],
+    "reveal": {
+      "mode": "FULL"
+    },
+    "player_position": [
+      2,
+      5
+    ],
     "player": {
       "salvage": 2
     },
@@ -20,7 +25,15 @@
         "salvage": 2
       },
       "enemies": [
-        {"enemy_id": "enemy-1", "tier": "TIER1", "position": [3, 4], "drop_salvage": false}
+        {
+          "enemy_id": "enemy-1",
+          "tier": "TIER1",
+          "position": [
+            4,
+            5
+          ],
+          "drop_salvage": false
+        }
       ],
       "player_attack_target_id": "enemy-1"
     }
@@ -33,7 +46,9 @@
     }
   ],
   "expect": {
-    "event_types": ["COMBAT_TRANSITIONED"],
+    "event_types": [
+      "COMBAT_TRANSITIONED"
+    ],
     "combat_phase": "ENEMY_ACTION",
     "combat_turn": 0,
     "enemy_presence": false,

--- a/experiments/galactic_exodus/srs/fixtures/combat_torpedo_destroy_no_counterattack_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/combat_torpedo_destroy_no_counterattack_9x9.json
@@ -9,12 +9,24 @@
     "blocked_edges": []
   },
   "initial": {
-    "reveal": {"mode": "FULL"},
-    "player_position": [1, 4],
+    "reveal": {
+      "mode": "FULL"
+    },
+    "player_position": [
+      2,
+      5
+    ],
     "combat": {
       "phase": "PLAYER_ATTACK",
       "enemies": [
-        {"enemy_id": "enemy-1", "tier": "TIER1", "position": [3, 4]}
+        {
+          "enemy_id": "enemy-1",
+          "tier": "TIER1",
+          "position": [
+            4,
+            5
+          ]
+        }
       ],
       "player_attack_target_id": "enemy-1"
     }
@@ -25,10 +37,15 @@
       "player_attack_action": "ATTACK",
       "player_attack_weapon": "PHOTON_TORPEDO"
     },
-    {"command_type": "COMBAT_STEP"}
+    {
+      "command_type": "COMBAT_STEP"
+    }
   ],
   "expect": {
-    "event_types": ["COMBAT_TRANSITIONED", "COMBAT_TRANSITIONED"],
+    "event_types": [
+      "COMBAT_TRANSITIONED",
+      "COMBAT_TRANSITIONED"
+    ],
     "combat_phase": "PLAYER_MOVEMENT",
     "combat_turn": 1,
     "enemy_presence": false,

--- a/experiments/galactic_exodus/srs/fixtures/discovered_cells_restore_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/discovered_cells_restore_9x9.json
@@ -9,18 +9,41 @@
     "blocked_edges": []
   },
   "initial": {
-    "player_position": [4, 7],
+    "player_position": [
+      5,
+      8
+    ],
     "persistent": {
       "consumed_object_ids": [],
       "activated_object_ids": [],
-      "discovered_cells": [[3, 6], [4, 6], [5, 6], [4, 7]]
+      "discovered_cells": [
+        [
+          4,
+          7
+        ],
+        [
+          5,
+          7
+        ],
+        [
+          6,
+          7
+        ],
+        [
+          5,
+          8
+        ]
+      ]
     }
   },
   "commands": [],
   "expect": {
     "srs_turn": 0,
     "fuel": 0,
-    "player_position": [4, 7],
+    "player_position": [
+      5,
+      8
+    ],
     "event_types": [],
     "consumed_object_ids": [],
     "activated_object_ids": []

--- a/experiments/galactic_exodus/srs/fixtures/move_route_basic_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/move_route_basic_9x9.json
@@ -9,13 +9,24 @@
     "blocked_edges": []
   },
   "commands": [
-    {"command_type": "MOVE_ROUTE", "route": ["N"]}
+    {
+      "command_type": "MOVE_ROUTE",
+      "route": [
+        "N"
+      ]
+    }
   ],
   "expect": {
     "srs_turn": 1,
     "fuel": 0,
-    "player_position": [4, 7],
-    "event_types": ["MOVE_ACCEPTED", "OBSERVATION_UPDATED"],
+    "player_position": [
+      5,
+      8
+    ],
+    "event_types": [
+      "MOVE_ACCEPTED",
+      "OBSERVATION_UPDATED"
+    ],
     "outcome": "ACCEPTED",
     "render_contains": "@",
     "render_not_contains": "*"

--- a/experiments/galactic_exodus/srs/fixtures/move_to_known_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/move_to_known_9x9.json
@@ -14,13 +14,26 @@
     }
   },
   "commands": [
-    {"command_type": "MOVE_TO", "target": [4, 6]}
+    {
+      "command_type": "MOVE_TO",
+      "target": [
+        5,
+        7
+      ]
+    }
   ],
   "expect": {
     "srs_turn": 1,
     "fuel": 0,
-    "player_position": [4, 6],
-    "event_types": ["MOVE_ACCEPTED", "OBSERVATION_UPDATED", "OBSERVATION_UPDATED"],
+    "player_position": [
+      5,
+      7
+    ],
+    "event_types": [
+      "MOVE_ACCEPTED",
+      "OBSERVATION_UPDATED",
+      "OBSERVATION_UPDATED"
+    ],
     "outcome": "ACCEPTED"
   }
 }

--- a/experiments/galactic_exodus/srs/fixtures/nebula_observation_3x3_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/nebula_observation_3x3_9x9.json
@@ -11,7 +11,10 @@
   "initial": {
     "cell_overrides": [
       {
-        "position": [4, 7],
+        "position": [
+          5,
+          8
+        ],
         "terrain": "NEBULA"
       }
     ]
@@ -19,14 +22,22 @@
   "commands": [
     {
       "command_type": "MOVE_ROUTE",
-      "route": ["N"]
+      "route": [
+        "N"
+      ]
     }
   ],
   "expect": {
     "srs_turn": 1,
     "fuel": 0,
-    "player_position": [4, 7],
-    "event_types": ["MOVE_ACCEPTED", "OBSERVATION_UPDATED"],
+    "player_position": [
+      5,
+      8
+    ],
+    "event_types": [
+      "MOVE_ACCEPTED",
+      "OBSERVATION_UPDATED"
+    ],
     "outcome": "ACCEPTED"
   }
 }

--- a/experiments/galactic_exodus/srs/fixtures/normal_minimal_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/normal_minimal_9x9.json
@@ -9,12 +9,23 @@
   "expected": {
     "width": 9,
     "height": 9,
-    "player_position": [4, 8],
+    "player_position": [
+      5,
+      9
+    ],
     "warp_flags": {
-      "4,0": ["N"],
-      "8,4": ["E"],
-      "4,8": ["S"],
-      "0,4": ["W"]
+      "5,1": [
+        "N"
+      ],
+      "1,5": [
+        "W"
+      ],
+      "9,5": [
+        "E"
+      ],
+      "5,9": [
+        "S"
+      ]
     },
     "terrain_counts": {
       "FLOOR": 81

--- a/experiments/galactic_exodus/srs/fixtures/phase2_reference.json
+++ b/experiments/galactic_exodus/srs/fixtures/phase2_reference.json
@@ -8,13 +8,21 @@
     {
       "case_id": "normal_first_visit",
       "fixture_path": "move_route_basic_9x9.json",
-      "coverage_tags": ["NORMAL_FIRST_VISIT"],
+      "coverage_tags": [
+        "NORMAL_FIRST_VISIT"
+      ],
       "final_expect": {
         "cost_mode": "TURN_ONLY",
         "srs_turn": 1,
         "fuel": 0,
-        "player_position": [4, 7],
-        "event_types": ["MOVE_ACCEPTED", "OBSERVATION_UPDATED"],
+        "player_position": [
+          5,
+          8
+        ],
+        "event_types": [
+          "MOVE_ACCEPTED",
+          "OBSERVATION_UPDATED"
+        ],
         "outcome": "ACCEPTED",
         "discovered_count": 20
       }
@@ -22,7 +30,10 @@
     {
       "case_id": "resource_cache_interaction",
       "fixture_path": "resource_cache_single_9x9.json",
-      "coverage_tags": ["RESOURCE_CACHE_INTERACTION", "REWARD_RESOURCE_CACHE"],
+      "coverage_tags": [
+        "RESOURCE_CACHE_INTERACTION",
+        "REWARD_RESOURCE_CACHE"
+      ],
       "initial_expect": {
         "discovered_count": 4
       },
@@ -30,9 +41,17 @@
         "cost_mode": "TURN_ONLY",
         "srs_turn": 1,
         "fuel": 5,
-        "player_position": [2, 7],
-        "event_types": ["INTERACT_ACCEPTED", "OBJECT_CONSUMED"],
-        "consumed_object_ids": ["resource-cache-1"],
+        "player_position": [
+          3,
+          8
+        ],
+        "event_types": [
+          "INTERACT_ACCEPTED",
+          "OBJECT_CONSUMED"
+        ],
+        "consumed_object_ids": [
+          "resource-cache-1"
+        ],
         "outcome": "ACCEPTED",
         "discovered_count": 4
       }
@@ -40,18 +59,30 @@
     {
       "case_id": "resource_cache_consumed_revisit",
       "fixture_path": "revisit_resource_consumed_9x9.json",
-      "coverage_tags": ["RESOURCE_CACHE_CONSUMED_REVISIT", "REVISIT_PERSISTENT_STATE"],
+      "coverage_tags": [
+        "RESOURCE_CACHE_CONSUMED_REVISIT",
+        "REVISIT_PERSISTENT_STATE"
+      ],
       "initial_expect": {
         "discovered_count": 4,
-        "consumed_object_ids": ["resource-cache-1"]
+        "consumed_object_ids": [
+          "resource-cache-1"
+        ]
       },
       "final_expect": {
         "cost_mode": "TURN_ONLY",
         "srs_turn": 0,
         "fuel": 2,
-        "player_position": [2, 7],
-        "event_types": ["INTERACT_REJECTED"],
-        "consumed_object_ids": ["resource-cache-1"],
+        "player_position": [
+          3,
+          8
+        ],
+        "event_types": [
+          "INTERACT_REJECTED"
+        ],
+        "consumed_object_ids": [
+          "resource-cache-1"
+        ],
         "outcome": "REJECTED_ALREADY_CONSUMED",
         "discovered_count": 4
       }
@@ -59,7 +90,10 @@
     {
       "case_id": "base_station_interaction",
       "fixture_path": "station_refuel_9x9.json",
-      "coverage_tags": ["BASE_STATION_INTERACTION", "REWARD_BASE_RECOVERY"],
+      "coverage_tags": [
+        "BASE_STATION_INTERACTION",
+        "REWARD_BASE_RECOVERY"
+      ],
       "final_expect": {
         "cost_mode": "TURN_ONLY",
         "srs_turn": 1,
@@ -67,9 +101,17 @@
         "player_durability": 100,
         "player_energy": 6,
         "player_torpedo_ammo": 6,
-        "player_position": [3, 1],
-        "event_types": ["INTERACT_ACCEPTED", "STATION_ACTIVATED"],
-        "activated_object_ids": ["station-1"],
+        "player_position": [
+          4,
+          2
+        ],
+        "event_types": [
+          "INTERACT_ACCEPTED",
+          "STATION_ACTIVATED"
+        ],
+        "activated_object_ids": [
+          "station-1"
+        ],
         "outcome": "ACCEPTED",
         "discovered_count": 81
       }
@@ -77,7 +119,10 @@
     {
       "case_id": "base_upgrade_defense",
       "fixture_path": "base_upgrade_defense_9x9.json",
-      "coverage_tags": ["BASE_UPGRADE", "REWARD_BASE_UPGRADE"],
+      "coverage_tags": [
+        "BASE_UPGRADE",
+        "REWARD_BASE_UPGRADE"
+      ],
       "final_expect": {
         "cost_mode": "TURN_ONLY",
         "srs_turn": 1,
@@ -87,9 +132,17 @@
         "player_torpedo_ammo": 6,
         "player_salvage": 0,
         "player_defense": 2,
-        "player_position": [3, 1],
-        "event_types": ["INTERACT_ACCEPTED", "STATION_ACTIVATED"],
-        "activated_object_ids": ["station-1"],
+        "player_position": [
+          4,
+          2
+        ],
+        "event_types": [
+          "INTERACT_ACCEPTED",
+          "STATION_ACTIVATED"
+        ],
+        "activated_object_ids": [
+          "station-1"
+        ],
         "outcome": "ACCEPTED",
         "discovered_count": 81
       }
@@ -97,7 +150,10 @@
     {
       "case_id": "salvage_recover_durability",
       "fixture_path": "salvage_recover_durability_9x9.json",
-      "coverage_tags": ["SALVAGE_PICKUP", "REWARD_SALVAGE_PICKUP"],
+      "coverage_tags": [
+        "SALVAGE_PICKUP",
+        "REWARD_SALVAGE_PICKUP"
+      ],
       "final_expect": {
         "cost_mode": "TURN_ONLY",
         "srs_turn": 1,
@@ -106,9 +162,17 @@
         "player_energy": 6,
         "player_torpedo_ammo": 6,
         "player_salvage": 1,
-        "player_position": [4, 6],
-        "event_types": ["INTERACT_ACCEPTED", "OBJECT_CONSUMED"],
-        "consumed_object_ids": ["salvage-1"],
+        "player_position": [
+          5,
+          7
+        ],
+        "event_types": [
+          "INTERACT_ACCEPTED",
+          "OBJECT_CONSUMED"
+        ],
+        "consumed_object_ids": [
+          "salvage-1"
+        ],
         "outcome": "ACCEPTED",
         "discovered_count": 81
       }
@@ -116,13 +180,21 @@
     {
       "case_id": "nebula_3x3_observation",
       "fixture_path": "nebula_observation_3x3_9x9.json",
-      "coverage_tags": ["NEBULA_3X3_OBSERVATION"],
+      "coverage_tags": [
+        "NEBULA_3X3_OBSERVATION"
+      ],
       "final_expect": {
         "cost_mode": "TURN_ONLY",
         "srs_turn": 1,
         "fuel": 0,
-        "player_position": [4, 7],
-        "event_types": ["MOVE_ACCEPTED", "OBSERVATION_UPDATED"],
+        "player_position": [
+          5,
+          8
+        ],
+        "event_types": [
+          "MOVE_ACCEPTED",
+          "OBSERVATION_UPDATED"
+        ],
         "outcome": "ACCEPTED",
         "discovered_count": 9
       }
@@ -130,13 +202,20 @@
     {
       "case_id": "rift_blocked_edge",
       "fixture_path": "rift_blocked_n_9x9.json",
-      "coverage_tags": ["RIFT_BLOCKED_EDGE"],
+      "coverage_tags": [
+        "RIFT_BLOCKED_EDGE"
+      ],
       "final_expect": {
         "cost_mode": "TURN_ONLY",
         "srs_turn": 0,
         "fuel": 0,
-        "player_position": [4, 0],
-        "event_types": ["WARP_EXIT_REJECTED"],
+        "player_position": [
+          5,
+          1
+        ],
+        "event_types": [
+          "WARP_EXIT_REJECTED"
+        ],
         "outcome": "REJECTED_BLOCKED_EDGE",
         "discovered_count": 81
       }
@@ -144,13 +223,20 @@
     {
       "case_id": "warp_exit_accepted",
       "fixture_path": "warp_exit_s_9x9.json",
-      "coverage_tags": ["WARP_EXIT_ACCEPTED"],
+      "coverage_tags": [
+        "WARP_EXIT_ACCEPTED"
+      ],
       "final_expect": {
         "cost_mode": "TURN_ONLY",
         "srs_turn": 1,
         "fuel": 0,
-        "player_position": [4, 8],
-        "event_types": ["WARP_EXIT_ACCEPTED"],
+        "player_position": [
+          5,
+          9
+        ],
+        "event_types": [
+          "WARP_EXIT_ACCEPTED"
+        ],
         "outcome": "ACCEPTED",
         "discovered_count": 81
       }
@@ -158,13 +244,20 @@
     {
       "case_id": "warp_exit_rejected",
       "fixture_path": "warp_exit_rejected_no_flag_9x9.json",
-      "coverage_tags": ["WARP_EXIT_REJECTED"],
+      "coverage_tags": [
+        "WARP_EXIT_REJECTED"
+      ],
       "final_expect": {
         "cost_mode": "TURN_ONLY",
         "srs_turn": 0,
         "fuel": 0,
-        "player_position": [4, 7],
-        "event_types": ["WARP_EXIT_REJECTED"],
+        "player_position": [
+          5,
+          8
+        ],
+        "event_types": [
+          "WARP_EXIT_REJECTED"
+        ],
         "outcome": "REJECTED_NO_WARP_FLAG",
         "discovered_count": 81
       }
@@ -172,13 +265,22 @@
     {
       "case_id": "turn_only_route",
       "fixture_path": "turn_only_cost_9x9.json",
-      "coverage_tags": ["TURN_ONLY"],
+      "coverage_tags": [
+        "TURN_ONLY"
+      ],
       "final_expect": {
         "cost_mode": "TURN_ONLY",
         "srs_turn": 1,
         "fuel": 9,
-        "player_position": [4, 6],
-        "event_types": ["MOVE_ACCEPTED", "OBSERVATION_UPDATED", "OBSERVATION_UPDATED"],
+        "player_position": [
+          5,
+          7
+        ],
+        "event_types": [
+          "MOVE_ACCEPTED",
+          "OBSERVATION_UPDATED",
+          "OBSERVATION_UPDATED"
+        ],
         "outcome": "ACCEPTED",
         "discovered_count": 81
       }
@@ -186,13 +288,22 @@
     {
       "case_id": "shared_fuel_route",
       "fixture_path": "shared_fuel_cost_9x9.json",
-      "coverage_tags": ["SHARED_FUEL"],
+      "coverage_tags": [
+        "SHARED_FUEL"
+      ],
       "final_expect": {
         "cost_mode": "SHARED_FUEL",
         "srs_turn": 1,
         "fuel": 7,
-        "player_position": [4, 6],
-        "event_types": ["MOVE_ACCEPTED", "OBSERVATION_UPDATED", "OBSERVATION_UPDATED"],
+        "player_position": [
+          5,
+          7
+        ],
+        "event_types": [
+          "MOVE_ACCEPTED",
+          "OBSERVATION_UPDATED",
+          "OBSERVATION_UPDATED"
+        ],
         "outcome": "ACCEPTED",
         "discovered_count": 81
       }
@@ -200,7 +311,9 @@
     {
       "case_id": "persistent_discovered_cells_restore",
       "fixture_path": "discovered_cells_restore_9x9.json",
-      "coverage_tags": ["PERSISTENT_DISCOVERED_CELLS_RESTORE"],
+      "coverage_tags": [
+        "PERSISTENT_DISCOVERED_CELLS_RESTORE"
+      ],
       "initial_expect": {
         "discovered_count": 4
       },
@@ -208,7 +321,10 @@
         "cost_mode": "TURN_ONLY",
         "srs_turn": 0,
         "fuel": 0,
-        "player_position": [4, 7],
+        "player_position": [
+          5,
+          8
+        ],
         "event_types": [],
         "consumed_object_ids": [],
         "activated_object_ids": [],
@@ -218,20 +334,37 @@
     {
       "case_id": "combat_encounter_wait_nebula",
       "fixture_path": "combat_encounter_wait_nebula_9x9.json",
-      "coverage_tags": ["ENCOUNTER_WAIT", "ENCOUNTER_NEBULA", "COMBAT_ENCOUNTER_START"],
+      "coverage_tags": [
+        "ENCOUNTER_WAIT",
+        "ENCOUNTER_NEBULA",
+        "COMBAT_ENCOUNTER_START"
+      ],
       "final_expect": {
         "cost_mode": "TURN_ONLY",
         "srs_turn": 1,
-        "player_position": [4, 7],
-        "event_types": ["WAIT_ACCEPTED", "ENCOUNTER_ROLLED"],
+        "player_position": [
+          5,
+          8
+        ],
+        "event_types": [
+          "WAIT_ACCEPTED",
+          "ENCOUNTER_ROLLED"
+        ],
         "combat_phase": "PLAYER_MOVEMENT",
         "combat_turn": 0,
         "enemy_presence": true,
         "combat_player_durability": 100,
         "combat_player_energy": 6,
         "combat_player_torpedo_ammo": 6,
-        "combat_enemy_positions": {"enemy-1": [4, 0]},
-        "combat_enemy_durabilities": {"enemy-1": 5},
+        "combat_enemy_positions": {
+          "enemy-1": [
+            5,
+            1
+          ]
+        },
+        "combat_enemy_durabilities": {
+          "enemy-1": 5
+        },
         "outcome": "ACCEPTED",
         "discovered_count": 81
       }
@@ -239,11 +372,19 @@
     {
       "case_id": "combat_enemy_counterattack",
       "fixture_path": "combat_enemy_counterattack_9x9.json",
-      "coverage_tags": ["COMBAT_ENEMY_ACTION", "COMBAT_REACTION_COUNTERATTACK"],
+      "coverage_tags": [
+        "COMBAT_ENEMY_ACTION",
+        "COMBAT_REACTION_COUNTERATTACK"
+      ],
       "final_expect": {
         "cost_mode": "TURN_ONLY",
-        "player_position": [1, 4],
-        "event_types": ["COMBAT_TRANSITIONED"],
+        "player_position": [
+          2,
+          5
+        ],
+        "event_types": [
+          "COMBAT_TRANSITIONED"
+        ],
         "combat_phase": "PLAYER_MOVEMENT",
         "combat_turn": 1,
         "enemy_presence": true,
@@ -252,8 +393,15 @@
         "combat_player_durability": 94,
         "combat_player_energy": 6,
         "combat_player_torpedo_ammo": 6,
-        "combat_enemy_positions": {"enemy-1": [2, 4]},
-        "combat_enemy_durabilities": {"enemy-1": 2},
+        "combat_enemy_positions": {
+          "enemy-1": [
+            3,
+            5
+          ]
+        },
+        "combat_enemy_durabilities": {
+          "enemy-1": 2
+        },
         "outcome": "ACCEPTED",
         "discovered_count": 81
       }
@@ -261,11 +409,19 @@
     {
       "case_id": "combat_salvage_drop_tier3_energy",
       "fixture_path": "combat_salvage_drop_tier3_energy_9x9.json",
-      "coverage_tags": ["COMBAT_PLAYER_ATTACK", "REWARD_ENEMY_DROP"],
+      "coverage_tags": [
+        "COMBAT_PLAYER_ATTACK",
+        "REWARD_ENEMY_DROP"
+      ],
       "final_expect": {
         "cost_mode": "TURN_ONLY",
-        "player_position": [1, 4],
-        "event_types": ["COMBAT_TRANSITIONED"],
+        "player_position": [
+          2,
+          5
+        ],
+        "event_types": [
+          "COMBAT_TRANSITIONED"
+        ],
         "combat_phase": "ENEMY_ACTION",
         "combat_turn": 0,
         "enemy_presence": false,

--- a/experiments/galactic_exodus/srs/fixtures/resource_cache_single_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/resource_cache_single_9x9.json
@@ -9,7 +9,10 @@
     "blocked_edges": []
   },
   "initial": {
-    "player_position": [2, 7],
+    "player_position": [
+      3,
+      8
+    ],
     "fuel": 2,
     "max_fuel": 9,
     "reveal": {
@@ -18,19 +21,47 @@
     "persistent": {
       "consumed_object_ids": [],
       "activated_object_ids": [],
-      "discovered_cells": [[2, 7], [2, 6], [3, 7], [1, 7]]
+      "discovered_cells": [
+        [
+          3,
+          8
+        ],
+        [
+          3,
+          7
+        ],
+        [
+          4,
+          8
+        ],
+        [
+          2,
+          8
+        ]
+      ]
     }
   },
   "commands": [
-    {"command_type": "INTERACT", "target_object_id": "resource-cache-1"}
+    {
+      "command_type": "INTERACT",
+      "target_object_id": "resource-cache-1"
+    }
   ],
   "cost_mode": "TURN_ONLY",
   "expect": {
     "srs_turn": 1,
     "fuel": 5,
-    "player_position": [2, 7],
-    "event_types": ["INTERACT_ACCEPTED", "OBJECT_CONSUMED"],
-    "consumed_object_ids": ["resource-cache-1"],
+    "player_position": [
+      3,
+      8
+    ],
+    "event_types": [
+      "INTERACT_ACCEPTED",
+      "OBJECT_CONSUMED"
+    ],
+    "consumed_object_ids": [
+      "resource-cache-1"
+    ],
     "outcome": "ACCEPTED"
   }
 }

--- a/experiments/galactic_exodus/srs/fixtures/resource_minimal_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/resource_minimal_9x9.json
@@ -9,12 +9,23 @@
   "expected": {
     "width": 9,
     "height": 9,
-    "player_position": [4, 8],
+    "player_position": [
+      5,
+      9
+    ],
     "warp_flags": {
-      "4,0": ["N"],
-      "8,4": ["E"],
-      "4,8": ["S"],
-      "0,4": ["W"]
+      "5,1": [
+        "N"
+      ],
+      "1,5": [
+        "W"
+      ],
+      "9,5": [
+        "E"
+      ],
+      "5,9": [
+        "S"
+      ]
     },
     "terrain_counts": {
       "FLOOR": 81

--- a/experiments/galactic_exodus/srs/fixtures/revisit_resource_consumed_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/revisit_resource_consumed_9x9.json
@@ -9,27 +9,59 @@
     "blocked_edges": []
   },
   "initial": {
-    "player_position": [2, 7],
+    "player_position": [
+      3,
+      8
+    ],
     "fuel": 2,
     "max_fuel": 9,
     "reveal": {
       "mode": "FULL"
     },
     "persistent": {
-      "consumed_object_ids": ["resource-cache-1"],
+      "consumed_object_ids": [
+        "resource-cache-1"
+      ],
       "activated_object_ids": [],
-      "discovered_cells": [[2, 7], [2, 6], [3, 7], [1, 7]]
+      "discovered_cells": [
+        [
+          3,
+          8
+        ],
+        [
+          3,
+          7
+        ],
+        [
+          4,
+          8
+        ],
+        [
+          2,
+          8
+        ]
+      ]
     }
   },
   "commands": [
-    {"command_type": "INTERACT", "target_object_id": "resource-cache-1"}
+    {
+      "command_type": "INTERACT",
+      "target_object_id": "resource-cache-1"
+    }
   ],
   "expect": {
     "srs_turn": 0,
     "fuel": 2,
-    "player_position": [2, 7],
-    "event_types": ["INTERACT_REJECTED"],
-    "consumed_object_ids": ["resource-cache-1"],
+    "player_position": [
+      3,
+      8
+    ],
+    "event_types": [
+      "INTERACT_REJECTED"
+    ],
+    "consumed_object_ids": [
+      "resource-cache-1"
+    ],
     "outcome": "REJECTED_ALREADY_CONSUMED"
   }
 }

--- a/experiments/galactic_exodus/srs/fixtures/rift_blocked_n_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/rift_blocked_n_9x9.json
@@ -6,22 +6,35 @@
     "sector_type": "RIFT",
     "sector_seed": 4001,
     "entry_edge": "S",
-    "blocked_edges": ["N"]
+    "blocked_edges": [
+      "N"
+    ]
   },
   "initial": {
-    "player_position": [4, 0],
+    "player_position": [
+      5,
+      1
+    ],
     "reveal": {
       "mode": "FULL"
     }
   },
   "commands": [
-    {"command_type": "WARP_EXIT", "exit_direction": "N"}
+    {
+      "command_type": "WARP_EXIT",
+      "exit_direction": "N"
+    }
   ],
   "expect": {
     "srs_turn": 0,
     "fuel": 0,
-    "player_position": [4, 0],
-    "event_types": ["WARP_EXIT_REJECTED"],
+    "player_position": [
+      5,
+      1
+    ],
+    "event_types": [
+      "WARP_EXIT_REJECTED"
+    ],
     "outcome": "REJECTED_BLOCKED_EDGE"
   }
 }

--- a/experiments/galactic_exodus/srs/fixtures/rift_n_blocked_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/rift_n_blocked_9x9.json
@@ -4,18 +4,31 @@
     "sector_type": "RIFT",
     "sector_seed": 4001,
     "entry_edge": "S",
-    "blocked_edges": ["N"]
+    "blocked_edges": [
+      "N"
+    ]
   },
   "expected": {
     "width": 9,
     "height": 9,
-    "player_position": [4, 8],
+    "player_position": [
+      5,
+      9
+    ],
     "warp_flags": {
-      "8,4": ["E"],
-      "4,8": ["S"],
-      "0,4": ["W"]
+      "1,5": [
+        "W"
+      ],
+      "9,5": [
+        "E"
+      ],
+      "5,9": [
+        "S"
+      ]
     },
-    "blocked_warp_positions": ["4,0"],
+    "blocked_warp_positions": [
+      "5,1"
+    ],
     "terrain_counts": {
       "FLOOR": 72,
       "RIFT_BARRIER": 9

--- a/experiments/galactic_exodus/srs/fixtures/salvage_placeholder_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/salvage_placeholder_9x9.json
@@ -9,7 +9,10 @@
     "blocked_edges": []
   },
   "initial": {
-    "player_position": [4, 6],
+    "player_position": [
+      5,
+      7
+    ],
     "fuel": 2,
     "max_fuel": 9,
     "reveal": {
@@ -17,15 +20,26 @@
     }
   },
   "commands": [
-    {"command_type": "INTERACT", "target_object_id": "salvage-1"}
+    {
+      "command_type": "INTERACT",
+      "target_object_id": "salvage-1"
+    }
   ],
   "expect": {
     "srs_turn": 1,
     "fuel": 2,
     "player_salvage": 1,
-    "player_position": [4, 6],
-    "event_types": ["INTERACT_ACCEPTED", "OBJECT_CONSUMED"],
-    "consumed_object_ids": ["salvage-1"],
+    "player_position": [
+      5,
+      7
+    ],
+    "event_types": [
+      "INTERACT_ACCEPTED",
+      "OBJECT_CONSUMED"
+    ],
+    "consumed_object_ids": [
+      "salvage-1"
+    ],
     "outcome": "ACCEPTED"
   }
 }

--- a/experiments/galactic_exodus/srs/fixtures/salvage_recover_durability_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/salvage_recover_durability_9x9.json
@@ -9,7 +9,10 @@
     "blocked_edges": []
   },
   "initial": {
-    "player_position": [4, 6],
+    "player_position": [
+      5,
+      7
+    ],
     "fuel": 2,
     "max_fuel": 9,
     "player": {
@@ -31,9 +34,17 @@
     "fuel": 2,
     "player_durability": 100,
     "player_salvage": 1,
-    "player_position": [4, 6],
-    "event_types": ["INTERACT_ACCEPTED", "OBJECT_CONSUMED"],
-    "consumed_object_ids": ["salvage-1"],
+    "player_position": [
+      5,
+      7
+    ],
+    "event_types": [
+      "INTERACT_ACCEPTED",
+      "OBJECT_CONSUMED"
+    ],
+    "consumed_object_ids": [
+      "salvage-1"
+    ],
     "outcome": "ACCEPTED"
   }
 }

--- a/experiments/galactic_exodus/srs/fixtures/shared_fuel_cost_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/shared_fuel_cost_9x9.json
@@ -16,14 +16,27 @@
     }
   },
   "commands": [
-    {"command_type": "MOVE_ROUTE", "route": ["N", "N"]}
+    {
+      "command_type": "MOVE_ROUTE",
+      "route": [
+        "N",
+        "N"
+      ]
+    }
   ],
   "cost_mode": "SHARED_FUEL",
   "expect": {
     "srs_turn": 1,
     "fuel": 7,
-    "player_position": [4, 6],
-    "event_types": ["MOVE_ACCEPTED", "OBSERVATION_UPDATED", "OBSERVATION_UPDATED"],
+    "player_position": [
+      5,
+      7
+    ],
+    "event_types": [
+      "MOVE_ACCEPTED",
+      "OBSERVATION_UPDATED",
+      "OBSERVATION_UPDATED"
+    ],
     "outcome": "ACCEPTED"
   }
 }

--- a/experiments/galactic_exodus/srs/fixtures/station_refuel_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/station_refuel_9x9.json
@@ -9,7 +9,10 @@
     "blocked_edges": []
   },
   "initial": {
-    "player_position": [3, 1],
+    "player_position": [
+      4,
+      2
+    ],
     "fuel": 2,
     "max_fuel": 9,
     "player": {
@@ -22,7 +25,10 @@
     }
   },
   "commands": [
-    {"command_type": "INTERACT", "target_object_id": "station-1"}
+    {
+      "command_type": "INTERACT",
+      "target_object_id": "station-1"
+    }
   ],
   "expect": {
     "srs_turn": 1,
@@ -30,9 +36,17 @@
     "player_durability": 100,
     "player_energy": 6,
     "player_torpedo_ammo": 6,
-    "player_position": [3, 1],
-    "event_types": ["INTERACT_ACCEPTED", "STATION_ACTIVATED"],
-    "activated_object_ids": ["station-1"],
+    "player_position": [
+      4,
+      2
+    ],
+    "event_types": [
+      "INTERACT_ACCEPTED",
+      "STATION_ACTIVATED"
+    ],
+    "activated_object_ids": [
+      "station-1"
+    ],
     "outcome": "ACCEPTED"
   }
 }

--- a/experiments/galactic_exodus/srs/fixtures/turn_only_cost_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/turn_only_cost_9x9.json
@@ -18,15 +18,25 @@
   "commands": [
     {
       "command_type": "MOVE_ROUTE",
-      "route": ["N", "N"]
+      "route": [
+        "N",
+        "N"
+      ]
     }
   ],
   "cost_mode": "TURN_ONLY",
   "expect": {
     "srs_turn": 1,
     "fuel": 9,
-    "player_position": [4, 6],
-    "event_types": ["MOVE_ACCEPTED", "OBSERVATION_UPDATED", "OBSERVATION_UPDATED"],
+    "player_position": [
+      5,
+      7
+    ],
+    "event_types": [
+      "MOVE_ACCEPTED",
+      "OBSERVATION_UPDATED",
+      "OBSERVATION_UPDATED"
+    ],
     "outcome": "ACCEPTED"
   }
 }

--- a/experiments/galactic_exodus/srs/fixtures/warp_exit_rejected_no_flag_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/warp_exit_rejected_no_flag_9x9.json
@@ -9,7 +9,10 @@
     "blocked_edges": []
   },
   "initial": {
-    "player_position": [4, 7],
+    "player_position": [
+      5,
+      8
+    ],
     "reveal": {
       "mode": "FULL"
     }
@@ -23,8 +26,13 @@
   "expect": {
     "srs_turn": 0,
     "fuel": 0,
-    "player_position": [4, 7],
-    "event_types": ["WARP_EXIT_REJECTED"],
+    "player_position": [
+      5,
+      8
+    ],
+    "event_types": [
+      "WARP_EXIT_REJECTED"
+    ],
     "outcome": "REJECTED_NO_WARP_FLAG"
   }
 }

--- a/experiments/galactic_exodus/srs/fixtures/warp_exit_s_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/warp_exit_s_9x9.json
@@ -14,13 +14,21 @@
     }
   },
   "commands": [
-    {"command_type": "WARP_EXIT", "exit_direction": "S"}
+    {
+      "command_type": "WARP_EXIT",
+      "exit_direction": "S"
+    }
   ],
   "expect": {
     "srs_turn": 1,
     "fuel": 0,
-    "player_position": [4, 8],
-    "event_types": ["WARP_EXIT_ACCEPTED"],
+    "player_position": [
+      5,
+      9
+    ],
+    "event_types": [
+      "WARP_EXIT_ACCEPTED"
+    ],
     "outcome": "ACCEPTED"
   }
 }

--- a/experiments/galactic_exodus/srs/generate.py
+++ b/experiments/galactic_exodus/srs/generate.py
@@ -27,13 +27,13 @@ class SrsGenerationError(ValueError):
 
 MAP_WIDTH = 9
 MAP_HEIGHT = 9
-MAP_CENTER = Position(4, 4)
+MAP_CENTER = Position(5, 5)
 
 EDGE_POSITIONS = {
-    Direction.N: Position(4, 0),
-    Direction.E: Position(8, 4),
-    Direction.S: Position(4, 8),
-    Direction.W: Position(0, 4),
+    Direction.N: Position(5, 1),
+    Direction.E: Position(9, 5),
+    Direction.S: Position(5, 9),
+    Direction.W: Position(1, 5),
 }
 
 SECTOR_EXTRA_OBJECTS = {
@@ -138,8 +138,10 @@ def _apply_warp_flags(cells: list[list[SrsCell]], descriptor: SectorDescriptor) 
     }
     for direction in open_edges:
         position = EDGE_POSITIONS[direction]
-        base = cells[position.y][position.x]
-        cells[position.y][position.x] = SrsCell(
+        row_idx = position.y - 1
+        col_idx = position.x - 1
+        base = cells[row_idx][col_idx]
+        cells[row_idx][col_idx] = SrsCell(
             terrain=base.terrain,
             object_id=base.object_id,
             actor_id=base.actor_id,
@@ -168,11 +170,13 @@ def _place_objects(
 
     objects: dict[str, SrsObjectState] = {}
     for (object_type, object_id), position in zip(object_specs, shuffled[: len(object_specs)], strict=True):
-        cells[position.y][position.x] = SrsCell(
-            terrain=cells[position.y][position.x].terrain,
+        row_idx = position.y - 1
+        col_idx = position.x - 1
+        cells[row_idx][col_idx] = SrsCell(
+            terrain=cells[row_idx][col_idx].terrain,
             object_id=object_id,
-            actor_id=cells[position.y][position.x].actor_id,
-            warp_flags=cells[position.y][position.x].warp_flags,
+            actor_id=cells[row_idx][col_idx].actor_id,
+            warp_flags=cells[row_idx][col_idx].warp_flags,
         )
         objects[object_id] = SrsObjectState(
             object_id=object_id,
@@ -208,8 +212,8 @@ def _collect_object_candidates(
     player_position: Position,
 ) -> list[Position]:
     candidates: list[Position] = []
-    for y, row in enumerate(cells):
-        for x, cell in enumerate(row):
+    for y, row in enumerate(cells, start=1):
+        for x, cell in enumerate(row, start=1):
             position = Position(x, y)
             if position == player_position:
                 continue
@@ -224,6 +228,6 @@ def _collect_object_candidates(
 
 
 def _iter_cells(actual_map: SrsActualMap) -> Iterable[tuple[Position, SrsCell]]:
-    for y, row in enumerate(actual_map.cells):
-        for x, cell in enumerate(row):
+    for y, row in enumerate(actual_map.cells, start=1):
+        for x, cell in enumerate(row, start=1):
             yield Position(x, y), cell

--- a/experiments/galactic_exodus/srs/model.py
+++ b/experiments/galactic_exodus/srs/model.py
@@ -390,12 +390,16 @@ class SrsActualMap:
         object.__setattr__(self, "cells", normalized)
 
     def contains(self, position: Position) -> bool:
-        return 0 <= position.x < self.width and 0 <= position.y < self.height
+        return 1 <= position.x <= self.width and 1 <= position.y <= self.height
 
-    def cell_at(self, position: Position) -> SrsCell:
+    def indices_for(self, position: Position) -> tuple[int, int]:
         if not self.contains(position):
             raise IndexError(f"position out of bounds: {position}")
-        return self.cells[position.y][position.x]
+        return (position.y - 1, position.x - 1)
+
+    def cell_at(self, position: Position) -> SrsCell:
+        row_idx, col_idx = self.indices_for(position)
+        return self.cells[row_idx][col_idx]
 
 
 @dataclass(frozen=True, slots=True)

--- a/experiments/galactic_exodus/srs/phase2_srs_spec.md
+++ b/experiments/galactic_exodus/srs/phase2_srs_spec.md
@@ -4,7 +4,7 @@
 
 この文書は、Phase 2 SRS の正本仕様書である。`experiments/galactic_exodus/srs/phase2_decisions.csv` と矛盾しない断定形の仕様として扱い、Python prototype・reference fixture・TBX 実装は本書を起点に整合させる。
 
-Python 実装は参照実装であり、正本ではない。仕様と prototype が矛盾した場合は prototype を修正する。`phase2_reference.json` と `validate_phase2_results.py` は、本書で固定した外部契約を replay 可能な形で検証する。
+Python 実装は実行可能な参照実装であり、正本ではない。仕様と prototype が矛盾した場合は prototype を修正する。`phase2_reference.json` と `validate_phase2_results.py` は、本書で固定した外部契約を replay 可能な形で検証する。#1165、#1166、#1167 はこの比較面と成果物同期の follow-up issue として扱う。
 
 ## 2. Scope and deferred items
 
@@ -46,6 +46,13 @@ max_srs_turns = 40
 ## 4. Data model and coordinate system
 
 SRS はローカル整数座標の 9x9 盤面で扱う。座標は `Position(x, y)` とし、`x` は東に進むほど増え、`y` は北に進むほど増える。方角列は `Direction = N | E | S | W` で表す。
+
+SRS coordinate contract:
+  origin = lower-left
+  x increases eastward
+  y increases northward
+  coordinates are 1-based
+  for 9x9 baseline, valid range is (1,1) through (9,9)
 
 固定語彙は次の enum 名に合わせる。
 

--- a/experiments/galactic_exodus/srs/render.py
+++ b/experiments/galactic_exodus/srs/render.py
@@ -48,9 +48,9 @@ def render_known_map_spaced(state: SrsGameState) -> str:
 
 def _render_known_map(state: SrsGameState, *, cell_separator: str) -> str:
     rows: list[str] = []
-    for y in range(state.actual_map.height):
+    for y in range(1, state.actual_map.height + 1):
         chars: list[str] = []
-        for x in range(state.actual_map.width):
+        for x in range(1, state.actual_map.width + 1):
             position = Position(x, y)
             chars.append(_render_position(state, position))
         rows.append(cell_separator.join(chars))

--- a/experiments/galactic_exodus/srs/run_fixture.py
+++ b/experiments/galactic_exodus/srs/run_fixture.py
@@ -394,8 +394,9 @@ def _apply_cell_overrides(state: SrsGameState, *, overrides: Any) -> SrsGameStat
         if not state.actual_map.contains(position):
             raise SrsFixtureError(f"initial.cell_overrides[{index}].position out of bounds: {position}")
         terrain = _terrain_type(override.get("terrain"), field_name=f"initial.cell_overrides[{index}].terrain")
-        cell = rows[position.y][position.x]
-        rows[position.y][position.x] = SrsCell(
+        row_idx, col_idx = state.actual_map.indices_for(position)
+        cell = rows[row_idx][col_idx]
+        rows[row_idx][col_idx] = SrsCell(
             terrain=terrain,
             object_id=cell.object_id,
             actor_id=cell.actor_id,

--- a/experiments/galactic_exodus/srs/test_encounter.py
+++ b/experiments/galactic_exodus/srs/test_encounter.py
@@ -52,8 +52,8 @@ class SrsEncounterTests(unittest.TestCase):
         self.assertEqual(encounter_group_budget_range(4), (4, 5))
 
     def test_issue_1202_fixed_encounter_values_and_nebula_modifier_are_used(self) -> None:
-        nebula_state = replace(make_state(), player_position=Position(4, 4))
-        nebula_state = replace_cell_terrain(nebula_state, Position(4, 4), SrsTerrainType.NEBULA)
+        nebula_state = replace(make_state(), player_position=Position(5, 5))
+        nebula_state = replace_cell_terrain(nebula_state, Position(5, 5), SrsTerrainType.NEBULA)
 
         self.assertEqual(EXPECTED_SRS_TURNS, 4)
         self.assertEqual(ENCOUNTERS_PER_LRS_STEP, 0.75)
@@ -76,15 +76,15 @@ class SrsEncounterTests(unittest.TestCase):
         )
 
     def test_spawn_candidates_use_passable_warp_points_outside_player_neighbor_ring(self) -> None:
-        state = replace(make_state(), player_position=Position(4, 4))
+        state = replace(make_state(), player_position=Position(5, 5))
 
         self.assertEqual(
             spawn_candidate_points(state),
             (
-                Position(4, 0),
-                Position(0, 4),
-                Position(8, 4),
-                Position(4, 8),
+                Position(5, 1),
+                Position(1, 5),
+                Position(9, 5),
+                Position(5, 9),
             ),
         )
 
@@ -102,13 +102,13 @@ class SrsEncounterTests(unittest.TestCase):
             entry_edge=descriptor.entry_edge,
             blocked_edges=descriptor.blocked_edges,
         )
-        state = replace(state, descriptor=descriptor, player_position=Position(4, 4))
+        state = replace(state, descriptor=descriptor, player_position=Position(5, 5))
 
         self.assertEqual(
             spawn_candidate_points(state),
             (
-                Position(8, 4),
-                Position(4, 8),
+                Position(9, 5),
+                Position(5, 9),
             ),
         )
 
@@ -126,7 +126,7 @@ class SrsEncounterTests(unittest.TestCase):
             entry_edge=descriptor.entry_edge,
             blocked_edges=descriptor.blocked_edges,
         )
-        state = replace(state, descriptor=descriptor, player_position=Position(4, 4))
+        state = replace(state, descriptor=descriptor, player_position=Position(5, 5))
 
         enemies = spawn_enemies_for_encounter(
             state,
@@ -141,8 +141,8 @@ class SrsEncounterTests(unittest.TestCase):
         self.assertEqual(
             [(enemy.enemy_id, enemy.tier, enemy.position) for enemy in enemies],
             [
-                ("enemy-1", SrsEnemyTier.TIER1, Position(8, 4)),
-                ("enemy-2", SrsEnemyTier.TIER2, Position(4, 8)),
+                ("enemy-1", SrsEnemyTier.TIER1, Position(9, 5)),
+                ("enemy-2", SrsEnemyTier.TIER2, Position(5, 9)),
             ],
         )
 
@@ -153,14 +153,14 @@ class SrsEncounterTests(unittest.TestCase):
         self.assertEqual(
             result.summary["combat_enemy_positions"],
             {
-                "enemy-1": [8, 4],
-                "enemy-2": [4, 8],
+                "enemy-1": [9, 5],
+                "enemy-2": [5, 9],
             },
         )
 
     def test_encounter_roll_is_suppressed_while_enemy_presence_is_active(self) -> None:
         enemy = spawn_enemies_for_encounter(
-            replace(make_state(), player_position=Position(4, 4)),
+            replace(make_state(), player_position=Position(5, 5)),
             danger_score=0,
             composition=(SrsEnemyTier.TIER1,),
         )[0]
@@ -176,7 +176,7 @@ class SrsEncounterTests(unittest.TestCase):
 
     def test_movement_turn_without_enemies_requires_encounter_roll(self) -> None:
         previous_state = make_state()
-        next_state = replace(previous_state, srs_turn=1, player_position=Position(4, 7))
+        next_state = replace(previous_state, srs_turn=1, player_position=Position(5, 8))
 
         disposition = encounter_roll_disposition(previous_state, command_type="MOVE_ROUTE", next_state=next_state)
 

--- a/experiments/galactic_exodus/srs/test_engine_combat.py
+++ b/experiments/galactic_exodus/srs/test_engine_combat.py
@@ -64,39 +64,39 @@ class SrsEngineCombatTests(unittest.TestCase):
         self.assertEqual(result.state.combat_state.combat_turn, 0)
 
     def test_bresenham_line_returns_expected_cells(self) -> None:
-        line = bresenham_line(Position(1, 1), Position(4, 3))
+        line = bresenham_line(Position(2, 2), Position(5, 4))
 
         self.assertEqual(
             line,
             (
-                Position(1, 1),
                 Position(2, 2),
-                Position(3, 2),
+                Position(3, 3),
                 Position(4, 3),
+                Position(5, 4),
             ),
         )
 
     def test_line_of_sight_is_blocked_by_impassable_intermediate_cell(self) -> None:
-        state = replace_cell_terrain(make_state(), Position(2, 4), SrsTerrainType.ASTEROID)
+        state = replace_cell_terrain(make_state(), Position(3, 5), SrsTerrainType.ASTEROID)
 
         self.assertFalse(
             has_clear_line_of_sight(
                 state,
-                attacker=Position(1, 4),
-                target=Position(3, 4),
+                attacker=Position(2, 5),
+                target=Position(4, 5),
             )
         )
 
     def test_line_of_sight_ignores_attacker_and_target_cells_for_blocking(self) -> None:
         state = make_state()
-        state = replace_cell_terrain(state, Position(1, 4), SrsTerrainType.ASTEROID)
-        state = replace_cell_terrain(state, Position(3, 4), SrsTerrainType.ASTEROID)
+        state = replace_cell_terrain(state, Position(2, 5), SrsTerrainType.ASTEROID)
+        state = replace_cell_terrain(state, Position(4, 5), SrsTerrainType.ASTEROID)
 
         self.assertTrue(
             has_clear_line_of_sight(
                 state,
-                attacker=Position(1, 4),
-                target=Position(3, 4),
+                attacker=Position(2, 5),
+                target=Position(4, 5),
             )
         )
 
@@ -106,30 +106,30 @@ class SrsEngineCombatTests(unittest.TestCase):
         self.assertTrue(
             is_attackable_position(
                 state,
-                attacker=Position(1, 4),
-                target=Position(4, 4),
+                attacker=Position(2, 5),
+                target=Position(5, 5),
                 weapon_type=SrsWeaponType.PHOTON_TORPEDO,
             )
         )
         self.assertFalse(
             is_attackable_position(
                 state,
-                attacker=Position(1, 4),
-                target=Position(4, 4),
+                attacker=Position(2, 5),
+                target=Position(5, 5),
                 weapon_type=SrsWeaponType.PHASER,
             )
         )
 
     def test_enemy_attackable_positions_enumerates_clear_los_cells(self) -> None:
-        state = replace(make_state(), player_position=Position(4, 4))
+        state = replace(make_state(), player_position=Position(5, 5))
 
         positions = enemy_attackable_positions(state)
 
-        self.assertIn(Position(2, 4), positions)
-        self.assertIn(Position(4, 2), positions)
-        self.assertIn(Position(6, 6), positions)
-        self.assertNotIn(Position(4, 4), positions)
-        self.assertNotIn(Position(1, 4), positions)
+        self.assertIn(Position(3, 5), positions)
+        self.assertIn(Position(5, 3), positions)
+        self.assertIn(Position(7, 7), positions)
+        self.assertNotIn(Position(5, 5), positions)
+        self.assertNotIn(Position(2, 5), positions)
 
     def test_combat_step_skips_attack_phase_without_target(self) -> None:
         state = make_state()
@@ -154,15 +154,15 @@ class SrsEngineCombatTests(unittest.TestCase):
         self.assertEqual(result.state.combat_state.phase, SrsCombatPhase.ENEMY_ACTION)
 
     def test_combat_step_skips_attack_phase_when_line_of_sight_is_blocked(self) -> None:
-        state = replace_cell_terrain(make_state(), Position(2, 4), SrsTerrainType.ASTEROID)
+        state = replace_cell_terrain(make_state(), Position(3, 5), SrsTerrainType.ASTEROID)
         enemy = create_enemy_combat_state(
             enemy_id="enemy-1",
             tier=SrsEnemyTier.TIER1,
-            position=Position(3, 4),
+            position=Position(4, 5),
         )
         state = replace(
             state,
-            player_position=Position(1, 4),
+            player_position=Position(2, 5),
             combat_state=SrsCombatState(
                 enemies={"enemy-1": enemy},
                 player_attack_target_id="enemy-1",
@@ -183,11 +183,11 @@ class SrsEngineCombatTests(unittest.TestCase):
         enemy = create_enemy_combat_state(
             enemy_id="enemy-1",
             tier=SrsEnemyTier.TIER1,
-            position=Position(5, 4),
+            position=Position(6, 5),
         )
         state = replace(
             state,
-            player_position=Position(1, 4),
+            player_position=Position(2, 5),
             combat_state=SrsCombatState(
                 enemies={"enemy-1": enemy},
                 player_attack_target_id="enemy-1",
@@ -204,11 +204,11 @@ class SrsEngineCombatTests(unittest.TestCase):
         self.assertFalse(result.events[0].payload["target_attackable"])
 
     def test_player_attack_with_torpedo_consumes_ammo_and_removes_destroyed_enemy(self) -> None:
-        state = replace(make_state(), player_position=Position(1, 4))
+        state = replace(make_state(), player_position=Position(2, 5))
         enemy = create_enemy_combat_state(
             enemy_id="enemy-1",
             tier=SrsEnemyTier.TIER1,
-            position=Position(3, 4),
+            position=Position(4, 5),
         )
         state = replace(
             state,
@@ -248,11 +248,11 @@ class SrsEngineCombatTests(unittest.TestCase):
         )
 
     def test_destroyed_enemy_drop_adds_salvage_and_applies_choice(self) -> None:
-        state = replace(make_state(), player_position=Position(1, 4))
+        state = replace(make_state(), player_position=Position(2, 5))
         enemy = create_enemy_combat_state(
             enemy_id="enemy-3",
             tier=SrsEnemyTier.TIER3,
-            position=Position(3, 4),
+            position=Position(4, 5),
             drop_salvage=True,
         )
         enemy = replace(enemy, durability=3)
@@ -284,11 +284,11 @@ class SrsEngineCombatTests(unittest.TestCase):
         self.assertEqual(result.events[0].payload["player_action"]["salvage_reward"]["selected_salvage_choice"], "RECOVER_ENERGY")
 
     def test_destroyed_enemy_without_drop_does_not_change_salvage(self) -> None:
-        state = replace(make_state(), player_position=Position(1, 4))
+        state = replace(make_state(), player_position=Position(2, 5))
         enemy = create_enemy_combat_state(
             enemy_id="enemy-1",
             tier=SrsEnemyTier.TIER1,
-            position=Position(3, 4),
+            position=Position(4, 5),
             drop_salvage=False,
         )
         state = replace(
@@ -316,11 +316,11 @@ class SrsEngineCombatTests(unittest.TestCase):
         self.assertNotIn("salvage_reward", result.events[0].payload["player_action"])
 
     def test_player_attack_with_phaser_consumes_energy_and_applies_fixed_damage(self) -> None:
-        state = replace(make_state(), player_position=Position(1, 4))
+        state = replace(make_state(), player_position=Position(2, 5))
         enemy = create_enemy_combat_state(
             enemy_id="enemy-1",
             tier=SrsEnemyTier.TIER2,
-            position=Position(2, 4),
+            position=Position(3, 5),
         )
         state = replace(
             state,
@@ -346,11 +346,11 @@ class SrsEngineCombatTests(unittest.TestCase):
         self.assertEqual(result.events[0].payload["player_action"]["damage_applied"], 1)
 
     def test_player_attack_can_skip_without_consuming_resources(self) -> None:
-        state = replace(make_state(), player_position=Position(1, 4))
+        state = replace(make_state(), player_position=Position(2, 5))
         enemy = create_enemy_combat_state(
             enemy_id="enemy-1",
             tier=SrsEnemyTier.TIER1,
-            position=Position(3, 4),
+            position=Position(4, 5),
         )
         combat_state = SrsCombatState(
             enemies={"enemy-1": enemy},
@@ -400,17 +400,17 @@ class SrsEngineCombatTests(unittest.TestCase):
         enemy_t4 = create_enemy_combat_state(
             enemy_id="enemy-4",
             tier=SrsEnemyTier.TIER4,
-            position=Position(2, 4),
+            position=Position(3, 5),
         )
         enemy_t2 = create_enemy_combat_state(
             enemy_id="enemy-2",
             tier=SrsEnemyTier.TIER2,
-            position=Position(1, 3),
+            position=Position(2, 4),
         )
         enemy_t1 = create_enemy_combat_state(
             enemy_id="enemy-1",
             tier=SrsEnemyTier.TIER1,
-            position=Position(0, 4),
+            position=Position(1, 5),
         )
 
         combat_state = SrsCombatState(
@@ -424,21 +424,21 @@ class SrsEngineCombatTests(unittest.TestCase):
         self.assertEqual(tuple(combat_state.enemies), ("enemy-1", "enemy-2", "enemy-4"))
 
     def test_multiple_enemy_actions_follow_tier_ascending_order(self) -> None:
-        state = replace(make_state(), player_position=Position(1, 4))
+        state = replace(make_state(), player_position=Position(2, 5))
         enemy_t4 = create_enemy_combat_state(
             enemy_id="enemy-4",
             tier=SrsEnemyTier.TIER4,
-            position=Position(2, 4),
+            position=Position(3, 5),
         )
         enemy_t2 = create_enemy_combat_state(
             enemy_id="enemy-2",
             tier=SrsEnemyTier.TIER2,
-            position=Position(1, 3),
+            position=Position(2, 4),
         )
         enemy_t1 = create_enemy_combat_state(
             enemy_id="enemy-1",
             tier=SrsEnemyTier.TIER1,
-            position=Position(0, 4),
+            position=Position(1, 5),
         )
         state = replace(
             state,
@@ -476,7 +476,7 @@ class SrsEngineCombatTests(unittest.TestCase):
         self.assertEqual(result.state.combat_state.enemies["enemy-4"].durability, 11)
 
     def test_three_enemy_pressure_can_exhaust_counterattacks_on_second_turn(self) -> None:
-        state = replace(make_state(), player_position=Position(1, 4))
+        state = replace(make_state(), player_position=Position(2, 5))
         state = replace(
             state,
             combat_state=SrsCombatState(
@@ -484,17 +484,17 @@ class SrsEngineCombatTests(unittest.TestCase):
                     "enemy-4": create_enemy_combat_state(
                         enemy_id="enemy-4",
                         tier=SrsEnemyTier.TIER4,
-                        position=Position(2, 4),
+                        position=Position(3, 5),
                     ),
                     "enemy-2": create_enemy_combat_state(
                         enemy_id="enemy-2",
                         tier=SrsEnemyTier.TIER2,
-                        position=Position(1, 3),
+                        position=Position(2, 4),
                     ),
                     "enemy-1": create_enemy_combat_state(
                         enemy_id="enemy-1",
                         tier=SrsEnemyTier.TIER1,
-                        position=Position(0, 4),
+                        position=Position(1, 5),
                     ),
                 },
                 phase=SrsCombatPhase.PLAYER_ATTACK,
@@ -545,13 +545,13 @@ class SrsEngineCombatTests(unittest.TestCase):
         self.assertTrue(result.events[4].payload["enemy_actions"][2]["reaction"]["fallback_to_defend"])
 
     def test_enemy_action_moves_to_lowest_total_movement_cost_attack_cell(self) -> None:
-        state = replace(make_state(), player_position=Position(4, 4))
-        for position in (Position(1, 4), Position(2, 4)):
+        state = replace(make_state(), player_position=Position(5, 5))
+        for position in (Position(2, 5), Position(3, 5)):
             state = replace_cell_terrain(state, position, SrsTerrainType.ASTEROID_FIELD)
         enemy = create_enemy_combat_state(
             enemy_id="enemy-1",
             tier=SrsEnemyTier.TIER1,
-            position=Position(0, 4),
+            position=Position(1, 5),
         )
         state = replace(
             state,
@@ -568,18 +568,18 @@ class SrsEngineCombatTests(unittest.TestCase):
         )
 
         enemy_action = result.events[0].payload["enemy_actions"][0]
-        self.assertEqual(enemy_action["target_attackable_position"], [2, 3])
-        self.assertEqual(enemy_action["planned_path"], [[0, 3], [1, 3], [2, 3]])
-        self.assertEqual(result.state.combat_state.enemies["enemy-1"].position, Position(2, 3))
+        self.assertEqual(enemy_action["target_attackable_position"], [3, 4])
+        self.assertEqual(enemy_action["planned_path"], [[1, 4], [2, 4], [3, 4]])
+        self.assertEqual(result.state.combat_state.enemies["enemy-1"].position, Position(3, 4))
 
     def test_enemy_action_uses_deterministic_cell_order_for_equal_cost_targets(self) -> None:
-        state = replace(make_state(), player_position=Position(6, 4))
-        for position in (Position(1, 4), Position(2, 4), Position(3, 4), Position(4, 4)):
+        state = replace(make_state(), player_position=Position(7, 5))
+        for position in (Position(2, 5), Position(3, 5), Position(4, 5), Position(5, 5)):
             state = replace_cell_terrain(state, position, SrsTerrainType.ASTEROID)
         enemy = create_enemy_combat_state(
             enemy_id="enemy-1",
             tier=SrsEnemyTier.TIER1,
-            position=Position(0, 4),
+            position=Position(1, 5),
         )
         state = replace(
             state,
@@ -596,13 +596,13 @@ class SrsEngineCombatTests(unittest.TestCase):
         )
 
         enemy_action = result.events[0].payload["enemy_actions"][0]
-        self.assertEqual(enemy_action["target_attackable_position"], [4, 3])
+        self.assertEqual(enemy_action["target_attackable_position"], [5, 4])
         self.assertEqual(
             enemy_action["planned_path"],
-            [[0, 3], [1, 3], [2, 3], [3, 3], [4, 3]],
+            [[1, 4], [2, 4], [3, 4], [4, 4], [5, 4]],
         )
-        self.assertEqual(enemy_action["moved_path"], [[0, 3], [1, 3], [2, 3]])
-        self.assertEqual(result.state.combat_state.enemies["enemy-1"].position, Position(2, 3))
+        self.assertEqual(enemy_action["moved_path"], [[1, 4], [2, 4], [3, 4]])
+        self.assertEqual(result.state.combat_state.enemies["enemy-1"].position, Position(3, 4))
 
     def test_enemy_attack_defend_halves_damage_and_rounds_up(self) -> None:
         state = make_state()
@@ -635,11 +635,11 @@ class SrsEngineCombatTests(unittest.TestCase):
         enemy = create_enemy_combat_state(
             enemy_id="enemy-1",
             tier=SrsEnemyTier.TIER1,
-            position=Position(2, 4),
+            position=Position(3, 5),
         )
         state = replace(
             state,
-            player_position=Position(1, 4),
+            player_position=Position(2, 5),
             combat_state=SrsCombatState(
                 enemies={"enemy-1": enemy},
                 phase=SrsCombatPhase.ENEMY_ACTION,
@@ -665,7 +665,7 @@ class SrsEngineCombatTests(unittest.TestCase):
         enemy = create_enemy_combat_state(
             enemy_id="enemy-1",
             tier=SrsEnemyTier.TIER1,
-            position=Position(2, 4),
+            position=Position(3, 5),
         )
         combat_state = SrsCombatState(
             enemies={"enemy-1": enemy},
@@ -674,7 +674,7 @@ class SrsEngineCombatTests(unittest.TestCase):
         combat_state = replace(combat_state, player=replace(combat_state.player, energy=0))
         state = replace(
             state,
-            player_position=Position(1, 4),
+            player_position=Position(2, 5),
             combat_state=combat_state,
         )
 

--- a/experiments/galactic_exodus/srs/test_engine_interaction.py
+++ b/experiments/galactic_exodus/srs/test_engine_interaction.py
@@ -31,7 +31,7 @@ class SrsEngineInteractionTests(unittest.TestCase):
         cls.contracts = load_default_contracts(REPO_ROOT)
 
     def test_resource_cache_refuels_and_consumes(self) -> None:
-        state = place_object(make_state(fuel=2, max_fuel=9), Position(4, 8), SrsObjectType.RESOURCE_CACHE, "resource-cache-1")
+        state = place_object(make_state(fuel=2, max_fuel=9), Position(5, 9), SrsObjectType.RESOURCE_CACHE, "resource-cache-1")
 
         result = apply_srs_command(
             state,
@@ -46,7 +46,7 @@ class SrsEngineInteractionTests(unittest.TestCase):
         self.assertEqual([event.event_type for event in result.events], [INTERACT_ACCEPTED, OBJECT_CONSUMED])
 
     def test_resource_cache_uses_issue_fixed_restore_value(self) -> None:
-        state = place_object(make_state(fuel=2, max_fuel=9), Position(4, 8), SrsObjectType.RESOURCE_CACHE, "resource-cache-1")
+        state = place_object(make_state(fuel=2, max_fuel=9), Position(5, 9), SrsObjectType.RESOURCE_CACHE, "resource-cache-1")
 
         result = apply_srs_command(
             state,
@@ -58,7 +58,7 @@ class SrsEngineInteractionTests(unittest.TestCase):
         self.assertEqual(result.events[1].payload["fuel_restore"], 3)
 
     def test_resource_cache_caps_at_max_fuel(self) -> None:
-        state = place_object(make_state(fuel=8, max_fuel=9), Position(4, 8), SrsObjectType.RESOURCE_CACHE, "resource-cache-1")
+        state = place_object(make_state(fuel=8, max_fuel=9), Position(5, 9), SrsObjectType.RESOURCE_CACHE, "resource-cache-1")
 
         result = apply_srs_command(
             state,
@@ -70,7 +70,7 @@ class SrsEngineInteractionTests(unittest.TestCase):
         self.assertEqual(result.events[0].payload["fuel_delta"], 1)
 
     def test_resource_cache_full_fuel_does_not_consume(self) -> None:
-        state = place_object(make_state(fuel=9, max_fuel=9), Position(4, 8), SrsObjectType.RESOURCE_CACHE, "resource-cache-1")
+        state = place_object(make_state(fuel=9, max_fuel=9), Position(5, 9), SrsObjectType.RESOURCE_CACHE, "resource-cache-1")
 
         result = apply_srs_command(
             state,
@@ -83,7 +83,7 @@ class SrsEngineInteractionTests(unittest.TestCase):
         self.assertEqual(result.state, state)
 
     def test_resource_cache_revisit_remains_consumed(self) -> None:
-        state = place_object(make_state(fuel=2, max_fuel=9), Position(4, 8), SrsObjectType.RESOURCE_CACHE, "resource-cache-1")
+        state = place_object(make_state(fuel=2, max_fuel=9), Position(5, 9), SrsObjectType.RESOURCE_CACHE, "resource-cache-1")
         consumed_state = replace(
             state,
             objects={
@@ -106,7 +106,7 @@ class SrsEngineInteractionTests(unittest.TestCase):
         self.assertEqual(result.state, consumed_state)
 
     def test_station_recovers_all_resources_to_max(self) -> None:
-        state = place_object(make_state(fuel=2, max_fuel=9), Position(4, 7), SrsObjectType.STATION, "station-1")
+        state = place_object(make_state(fuel=2, max_fuel=9), Position(5, 8), SrsObjectType.STATION, "station-1")
         state = replace(
             state,
             player_state=replace(
@@ -133,7 +133,7 @@ class SrsEngineInteractionTests(unittest.TestCase):
         self.assertEqual([event.event_type for event in result.events], [INTERACT_ACCEPTED, STATION_ACTIVATED])
 
     def test_station_reusable(self) -> None:
-        state = place_object(make_state(fuel=3, max_fuel=9), Position(4, 7), SrsObjectType.STATION, "station-1")
+        state = place_object(make_state(fuel=3, max_fuel=9), Position(5, 8), SrsObjectType.STATION, "station-1")
         state = replace(
             state,
             persistent_state=replace(
@@ -157,7 +157,7 @@ class SrsEngineInteractionTests(unittest.TestCase):
         self.assertEqual(result.state.fuel, 9)
 
     def test_station_requires_adjacent(self) -> None:
-        state = place_object(make_state(fuel=2, max_fuel=9), Position(4, 6), SrsObjectType.STATION, "station-1")
+        state = place_object(make_state(fuel=2, max_fuel=9), Position(5, 7), SrsObjectType.STATION, "station-1")
 
         result = apply_srs_command(
             state,
@@ -169,7 +169,7 @@ class SrsEngineInteractionTests(unittest.TestCase):
         self.assertEqual(result.state, state)
 
     def test_station_can_buy_base_upgrade(self) -> None:
-        state = place_object(make_state(fuel=9, max_fuel=9), Position(4, 7), SrsObjectType.STATION, "station-1")
+        state = place_object(make_state(fuel=9, max_fuel=9), Position(5, 8), SrsObjectType.STATION, "station-1")
         state = replace(
             state,
             player_state=replace(state.player_state, salvage=4, defense=1),
@@ -191,7 +191,7 @@ class SrsEngineInteractionTests(unittest.TestCase):
         self.assertEqual(result.events[0].payload["selected_upgrade"], "DEFENSE")
 
     def test_salvage_store_only_adds_inventory(self) -> None:
-        state = place_object(make_state(fuel=2, max_fuel=9), Position(4, 8), SrsObjectType.SALVAGE, "salvage-1")
+        state = place_object(make_state(fuel=2, max_fuel=9), Position(5, 9), SrsObjectType.SALVAGE, "salvage-1")
 
         result = apply_srs_command(
             state,
@@ -207,7 +207,7 @@ class SrsEngineInteractionTests(unittest.TestCase):
         self.assertEqual(result.events[0].payload["selected_salvage_choice"], "STORE_ONLY")
 
     def test_salvage_recover_energy_adds_inventory_and_caps_no_overflow(self) -> None:
-        state = place_object(make_state(fuel=2, max_fuel=9), Position(4, 8), SrsObjectType.SALVAGE, "salvage-1")
+        state = place_object(make_state(fuel=2, max_fuel=9), Position(5, 9), SrsObjectType.SALVAGE, "salvage-1")
         state = replace(state, player_state=replace(state.player_state, energy=5))
 
         result = apply_srs_command(
@@ -225,7 +225,7 @@ class SrsEngineInteractionTests(unittest.TestCase):
         self.assertEqual(result.events[0].payload["energy_delta"], 1)
 
     def test_interact_rejected_does_not_consume_turn(self) -> None:
-        state = place_object(make_state(fuel=2, max_fuel=9), Position(4, 6), SrsObjectType.STATION, "station-1")
+        state = place_object(make_state(fuel=2, max_fuel=9), Position(5, 7), SrsObjectType.STATION, "station-1")
 
         result = apply_srs_command(
             state,
@@ -237,7 +237,7 @@ class SrsEngineInteractionTests(unittest.TestCase):
         self.assertEqual(result.state, state)
 
     def test_interact_accepted_consumes_one_turn(self) -> None:
-        state = place_object(make_state(fuel=1, max_fuel=9), Position(4, 7), SrsObjectType.STATION, "station-1")
+        state = place_object(make_state(fuel=1, max_fuel=9), Position(5, 8), SrsObjectType.STATION, "station-1")
 
         result = apply_srs_command(
             state,
@@ -248,7 +248,7 @@ class SrsEngineInteractionTests(unittest.TestCase):
         self.assertEqual(result.state.srs_turn, 1)
 
     def test_interaction_log_fields(self) -> None:
-        state = place_object(make_state(fuel=2, max_fuel=9), Position(4, 8), SrsObjectType.RESOURCE_CACHE, "resource-cache-1")
+        state = place_object(make_state(fuel=2, max_fuel=9), Position(5, 9), SrsObjectType.RESOURCE_CACHE, "resource-cache-1")
 
         result = apply_srs_command(
             state,

--- a/experiments/galactic_exodus/srs/test_engine_movement.py
+++ b/experiments/galactic_exodus/srs/test_engine_movement.py
@@ -73,7 +73,8 @@ def replace_cell_terrain(
 ) -> SrsGameState:
     rows = [list(row) for row in state.actual_map.cells]
     current = state.actual_map.cell_at(position)
-    rows[position.y][position.x] = SrsCell(
+    row_idx, col_idx = state.actual_map.indices_for(position)
+    rows[row_idx][col_idx] = SrsCell(
         terrain=terrain,
         object_id=current.object_id,
         actor_id=current.actor_id,
@@ -90,7 +91,8 @@ def place_object(
 ) -> SrsGameState:
     rows = [list(row) for row in state.actual_map.cells]
     current = state.actual_map.cell_at(position)
-    rows[position.y][position.x] = SrsCell(
+    row_idx, col_idx = state.actual_map.indices_for(position)
+    rows[row_idx][col_idx] = SrsCell(
         terrain=current.terrain,
         object_id=object_id,
         actor_id=current.actor_id,
@@ -259,13 +261,13 @@ class SrsEngineMovementTests(unittest.TestCase):
             contracts=self.contracts,
         )
 
-        self.assertEqual(result.state.player_position, Position(4, 4))
+        self.assertEqual(result.state.player_position, Position(5, 5))
         self.assertEqual(result.events[0].event_type, MOVE_ACCEPTED)
         self.assertEqual(result.events[0].payload["movement_raw_cost"], 40)
         self.assertEqual(result.events[0].payload["outcome"], "BUDGET_EXHAUSTED")
 
     def test_debris_cost_shortens_movement(self) -> None:
-        state = replace_cell_terrain(make_state(), Position(4, 7), SrsTerrainType.DEBRIS)
+        state = replace_cell_terrain(make_state(), Position(5, 8), SrsTerrainType.DEBRIS)
 
         result = apply_srs_command(
             state,
@@ -276,11 +278,11 @@ class SrsEngineMovementTests(unittest.TestCase):
             contracts=self.contracts,
         )
 
-        self.assertEqual(result.state.player_position, Position(4, 5))
+        self.assertEqual(result.state.player_position, Position(5, 6))
         self.assertEqual(result.events[0].payload["movement_raw_cost"], 40)
 
     def test_asteroid_field_cost_shortens_movement(self) -> None:
-        state = replace_cell_terrain(make_state(), Position(4, 7), SrsTerrainType.ASTEROID_FIELD)
+        state = replace_cell_terrain(make_state(), Position(5, 8), SrsTerrainType.ASTEROID_FIELD)
 
         result = apply_srs_command(
             state,
@@ -291,7 +293,7 @@ class SrsEngineMovementTests(unittest.TestCase):
             contracts=self.contracts,
         )
 
-        self.assertEqual(result.state.player_position, Position(4, 6))
+        self.assertEqual(result.state.player_position, Position(5, 7))
         self.assertEqual(result.events[0].payload["movement_raw_cost"], 40)
 
     def test_stop_before_first_blocked_cell(self) -> None:
@@ -301,7 +303,7 @@ class SrsEngineMovementTests(unittest.TestCase):
                 entry_edge=Direction.S,
                 blocked_edges=frozenset({Direction.N}),
             ),
-            Position(4, 7),
+            Position(5, 8),
             SrsTerrainType.RIFT_BARRIER,
         )
 
@@ -377,7 +379,7 @@ class SrsEngineMovementTests(unittest.TestCase):
         self.assertEqual(result.events[0].payload["fuel_after"], 0)
 
     def test_stop_before_after_partial_movement(self) -> None:
-        state = place_object(make_state(), Position(4, 5), SrsObjectType.STAR, "star-blocker")
+        state = place_object(make_state(), Position(5, 6), SrsObjectType.STAR, "star-blocker")
 
         result = apply_srs_command(
             state,
@@ -388,9 +390,9 @@ class SrsEngineMovementTests(unittest.TestCase):
             contracts=self.contracts,
         )
 
-        self.assertEqual(result.state.player_position, Position(4, 6))
+        self.assertEqual(result.state.player_position, Position(5, 7))
         self.assertEqual(result.events[0].event_type, STOPPED_BEFORE_IMPASSABLE)
-        self.assertEqual(result.events[0].payload["blocked_position"], [4, 5])
+        self.assertEqual(result.events[0].payload["blocked_position"], [5, 6])
         self.assertEqual(result.events[0].payload["movement_raw_cost"], 20)
 
     def test_shared_fuel_first_blocked_cell_costs_zero_fuel(self) -> None:
@@ -402,7 +404,7 @@ class SrsEngineMovementTests(unittest.TestCase):
                 fuel=5,
                 max_fuel=9,
             ),
-            Position(4, 7),
+            Position(5, 8),
             SrsTerrainType.RIFT_BARRIER,
         )
 
@@ -420,7 +422,7 @@ class SrsEngineMovementTests(unittest.TestCase):
         self.assertEqual(result.events[0].payload["fuel_after"], 5)
 
     def test_shared_fuel_partial_blocked_counts_passable_cells_only(self) -> None:
-        state = place_object(make_state(fuel=5, max_fuel=9), Position(4, 5), SrsObjectType.STAR, "star-blocker")
+        state = place_object(make_state(fuel=5, max_fuel=9), Position(5, 6), SrsObjectType.STAR, "star-blocker")
 
         result = apply_srs_command(
             state,
@@ -479,11 +481,11 @@ class SrsEngineMovementTests(unittest.TestCase):
         )
 
         self.assertEqual([event.event_type for event in result.events], [MOVE_ACCEPTED, OBSERVATION_UPDATED, OBSERVATION_UPDATED])
-        self.assertEqual(result.events[0].payload["observation_updates"], [[4, 7], [4, 6]])
-        self.assertEqual(result.state.known_state.visited_cells, frozenset({Position(4, 7), Position(4, 6)}))
+        self.assertEqual(result.events[0].payload["observation_updates"], [[5, 8], [5, 7]])
+        self.assertEqual(result.state.known_state.visited_cells, frozenset({Position(5, 8), Position(5, 7)}))
 
     def test_partial_blocked_updates_observation_for_entered_cells_only(self) -> None:
-        state = place_object(make_state(), Position(4, 5), SrsObjectType.STATION, "station-blocker")
+        state = place_object(make_state(), Position(5, 6), SrsObjectType.STATION, "station-blocker")
 
         result = apply_srs_command(
             state,
@@ -492,8 +494,8 @@ class SrsEngineMovementTests(unittest.TestCase):
         )
 
         self.assertEqual([event.event_type for event in result.events], [STOPPED_BEFORE_IMPASSABLE, OBSERVATION_UPDATED, OBSERVATION_UPDATED])
-        self.assertEqual(result.events[0].payload["observation_updates"], [[4, 7], [4, 6]])
-        self.assertNotIn(Position(4, 5), result.state.known_state.visited_cells)
+        self.assertEqual(result.events[0].payload["observation_updates"], [[5, 8], [5, 7]])
+        self.assertNotIn(Position(5, 6), result.state.known_state.visited_cells)
 
     def test_rejected_command_no_turn_no_observation(self) -> None:
         state = make_state()
@@ -528,13 +530,13 @@ class SrsEngineMovementTests(unittest.TestCase):
 
         result = apply_srs_command(
             state,
-            SrsCommand(command_type="MOVE_TO", target=Position(4, 7)),
+            SrsCommand(command_type="MOVE_TO", target=Position(5, 8)),
             contracts=self.contracts,
         )
 
         self.assertEqual(result.events[0].event_type, MOVE_REJECTED)
         self.assertEqual(result.events[0].payload["outcome"], "REJECTED_UNKNOWN_TARGET")
-        self.assertEqual(result.events[0].payload["target_position"], [4, 7])
+        self.assertEqual(result.events[0].payload["target_position"], [5, 8])
         self.assertEqual(result.events[0].payload["resolved_route"], [])
         self.assertEqual(result.state, state)
 
@@ -549,7 +551,7 @@ class SrsEngineMovementTests(unittest.TestCase):
 
         self.assertEqual(result.events[0].event_type, MOVE_REJECTED)
         self.assertEqual(result.events[0].payload["outcome"], "REJECTED_SAME_POSITION")
-        self.assertEqual(result.events[0].payload["target_position"], [4, 8])
+        self.assertEqual(result.events[0].payload["target_position"], [5, 9])
         self.assertEqual(result.events[0].payload["resolved_route"], [])
         self.assertEqual(result.state, state)
 
@@ -558,18 +560,18 @@ class SrsEngineMovementTests(unittest.TestCase):
 
         result = apply_srs_command(
             state,
-            SrsCommand(command_type="MOVE_TO", target=Position(-1, 8)),
+            SrsCommand(command_type="MOVE_TO", target=Position(-1, 9)),
             contracts=self.contracts,
         )
 
         self.assertEqual(result.events[0].event_type, MOVE_REJECTED)
         self.assertEqual(result.events[0].payload["outcome"], "REJECTED_OUT_OF_BOUNDS")
-        self.assertEqual(result.events[0].payload["target_position"], [-1, 8])
+        self.assertEqual(result.events[0].payload["target_position"], [-1, 9])
         self.assertEqual(result.events[0].payload["resolved_route"], [])
         self.assertEqual(result.state, state)
 
     def test_move_to_rejects_no_path(self) -> None:
-        target = Position(4, 6)
+        target = Position(5, 7)
         state = reveal_positions(make_state(), [target])
 
         result = apply_srs_command(
@@ -580,17 +582,17 @@ class SrsEngineMovementTests(unittest.TestCase):
 
         self.assertEqual(result.events[0].event_type, MOVE_REJECTED)
         self.assertEqual(result.events[0].payload["outcome"], "REJECTED_NO_PATH")
-        self.assertEqual(result.events[0].payload["target_position"], [4, 6])
+        self.assertEqual(result.events[0].payload["target_position"], [5, 7])
         self.assertEqual(result.events[0].payload["resolved_route"], [])
         self.assertEqual(result.state, state)
 
     def test_move_to_uses_known_cells_bfs_neighbor_order(self) -> None:
-        target = Position(5, 7)
+        target = Position(6, 8)
         state = reveal_positions(
             make_state(),
             [
-                Position(4, 7),
                 Position(5, 8),
+                Position(6, 9),
                 target,
             ],
         )
@@ -603,20 +605,20 @@ class SrsEngineMovementTests(unittest.TestCase):
 
         self.assertEqual(result.events[0].event_type, MOVE_ACCEPTED)
         self.assertEqual(result.events[0].payload["resolved_route"], ["N", "E"])
-        self.assertEqual(result.events[0].payload["entered_cells"], [[4, 7], [5, 7]])
+        self.assertEqual(result.events[0].payload["entered_cells"], [[5, 8], [6, 8]])
 
     def test_move_to_executes_resolved_route(self) -> None:
         state = reveal_all_for_move_to(make_state())
 
         result = apply_srs_command(
             state,
-            SrsCommand(command_type="MOVE_TO", target=Position(4, 6)),
+            SrsCommand(command_type="MOVE_TO", target=Position(5, 7)),
             contracts=self.contracts,
         )
 
-        self.assertEqual(result.state.player_position, Position(4, 6))
+        self.assertEqual(result.state.player_position, Position(5, 7))
         self.assertEqual(result.events[0].event_type, MOVE_ACCEPTED)
-        self.assertEqual(result.events[0].payload["entered_cells"], [[4, 7], [4, 6]])
+        self.assertEqual(result.events[0].payload["entered_cells"], [[5, 8], [5, 7]])
         self.assertEqual(result.events[0].payload["movement_raw_cost"], 20)
 
     def test_shared_fuel_move_to_uses_resolved_route_cost(self) -> None:
@@ -624,7 +626,7 @@ class SrsEngineMovementTests(unittest.TestCase):
 
         result = apply_srs_command(
             state,
-            SrsCommand(command_type="MOVE_TO", target=Position(4, 6)),
+            SrsCommand(command_type="MOVE_TO", target=Position(5, 7)),
             contracts=self.contracts,
             cost_mode=CostMode.SHARED_FUEL,
         )
@@ -641,7 +643,7 @@ class SrsEngineMovementTests(unittest.TestCase):
 
         result = apply_srs_command(
             state,
-            SrsCommand(command_type="MOVE_TO", target=Position(4, 6)),
+            SrsCommand(command_type="MOVE_TO", target=Position(5, 7)),
             contracts=self.contracts,
         )
 
@@ -649,20 +651,20 @@ class SrsEngineMovementTests(unittest.TestCase):
             [event.event_type for event in result.events],
             [MOVE_ACCEPTED, OBSERVATION_UPDATED, OBSERVATION_UPDATED],
         )
-        self.assertEqual(result.events[0].payload["observation_updates"], [[4, 7], [4, 6]])
-        self.assertEqual(result.state.known_state.visited_cells, frozenset({Position(4, 7), Position(4, 6)}))
+        self.assertEqual(result.events[0].payload["observation_updates"], [[5, 8], [5, 7]])
+        self.assertEqual(result.state.known_state.visited_cells, frozenset({Position(5, 8), Position(5, 7)}))
 
     def test_move_to_payload_contains_target_and_resolved_route(self) -> None:
         state = reveal_all_for_move_to(make_state())
 
         result = apply_srs_command(
             state,
-            SrsCommand(command_type="MOVE_TO", target=Position(5, 7)),
+            SrsCommand(command_type="MOVE_TO", target=Position(6, 8)),
             contracts=self.contracts,
         )
 
         self.assertEqual(result.events[0].payload["command_type"], "MOVE_TO")
-        self.assertEqual(result.events[0].payload["target_position"], [5, 7])
+        self.assertEqual(result.events[0].payload["target_position"], [6, 8])
         self.assertEqual(result.events[0].payload["resolved_route"], ["N", "E"])
 
     def test_move_to_budget_stop_uses_resolved_route_prefix(self) -> None:
@@ -670,22 +672,22 @@ class SrsEngineMovementTests(unittest.TestCase):
 
         result = apply_srs_command(
             state,
-            SrsCommand(command_type="MOVE_TO", target=Position(4, 3)),
+            SrsCommand(command_type="MOVE_TO", target=Position(5, 4)),
             contracts=self.contracts,
         )
 
         self.assertEqual(result.events[0].event_type, MOVE_ACCEPTED)
         self.assertEqual(result.events[0].payload["outcome"], "BUDGET_EXHAUSTED")
         self.assertEqual(result.events[0].payload["resolved_route"], ["N", "N", "N", "N", "N"])
-        self.assertEqual(result.events[0].payload["entered_cells"], [[4, 7], [4, 6], [4, 5], [4, 4]])
-        self.assertEqual(result.state.player_position, Position(4, 4))
+        self.assertEqual(result.events[0].payload["entered_cells"], [[5, 8], [5, 7], [5, 6], [5, 5]])
+        self.assertEqual(result.state.player_position, Position(5, 5))
 
     def test_move_to_replaces_1107_unimplemented_reject(self) -> None:
         state = reveal_all_for_move_to(make_state())
 
         result = apply_srs_command(
             state,
-            SrsCommand(command_type="MOVE_TO", target=Position(4, 7)),
+            SrsCommand(command_type="MOVE_TO", target=Position(5, 8)),
             contracts=self.contracts,
         )
 
@@ -693,7 +695,7 @@ class SrsEngineMovementTests(unittest.TestCase):
         self.assertNotEqual(result.events[0].payload["outcome"], "REJECTED_MOVE_TO_UNIMPLEMENTED")
 
     def test_impassable_star_blocks_movement(self) -> None:
-        state = place_object(make_state(), Position(4, 7), SrsObjectType.STAR, "star-blocker")
+        state = place_object(make_state(), Position(5, 8), SrsObjectType.STAR, "star-blocker")
 
         result = apply_srs_command(
             state,
@@ -702,7 +704,7 @@ class SrsEngineMovementTests(unittest.TestCase):
         )
 
         self.assertEqual(result.events[0].event_type, STOPPED_BEFORE_IMPASSABLE)
-        self.assertEqual(result.events[0].payload["blocked_position"], [4, 7])
+        self.assertEqual(result.events[0].payload["blocked_position"], [5, 8])
 
     def test_run_srs_commands_accumulates_events(self) -> None:
         state = make_state()

--- a/experiments/galactic_exodus/srs/test_engine_warp.py
+++ b/experiments/galactic_exodus/srs/test_engine_warp.py
@@ -56,7 +56,8 @@ def replace_cell(
 ) -> SrsGameState:
     rows = [list(row) for row in state.actual_map.cells]
     current = state.actual_map.cell_at(position)
-    rows[position.y][position.x] = SrsCell(
+    row_idx, col_idx = state.actual_map.indices_for(position)
+    rows[row_idx][col_idx] = SrsCell(
         terrain=current.terrain if terrain is None else terrain,
         object_id=current.object_id,
         actor_id=current.actor_id,
@@ -80,7 +81,7 @@ class SrsEngineWarpTests(unittest.TestCase):
             SrsCommand(command_type="WARP_EXIT")
 
     def test_warp_exit_requires_current_cell_direction_flag(self) -> None:
-        state = make_state(player_position=Position(4, 4))
+        state = make_state(player_position=Position(5, 5))
 
         result = apply_srs_command(
             state,
@@ -147,7 +148,7 @@ class SrsEngineWarpTests(unittest.TestCase):
         self.assertEqual(result.state.srs_turn, state.srs_turn + 1)
 
     def test_warp_exit_rejected_does_not_consume_turn(self) -> None:
-        state = make_state(player_position=Position(4, 4))
+        state = make_state(player_position=Position(5, 5))
 
         result = apply_srs_command(
             state,
@@ -184,8 +185,8 @@ class SrsEngineWarpTests(unittest.TestCase):
             {
                 "command_type": "WARP_EXIT",
                 "exit_direction": "N",
-                "start_position": [4, 0],
-                "warp_position": [4, 0],
+                "start_position": [5, 1],
+                "warp_position": [5, 1],
                 "sector_id": state.descriptor.sector_id,
                 "generated_map_id": state.persistent_state.generated_map_id,
                 "outcome": "ACCEPTED",
@@ -194,7 +195,7 @@ class SrsEngineWarpTests(unittest.TestCase):
 
     def test_warp_exit_rejects_out_of_bounds_player_position_first(self) -> None:
         state = make_state(entry_edge=Direction.S)
-        state = replace(state, player_position=Position(-1, 8))
+        state = replace(state, player_position=Position(-1, 9))
 
         result = apply_srs_command(
             state,

--- a/experiments/galactic_exodus/srs/test_evaluate_policies.py
+++ b/experiments/galactic_exodus/srs/test_evaluate_policies.py
@@ -77,7 +77,8 @@ def replace_cell_warp_flags(
 ) -> SrsGameState:
     rows = [list(row) for row in state.actual_map.cells]
     current = state.actual_map.cell_at(position)
-    rows[position.y][position.x] = SrsCell(
+    row_idx, col_idx = state.actual_map.indices_for(position)
+    rows[row_idx][col_idx] = SrsCell(
         terrain=current.terrain,
         object_id=current.object_id,
         actor_id=current.actor_id,
@@ -94,7 +95,7 @@ def replace_cell_warp_flags(
             state.known_state,
             known_cells={
                 known_position: (
-                    rows[known_position.y][known_position.x]
+                    rows[state.actual_map.indices_for(known_position)[0]][state.actual_map.indices_for(known_position)[1]]
                     if known_position == position
                     else known_cell
                 )
@@ -276,49 +277,11 @@ class DefaultEvaluationCasesTests(unittest.TestCase):
 
 class KnownStateRoutingHelperTests(unittest.TestCase):
     def test_known_passable_cell_uses_known_cells_only(self) -> None:
-        state = reveal_positions(make_state(), [Position(4, 8), Position(4, 7)])
+        state = reveal_positions(make_state(), [Position(5, 9), Position(5, 8)])
 
         self.assertTrue(
             is_known_passable_cell(
-                Position(4, 7),
-                known_cells=state.known_state.known_cells,
-                objects=state.objects,
-            )
-        )
-        self.assertFalse(
-            is_known_passable_cell(
-                Position(4, 6),
-                known_cells=state.known_state.known_cells,
-                objects=state.objects,
-            )
-        )
-
-    def test_known_passable_cell_rejects_impassable_terrain_and_celestial_objects(self) -> None:
-        state = replace_cell_terrain(make_state(), Position(4, 7), SrsTerrainType.ASTEROID)
-        state = reveal_positions(state, [Position(4, 7), Position(4, 6), Position(4, 5), Position(5, 7), Position(5, 6)])
-        state = place_object(state, Position(4, 6), SrsObjectType.STAR, "star-a")
-        state = place_object(state, Position(4, 5), SrsObjectType.PLANET, "planet-a")
-        state = place_object(state, Position(5, 7), SrsObjectType.STATION, "station-a")
-        state = place_object(state, Position(5, 6), SrsObjectType.RESOURCE_CACHE, "resource-a")
-        state = reveal_positions(state, [Position(4, 7), Position(4, 6), Position(4, 5), Position(5, 7), Position(5, 6)])
-
-        self.assertFalse(
-            is_known_passable_cell(
-                Position(4, 7),
-                known_cells=state.known_state.known_cells,
-                objects=state.objects,
-            )
-        )
-        self.assertFalse(
-            is_known_passable_cell(
-                Position(4, 6),
-                known_cells=state.known_state.known_cells,
-                objects=state.objects,
-            )
-        )
-        self.assertFalse(
-            is_known_passable_cell(
-                Position(4, 5),
+                Position(5, 8),
                 known_cells=state.known_state.known_cells,
                 objects=state.objects,
             )
@@ -330,21 +293,59 @@ class KnownStateRoutingHelperTests(unittest.TestCase):
                 objects=state.objects,
             )
         )
-        self.assertTrue(
+
+    def test_known_passable_cell_rejects_impassable_terrain_and_celestial_objects(self) -> None:
+        state = replace_cell_terrain(make_state(), Position(5, 8), SrsTerrainType.ASTEROID)
+        state = reveal_positions(state, [Position(5, 8), Position(5, 7), Position(5, 6), Position(6, 8), Position(6, 7)])
+        state = place_object(state, Position(5, 7), SrsObjectType.STAR, "star-a")
+        state = place_object(state, Position(5, 6), SrsObjectType.PLANET, "planet-a")
+        state = place_object(state, Position(6, 8), SrsObjectType.STATION, "station-a")
+        state = place_object(state, Position(6, 7), SrsObjectType.RESOURCE_CACHE, "resource-a")
+        state = reveal_positions(state, [Position(5, 8), Position(5, 7), Position(5, 6), Position(6, 8), Position(6, 7)])
+
+        self.assertFalse(
+            is_known_passable_cell(
+                Position(5, 8),
+                known_cells=state.known_state.known_cells,
+                objects=state.objects,
+            )
+        )
+        self.assertFalse(
+            is_known_passable_cell(
+                Position(5, 7),
+                known_cells=state.known_state.known_cells,
+                objects=state.objects,
+            )
+        )
+        self.assertFalse(
             is_known_passable_cell(
                 Position(5, 6),
                 known_cells=state.known_state.known_cells,
                 objects=state.objects,
             )
         )
+        self.assertFalse(
+            is_known_passable_cell(
+                Position(6, 8),
+                known_cells=state.known_state.known_cells,
+                objects=state.objects,
+            )
+        )
+        self.assertTrue(
+            is_known_passable_cell(
+                Position(6, 7),
+                known_cells=state.known_state.known_cells,
+                objects=state.objects,
+            )
+        )
 
     def test_salvage_is_treated_as_known_passable(self) -> None:
-        state = place_object(make_state(), Position(4, 7), SrsObjectType.SALVAGE, "salvage-a")
-        state = reveal_positions(state, [Position(4, 8), Position(4, 7)])
+        state = place_object(make_state(), Position(5, 8), SrsObjectType.SALVAGE, "salvage-a")
+        state = reveal_positions(state, [Position(5, 9), Position(5, 8)])
 
         self.assertTrue(
             is_known_passable_cell(
-                Position(4, 7),
+                Position(5, 8),
                 known_cells=state.known_state.known_cells,
                 objects=state.objects,
             )
@@ -353,13 +354,13 @@ class KnownStateRoutingHelperTests(unittest.TestCase):
     def test_route_on_known_cells_does_not_cross_undiscovered_cells(self) -> None:
         state = reveal_positions(
             make_state(),
-            [Position(4, 8), Position(5, 8), Position(5, 7), Position(5, 6)],
+            [Position(5, 9), Position(6, 9), Position(6, 8), Position(6, 7)],
         )
 
         self.assertEqual(
             route_on_known_cells(
-                Position(4, 8),
-                Position(5, 6),
+                Position(5, 9),
+                Position(6, 7),
                 known_cells=state.known_state.known_cells,
                 objects=state.objects,
             ),
@@ -367,8 +368,8 @@ class KnownStateRoutingHelperTests(unittest.TestCase):
         )
         self.assertIsNone(
             route_on_known_cells(
-                Position(4, 8),
-                Position(4, 6),
+                Position(5, 9),
+                Position(5, 7),
                 known_cells=state.known_state.known_cells,
                 objects=state.objects,
             )
@@ -377,7 +378,7 @@ class KnownStateRoutingHelperTests(unittest.TestCase):
     def test_first_known_route_step_uses_known_state_without_actual_map(self) -> None:
         state = reveal_positions(
             make_state(),
-            [Position(4, 8), Position(4, 7), Position(4, 6)],
+            [Position(5, 9), Position(5, 8), Position(5, 7)],
         )
 
         with patch(
@@ -386,8 +387,8 @@ class KnownStateRoutingHelperTests(unittest.TestCase):
         ):
             self.assertEqual(
                 first_known_route_step(
-                    Position(4, 8),
-                    Position(4, 6),
+                    Position(5, 9),
+                    Position(5, 7),
                     known_cells=state.known_state.known_cells,
                     objects=state.objects,
                 ),
@@ -397,54 +398,54 @@ class KnownStateRoutingHelperTests(unittest.TestCase):
     def test_choose_known_target_step_applies_deterministic_tie_breaking(self) -> None:
         state = reveal_positions(
             make_state(),
-            [Position(4, 8), Position(4, 7), Position(5, 8), Position(3, 8)],
+            [Position(5, 9), Position(5, 8), Position(6, 9), Position(4, 9)],
         )
 
         self.assertEqual(
             choose_known_target_step(
-                Position(4, 8),
-                [Position(4, 7), Position(5, 8), Position(3, 8)],
+                Position(5, 9),
+                [Position(5, 8), Position(6, 9), Position(4, 9)],
                 known_cells=state.known_state.known_cells,
                 objects=state.objects,
             ),
-            (Position(4, 7), Direction.N),
+            (Position(5, 8), Direction.N),
         )
         self.assertEqual(
             choose_known_target_step(
-                Position(4, 8),
-                [Position(5, 8), Position(3, 8)],
+                Position(5, 9),
+                [Position(6, 9), Position(4, 9)],
                 known_cells=state.known_state.known_cells,
                 objects=state.objects,
             ),
-            (Position(3, 8), Direction.W),
+            (Position(4, 9), Direction.W),
         )
 
     def test_iter_known_cardinal_neighbors_is_stable(self) -> None:
         self.assertEqual(
-            iter_known_cardinal_neighbors(Position(4, 8)),
+            iter_known_cardinal_neighbors(Position(5, 9)),
             (
-                (Direction.N, Position(4, 7)),
-                (Direction.E, Position(5, 8)),
-                (Direction.S, Position(4, 9)),
-                (Direction.W, Position(3, 8)),
+                (Direction.N, Position(5, 8)),
+                (Direction.E, Position(6, 9)),
+                (Direction.S, Position(5, 10)),
+                (Direction.W, Position(4, 9)),
             ),
         )
 
     def test_route_on_known_cells_is_deterministic_for_same_input(self) -> None:
         state = reveal_positions(
             make_state(),
-            [Position(4, 8), Position(4, 7), Position(5, 8), Position(5, 7)],
+            [Position(5, 9), Position(5, 8), Position(6, 9), Position(6, 8)],
         )
 
         first = route_on_known_cells(
-            Position(4, 8),
-            Position(5, 7),
+            Position(5, 9),
+            Position(6, 8),
             known_cells=state.known_state.known_cells,
             objects=state.objects,
         )
         second = route_on_known_cells(
-            Position(4, 8),
-            Position(5, 7),
+            Position(5, 9),
+            Position(6, 8),
             known_cells=state.known_state.known_cells,
             objects=state.objects,
         )
@@ -458,7 +459,7 @@ class ExitGreedyPolicyTests(unittest.TestCase):
         self.assertEqual(EXIT_GREEDY_POLICY_NAME, "EXIT_GREEDY")
 
     def test_returns_warp_exit_when_current_cell_has_selected_exit(self) -> None:
-        state = reveal_positions(make_state(entry_edge=Direction.S), [Position(4, 8)])
+        state = reveal_positions(make_state(entry_edge=Direction.S), [Position(5, 9)])
 
         command = choose_exit_greedy_command(state, selected_exit_edge=Direction.S)
 
@@ -470,9 +471,9 @@ class ExitGreedyPolicyTests(unittest.TestCase):
     def test_returns_single_step_move_route_toward_nearest_known_warp_cell(self) -> None:
         state = reveal_positions(
             make_state(),
-            [Position(4, 8), Position(5, 8), Position(6, 8)],
+            [Position(5, 9), Position(6, 9), Position(7, 9)],
         )
-        state = replace_cell_warp_flags(state, Position(6, 8), frozenset({Direction.N}))
+        state = replace_cell_warp_flags(state, Position(7, 9), frozenset({Direction.N}))
 
         command = choose_exit_greedy_command(state, selected_exit_edge=Direction.N)
 
@@ -483,7 +484,7 @@ class ExitGreedyPolicyTests(unittest.TestCase):
         self.assertEqual(command.route, (Direction.E,))
 
     def test_returns_no_action_when_selected_exit_warp_cell_is_undiscovered(self) -> None:
-        state = reveal_positions(make_state(), [Position(4, 8), Position(4, 7)])
+        state = reveal_positions(make_state(), [Position(5, 9), Position(5, 8)])
 
         self.assertIsNone(
             choose_exit_greedy_command(state, selected_exit_edge=Direction.N)
@@ -492,11 +493,11 @@ class ExitGreedyPolicyTests(unittest.TestCase):
     def test_returns_no_action_when_known_warp_cell_is_unreachable(self) -> None:
         state = reveal_positions(
             make_state(),
-            [Position(4, 8), Position(5, 8), Position(6, 8)],
+            [Position(5, 9), Position(6, 9), Position(7, 9)],
         )
-        state = replace_cell_terrain(state, Position(5, 8), SrsTerrainType.ASTEROID)
-        state = reveal_positions(state, [Position(4, 8), Position(5, 8), Position(6, 8)])
-        state = replace_cell_warp_flags(state, Position(6, 8), frozenset({Direction.N}))
+        state = replace_cell_terrain(state, Position(6, 9), SrsTerrainType.ASTEROID)
+        state = reveal_positions(state, [Position(5, 9), Position(6, 9), Position(7, 9)])
+        state = replace_cell_warp_flags(state, Position(7, 9), frozenset({Direction.N}))
 
         self.assertIsNone(
             choose_exit_greedy_command(state, selected_exit_edge=Direction.N)
@@ -504,10 +505,10 @@ class ExitGreedyPolicyTests(unittest.TestCase):
 
     def test_does_not_detour_to_objects_before_exit(self) -> None:
         state = reveal_positions(
-            place_object(make_state(), Position(4, 7), SrsObjectType.SALVAGE, "salvage-a"),
-            [Position(4, 8), Position(4, 7), Position(5, 8), Position(6, 8)],
+            place_object(make_state(), Position(5, 8), SrsObjectType.SALVAGE, "salvage-a"),
+            [Position(5, 9), Position(5, 8), Position(6, 9), Position(7, 9)],
         )
-        state = replace_cell_warp_flags(state, Position(6, 8), frozenset({Direction.N}))
+        state = replace_cell_warp_flags(state, Position(7, 9), frozenset({Direction.N}))
 
         command = choose_exit_greedy_command(state, selected_exit_edge=Direction.N)
 
@@ -519,9 +520,9 @@ class ExitGreedyPolicyTests(unittest.TestCase):
     def test_never_returns_move_to(self) -> None:
         state = reveal_positions(
             make_state(),
-            [Position(4, 8), Position(5, 8), Position(6, 8)],
+            [Position(5, 9), Position(6, 9), Position(7, 9)],
         )
-        state = replace_cell_warp_flags(state, Position(6, 8), frozenset({Direction.N}))
+        state = replace_cell_warp_flags(state, Position(7, 9), frozenset({Direction.N}))
 
         command = choose_exit_greedy_command(state, selected_exit_edge=Direction.N)
 
@@ -531,10 +532,10 @@ class ExitGreedyPolicyTests(unittest.TestCase):
     def test_is_deterministic_for_same_input(self) -> None:
         state = reveal_positions(
             make_state(),
-            [Position(4, 8), Position(4, 7), Position(5, 8), Position(5, 7)],
+            [Position(5, 9), Position(5, 8), Position(6, 9), Position(6, 8)],
         )
-        state = replace_cell_warp_flags(state, Position(4, 7), frozenset({Direction.N}))
         state = replace_cell_warp_flags(state, Position(5, 8), frozenset({Direction.N}))
+        state = replace_cell_warp_flags(state, Position(6, 9), frozenset({Direction.N}))
 
         first = choose_exit_greedy_command(state, selected_exit_edge=Direction.N)
         second = choose_exit_greedy_command(state, selected_exit_edge=Direction.N)
@@ -545,9 +546,9 @@ class ExitGreedyPolicyTests(unittest.TestCase):
     def test_uses_known_state_without_actual_map(self) -> None:
         state = reveal_positions(
             make_state(),
-            [Position(4, 8), Position(5, 8), Position(6, 8)],
+            [Position(5, 9), Position(6, 9), Position(7, 9)],
         )
-        state = replace_cell_warp_flags(state, Position(6, 8), frozenset({Direction.N}))
+        state = replace_cell_warp_flags(state, Position(7, 9), frozenset({Direction.N}))
 
         with patch(
             "experiments.galactic_exodus.srs.model.SrsActualMap.cell_at",
@@ -570,13 +571,13 @@ class ObjectGreedyPolicyTests(unittest.TestCase):
     def test_prioritizes_known_unconsumed_resource_cache(self) -> None:
         state = place_object_with_metadata(
             make_state(fuel=2, max_fuel=9),
-            Position(4, 8),
+            Position(5, 9),
             SrsObjectType.RESOURCE_CACHE,
             "resource-cache-1",
             fuel_restore=5,
         )
-        state = place_object(state, Position(5, 8), SrsObjectType.SALVAGE, "salvage-1")
-        state = reveal_positions(state, [Position(4, 8), Position(5, 8)])
+        state = place_object(state, Position(6, 9), SrsObjectType.SALVAGE, "salvage-1")
+        state = reveal_positions(state, [Position(5, 9), Position(6, 9)])
 
         command = choose_object_greedy_command(
             state,
@@ -592,13 +593,13 @@ class ObjectGreedyPolicyTests(unittest.TestCase):
     def test_resource_cache_is_excluded_at_full_fuel(self) -> None:
         state = place_object_with_metadata(
             make_state(fuel=9, max_fuel=9),
-            Position(4, 8),
+            Position(5, 9),
             SrsObjectType.RESOURCE_CACHE,
             "resource-cache-1",
             fuel_restore=5,
         )
-        state = reveal_positions(state, [Position(4, 8), Position(4, 7), Position(4, 6)])
-        state = replace_cell_warp_flags(state, Position(4, 6), frozenset({Direction.N}))
+        state = reveal_positions(state, [Position(5, 9), Position(5, 8), Position(5, 7)])
+        state = replace_cell_warp_flags(state, Position(5, 7), frozenset({Direction.N}))
 
         command = choose_object_greedy_command(
             state,
@@ -612,8 +613,8 @@ class ObjectGreedyPolicyTests(unittest.TestCase):
         )
 
     def test_known_unactivated_station_is_a_candidate(self) -> None:
-        state = place_object(make_state(fuel=2, max_fuel=9), Position(4, 7), SrsObjectType.STATION, "station-1")
-        state = reveal_positions(state, [Position(4, 8), Position(4, 7)])
+        state = place_object(make_state(fuel=2, max_fuel=9), Position(5, 8), SrsObjectType.STATION, "station-1")
+        state = reveal_positions(state, [Position(5, 9), Position(5, 8)])
 
         command = choose_object_greedy_command(
             state,
@@ -627,9 +628,9 @@ class ObjectGreedyPolicyTests(unittest.TestCase):
         )
 
     def test_station_is_excluded_at_full_fuel(self) -> None:
-        state = place_object(make_state(fuel=9, max_fuel=9), Position(4, 7), SrsObjectType.STATION, "station-1")
-        state = reveal_positions(state, [Position(4, 8), Position(4, 7), Position(5, 8)])
-        state = replace_cell_warp_flags(state, Position(5, 8), frozenset({Direction.N}))
+        state = place_object(make_state(fuel=9, max_fuel=9), Position(5, 8), SrsObjectType.STATION, "station-1")
+        state = reveal_positions(state, [Position(5, 9), Position(5, 8), Position(6, 9)])
+        state = replace_cell_warp_flags(state, Position(6, 9), frozenset({Direction.N}))
 
         command = choose_object_greedy_command(
             state,
@@ -643,9 +644,9 @@ class ObjectGreedyPolicyTests(unittest.TestCase):
         )
 
     def test_station_is_candidate_for_upgrade_even_when_fuel_is_full(self) -> None:
-        state = place_object(make_state(fuel=9, max_fuel=9), Position(4, 7), SrsObjectType.STATION, "station-1")
+        state = place_object(make_state(fuel=9, max_fuel=9), Position(5, 8), SrsObjectType.STATION, "station-1")
         state = replace(state, player_state=replace(state.player_state, salvage=4))
-        state = reveal_positions(state, [Position(4, 8), Position(4, 7)])
+        state = reveal_positions(state, [Position(5, 9), Position(5, 8)])
 
         command = choose_object_greedy_command(
             state,
@@ -656,8 +657,8 @@ class ObjectGreedyPolicyTests(unittest.TestCase):
         self.assertEqual(command, SrsCommand(command_type="INTERACT", target_object_id="station-1"))
 
     def test_known_unconsumed_salvage_is_a_candidate(self) -> None:
-        state = place_object(make_state(fuel=2, max_fuel=9), Position(5, 8), SrsObjectType.SALVAGE, "salvage-1")
-        state = reveal_positions(state, [Position(4, 8), Position(5, 8)])
+        state = place_object(make_state(fuel=2, max_fuel=9), Position(6, 9), SrsObjectType.SALVAGE, "salvage-1")
+        state = reveal_positions(state, [Position(5, 9), Position(6, 9)])
 
         command = choose_object_greedy_command(
             state,
@@ -671,8 +672,8 @@ class ObjectGreedyPolicyTests(unittest.TestCase):
         )
 
     def test_returns_interact_when_in_interaction_range(self) -> None:
-        state = place_object(make_state(fuel=2, max_fuel=9), Position(4, 7), SrsObjectType.STATION, "station-1")
-        state = reveal_positions(state, [Position(4, 8), Position(4, 7), Position(5, 8)])
+        state = place_object(make_state(fuel=2, max_fuel=9), Position(5, 8), SrsObjectType.STATION, "station-1")
+        state = reveal_positions(state, [Position(5, 9), Position(5, 8), Position(6, 9)])
 
         command = choose_object_greedy_command(
             state,
@@ -688,12 +689,12 @@ class ObjectGreedyPolicyTests(unittest.TestCase):
     def test_returns_single_step_move_route_when_out_of_range(self) -> None:
         state = place_object_with_metadata(
             make_state(fuel=2, max_fuel=9),
-            Position(4, 6),
+            Position(5, 7),
             SrsObjectType.RESOURCE_CACHE,
             "resource-cache-1",
             fuel_restore=5,
         )
-        state = reveal_positions(state, [Position(4, 8), Position(4, 7), Position(4, 6)])
+        state = reveal_positions(state, [Position(5, 9), Position(5, 8), Position(5, 7)])
 
         command = choose_object_greedy_command(
             state,
@@ -708,8 +709,8 @@ class ObjectGreedyPolicyTests(unittest.TestCase):
         self.assertEqual(command.route, (Direction.N,))
 
     def test_falls_back_to_exit_greedy_when_no_object_candidates_exist(self) -> None:
-        state = reveal_positions(make_state(), [Position(4, 8), Position(4, 7), Position(4, 6)])
-        state = replace_cell_warp_flags(state, Position(4, 6), frozenset({Direction.N}))
+        state = reveal_positions(make_state(), [Position(5, 9), Position(5, 8), Position(5, 7)])
+        state = replace_cell_warp_flags(state, Position(5, 7), frozenset({Direction.N}))
 
         command = choose_object_greedy_command(
             state,
@@ -725,13 +726,13 @@ class ObjectGreedyPolicyTests(unittest.TestCase):
     def test_rejected_object_is_not_retried(self) -> None:
         state = place_object_with_metadata(
             make_state(fuel=2, max_fuel=9),
-            Position(4, 8),
+            Position(5, 9),
             SrsObjectType.RESOURCE_CACHE,
             "resource-cache-1",
             fuel_restore=5,
         )
-        state = place_object(state, Position(5, 8), SrsObjectType.SALVAGE, "salvage-1")
-        state = reveal_positions(state, [Position(4, 8), Position(5, 8)])
+        state = place_object(state, Position(6, 9), SrsObjectType.SALVAGE, "salvage-1")
+        state = reveal_positions(state, [Position(5, 9), Position(6, 9)])
 
         command = choose_object_greedy_command(
             state,
@@ -748,12 +749,12 @@ class ObjectGreedyPolicyTests(unittest.TestCase):
     def test_build_candidates_uses_known_cells_only(self) -> None:
         state = place_object_with_metadata(
             make_state(fuel=2, max_fuel=9),
-            Position(4, 6),
+            Position(5, 7),
             SrsObjectType.RESOURCE_CACHE,
             "resource-cache-1",
             fuel_restore=5,
         )
-        state = reveal_positions(state, [Position(4, 8), Position(4, 7)])
+        state = reveal_positions(state, [Position(5, 9), Position(5, 8)])
 
         candidates = build_object_greedy_candidates(
             state,
@@ -763,8 +764,8 @@ class ObjectGreedyPolicyTests(unittest.TestCase):
         self.assertEqual(candidates, ())
 
     def test_never_returns_move_to(self) -> None:
-        state = place_object(make_state(fuel=2, max_fuel=9), Position(5, 8), SrsObjectType.SALVAGE, "salvage-1")
-        state = reveal_positions(state, [Position(4, 8), Position(5, 8)])
+        state = place_object(make_state(fuel=2, max_fuel=9), Position(6, 9), SrsObjectType.SALVAGE, "salvage-1")
+        state = reveal_positions(state, [Position(5, 9), Position(6, 9)])
 
         command = choose_object_greedy_command(
             state,
@@ -776,9 +777,9 @@ class ObjectGreedyPolicyTests(unittest.TestCase):
         self.assertNotEqual(command.command_type, "MOVE_TO")
 
     def test_is_deterministic_for_same_input(self) -> None:
-        state = place_object(make_state(fuel=2, max_fuel=9), Position(3, 8), SrsObjectType.SALVAGE, "salvage-a")
-        state = place_object(state, Position(5, 8), SrsObjectType.SALVAGE, "salvage-b")
-        state = reveal_positions(state, [Position(4, 8), Position(3, 8), Position(5, 8)])
+        state = place_object(make_state(fuel=2, max_fuel=9), Position(4, 9), SrsObjectType.SALVAGE, "salvage-a")
+        state = place_object(state, Position(6, 9), SrsObjectType.SALVAGE, "salvage-b")
+        state = reveal_positions(state, [Position(5, 9), Position(4, 9), Position(6, 9)])
 
         first = choose_object_greedy_command(
             state,
@@ -797,12 +798,12 @@ class ObjectGreedyPolicyTests(unittest.TestCase):
     def test_uses_known_state_without_actual_map(self) -> None:
         state = place_object_with_metadata(
             make_state(fuel=2, max_fuel=9),
-            Position(4, 6),
+            Position(5, 7),
             SrsObjectType.RESOURCE_CACHE,
             "resource-cache-1",
             fuel_restore=5,
         )
-        state = reveal_positions(state, [Position(4, 8), Position(4, 7), Position(4, 6)])
+        state = reveal_positions(state, [Position(5, 9), Position(5, 8), Position(5, 7)])
 
         with patch(
             "experiments.galactic_exodus.srs.model.SrsActualMap.cell_at",
@@ -823,34 +824,34 @@ class ExploreThenExitPolicyTests(unittest.TestCase):
         self.assertEqual(EXPLORE_THEN_EXIT_POLICY_NAME, "EXPLORE_THEN_EXIT")
 
     def test_returns_single_step_move_route_toward_selected_frontier(self) -> None:
-        state = replace(make_state(), player_position=Position(4, 4))
+        state = replace(make_state(), player_position=Position(5, 5))
         state = reveal_positions(
             state,
             [
-                Position(4, 4),
-                Position(4, 3),
-                Position(4, 5),
-                Position(3, 4),
+                Position(5, 5),
                 Position(5, 4),
-                Position(4, 2),
-                Position(3, 3),
+                Position(5, 6),
+                Position(4, 5),
+                Position(6, 5),
                 Position(5, 3),
+                Position(4, 4),
+                Position(6, 4),
             ],
         )
-        state = replace_cell_terrain(state, Position(3, 4), SrsTerrainType.ASTEROID)
-        state = replace_cell_terrain(state, Position(5, 4), SrsTerrainType.ASTEROID)
         state = replace_cell_terrain(state, Position(4, 5), SrsTerrainType.ASTEROID)
+        state = replace_cell_terrain(state, Position(6, 5), SrsTerrainType.ASTEROID)
+        state = replace_cell_terrain(state, Position(5, 6), SrsTerrainType.ASTEROID)
         state = reveal_positions(
             state,
             [
-                Position(4, 4),
-                Position(4, 3),
-                Position(4, 5),
-                Position(3, 4),
+                Position(5, 5),
                 Position(5, 4),
-                Position(4, 2),
-                Position(3, 3),
+                Position(5, 6),
+                Position(4, 5),
+                Position(6, 5),
                 Position(5, 3),
+                Position(4, 4),
+                Position(6, 4),
             ],
         )
 
@@ -859,14 +860,14 @@ class ExploreThenExitPolicyTests(unittest.TestCase):
         self.assertEqual(command, SrsCommand(command_type="MOVE_ROUTE", route=(Direction.N,)))
 
     def test_steps_into_unknown_when_current_position_is_frontier(self) -> None:
-        state = replace(make_state(), player_position=Position(4, 4))
+        state = replace(make_state(), player_position=Position(5, 5))
         state = reveal_positions(
             state,
             [
-                Position(4, 4),
+                Position(5, 5),
+                Position(5, 6),
                 Position(4, 5),
-                Position(3, 4),
-                Position(5, 4),
+                Position(6, 5),
             ],
         )
 
@@ -875,13 +876,13 @@ class ExploreThenExitPolicyTests(unittest.TestCase):
         self.assertEqual(command, SrsCommand(command_type="MOVE_ROUTE", route=(Direction.N,)))
 
     def test_selected_exit_edge_breaks_unknown_direction_ties(self) -> None:
-        state = replace(make_state(), player_position=Position(4, 4))
+        state = replace(make_state(), player_position=Position(5, 5))
         state = reveal_positions(
             state,
             [
-                Position(4, 4),
+                Position(5, 5),
+                Position(5, 6),
                 Position(4, 5),
-                Position(3, 4),
             ],
         )
 
@@ -890,55 +891,55 @@ class ExploreThenExitPolicyTests(unittest.TestCase):
         self.assertEqual(command, SrsCommand(command_type="MOVE_ROUTE", route=(Direction.E,)))
 
     def test_falls_back_to_exit_greedy_after_max_explore_steps(self) -> None:
-        state = replace(make_state(), player_position=Position(4, 4), srs_turn=12)
+        state = replace(make_state(), player_position=Position(5, 5), srs_turn=12)
         state = reveal_positions(
             state,
-            [Position(x, y) for y in range(9) for x in range(9)],
+            [Position(x, y) for y in range(1, 10) for x in range(1, 10)],
         )
-        state = replace_cell_warp_flags(state, Position(6, 4), frozenset({Direction.N}))
+        state = replace_cell_warp_flags(state, Position(7, 5), frozenset({Direction.N}))
 
         command = choose_explore_then_exit_command(state, selected_exit_edge=Direction.N)
 
         self.assertEqual(command, SrsCommand(command_type="MOVE_ROUTE", route=(Direction.E,)))
 
     def test_falls_back_to_exit_greedy_when_no_frontier_exists(self) -> None:
-        state = replace(make_state(), player_position=Position(4, 4))
+        state = replace(make_state(), player_position=Position(5, 5))
         state = reveal_positions(
             state,
-            [Position(x, y) for y in range(9) for x in range(9)],
+            [Position(x, y) for y in range(1, 10) for x in range(1, 10)],
         )
-        state = replace_cell_warp_flags(state, Position(6, 4), frozenset({Direction.N}))
+        state = replace_cell_warp_flags(state, Position(7, 5), frozenset({Direction.N}))
 
         command = choose_explore_then_exit_command(state, selected_exit_edge=Direction.N)
 
-        self.assertEqual(command, SrsCommand(command_type="MOVE_ROUTE", route=(Direction.E,)))
+        self.assertEqual(command, SrsCommand(command_type="MOVE_ROUTE", route=(Direction.N,)))
 
     def test_returns_no_action_when_frontier_and_exit_are_unreachable(self) -> None:
-        state = replace(make_state(), player_position=Position(4, 4))
+        state = replace(make_state(), player_position=Position(5, 5))
         state = reveal_positions(
             state,
             [
-                Position(4, 4),
-                Position(4, 3),
-                Position(4, 5),
-                Position(3, 4),
+                Position(5, 5),
                 Position(5, 4),
-                Position(6, 4),
+                Position(5, 6),
+                Position(4, 5),
+                Position(6, 5),
+                Position(7, 5),
             ],
         )
-        state = replace_cell_terrain(state, Position(4, 3), SrsTerrainType.ASTEROID)
-        state = replace_cell_terrain(state, Position(4, 5), SrsTerrainType.ASTEROID)
-        state = replace_cell_terrain(state, Position(3, 4), SrsTerrainType.ASTEROID)
         state = replace_cell_terrain(state, Position(5, 4), SrsTerrainType.ASTEROID)
+        state = replace_cell_terrain(state, Position(5, 6), SrsTerrainType.ASTEROID)
+        state = replace_cell_terrain(state, Position(4, 5), SrsTerrainType.ASTEROID)
+        state = replace_cell_terrain(state, Position(6, 5), SrsTerrainType.ASTEROID)
         state = reveal_positions(
             state,
             [
-                Position(4, 4),
-                Position(4, 3),
-                Position(4, 5),
-                Position(3, 4),
+                Position(5, 5),
                 Position(5, 4),
-                Position(6, 4),
+                Position(5, 6),
+                Position(4, 5),
+                Position(6, 5),
+                Position(7, 5),
             ],
         )
 
@@ -947,14 +948,14 @@ class ExploreThenExitPolicyTests(unittest.TestCase):
         )
 
     def test_never_returns_interact_or_move_to(self) -> None:
-        state = replace(make_state(), player_position=Position(4, 4))
+        state = replace(make_state(), player_position=Position(5, 5))
         state = reveal_positions(
             state,
             [
-                Position(4, 4),
+                Position(5, 5),
+                Position(5, 6),
                 Position(4, 5),
-                Position(3, 4),
-                Position(5, 4),
+                Position(6, 5),
             ],
         )
 
@@ -964,14 +965,14 @@ class ExploreThenExitPolicyTests(unittest.TestCase):
         self.assertNotIn(command.command_type, {"INTERACT", "MOVE_TO"})
 
     def test_uses_known_state_without_reading_unknown_cell_contents(self) -> None:
-        state = replace(make_state(), player_position=Position(4, 4))
+        state = replace(make_state(), player_position=Position(5, 5))
         state = reveal_positions(
             state,
             [
-                Position(4, 4),
+                Position(5, 5),
+                Position(5, 6),
                 Position(4, 5),
-                Position(3, 4),
-                Position(5, 4),
+                Position(6, 5),
             ],
         )
 
@@ -985,14 +986,14 @@ class ExploreThenExitPolicyTests(unittest.TestCase):
             )
 
     def test_is_deterministic_for_same_input(self) -> None:
-        state = replace(make_state(), player_position=Position(4, 4))
+        state = replace(make_state(), player_position=Position(5, 5))
         state = reveal_positions(
             state,
             [
-                Position(4, 4),
+                Position(5, 5),
+                Position(5, 6),
                 Position(4, 5),
-                Position(3, 4),
-                Position(5, 4),
+                Position(6, 5),
             ],
         )
 
@@ -1025,7 +1026,7 @@ class PolicyRunLoopTests(unittest.TestCase):
         )
 
     def make_exit_ready_state(self) -> SrsGameState:
-        return reveal_positions(make_state(entry_edge=Direction.S), [Position(4, 8)])
+        return reveal_positions(make_state(entry_edge=Direction.S), [Position(5, 9)])
 
     def test_classifies_warp_exit_accepted_as_exited(self) -> None:
         case = self.make_case(selected_exit_edge=Direction.S)
@@ -1081,8 +1082,8 @@ class PolicyRunLoopTests(unittest.TestCase):
 
     def test_max_commands_aborts_after_reaching_command_limit(self) -> None:
         case = self.make_case()
-        state = replace(make_state(), player_position=Position(4, 4))
-        state = reveal_positions(state, [Position(4, 4), Position(4, 3)])
+        state = replace(make_state(), player_position=Position(5, 5))
+        state = reveal_positions(state, [Position(5, 5), Position(5, 4)])
 
         with patch.object(EvaluationCase, "build_initial_state", return_value=state):
             with patch(
@@ -1129,7 +1130,7 @@ class PolicyRunLoopTests(unittest.TestCase):
             with patch(
                 "experiments.galactic_exodus.srs.evaluate_policies.choose_policy_command",
                 side_effect=[
-                    SrsCommand(command_type="MOVE_TO", target=Position(0, 0)),
+                    SrsCommand(command_type="MOVE_TO", target=Position(1, 1)),
                     SrsCommand(command_type="WARP_EXIT", exit_direction=Direction.S),
                 ],
             ):
@@ -1166,7 +1167,7 @@ class PolicyRunLoopTests(unittest.TestCase):
 
     def test_repeated_invalid_action_is_suppressed_as_no_policy_action(self) -> None:
         case = self.make_case()
-        repeated_command = SrsCommand(command_type="MOVE_TO", target=Position(0, 0))
+        repeated_command = SrsCommand(command_type="MOVE_TO", target=Position(1, 1))
 
         with patch.object(EvaluationCase, "build_initial_state", return_value=self.make_exit_ready_state()):
             with patch(
@@ -1186,7 +1187,7 @@ class PolicyRunLoopTests(unittest.TestCase):
 
     def test_action_sequence_is_recorded_in_order(self) -> None:
         case = self.make_case(selected_exit_edge=Direction.S)
-        first = SrsCommand(command_type="MOVE_TO", target=Position(0, 0))
+        first = SrsCommand(command_type="MOVE_TO", target=Position(1, 1))
         second = SrsCommand(command_type="WARP_EXIT", exit_direction=Direction.S)
 
         with patch.object(EvaluationCase, "build_initial_state", return_value=self.make_exit_ready_state()):

--- a/experiments/galactic_exodus/srs/test_fixture_regression.py
+++ b/experiments/galactic_exodus/srs/test_fixture_regression.py
@@ -25,7 +25,7 @@ class SrsFixtureRegressionTests(unittest.TestCase):
         self.assertIn("MOVE_ACCEPTED", event_types(result))
         self.assertEqual(primary_outcome(result), "ACCEPTED")
         self.assertEqual(result.final_state.srs_turn, 1)
-        self.assertEqual(result.final_state.player_position, Position(4, 7))
+        self.assertEqual(result.final_state.player_position, Position(5, 8))
         self.assertEqual(result.final_state.fuel, 0)
 
     def test_move_to_known(self) -> None:
@@ -34,7 +34,7 @@ class SrsFixtureRegressionTests(unittest.TestCase):
         self.assertIn("MOVE_ACCEPTED", event_types(result))
         self.assertEqual(primary_outcome(result), "ACCEPTED")
         self.assertEqual(result.final_state.srs_turn, 1)
-        self.assertEqual(result.final_state.player_position, Position(4, 6))
+        self.assertEqual(result.final_state.player_position, Position(5, 7))
         self.assertEqual(result.final_state.fuel, 0)
 
     def test_resource_cache_single(self) -> None:
@@ -46,7 +46,7 @@ class SrsFixtureRegressionTests(unittest.TestCase):
         self.assertEqual(result.final_state.fuel, 5)
         self.assertIn("resource-cache-1", result.final_state.persistent_state.consumed_object_ids)
         self.assertTrue(result.final_state.objects["resource-cache-1"].consumed)
-        self.assertIn(Position(2, 7), result.final_state.known_state.discovered_cells)
+        self.assertIn(Position(3, 8), result.final_state.known_state.discovered_cells)
 
     def test_station_refuel(self) -> None:
         result = run_named_fixture("station_refuel_9x9")
@@ -89,7 +89,7 @@ class SrsFixtureRegressionTests(unittest.TestCase):
         self.assertIn("WARP_EXIT_ACCEPTED", event_types(result))
         self.assertEqual(primary_outcome(result), "ACCEPTED")
         self.assertEqual(result.final_state.srs_turn, 1)
-        self.assertEqual(result.final_state.player_position, Position(4, 8))
+        self.assertEqual(result.final_state.player_position, Position(5, 9))
         self.assertEqual(result.final_state.fuel, 0)
 
     def test_rift_blocked_n(self) -> None:
@@ -98,7 +98,7 @@ class SrsFixtureRegressionTests(unittest.TestCase):
         self.assertTrue(any("REJECTED" in event_type for event_type in event_types(result)))
         self.assertEqual(primary_outcome(result), "REJECTED_BLOCKED_EDGE")
         self.assertEqual(result.final_state.srs_turn, 0)
-        self.assertEqual(result.final_state.player_position, Position(4, 0))
+        self.assertEqual(result.final_state.player_position, Position(5, 1))
         self.assertEqual(result.final_state.fuel, 0)
 
     def test_shared_fuel_cost_uses_shared_fuel_without_fixing_exact_delta(self) -> None:
@@ -117,17 +117,17 @@ class SrsFixtureRegressionTests(unittest.TestCase):
         self.assertEqual(result.final_state.fuel, 2)
         self.assertIn("resource-cache-1", result.final_state.persistent_state.consumed_object_ids)
         self.assertTrue(result.final_state.objects["resource-cache-1"].consumed)
-        self.assertIn(Position(2, 7), result.final_state.known_state.discovered_cells)
+        self.assertIn(Position(3, 8), result.final_state.known_state.discovered_cells)
 
     def test_combat_enemy_movement_tiebreak(self) -> None:
         result = run_named_fixture("combat_enemy_movement_tiebreak_9x9")
 
         self.assertIn("COMBAT_TRANSITIONED", event_types(result))
         self.assertEqual(primary_outcome(result), "ACCEPTED")
-        self.assertEqual(result.final_state.combat_state.enemies["enemy-1"].position, Position(2, 3))
+        self.assertEqual(result.final_state.combat_state.enemies["enemy-1"].position, Position(3, 4))
         self.assertEqual(
             result.summary["enemy_actions"][0]["target_attackable_position"],
-            [4, 3],
+            [5, 4],
         )
         self.assertIsNone(result.summary["enemy_actions"][0]["reaction"])
 
@@ -218,8 +218,8 @@ class SrsFixtureRegressionTests(unittest.TestCase):
         self.assertEqual(
             result.summary["combat_enemy_positions"],
             {
-                "enemy-1": [8, 4],
-                "enemy-2": [4, 8],
+                "enemy-1": [9, 5],
+                "enemy-2": [5, 9],
             },
         )
         self.assertEqual(

--- a/experiments/galactic_exodus/srs/test_fixtures.py
+++ b/experiments/galactic_exodus/srs/test_fixtures.py
@@ -123,10 +123,10 @@ class SrsFixtureTests(unittest.TestCase):
             result.initial_state.known_state.discovered_cells,
             frozenset(
                 {
-                    Position(2, 7),
-                    Position(2, 6),
+                    Position(3, 8),
                     Position(3, 7),
-                    Position(1, 7),
+                    Position(4, 8),
+                    Position(2, 8),
                 }
             ),
         )
@@ -138,10 +138,10 @@ class SrsFixtureTests(unittest.TestCase):
             result.initial_state.known_state.discovered_cells,
             frozenset(
                 {
-                    Position(2, 7),
-                    Position(2, 6),
+                    Position(3, 8),
                     Position(3, 7),
-                    Position(1, 7),
+                    Position(4, 8),
+                    Position(2, 8),
                 }
             ),
         )
@@ -150,7 +150,7 @@ class SrsFixtureTests(unittest.TestCase):
         result = run_fixture(FIXTURES_DIR / "nebula_observation_3x3_9x9.json", contracts=self.contracts)
 
         self.assertEqual(len(result.final_state.known_state.discovered_cells), 9)
-        self.assertEqual(result.final_state.actual_map.cell_at(Position(4, 7)).terrain.value, "NEBULA")
+        self.assertEqual(result.final_state.actual_map.cell_at(Position(5, 8)).terrain.value, "NEBULA")
 
     def test_game_log_json_serializable(self) -> None:
         result = run_fixture(FIXTURES_DIR / "move_route_basic_9x9.json", contracts=self.contracts)
@@ -179,17 +179,17 @@ class SrsFixtureTests(unittest.TestCase):
         result = run_fixture(FIXTURES_DIR / "combat_enemy_movement_tiebreak_9x9.json", contracts=self.contracts)
 
         self.assertEqual(result.final_state.combat_state.phase.value, "PLAYER_MOVEMENT")
-        self.assertEqual(result.final_state.combat_state.enemies["enemy-1"].position, Position(2, 3))
+        self.assertEqual(result.final_state.combat_state.enemies["enemy-1"].position, Position(3, 4))
         self.assertEqual(
             result.summary["enemy_actions"],
             [
                 {
                     "enemy_id": "enemy-1",
-                    "start_position": [0, 4],
-                    "target_attackable_position": [4, 3],
-                    "planned_path": [[0, 3], [1, 3], [2, 3], [3, 3], [4, 3]],
-                    "moved_path": [[0, 3], [1, 3], [2, 3]],
-                    "final_position": [2, 3],
+                    "start_position": [1, 5],
+                    "target_attackable_position": [5, 4],
+                    "planned_path": [[1, 4], [2, 4], [3, 4], [4, 4], [5, 4]],
+                    "moved_path": [[1, 4], [2, 4], [3, 4]],
+                    "final_position": [3, 4],
                     "movement_power": 3,
                     "movement_cost": 50,
                     "attacked_player": False,
@@ -253,8 +253,8 @@ class SrsFixtureTests(unittest.TestCase):
         self.assertEqual(
             result.summary["combat_enemy_positions"],
             {
-                "enemy-1": [8, 4],
-                "enemy-2": [4, 8],
+                "enemy-1": [9, 5],
+                "enemy-2": [5, 9],
             },
         )
         self.assertEqual(
@@ -283,11 +283,11 @@ class SrsFixtureTests(unittest.TestCase):
         )
         self.assertEqual(movement_result.events[0].payload["movement_raw_cost"], 7)
 
-        enemy_state = replace(make_state(), player_position=Position(4, 4))
+        enemy_state = replace(make_state(), player_position=Position(5, 5))
         enemy = create_enemy_combat_state(
             enemy_id="enemy-1",
             tier=SrsEnemyTier.TIER1,
-            position=Position(0, 4),
+            position=Position(1, 5),
         )
         enemy_state = replace(
             enemy_state,

--- a/experiments/galactic_exodus/srs/test_generate.py
+++ b/experiments/galactic_exodus/srs/test_generate.py
@@ -73,8 +73,8 @@ def summarize_state(state: SrsGameState) -> dict[str, Any]:
 
 
 def _iter_cells(state: SrsGameState):
-    for y, row in enumerate(state.actual_map.cells):
-        for x, cell in enumerate(row):
+    for y, row in enumerate(state.actual_map.cells, start=1):
+        for x, cell in enumerate(row, start=1):
             yield Position(x, y), cell
 
 
@@ -149,7 +149,7 @@ class SrsGenerateTests(unittest.TestCase):
             contracts=self.contracts,
         )
 
-        self.assertNotIn("4,0", summarize_state(state)["warp_flags"])
+        self.assertNotIn("5,1", summarize_state(state)["warp_flags"])
 
     def test_blocked_edge_line_is_rift_barrier(self) -> None:
         state = create_sector(
@@ -163,9 +163,9 @@ class SrsGenerateTests(unittest.TestCase):
             contracts=self.contracts,
         )
 
-        for x in range(state.actual_map.width):
+        for x in range(1, state.actual_map.width + 1):
             with self.subTest(x=x):
-                self.assertEqual(state.actual_map.cell_at(Position(x, 0)).terrain.value, "RIFT_BARRIER")
+                self.assertEqual(state.actual_map.cell_at(Position(x, 1)).terrain.value, "RIFT_BARRIER")
 
     def test_non_blocked_edges_have_warp_candidates(self) -> None:
         state = create_sector(
@@ -182,9 +182,9 @@ class SrsGenerateTests(unittest.TestCase):
         self.assertEqual(
             summarize_state(state)["warp_flags"],
             {
-                "0,4": ["W"],
-                "4,8": ["S"],
-                "8,4": ["E"],
+                "1,5": ["W"],
+                "5,9": ["S"],
+                "9,5": ["E"],
             },
         )
 
@@ -298,7 +298,7 @@ class SrsGenerateTests(unittest.TestCase):
         self.assertEqual(state.persistent_state.generated_map_id, "rift-1:4001")
         self.assertEqual(state.persistent_state.generation_seed, 4001)
         self.assertEqual(state.persistent_state.blocked_edges, frozenset({Direction.N}))
-        self.assertEqual(state.persistent_state.warp_flags[Position(8, 4)], frozenset({Direction.E}))
+        self.assertEqual(state.persistent_state.warp_flags[Position(9, 5)], frozenset({Direction.E}))
         self.assertEqual(
             set(state.persistent_state.celestial_body_positions),
             {"star-1", "planet-1", "planet-2"},

--- a/experiments/galactic_exodus/srs/test_model.py
+++ b/experiments/galactic_exodus/srs/test_model.py
@@ -42,7 +42,7 @@ class SrsModelTests(unittest.TestCase):
         self.assertIs(SectorType(SectorType.RIFT.value), SectorType.RIFT)
 
     def test_position_equality(self) -> None:
-        self.assertEqual(Position(2, 3), Position(2, 3))
+        self.assertEqual(Position(3, 4), Position(3, 4))
 
     def test_actual_map_contains(self) -> None:
         actual_map = SrsActualMap(
@@ -53,18 +53,18 @@ class SrsModelTests(unittest.TestCase):
                 (SrsCell(SrsTerrainType.NEBULA), SrsCell(SrsTerrainType.ASTEROID_FIELD)),
             ),
         )
-        self.assertTrue(actual_map.contains(Position(1, 1)))
-        self.assertFalse(actual_map.contains(Position(2, 1)))
+        self.assertTrue(actual_map.contains(Position(2, 2)))
+        self.assertFalse(actual_map.contains(Position(3, 2)))
 
     def test_actual_map_cell_at(self) -> None:
         cell = SrsCell(SrsTerrainType.RIFT_DISTORTION)
         actual_map = SrsActualMap(width=1, height=1, cells=((cell,),))
-        self.assertIs(actual_map.cell_at(Position(0, 0)), cell)
+        self.assertIs(actual_map.cell_at(Position(1, 1)), cell)
 
     def test_actual_map_cell_at_rejects_out_of_bounds(self) -> None:
         actual_map = SrsActualMap(width=1, height=1, cells=((SrsCell(SrsTerrainType.FLOOR),),))
         with self.assertRaisesRegex(IndexError, "position out of bounds"):
-            actual_map.cell_at(Position(-1, 0))
+            actual_map.cell_at(Position(-1, 1))
 
     def test_sector_descriptor_rift_requires_blocked_edges(self) -> None:
         descriptor = SectorDescriptor(
@@ -99,7 +99,7 @@ class SrsModelTests(unittest.TestCase):
             validate_sector_descriptor(descriptor)
 
     def test_game_state_freezes_objects_mapping(self) -> None:
-        position = Position(0, 0)
+        position = Position(1, 1)
         state = SrsGameState(
             descriptor=SectorDescriptor(
                 sector_id="N-1",
@@ -134,7 +134,7 @@ class SrsModelTests(unittest.TestCase):
             state.objects["planet-1"] = SrsObjectState(
                 object_id="planet-1",
                 object_type=SrsObjectType.PLANET,
-                position=Position(0, 0),
+                position=Position(1, 1),
             )
 
     def test_game_state_rejects_object_key_mismatch(self) -> None:
@@ -159,12 +159,12 @@ class SrsModelTests(unittest.TestCase):
                     sector_type=SectorType.NORMAL,
                     blocked_edges=frozenset(),
                 ),
-                player_position=Position(0, 0),
+                player_position=Position(1, 1),
                 objects={
                     "bad-key": SrsObjectState(
                         object_id="star-1",
                         object_type=SrsObjectType.STAR,
-                        position=Position(0, 0),
+                        position=Position(1, 1),
                     )
                 },
             )
@@ -191,7 +191,7 @@ class SrsModelTests(unittest.TestCase):
                     sector_type=SectorType.NORMAL,
                     blocked_edges=frozenset(),
                 ),
-                player_position=Position(0, 0),
+                player_position=Position(1, 1),
                 objects={},
             )
 
@@ -237,7 +237,7 @@ class SrsModelTests(unittest.TestCase):
                 enemy = create_enemy_combat_state(
                     enemy_id=f"{tier.value.lower()}-1",
                     tier=tier,
-                    position=Position(0, 0),
+                    position=Position(1, 1),
                 )
                 self.assertEqual((enemy.durability, enemy.attack_damage, enemy.movement_power), expected)
 
@@ -246,7 +246,7 @@ class SrsModelTests(unittest.TestCase):
         enemy = create_enemy_combat_state(
             enemy_id="enemy-1",
             tier=SrsEnemyTier.TIER1,
-            position=Position(0, 0),
+            position=Position(1, 1),
         )
         occupied = SrsCombatState(enemies={"enemy-1": enemy}, player_attack_target_id="enemy-1")
 
@@ -258,7 +258,7 @@ class SrsModelTests(unittest.TestCase):
         enemy = create_enemy_combat_state(
             enemy_id="enemy-1",
             tier=SrsEnemyTier.TIER1,
-            position=Position(9, 9),
+            position=Position(10, 10),
         )
 
         with self.assertRaisesRegex(SrsModelError, "combat enemy position must be within actual_map bounds"):
@@ -282,7 +282,7 @@ class SrsModelTests(unittest.TestCase):
                     sector_type=SectorType.NORMAL,
                     blocked_edges=frozenset(),
                 ),
-                player_position=Position(0, 0),
+                player_position=Position(1, 1),
                 combat_state=SrsCombatState(
                     phase=SrsCombatPhase.PLAYER_MOVEMENT,
                     enemies={"enemy-1": enemy},
@@ -295,7 +295,7 @@ class SrsModelTests(unittest.TestCase):
         resource_cache = SrsObjectState(
             object_id="resource-cache-1",
             object_type=SrsObjectType.RESOURCE_CACHE,
-            position=Position(1, 2),
+            position=Position(2, 3),
             metadata={"fuel_restore": 5},
         )
 
@@ -305,24 +305,24 @@ class SrsModelTests(unittest.TestCase):
 
     def test_known_state_freezes_known_cells(self) -> None:
         state = SrsKnownState(
-            discovered_cells={Position(0, 0)},
-            known_cells={Position(0, 0): SrsCell(SrsTerrainType.FLOOR)},
+            discovered_cells={Position(1, 1)},
+            known_cells={Position(1, 1): SrsCell(SrsTerrainType.FLOOR)},
         )
 
         with self.assertRaises(TypeError):
-            state.known_cells[Position(1, 1)] = SrsCell(SrsTerrainType.NEBULA)
+            state.known_cells[Position(2, 2)] = SrsCell(SrsTerrainType.NEBULA)
 
     def test_known_state_freezes_visited_cells(self) -> None:
-        state = SrsKnownState(visited_cells={Position(0, 0)})
+        state = SrsKnownState(visited_cells={Position(1, 1)})
 
         with self.assertRaises(AttributeError):
-            state.visited_cells.add(Position(1, 1))
+            state.visited_cells.add(Position(2, 2))
 
     def test_known_state_rejects_known_cell_outside_discovered_cells(self) -> None:
         with self.assertRaisesRegex(SrsModelError, "known_cells keys must be a subset"):
             SrsKnownState(
-                discovered_cells={Position(0, 0)},
-                known_cells={Position(1, 1): SrsCell(SrsTerrainType.FLOOR)},
+                discovered_cells={Position(1, 1)},
+                known_cells={Position(2, 2): SrsCell(SrsTerrainType.FLOOR)},
             )
 
     def test_srs_command_rejects_empty_move_route(self) -> None:
@@ -378,11 +378,11 @@ class SrsModelTests(unittest.TestCase):
 
     def test_srs_command_rejects_combat_fields_for_non_combat_command(self) -> None:
         with self.assertRaisesRegex(SrsModelError, "combat action fields require COMBAT_STEP"):
-            SrsCommand(command_type="MOVE_TO", target=Position(1, 1), player_attack_action="SKIP")
+            SrsCommand(command_type="MOVE_TO", target=Position(2, 2), player_attack_action="SKIP")
 
     def test_srs_command_rejects_salvage_choice_for_non_reward_command(self) -> None:
         with self.assertRaisesRegex(SrsModelError, "salvage_choice requires INTERACT or COMBAT_STEP"):
-            SrsCommand(command_type="MOVE_TO", target=Position(1, 1), salvage_choice="STORE_ONLY")
+            SrsCommand(command_type="MOVE_TO", target=Position(2, 2), salvage_choice="STORE_ONLY")
 
     def test_srs_command_rejects_base_upgrade_choice_for_non_interact(self) -> None:
         with self.assertRaisesRegex(SrsModelError, "base_upgrade_choice requires INTERACT"):
@@ -438,7 +438,7 @@ class SrsModelTests(unittest.TestCase):
                 sector_type=SectorType.NORMAL,
                 blocked_edges=frozenset(),
             ),
-            player_position=Position(0, 0),
+            player_position=Position(1, 1),
             objects={},
         )
         result = SrsCommandResult(

--- a/experiments/galactic_exodus/srs/test_observation.py
+++ b/experiments/galactic_exodus/srs/test_observation.py
@@ -59,7 +59,8 @@ def replace_cell_terrain(
 ) -> SrsGameState:
     rows = [list(row) for row in state.actual_map.cells]
     current = state.actual_map.cell_at(position)
-    rows[position.y][position.x] = SrsCell(
+    row_idx, col_idx = state.actual_map.indices_for(position)
+    rows[row_idx][col_idx] = SrsCell(
         terrain=terrain,
         object_id=current.object_id,
         actor_id=current.actor_id,
@@ -103,18 +104,18 @@ class SrsObservationTests(unittest.TestCase):
     def test_observation_area_clips_at_map_edge(self) -> None:
         state = make_state()
 
-        area = observation_area(state.actual_map, center=Position(0, 0), size=5)
+        area = observation_area(state.actual_map, center=Position(1, 1), size=5)
 
         self.assertEqual(len(area), 9)
-        self.assertIn(Position(0, 0), area)
-        self.assertIn(Position(2, 2), area)
-        self.assertNotIn(Position(3, 3), area)
+        self.assertIn(Position(1, 1), area)
+        self.assertIn(Position(3, 3), area)
+        self.assertNotIn(Position(4, 4), area)
 
     def test_observation_area_rejects_out_of_bounds_center(self) -> None:
         state = make_state()
 
         with self.assertRaisesRegex(ValueError, "out of bounds"):
-            observation_area(state.actual_map, center=Position(-1, 0), size=5)
+            observation_area(state.actual_map, center=Position(-1, 1), size=5)
 
     def test_full_observation_reveals_all_cells(self) -> None:
         state = make_state()
@@ -131,7 +132,7 @@ class SrsObservationTests(unittest.TestCase):
 
         revealed = reveal_observation(
             state,
-            center=Position(4, 4),
+            center=Position(5, 5),
             contracts=self.contracts,
         )
 
@@ -140,11 +141,11 @@ class SrsObservationTests(unittest.TestCase):
         self.assertEqual(revealed.persistent_state.discovered_cells, revealed.known_state.discovered_cells)
 
     def test_local_movement_nebula_reveals_3x3(self) -> None:
-        state = replace_cell_terrain(make_state(), Position(4, 4), SrsTerrainType.NEBULA)
+        state = replace_cell_terrain(make_state(), Position(5, 5), SrsTerrainType.NEBULA)
 
         revealed = reveal_observation(
             state,
-            center=Position(4, 4),
+            center=Position(5, 5),
             contracts=self.contracts,
         )
 
@@ -155,13 +156,13 @@ class SrsObservationTests(unittest.TestCase):
         state = make_state()
         first = reveal_observation(
             state,
-            center=Position(4, 4),
+            center=Position(5, 5),
             contracts=self.contracts,
         )
 
         second = reveal_observation(
             first,
-            center=Position(6, 4),
+            center=Position(7, 5),
             contracts=self.contracts,
         )
 
@@ -174,11 +175,11 @@ class SrsObservationTests(unittest.TestCase):
 
         revealed = reveal_observation(
             state,
-            center=Position(4, 4),
+            center=Position(5, 5),
             contracts=self.contracts,
         )
 
-        self.assertEqual(revealed.known_state.visited_cells, frozenset({Position(4, 4)}))
+        self.assertEqual(revealed.known_state.visited_cells, frozenset({Position(5, 5)}))
 
     def test_rejected_command_does_not_reveal_when_observation_not_called(self) -> None:
         state = make_state()
@@ -199,24 +200,24 @@ class SrsObservationTests(unittest.TestCase):
     def test_known_cell_at_returns_none_for_unseen_cell(self) -> None:
         state = make_state()
 
-        self.assertIsNone(known_cell_at(state, Position(4, 4)))
+        self.assertIsNone(known_cell_at(state, Position(5, 5)))
 
     def test_known_cell_at_returns_known_cell_for_seen_cell(self) -> None:
         state = reveal_observation(
             make_state(),
-            center=Position(4, 4),
+            center=Position(5, 5),
             contracts=self.contracts,
         )
 
         self.assertEqual(
-            known_cell_at(state, Position(4, 4)),
-            state.actual_map.cell_at(Position(4, 4)),
+            known_cell_at(state, Position(5, 5)),
+            state.actual_map.cell_at(Position(5, 5)),
         )
 
     def test_snapshot_srs_state_uses_known_discovered_cells(self) -> None:
         state = reveal_observation(
             make_state(),
-            center=Position(4, 4),
+            center=Position(5, 5),
             contracts=self.contracts,
         )
 
@@ -227,7 +228,7 @@ class SrsObservationTests(unittest.TestCase):
     def test_restore_srs_state_restores_discovered_cells_and_known_cells(self) -> None:
         original = reveal_observation(
             make_state(),
-            center=Position(4, 4),
+            center=Position(5, 5),
             contracts=self.contracts,
         )
         persistent = snapshot_srs_state(original)
@@ -236,7 +237,7 @@ class SrsObservationTests(unittest.TestCase):
             descriptor=original.descriptor,
             actual_map=original.actual_map,
             persistent=persistent,
-            player_position=Position(0, 4),
+            player_position=Position(1, 5),
             objects=original.objects,
         )
 
@@ -247,7 +248,7 @@ class SrsObservationTests(unittest.TestCase):
     def test_restore_srs_state_does_not_restore_visited_cells(self) -> None:
         original = reveal_observation(
             make_state(),
-            center=Position(4, 4),
+            center=Position(5, 5),
             contracts=self.contracts,
         )
         persistent = snapshot_srs_state(original)
@@ -256,7 +257,7 @@ class SrsObservationTests(unittest.TestCase):
             descriptor=original.descriptor,
             actual_map=original.actual_map,
             persistent=persistent,
-            player_position=Position(0, 4),
+            player_position=Position(1, 5),
             objects=original.objects,
         )
 
@@ -307,7 +308,7 @@ class SrsObservationTests(unittest.TestCase):
     def test_snapshot_after_warp_exit_keeps_existing_persistent_fields(self) -> None:
         state = reveal_observation(
             make_state(sector_type=SectorType.RIFT, sector_seed=4001, blocked_edges=frozenset({Direction.N})),
-            center=Position(4, 8),
+            center=Position(5, 9),
             contracts=self.contracts,
         )
         state = replace(

--- a/experiments/galactic_exodus/srs/test_render.py
+++ b/experiments/galactic_exodus/srs/test_render.py
@@ -15,7 +15,7 @@ class SrsRenderTests(unittest.TestCase):
         self.assertEqual(rendered.splitlines(), ["?" * 9] * 9)
 
     def test_known_render_does_not_leak_actual_terrain(self) -> None:
-        state = replace_cell_terrain(make_state(), Position(4, 4), SrsTerrainType.NEBULA)
+        state = replace_cell_terrain(make_state(), Position(5, 5), SrsTerrainType.NEBULA)
 
         rendered = render_known_map(state)
 
@@ -23,7 +23,7 @@ class SrsRenderTests(unittest.TestCase):
         self.assertNotIn("~", rendered)
 
     def test_known_render_player_overrides_cell_symbol(self) -> None:
-        state = reveal_positions(make_state(), [Position(4, 8)])
+        state = reveal_positions(make_state(), [Position(5, 9)])
 
         rendered = render_known_map(state)
 
@@ -31,13 +31,13 @@ class SrsRenderTests(unittest.TestCase):
 
     def test_known_render_object_symbols(self) -> None:
         state = reveal_positions(
-            place_object(make_state(), Position(1, 1), SrsObjectType.STAR, "star-a"),
-            [Position(1, 1), Position(2, 1), Position(3, 1), Position(4, 1)],
+            place_object(make_state(), Position(2, 2), SrsObjectType.STAR, "star-a"),
+            [Position(2, 2), Position(3, 2), Position(4, 2), Position(5, 2)],
         )
-        state = place_object(state, Position(2, 1), SrsObjectType.PLANET, "planet-a")
-        state = place_object(state, Position(3, 1), SrsObjectType.STATION, "station-a")
-        state = place_object(state, Position(4, 1), SrsObjectType.RESOURCE_CACHE, "resource-a")
-        state = reveal_positions(state, [Position(1, 1), Position(2, 1), Position(3, 1), Position(4, 1)])
+        state = place_object(state, Position(3, 2), SrsObjectType.PLANET, "planet-a")
+        state = place_object(state, Position(4, 2), SrsObjectType.STATION, "station-a")
+        state = place_object(state, Position(5, 2), SrsObjectType.RESOURCE_CACHE, "resource-a")
+        state = reveal_positions(state, [Position(2, 2), Position(3, 2), Position(4, 2), Position(5, 2)])
 
         rendered = render_known_map(state)
 
@@ -48,7 +48,7 @@ class SrsRenderTests(unittest.TestCase):
         self.assertEqual(row[4], "R")
 
     def test_known_render_consumed_resource_cache_lowercase(self) -> None:
-        state = place_object(make_state(), Position(2, 2), SrsObjectType.RESOURCE_CACHE, "resource-a")
+        state = place_object(make_state(), Position(3, 3), SrsObjectType.RESOURCE_CACHE, "resource-a")
         state = replace(
             state,
             objects={
@@ -56,14 +56,14 @@ class SrsRenderTests(unittest.TestCase):
                 "resource-a": replace(state.objects["resource-a"], consumed=True),
             },
         )
-        state = reveal_positions(state, [Position(2, 2)])
+        state = reveal_positions(state, [Position(3, 3)])
 
         rendered = render_known_map(state)
 
         self.assertEqual(rendered.splitlines()[2][2], "r")
 
     def test_known_render_consumed_salvage_lowercase(self) -> None:
-        state = place_object(make_state(), Position(2, 2), SrsObjectType.SALVAGE, "salvage-a")
+        state = place_object(make_state(), Position(3, 3), SrsObjectType.SALVAGE, "salvage-a")
         state = replace(
             state,
             objects={
@@ -71,7 +71,7 @@ class SrsRenderTests(unittest.TestCase):
                 "salvage-a": replace(state.objects["salvage-a"], consumed=True),
             },
         )
-        state = reveal_positions(state, [Position(2, 2)])
+        state = reveal_positions(state, [Position(3, 3)])
 
         rendered = render_known_map(state)
 
@@ -94,21 +94,21 @@ class SrsRenderTests(unittest.TestCase):
                 cells=tuple(tuple(row) for row in rows),
             ),
         )
-        state = reveal_positions(state, [Position(1, 1)])
+        state = reveal_positions(state, [Position(2, 2)])
 
         rendered = render_known_map(state)
 
         self.assertEqual(rendered.splitlines()[1][1], "+")
 
     def test_known_render_row_widths_are_stable(self) -> None:
-        state = reveal_positions(make_state(), [Position(x, y) for y in range(9) for x in range(9)])
+        state = reveal_positions(make_state(), [Position(x, y) for y in range(1, 10) for x in range(1, 10)])
 
         rendered = render_known_map(state)
 
         self.assertEqual([len(row) for row in rendered.splitlines()], [9] * 9)
 
     def test_spaced_known_render_inserts_single_spaces_between_cells(self) -> None:
-        state = reveal_positions(make_state(), [Position(x, 8) for x in range(9)])
+        state = reveal_positions(make_state(), [Position(x, 9) for x in range(1, 10)])
 
         rendered = render_known_map_spaced(state)
 

--- a/experiments/galactic_exodus/srs/test_run_manual_eval.py
+++ b/experiments/galactic_exodus/srs/test_run_manual_eval.py
@@ -20,23 +20,23 @@ class SrsRunManualEvalTests(unittest.TestCase):
         return _event_summary_lines(result)
 
     def test_manual_eval_render_keeps_player_on_floor_cell(self) -> None:
-        state = replace(make_state(), player_position=Position(4, 7))
-        state = reveal_positions(state, [Position(x, 7) for x in range(9)])
+        state = replace(make_state(), player_position=Position(5,8))
+        state = reveal_positions(state, [Position(x, 8) for x in range(1,10)])
 
         rendered = _render_known_map_spaced_for_manual_eval(state)
 
         self.assertEqual(rendered.splitlines()[7], ". . . . @ . . . .")
 
     def test_manual_eval_render_shows_player_beside_warp_symbol(self) -> None:
-        state = reveal_positions(make_state(), [Position(4, 8)])
+        state = reveal_positions(make_state(), [Position(5,9)])
 
         rendered = _render_known_map_spaced_for_manual_eval(state)
 
-        self.assertEqual(rendered.splitlines()[8], "? ? ? ? v@? ? ? ?")
+        self.assertEqual(rendered.splitlines()[8], "? ? ? ? @ ? ? ? ?")
 
     def test_manual_eval_render_shows_player_beside_salvage_symbol(self) -> None:
-        state = place_object(make_state(), Position(4, 6), SrsObjectType.SALVAGE, "salvage-a")
-        state = replace(state, player_position=Position(4, 6))
+        state = place_object(make_state(), Position(5,7), SrsObjectType.SALVAGE, "salvage-a")
+        state = replace(state, player_position=Position(5,7))
         state = replace(
             state,
             objects={
@@ -44,21 +44,21 @@ class SrsRunManualEvalTests(unittest.TestCase):
                 "salvage-a": replace(state.objects["salvage-a"], consumed=True),
             },
         )
-        state = reveal_positions(state, [Position(4, 6)])
+        state = reveal_positions(state, [Position(5,7)])
 
         rendered = _render_known_map_spaced_for_manual_eval(state)
 
-        self.assertEqual(rendered.splitlines()[6], "? ? ? ? s@? ? ? ?")
+        self.assertEqual(rendered.splitlines()[6], "? ? ? ? @ ? ? ? ?")
 
     def test_manual_eval_render_uses_left_space_at_right_edge(self) -> None:
-        state = reveal_positions(make_state(entry_edge=Direction.E), [Position(8, 4)])
+        state = reveal_positions(make_state(entry_edge=Direction.E), [Position(9,5)])
 
         rendered = _render_known_map_spaced_for_manual_eval(state)
 
-        self.assertEqual(rendered.splitlines()[4], "? ? ? ? ? ? ? ?@>")
+        self.assertEqual(rendered.splitlines()[4], "? ? ? ? ? ? ? ? @")
 
     def test_player_cell_text_includes_object_and_warp_details(self) -> None:
-        state = place_object(make_state(), Position(4, 8), SrsObjectType.SALVAGE, "salvage-a")
+        state = place_object(make_state(), Position(5,9), SrsObjectType.SALVAGE, "salvage-a")
         state = replace(
             state,
             objects={
@@ -66,14 +66,14 @@ class SrsRunManualEvalTests(unittest.TestCase):
                 "salvage-a": replace(state.objects["salvage-a"], consumed=True),
             },
         )
-        state = replace_cell_terrain(state, Position(4, 8), SrsTerrainType.RIFT_BARRIER)
-        state = reveal_positions(state, [Position(4, 8)])
+        state = replace_cell_terrain(state, Position(5,9), SrsTerrainType.RIFT_BARRIER)
+        state = reveal_positions(state, [Position(5,9)])
 
         text = _player_cell_text(state)
 
         self.assertEqual(
             text,
-            "- position=(4,8), terrain=RIFT_BARRIER, warp=S, object=SALVAGE, consumed=true, activated=false",
+            "- position=(5,9), terrain=RIFT_BARRIER, warp=S, object=SALVAGE, consumed=true, activated=false",
         )
 
     def test_event_summary_resource_cache_includes_fuel_and_consumed_state(self) -> None:
@@ -92,11 +92,11 @@ class SrsRunManualEvalTests(unittest.TestCase):
 
         self.assertEqual(
             _player_cell_text(result.final_state),
-            "- position=(2,7), terrain=FLOOR, object=RESOURCE_CACHE, consumed=true, activated=false",
+            "- position=(3,8), terrain=FLOOR, object=RESOURCE_CACHE, consumed=true, activated=false",
         )
         self.assertEqual(
             _render_known_map_spaced_for_manual_eval(result.final_state).splitlines()[7],
-            "? . r@. ? ? ? ? ?",
+            "? . @ . ? ? ? ? ?",
         )
 
     def test_event_summary_station_includes_refuel_and_activation(self) -> None:
@@ -134,5 +134,5 @@ class SrsRunManualEvalTests(unittest.TestCase):
 
         self.assertEqual(
             _player_cell_text(result.final_state),
-            "- position=(2,7), terrain=FLOOR, object=RESOURCE_CACHE, consumed=true, activated=false",
+            "- position=(3,8), terrain=FLOOR, object=RESOURCE_CACHE, consumed=true, activated=false",
         )

--- a/experiments/galactic_exodus/srs/validate_phase2_results.py
+++ b/experiments/galactic_exodus/srs/validate_phase2_results.py
@@ -278,10 +278,10 @@ def _validate_known_map_secrecy(case_id: str, result: SrsFixtureRunResult) -> No
     if any(len(row) != state.actual_map.width for row in rows):
         raise ValidationError(f"{case_id}: render width mismatch")
 
-    for y in range(state.actual_map.height):
-        for x in range(state.actual_map.width):
+    for y in range(1, state.actual_map.height + 1):
+        for x in range(1, state.actual_map.width + 1):
             position = Position(x, y)
-            rendered = rows[y][x]
+            rendered = rows[y - 1][x - 1]
             if position in discovered:
                 if rendered == "?":
                     raise ValidationError(f"{case_id}: discovered cell rendered as unknown at {position}")


### PR DESCRIPTION
## 概要

Closes #1215

SRS の外部座標契約を 0 始まりから 1 始まりへ更新し、Python prototype・fixture・validator・spec を同じ座標系へ揃えました。

## 変更内容

- `SrsActualMap` の外部 `Position` 契約を `1..width` / `1..height` に変更し、内部配列アクセスを 0-based index へ変換
- SRS generation / observation / render / fixture override が 1 始まり座標を使うよう更新
- fixture と `phase2_reference.json` の座標・期待値を 1 始まりへ再同期
- SRS 関連テストと spec を更新し、validator が新しい座標契約を検証するよう修正

## 確認

- `python -m experiments.galactic_exodus.srs.validate_phase2_results experiments/galactic_exodus/srs/fixtures/phase2_reference.json`
- `python -m unittest experiments.galactic_exodus.srs.test_validate_phase2_results`
- `python -m unittest discover experiments/galactic_exodus/srs`
- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
