### PR TITLE
SRS内部座標のN/S edge契約を修正

### DIFF
--- a/experiments/galactic_exodus/srs/fixtures/base_minimal_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/base_minimal_9x9.json
@@ -9,11 +9,11 @@
   "expected": {
     "width": 9,
     "height": 9,
-    "player_position": [4, 8],
+    "player_position": [4, 0],
     "warp_flags": {
-      "4,0": ["N"],
+      "4,8": ["N"],
       "8,4": ["E"],
-      "4,8": ["S"],
+      "4,0": ["S"],
       "0,4": ["W"]
     },
     "terrain_counts": {

--- a/experiments/galactic_exodus/srs/fixtures/normal_minimal_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/normal_minimal_9x9.json
@@ -9,11 +9,11 @@
   "expected": {
     "width": 9,
     "height": 9,
-    "player_position": [4, 8],
+    "player_position": [4, 0],
     "warp_flags": {
-      "4,0": ["N"],
+      "4,8": ["N"],
       "8,4": ["E"],
-      "4,8": ["S"],
+      "4,0": ["S"],
       "0,4": ["W"]
     },
     "terrain_counts": {

--- a/experiments/galactic_exodus/srs/fixtures/resource_minimal_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/resource_minimal_9x9.json
@@ -9,11 +9,11 @@
   "expected": {
     "width": 9,
     "height": 9,
-    "player_position": [4, 8],
+    "player_position": [4, 0],
     "warp_flags": {
-      "4,0": ["N"],
+      "4,8": ["N"],
       "8,4": ["E"],
-      "4,8": ["S"],
+      "4,0": ["S"],
       "0,4": ["W"]
     },
     "terrain_counts": {

--- a/experiments/galactic_exodus/srs/fixtures/rift_n_blocked_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/rift_n_blocked_9x9.json
@@ -9,13 +9,13 @@
   "expected": {
     "width": 9,
     "height": 9,
-    "player_position": [4, 8],
+    "player_position": [4, 0],
     "warp_flags": {
       "8,4": ["E"],
-      "4,8": ["S"],
+      "4,0": ["S"],
       "0,4": ["W"]
     },
-    "blocked_warp_positions": ["4,0"],
+    "blocked_warp_positions": ["4,8"],
     "terrain_counts": {
       "FLOOR": 72,
       "RIFT_BARRIER": 9

--- a/experiments/galactic_exodus/srs/generate.py
+++ b/experiments/galactic_exodus/srs/generate.py
@@ -29,10 +29,12 @@ MAP_WIDTH = 9
 MAP_HEIGHT = 9
 MAP_CENTER = Position(4, 4)
 
+# Internal SRS coordinates are 0-origin lower-left:
+# x increases eastward and y increases northward.
 EDGE_POSITIONS = {
-    Direction.N: Position(4, 0),
+    Direction.N: Position(4, 8),
     Direction.E: Position(8, 4),
-    Direction.S: Position(4, 8),
+    Direction.S: Position(4, 0),
     Direction.W: Position(0, 4),
 }
 
@@ -117,14 +119,14 @@ def _make_floor_cells(*, width: int, height: int) -> list[list[SrsCell]]:
 def _apply_rift_barriers(cells: list[list[SrsCell]], blocked_edges: frozenset[Direction]) -> None:
     for edge in blocked_edges:
         if edge is Direction.N:
-            for x in range(len(cells[0])):
-                cells[0][x] = SrsCell(terrain=SrsTerrainType.RIFT_BARRIER)
+            for x in range(len(cells[-1])):
+                cells[-1][x] = SrsCell(terrain=SrsTerrainType.RIFT_BARRIER)
         elif edge is Direction.E:
             for row in cells:
                 row[-1] = SrsCell(terrain=SrsTerrainType.RIFT_BARRIER)
         elif edge is Direction.S:
-            for x in range(len(cells[-1])):
-                cells[-1][x] = SrsCell(terrain=SrsTerrainType.RIFT_BARRIER)
+            for x in range(len(cells[0])):
+                cells[0][x] = SrsCell(terrain=SrsTerrainType.RIFT_BARRIER)
         elif edge is Direction.W:
             for row in cells:
                 row[0] = SrsCell(terrain=SrsTerrainType.RIFT_BARRIER)

--- a/experiments/galactic_exodus/srs/test_generate.py
+++ b/experiments/galactic_exodus/srs/test_generate.py
@@ -83,6 +83,17 @@ class SrsGenerateTests(unittest.TestCase):
     def setUpClass(cls) -> None:
         cls.contracts = load_default_contracts(REPO_ROOT)
 
+    def test_internal_edge_positions_are_lower_left_origin(self) -> None:
+        self.assertEqual(
+            EDGE_POSITIONS,
+            {
+                Direction.N: Position(4, 8),
+                Direction.E: Position(8, 4),
+                Direction.S: Position(4, 0),
+                Direction.W: Position(0, 4),
+            },
+        )
+
     def test_same_seed_same_map(self) -> None:
         descriptor = SectorDescriptor("normal-1", SectorType.NORMAL, 1001, Direction.S)
         first = create_sector(descriptor, contracts=self.contracts)
@@ -149,9 +160,9 @@ class SrsGenerateTests(unittest.TestCase):
             contracts=self.contracts,
         )
 
-        self.assertNotIn("4,0", summarize_state(state)["warp_flags"])
+        self.assertNotIn("4,8", summarize_state(state)["warp_flags"])
 
-    def test_blocked_edge_line_is_rift_barrier(self) -> None:
+    def test_north_blocked_edge_line_is_rift_barrier(self) -> None:
         state = create_sector(
             SectorDescriptor(
                 "rift-1",
@@ -159,6 +170,22 @@ class SrsGenerateTests(unittest.TestCase):
                 4001,
                 Direction.S,
                 blocked_edges=frozenset({Direction.N}),
+            ),
+            contracts=self.contracts,
+        )
+
+        for x in range(state.actual_map.width):
+            with self.subTest(x=x):
+                self.assertEqual(state.actual_map.cell_at(Position(x, 8)).terrain.value, "RIFT_BARRIER")
+
+    def test_south_blocked_edge_line_is_rift_barrier(self) -> None:
+        state = create_sector(
+            SectorDescriptor(
+                "rift-1",
+                SectorType.RIFT,
+                4001,
+                Direction.N,
+                blocked_edges=frozenset({Direction.S}),
             ),
             contracts=self.contracts,
         )
@@ -183,7 +210,7 @@ class SrsGenerateTests(unittest.TestCase):
             summarize_state(state)["warp_flags"],
             {
                 "0,4": ["W"],
-                "4,8": ["S"],
+                "4,0": ["S"],
                 "8,4": ["E"],
             },
         )


### PR DESCRIPTION
## 概要

Refs #1221
Parent: #1218

SRS internal coordinate を `0-origin + lower-left` として扱う方針に合わせ、生成時の N/S edge と RIFT_BARRIER 配置を修正します。

## 変更内容

- `generate.py`
  - `EDGE_POSITIONS` を internal lower-left に合わせて修正
  - `N = Position(4, 8)` / `S = Position(4, 0)`
  - N/S blocked edge の `RIFT_BARRIER` 配置を修正
- `test_generate.py`
  - internal edge position 契約テストを追加
  - N/S blocked edge の RIFT_BARRIER テストを追加
  - 既存の N/S 逆向き期待値を更新
- generation fixture 最小4件
  - `normal_minimal_9x9.json`
  - `base_minimal_9x9.json`
  - `resource_minimal_9x9.json`
  - `rift_n_blocked_9x9.json`

## 注意

このPRは #1221 の生成契約修正を進めるための第一段です。

`phase2_srs_spec.md` の internal/display 座標契約追記、全 fixture / validator / render の同期は #1222 / #1223 側で続けて扱う想定です。

## 確認したいコマンド

```bash
python -m unittest experiments.galactic_exodus.srs.test_generate
python -m unittest discover experiments/galactic_exodus/srs
```

手元での実行は未確認です。CIで影響範囲を確認してください。
