### PR TITLE
LRS border-light macro map を実装

### DIFF
--- a/experiments/galactic_exodus/display.py
+++ b/experiments/galactic_exodus/display.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from experiments.galactic_exodus import engine, simulate
+
+_OUTER_BORDER = "  +---+---+---+---+---+---+---+---+"
+_X_AXIS_LABEL = "    1   2   3   4   5   6   7   8"
+
+
+def render_lrs_border_light_map(state: engine.GameState) -> str:
+    """Render the LRS known macro map using the #1076 border-light baseline."""
+    lines = [_OUTER_BORDER]
+    for y in range(simulate.HEIGHT, 0, -1):
+        lines.append(_render_cell_row(state, y))
+        if y > 1:
+            lines.append(_render_horizontal_edge_row(state, y))
+        else:
+            lines.append(_OUTER_BORDER)
+    lines.append(_X_AXIS_LABEL)
+    return "\n".join(lines)
+
+
+def _render_cell_row(state: engine.GameState, y: int) -> str:
+    segments: list[str] = []
+    for x in range(1, simulate.WIDTH + 1):
+        position = (x, y)
+        segments.append(f" {_lrs_cell_symbol(state, position)} ")
+        if x < simulate.WIDTH:
+            segments.append("|" if _has_known_vertical_rift(state, position, (x + 1, y)) else " ")
+    return f"{y} |{''.join(segments)}|"
+
+
+def _render_horizontal_edge_row(state: engine.GameState, y: int) -> str:
+    content = list(" " * 31)
+    for x in range(1, simulate.WIDTH):
+        upper_edge = _has_known_vertical_rift(state, (x, y), (x + 1, y))
+        lower_edge = _has_known_vertical_rift(state, (x, y - 1), (x + 1, y - 1))
+        if upper_edge or lower_edge:
+            content[4 * x - 1] = "+"
+    for x in range(1, simulate.WIDTH + 1):
+        if not _has_known_horizontal_rift(state, (x, y), (x, y - 1)):
+            continue
+        if x == 1:
+            content[0:4] = list("---+")
+        elif x == simulate.WIDTH:
+            content[27:31] = list("+---")
+        else:
+            start = 4 * (x - 1) - 1
+            content[start : start + 5] = list("+---+")
+    return f"  +{''.join(content)}+"
+
+
+def _has_known_vertical_rift(
+    state: engine.GameState,
+    position_a: simulate.Position,
+    position_b: simulate.Position,
+) -> bool:
+    edge = simulate.normalize_edge(position_a, position_b)
+    return state.known_routes.get(edge) == engine.ROUTE_RIFT
+
+
+def _has_known_horizontal_rift(
+    state: engine.GameState,
+    position_a: simulate.Position,
+    position_b: simulate.Position,
+) -> bool:
+    edge = simulate.normalize_edge(position_a, position_b)
+    return state.known_routes.get(edge) == engine.ROUTE_RIFT
+
+
+def _lrs_cell_symbol(state: engine.GameState, position: simulate.Position) -> str:
+    if position == state.player_position:
+        return "@"
+    if position == state.settings.start_position:
+        return "S"
+    if position == state.settings.goal_position:
+        return "H"
+    if position in state.used_resource_positions:
+        if state.known_cells.get(position) == engine.RESOURCE_CELL:
+            return "r"
+        return "?"
+    symbol = state.known_cells.get(position)
+    if symbol in engine.VALID_CELL_SYMBOLS:
+        return symbol
+    return "?"

--- a/experiments/galactic_exodus/play.py
+++ b/experiments/galactic_exodus/play.py
@@ -11,6 +11,7 @@ if __package__ in (None, ""):
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from experiments.galactic_exodus import engine, simulate
+from experiments.galactic_exodus.display import render_lrs_border_light_map
 
 ABORTED_BY_USER = engine.FINAL_OUTCOME_ABORTED_NO_POLICY_ACTION
 KNOWN_TERRAIN_SYMBOLS = {".", "N", "A", "@", "B", "R"}
@@ -100,9 +101,8 @@ def main(
 
 def render_state(state: engine.GameState, output: TextIO) -> None:
     output.write("MAP:\n")
-    for row in board_lines(state):
-        output.write(f"{row}\n")
-    output.write("  1 2 3 4 5 6 7 8\n")
+    output.write(render_lrs_border_light_map(state))
+    output.write("\n")
     output.write(
         f"SEED: requested={state.requested_seed} effective={state.effective_seed} rerolls={state.reroll_count}\n"
     )

--- a/experiments/galactic_exodus/test_display.py
+++ b/experiments/galactic_exodus/test_display.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import unittest
+
+from experiments.galactic_exodus import display, engine, simulate
+from experiments.galactic_exodus.test_engine import filled_cells
+from experiments.galactic_exodus.test_engine import make_actual_map
+from experiments.galactic_exodus.test_engine import make_state
+
+
+def make_snapshot_state() -> engine.GameState:
+    cells = filled_cells(".")
+    cells[(4, 7)] = "N"
+    actual_map = make_actual_map(
+        cells=cells,
+        base_position=(4, 5),
+        resource_positions=((3, 6),),
+    )
+    vertical_rift = simulate.normalize_edge((3, 6), (4, 6))
+    horizontal_rift = simulate.normalize_edge((3, 5), (3, 4))
+    known_cells = {
+        (1, 1): "S",
+        (2, 1): ".",
+        (3, 1): ".",
+        (2, 4): ".",
+        (3, 4): ".",
+        (4, 4): ".",
+        (2, 5): ".",
+        (3, 5): ".",
+        (4, 5): "B",
+        (2, 6): ".",
+        (3, 6): "R",
+        (4, 6): ".",
+        (2, 7): ".",
+        (3, 7): ".",
+        (4, 7): "N",
+        (8, 8): "H",
+    }
+    return make_state(
+        actual_map=actual_map,
+        player_position=(3, 5),
+        known_cells=known_cells,
+        visited_cells={(1, 1), (3, 5)},
+        known_routes={
+            vertical_rift: engine.ROUTE_RIFT,
+            horizontal_rift: engine.ROUTE_RIFT,
+        },
+        path=[(1, 1), (2, 1), (3, 1), (3, 5)],
+    )
+
+
+class DisplayTests(unittest.TestCase):
+    def test_empty_known_map_shape(self) -> None:
+        state = make_state(actual_map=make_actual_map(cells=filled_cells(".")))
+
+        rendered = display.render_lrs_border_light_map(state)
+        lines = rendered.splitlines()
+
+        self.assertEqual(len(lines), 18)
+        self.assertEqual(lines[0], "  +---+---+---+---+---+---+---+---+")
+        self.assertEqual(lines[16], "  +---+---+---+---+---+---+---+---+")
+        self.assertEqual([line[0] for line in lines[1:16:2]], list("87654321"))
+        self.assertEqual(lines[17], "    1   2   3   4   5   6   7   8")
+
+    def test_current_position_uses_at_mark(self) -> None:
+        state = make_state(actual_map=make_actual_map(cells=filled_cells(".")))
+
+        rendered = display.render_lrs_border_light_map(state)
+
+        self.assertIn("1 | @   ?   ?   ?   ?   ?   ?   ? |", rendered)
+        self.assertNotIn("P", rendered)
+
+    def test_used_resource_uses_lowercase_r_only_when_known(self) -> None:
+        actual_map = make_actual_map(
+            cells=filled_cells("."),
+            resource_positions=((2, 1), (3, 1)),
+        )
+        state = make_state(
+            actual_map=actual_map,
+            known_cells={
+                (1, 1): "S",
+                (2, 1): "R",
+                (8, 8): "H",
+            },
+            used_resource_positions={(2, 1), (3, 1)},
+        )
+
+        rendered = display.render_lrs_border_light_map(state)
+
+        self.assertIn("1 | @   r   ?   ?   ?   ?   ?   ? |", rendered)
+
+    def test_vertical_known_rift_edge_is_rendered(self) -> None:
+        state = make_snapshot_state()
+
+        rendered = display.render_lrs_border_light_map(state)
+
+        self.assertIn("6 | ?   .   R | .   ?   ?   ?   ? |", rendered)
+
+    def test_horizontal_known_rift_edge_is_rendered(self) -> None:
+        state = make_snapshot_state()
+
+        rendered = display.render_lrs_border_light_map(state)
+
+        self.assertIn("  +       +---+                   +", rendered)
+
+    def test_actual_but_unknown_rift_is_hidden(self) -> None:
+        hidden_edge = simulate.normalize_edge((3, 5), (3, 4))
+        actual_map = make_actual_map(
+            cells=filled_cells("."),
+            rift_edges=(hidden_edge,),
+        )
+        state = make_state(actual_map=actual_map)
+
+        rendered = display.render_lrs_border_light_map(state)
+
+        self.assertNotIn("+---+", rendered.splitlines()[8])
+
+    def test_known_open_route_is_not_rendered_as_blocker(self) -> None:
+        open_edge = simulate.normalize_edge((1, 1), (2, 1))
+        state = make_state(
+            actual_map=make_actual_map(cells=filled_cells("."), rift_edges=(open_edge,)),
+            known_routes={open_edge: engine.ROUTE_OPEN},
+        )
+
+        rendered = display.render_lrs_border_light_map(state)
+
+        self.assertIn("1 | @   ?   ?   ?   ?   ?   ?   ? |", rendered)
+        self.assertEqual(rendered.splitlines()[15], "1 | @   ?   ?   ?   ?   ?   ?   ? |")
+
+    def test_snapshot_matches_border_light_baseline(self) -> None:
+        state = make_snapshot_state()
+
+        rendered = display.render_lrs_border_light_map(state)
+
+        self.assertEqual(
+            rendered,
+            "\n".join(
+                [
+                    "  +---+---+---+---+---+---+---+---+",
+                    "8 | ?   ?   ?   ?   ?   ?   ?   H |",
+                    "  +                               +",
+                    "7 | ?   .   .   N   ?   ?   ?   ? |",
+                    "  +           +                   +",
+                    "6 | ?   .   R | .   ?   ?   ?   ? |",
+                    "  +           +                   +",
+                    "5 | ?   .   @   B   ?   ?   ?   ? |",
+                    "  +       +---+                   +",
+                    "4 | ?   .   .   .   ?   ?   ?   ? |",
+                    "  +                               +",
+                    "3 | ?   ?   ?   ?   ?   ?   ?   ? |",
+                    "  +                               +",
+                    "2 | ?   ?   ?   ?   ?   ?   ?   ? |",
+                    "  +                               +",
+                    "1 | S   .   .   ?   ?   ?   ?   ? |",
+                    "  +---+---+---+---+---+---+---+---+",
+                    "    1   2   3   4   5   6   7   8",
+                ]
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experiments/galactic_exodus/test_play.py
+++ b/experiments/galactic_exodus/test_play.py
@@ -239,6 +239,17 @@ class PlayCliTests(unittest.TestCase):
         self.assertIn("LAST SUPPLY: R(3,2)\n", rendered)
         self.assertIn("USED R: (2,3),(3,2)\n", rendered)
 
+    def test_render_state_uses_border_light_map(self) -> None:
+        state = make_state(actual_map=make_actual_map(cells=filled_cells(".")))
+
+        stdout = io.StringIO()
+        play.render_state(state, stdout)
+        rendered = stdout.getvalue()
+
+        self.assertIn("MAP:\n  +---+---+---+---+---+---+---+---+\n", rendered)
+        self.assertNotIn("y=8 ", rendered)
+        self.assertIn("1 | @   ?   ?   ?   ?   ?   ?   ? |\n", rendered)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 概要

Closes #1231

Galactic Exodus の LRS 表示を `play.py` から分離し、#1076 baseline の border-light macro map を `display.py` で描画するようにしました。

## 変更内容

- `experiments/galactic_exodus/display.py` を追加し、`render_lrs_border_light_map()` を実装
- 既知 sector / 現在位置 / 使用済み resource / known RIFT edge を border-light 形式で描画
- `play.render_state()` の MAP セクションを新 renderer に切り替え
- `board_lines()` / `display_symbol()` は fallback API として維持
- LRS snapshot と edge/resource/current-position の回帰テストを追加

## 確認

- `python -m unittest experiments.galactic_exodus.test_display`
- `python -m unittest experiments.galactic_exodus.test_play`
- `python -m unittest discover experiments/galactic_exodus`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
