### PR TITLE
SRS表示座標を1-origin左下に揃える

### DIFF
--- a/experiments/galactic_exodus/srs/render.py
+++ b/experiments/galactic_exodus/srs/render.py
@@ -46,9 +46,21 @@ def render_known_map_spaced(state: SrsGameState) -> str:
     return _render_known_map(state, cell_separator=" ")
 
 
+def to_display_position(position: Position) -> tuple[int, int]:
+    return (position.x + 1, position.y + 1)
+
+
+def from_display_position(x: int, y: int) -> Position:
+    return Position(x - 1, y - 1)
+
+
+def render_row_for_internal_y(*, height: int, y: int) -> int:
+    return height - 1 - y
+
+
 def _render_known_map(state: SrsGameState, *, cell_separator: str) -> str:
     rows: list[str] = []
-    for y in range(state.actual_map.height):
+    for y in range(state.actual_map.height - 1, -1, -1):
         chars: list[str] = []
         for x in range(state.actual_map.width):
             position = Position(x, y)

--- a/experiments/galactic_exodus/srs/run_manual_eval.py
+++ b/experiments/galactic_exodus/srs/run_manual_eval.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Iterable, Mapping, Sequence
 
 from experiments.galactic_exodus.srs.model import Position, SrsGameState
-from experiments.galactic_exodus.srs.render import render_known_map_spaced
+from experiments.galactic_exodus.srs.render import render_known_map_spaced, render_row_for_internal_y, to_display_position
 from experiments.galactic_exodus.srs.run_fixture import FIXTURES_DIR, SrsFixtureRunResult, run_fixture
 
 try:
@@ -151,7 +151,8 @@ def _markdown_list(text: str) -> str:
 
 def _format_position(value: object) -> str:
     if isinstance(value, (list, tuple)) and len(value) == 2:
-        return f"({value[0]},{value[1]})"
+        display_x, display_y = to_display_position(Position(value[0], value[1]))
+        return f"({display_x},{display_y})"
     return "-"
 
 
@@ -319,10 +320,11 @@ def _render_known_map_spaced_for_manual_eval(state: SrsGameState) -> str:
 
     hidden_player_state = replace(state, player_position=Position(-1, -1))
     underlay_rows = render_known_map_spaced(hidden_player_state).splitlines()
-    if not (0 <= player.y < len(underlay_rows)):
+    player_row_index = render_row_for_internal_y(height=state.actual_map.height, y=player.y)
+    if not (0 <= player_row_index < len(underlay_rows)):
         return render
 
-    player_row = underlay_rows[player.y]
+    player_row = underlay_rows[player_row_index]
     player_cell_index = player.x * 2
     if not (0 <= player_cell_index < len(player_row)):
         return render
@@ -339,17 +341,19 @@ def _render_known_map_spaced_for_manual_eval(state: SrsGameState) -> str:
     else:
         row_chars.append("@")
 
-    underlay_rows[player.y] = "".join(row_chars)
+    underlay_rows[player_row_index] = "".join(row_chars)
     return "\n".join(underlay_rows)
 
 
 def _player_cell_text(state: SrsGameState) -> str:
     player = state.player_position
     if not state.actual_map.contains(player):
-        return f"- position=({player.x},{player.y}), out_of_bounds=True"
+        display_x, display_y = to_display_position(player)
+        return f"- position=({display_x},{display_y}), out_of_bounds=True"
 
     cell = state.actual_map.cell_at(player)
-    details = [f"position=({player.x},{player.y})", f"terrain={cell.terrain.value}"]
+    display_x, display_y = to_display_position(player)
+    details = [f"position=({display_x},{display_y})", f"terrain={cell.terrain.value}"]
 
     if cell.warp_flags:
         warp = "".join(direction.value for direction in sorted(cell.warp_flags, key=lambda direction: direction.value))

--- a/experiments/galactic_exodus/srs/test_render.py
+++ b/experiments/galactic_exodus/srs/test_render.py
@@ -4,11 +4,20 @@ import unittest
 from dataclasses import replace
 
 from experiments.galactic_exodus.srs.model import Direction, Position, SrsCell, SrsObjectType, SrsTerrainType
-from experiments.galactic_exodus.srs.render import render_known_map, render_known_map_spaced
+from experiments.galactic_exodus.srs.render import (
+    from_display_position,
+    render_known_map,
+    render_known_map_spaced,
+    render_row_for_internal_y,
+    to_display_position,
+)
 from experiments.galactic_exodus.srs.test_engine_movement import make_state, place_object, reveal_positions, replace_cell_terrain
 
 
 class SrsRenderTests(unittest.TestCase):
+    def _row_for_internal_y(self, *, height: int, y: int) -> int:
+        return render_row_for_internal_y(height=height, y=y)
+
     def test_known_render_unknown_cells_are_question_marks(self) -> None:
         rendered = render_known_map(make_state())
 
@@ -19,7 +28,7 @@ class SrsRenderTests(unittest.TestCase):
 
         rendered = render_known_map(state)
 
-        self.assertEqual(rendered.splitlines()[4][4], "?")
+        self.assertEqual(rendered.splitlines()[self._row_for_internal_y(height=9, y=4)][4], "?")
         self.assertNotIn("~", rendered)
 
     def test_known_render_player_overrides_cell_symbol(self) -> None:
@@ -27,7 +36,7 @@ class SrsRenderTests(unittest.TestCase):
 
         rendered = render_known_map(state)
 
-        self.assertEqual(rendered.splitlines()[0][4], "@")
+        self.assertEqual(rendered.splitlines()[self._row_for_internal_y(height=9, y=0)][4], "@")
 
     def test_known_render_object_symbols(self) -> None:
         state = reveal_positions(
@@ -41,7 +50,7 @@ class SrsRenderTests(unittest.TestCase):
 
         rendered = render_known_map(state)
 
-        row = rendered.splitlines()[1]
+        row = rendered.splitlines()[self._row_for_internal_y(height=9, y=1)]
         self.assertEqual(row[1], "*")
         self.assertEqual(row[2], "o")
         self.assertEqual(row[3], "S")
@@ -60,7 +69,7 @@ class SrsRenderTests(unittest.TestCase):
 
         rendered = render_known_map(state)
 
-        self.assertEqual(rendered.splitlines()[2][2], "r")
+        self.assertEqual(rendered.splitlines()[self._row_for_internal_y(height=9, y=2)][2], "r")
 
     def test_known_render_consumed_salvage_lowercase(self) -> None:
         state = place_object(make_state(), Position(2, 2), SrsObjectType.SALVAGE, "salvage-a")
@@ -75,7 +84,7 @@ class SrsRenderTests(unittest.TestCase):
 
         rendered = render_known_map(state)
 
-        self.assertEqual(rendered.splitlines()[2][2], "s")
+        self.assertEqual(rendered.splitlines()[self._row_for_internal_y(height=9, y=2)][2], "s")
 
     def test_known_render_warp_symbols(self) -> None:
         state = make_state()
@@ -98,7 +107,39 @@ class SrsRenderTests(unittest.TestCase):
 
         rendered = render_known_map(state)
 
-        self.assertEqual(rendered.splitlines()[1][1], "+")
+        self.assertEqual(rendered.splitlines()[self._row_for_internal_y(height=9, y=1)][1], "+")
+
+    def test_render_top_row_is_internal_north_row(self) -> None:
+        state = reveal_positions(make_state(), [Position(3, 8)])
+
+        rendered = render_known_map(state)
+        lines = rendered.splitlines()
+
+        self.assertEqual(lines[0][3], ".")
+        self.assertEqual(lines[8][3], "?")
+
+    def test_render_bottom_row_is_internal_south_row(self) -> None:
+        state = reveal_positions(make_state(), [Position(4, 0)])
+
+        rendered = render_known_map(state)
+        lines = rendered.splitlines()
+
+        self.assertEqual(lines[0][4], "?")
+        self.assertEqual(lines[8][4], "@")
+
+    def test_display_position_converts_internal_zero_origin_to_display_one_origin(self) -> None:
+        self.assertEqual(to_display_position(Position(0, 0)), (1, 1))
+        self.assertEqual(to_display_position(Position(8, 8)), (9, 9))
+
+    def test_from_display_position_converts_display_one_origin_to_internal_zero_origin(self) -> None:
+        self.assertEqual(from_display_position(1, 1), Position(0, 0))
+        self.assertEqual(from_display_position(9, 9), Position(8, 8))
+
+    def test_warp_points_have_expected_display_coordinates(self) -> None:
+        self.assertEqual(to_display_position(Position(4, 8)), (5, 9))
+        self.assertEqual(to_display_position(Position(8, 4)), (9, 5))
+        self.assertEqual(to_display_position(Position(4, 0)), (5, 1))
+        self.assertEqual(to_display_position(Position(0, 4)), (1, 5))
 
     def test_known_render_row_widths_are_stable(self) -> None:
         state = reveal_positions(make_state(), [Position(x, y) for y in range(9) for x in range(9)])
@@ -113,6 +154,6 @@ class SrsRenderTests(unittest.TestCase):
         rendered = render_known_map_spaced(state)
 
         lines = rendered.splitlines()
-        self.assertEqual(lines[0], ". . . . @ . . . .")
-        self.assertEqual(lines[8], "? ? ? ? ? ? ? ? ?")
+        self.assertEqual(lines[0], "? ? ? ? ? ? ? ? ?")
+        self.assertEqual(lines[8], ". . . . @ . . . .")
         self.assertEqual([len(row) for row in lines], [17] * 9)

--- a/experiments/galactic_exodus/srs/test_run_manual_eval.py
+++ b/experiments/galactic_exodus/srs/test_run_manual_eval.py
@@ -11,10 +11,14 @@ from experiments.galactic_exodus.srs.run_manual_eval import (
     _player_cell_text,
     _render_known_map_spaced_for_manual_eval,
 )
+from experiments.galactic_exodus.srs.render import render_row_for_internal_y
 from experiments.galactic_exodus.srs.test_engine_movement import make_state, place_object, reveal_positions, replace_cell_terrain
 
 
 class SrsRunManualEvalTests(unittest.TestCase):
+    def _row_for_internal_y(self, *, height: int, y: int) -> int:
+        return render_row_for_internal_y(height=height, y=y)
+
     def _summary_lines_for_fixture(self, fixture_name: str) -> list[str]:
         result = run_fixture(Path(__file__).resolve().parent / "fixtures" / fixture_name)
         return _event_summary_lines(result)
@@ -25,14 +29,14 @@ class SrsRunManualEvalTests(unittest.TestCase):
 
         rendered = _render_known_map_spaced_for_manual_eval(state)
 
-        self.assertEqual(rendered.splitlines()[1], ". . . . @ . . . .")
+        self.assertEqual(rendered.splitlines()[self._row_for_internal_y(height=9, y=1)], ". . . . @ . . . .")
 
     def test_manual_eval_render_shows_player_beside_warp_symbol(self) -> None:
         state = reveal_positions(make_state(), [Position(4, 0)])
 
         rendered = _render_known_map_spaced_for_manual_eval(state)
 
-        self.assertEqual(rendered.splitlines()[0], "? ? ? ? v@? ? ? ?")
+        self.assertEqual(rendered.splitlines()[self._row_for_internal_y(height=9, y=0)], "? ? ? ? v@? ? ? ?")
 
     def test_manual_eval_render_shows_player_beside_salvage_symbol(self) -> None:
         state = place_object(make_state(), Position(4, 2), SrsObjectType.SALVAGE, "salvage-a")
@@ -48,14 +52,14 @@ class SrsRunManualEvalTests(unittest.TestCase):
 
         rendered = _render_known_map_spaced_for_manual_eval(state)
 
-        self.assertEqual(rendered.splitlines()[2], "? ? ? ? s@? ? ? ?")
+        self.assertEqual(rendered.splitlines()[self._row_for_internal_y(height=9, y=2)], "? ? ? ? s@? ? ? ?")
 
     def test_manual_eval_render_uses_left_space_at_right_edge(self) -> None:
         state = reveal_positions(make_state(entry_edge=Direction.E), [Position(8, 4)])
 
         rendered = _render_known_map_spaced_for_manual_eval(state)
 
-        self.assertEqual(rendered.splitlines()[4], "? ? ? ? ? ? ? ?@>")
+        self.assertEqual(rendered.splitlines()[self._row_for_internal_y(height=9, y=4)], "? ? ? ? ? ? ? ?@>")
 
     def test_player_cell_text_includes_object_and_warp_details(self) -> None:
         state = place_object(make_state(), Position(4, 0), SrsObjectType.SALVAGE, "salvage-a")
@@ -73,8 +77,15 @@ class SrsRunManualEvalTests(unittest.TestCase):
 
         self.assertEqual(
             text,
-            "- position=(4,0), terrain=RIFT_BARRIER, warp=S, object=SALVAGE, consumed=true, activated=false",
+            "- position=(5,1), terrain=RIFT_BARRIER, warp=S, object=SALVAGE, consumed=true, activated=false",
         )
+
+    def test_event_summary_positions_use_display_coordinates(self) -> None:
+        lines = self._summary_lines_for_fixture("move_to_known_9x9.json")
+
+        self.assertIn("turn 1: MOVE_ACCEPTED MOVE_TO (5,1) -> (5,3) fuel 0->0", lines)
+        self.assertIn("turn 1: OBSERVATION_UPDATED center=(5,2) new=0 total=81", lines)
+        self.assertIn("turn 1: OBSERVATION_UPDATED center=(5,3) new=0 total=81", lines)
 
     def test_event_summary_resource_cache_includes_fuel_and_consumed_state(self) -> None:
         lines = self._summary_lines_for_fixture("resource_cache_single_9x9.json")
@@ -92,10 +103,10 @@ class SrsRunManualEvalTests(unittest.TestCase):
 
         self.assertEqual(
             _player_cell_text(result.final_state),
-            "- position=(2,7), terrain=FLOOR, object=RESOURCE_CACHE, consumed=true, activated=false",
+            "- position=(3,8), terrain=FLOOR, object=RESOURCE_CACHE, consumed=true, activated=false",
         )
         self.assertEqual(
-            _render_known_map_spaced_for_manual_eval(result.final_state).splitlines()[7],
+            _render_known_map_spaced_for_manual_eval(result.final_state).splitlines()[self._row_for_internal_y(height=9, y=7)],
             "? . r@. ? ? ? ? ?",
         )
 
@@ -134,5 +145,5 @@ class SrsRunManualEvalTests(unittest.TestCase):
 
         self.assertEqual(
             _player_cell_text(result.final_state),
-            "- position=(2,7), terrain=FLOOR, object=RESOURCE_CACHE, consumed=true, activated=false",
+            "- position=(3,8), terrain=FLOOR, object=RESOURCE_CACHE, consumed=true, activated=false",
         )

--- a/experiments/galactic_exodus/srs/validate_phase2_results.py
+++ b/experiments/galactic_exodus/srs/validate_phase2_results.py
@@ -14,6 +14,7 @@ if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 
 from experiments.galactic_exodus.srs.model import Position
+from experiments.galactic_exodus.srs.render import render_row_for_internal_y
 from experiments.galactic_exodus.srs.run_fixture import FIXTURES_DIR, REPO_ROOT, SrsFixtureRunResult, run_fixture
 
 
@@ -281,7 +282,7 @@ def _validate_known_map_secrecy(case_id: str, result: SrsFixtureRunResult) -> No
     for y in range(state.actual_map.height):
         for x in range(state.actual_map.width):
             position = Position(x, y)
-            rendered = rows[y][x]
+            rendered = rows[render_row_for_internal_y(height=state.actual_map.height, y=y)][x]
             if position in discovered:
                 if rendered == "?":
                     raise ValidationError(f"{case_id}: discovered cell rendered as unknown at {position}")


### PR DESCRIPTION
## 概要

Closes #1223

SRS の内部座標は 0-origin lower-left のまま維持しつつ、render と manual eval などの user-facing 表示を 1-origin lower-left に揃えました。

## 変更内容

- `render_known_map()` / `render_known_map_spaced()` を north-to-south 描画へ変更
- `to_display_position()` / `from_display_position()` を追加
- manual eval の event summary / player cell 表示を display 座標へ変換
- manual eval overlay と render secrecy validator を新しい行順へ追従
- render / manual eval の回帰テストを追加・更新
- #1214 に display coordinate 前提の補足コメントを投稿

## 確認

- `python -m unittest experiments.galactic_exodus.srs.test_render`
- `python -m unittest experiments.galactic_exodus.srs.test_run_manual_eval`
- `python experiments/galactic_exodus/srs/validate_phase2_results.py experiments/galactic_exodus/srs/fixtures/phase2_reference.json`
- `python -m unittest discover experiments/galactic_exodus/srs`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
