### PR TITLE
SRS local map display renderer を baseline に同期

### DIFF
--- a/experiments/galactic_exodus/srs/__init__.py
+++ b/experiments/galactic_exodus/srs/__init__.py
@@ -4,6 +4,7 @@ __all__ = [
     "SrsFixtureError",
     "SrsFixtureRunResult",
     "fixture_result_to_jsonable",
+    "render_display_map",
     "render_known_map",
     "render_known_map_spaced",
     "run_fixture",
@@ -12,7 +13,7 @@ __all__ = [
 
 
 def __getattr__(name: str):
-    if name in {"render_known_map", "render_known_map_spaced"}:
+    if name in {"render_display_map", "render_known_map", "render_known_map_spaced"}:
         from importlib import import_module
 
         render_module = import_module("experiments.galactic_exodus.srs.render")

--- a/experiments/galactic_exodus/srs/render.py
+++ b/experiments/galactic_exodus/srs/render.py
@@ -46,6 +46,19 @@ def render_known_map_spaced(state: SrsGameState) -> str:
     return _render_known_map(state, cell_separator=" ")
 
 
+def render_display_map(state: SrsGameState) -> str:
+    rows: list[str] = []
+    for display_y in range(state.actual_map.height, 0, -1):
+        symbols: list[str] = []
+        for display_x in range(1, state.actual_map.width + 1):
+            internal_position = from_display_position(display_x, display_y)
+            symbols.append(_display_cell_symbol(state, internal_position))
+        rows.append(f"{display_y:>2}  {' '.join(symbols)}")
+
+    x_axis = "    " + " ".join(str(display_x) for display_x in range(1, state.actual_map.width + 1))
+    return "\n".join([*rows, "", x_axis])
+
+
 def to_display_position(position: Position) -> tuple[int, int]:
     return (position.x + 1, position.y + 1)
 
@@ -75,6 +88,28 @@ def _render_position(state: SrsGameState, position: Position) -> str:
     if position == state.player_position:
         return "@"
 
+    return _known_cell_symbol(state, position)
+
+
+def _display_cell_symbol(state: SrsGameState, position: Position) -> str:
+    if position == state.player_position:
+        return "@"
+    if position not in state.known_state.discovered_cells:
+        return UNKNOWN_SYMBOL
+    if _has_visible_enemy(state, position):
+        return "e"
+
+    return _known_cell_symbol(state, position)
+
+
+def _has_visible_enemy(state: SrsGameState, position: Position) -> bool:
+    combat_state = state.combat_state
+    if combat_state is None:
+        return False
+    return any(enemy.position == position for enemy in combat_state.enemies.values())
+
+
+def _known_cell_symbol(state: SrsGameState, position: Position) -> str:
     cell = state.known_state.known_cells[position]
     if cell.object_id is not None:
         object_state = state.objects[cell.object_id]

--- a/experiments/galactic_exodus/srs/run_manual_eval.py
+++ b/experiments/galactic_exodus/srs/run_manual_eval.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Iterable, Mapping, Sequence
 
 from experiments.galactic_exodus.srs.model import Position, SrsGameState
-from experiments.galactic_exodus.srs.render import render_known_map_spaced, render_row_for_internal_y, to_display_position
+from experiments.galactic_exodus.srs.render import render_display_map, render_row_for_internal_y, to_display_position
 from experiments.galactic_exodus.srs.run_fixture import FIXTURES_DIR, SrsFixtureRunResult, run_fixture
 
 try:
@@ -313,27 +313,28 @@ def _event_summary_text(result: SrsFixtureRunResult) -> str:
 
 
 def _render_known_map_spaced_for_manual_eval(state: SrsGameState) -> str:
-    render = render_known_map_spaced(state)
+    render = render_display_map(state)
     player = state.player_position
     if not state.actual_map.contains(player):
         return render
 
     hidden_player_state = replace(state, player_position=Position(-1, -1))
-    underlay_rows = render_known_map_spaced(hidden_player_state).splitlines()
+    underlay_rows = render_display_map(hidden_player_state).splitlines()
     player_row_index = render_row_for_internal_y(height=state.actual_map.height, y=player.y)
     if not (0 <= player_row_index < len(underlay_rows)):
         return render
 
     player_row = underlay_rows[player_row_index]
+    cell_text = player_row[4:]
     player_cell_index = player.x * 2
-    if not (0 <= player_cell_index < len(player_row)):
+    if not (0 <= player_cell_index < len(cell_text)):
         return render
 
-    under_player = player_row[player_cell_index]
+    under_player = cell_text[player_cell_index]
     if under_player in {"?", "."}:
         return render
 
-    row_chars = list(player_row)
+    row_chars = list(cell_text)
     if player.x < state.actual_map.width - 1:
         row_chars[player_cell_index + 1] = "@"
     elif player.x > 0:
@@ -341,7 +342,7 @@ def _render_known_map_spaced_for_manual_eval(state: SrsGameState) -> str:
     else:
         row_chars.append("@")
 
-    underlay_rows[player_row_index] = "".join(row_chars)
+    underlay_rows[player_row_index] = player_row[:4] + "".join(row_chars)
     return "\n".join(underlay_rows)
 
 
@@ -398,8 +399,8 @@ def _write_header(path: Path, fixture_paths: tuple[Path, ...]) -> None:
         "# SRS Manual Evaluation",
         "",
         f"- created_at: {datetime.now().isoformat(timespec='seconds')}",
-        "- renderer: manual-eval overlay over render_known_map_spaced",
-        "- note: compact render / JSON API は fixture regression 用に維持する",
+        "- renderer: manual-eval overlay over render_display_map",
+        "- note: compact render / spaced render / JSON API は fixture regression 用に維持する",
         "- note: 重要記号と現在位置が重なる場合、足元記号を残して `@` を隣接空白へ表示する",
         "",
         "## 判定基準",

--- a/experiments/galactic_exodus/srs/test_render.py
+++ b/experiments/galactic_exodus/srs/test_render.py
@@ -3,9 +3,19 @@ from __future__ import annotations
 import unittest
 from dataclasses import replace
 
-from experiments.galactic_exodus.srs.model import Direction, Position, SrsCell, SrsObjectType, SrsTerrainType
+from experiments.galactic_exodus.srs.model import (
+    Direction,
+    Position,
+    SrsCell,
+    SrsCombatState,
+    SrsEnemyTier,
+    SrsObjectType,
+    SrsTerrainType,
+    create_enemy_combat_state,
+)
 from experiments.galactic_exodus.srs.render import (
     from_display_position,
+    render_display_map,
     render_known_map,
     render_known_map_spaced,
     render_row_for_internal_y,
@@ -17,6 +27,110 @@ from experiments.galactic_exodus.srs.test_engine_movement import make_state, pla
 class SrsRenderTests(unittest.TestCase):
     def _row_for_internal_y(self, *, height: int, y: int) -> int:
         return render_row_for_internal_y(height=height, y=y)
+
+    def _replace_cell(
+        self,
+        state,
+        position: Position,
+        *,
+        terrain: SrsTerrainType | None = None,
+        object_id: str | None = None,
+        warp_flags: frozenset[Direction] | None = None,
+    ):
+        rows = [list(row) for row in state.actual_map.cells]
+        current = state.actual_map.cell_at(position)
+        rows[position.y][position.x] = SrsCell(
+            terrain=current.terrain if terrain is None else terrain,
+            object_id=current.object_id if object_id is None else object_id,
+            actor_id=current.actor_id,
+            warp_flags=current.warp_flags if warp_flags is None else warp_flags,
+        )
+        return replace(
+            state,
+            actual_map=replace(
+                state.actual_map,
+                cells=tuple(tuple(row) for row in rows),
+            ),
+        )
+
+    def _display_row(self, rendered: str, display_y: int) -> str:
+        return rendered.splitlines()[9 - display_y]
+
+    def _display_symbols(self, rendered: str, display_y: int) -> list[str]:
+        return self._display_row(rendered, display_y).split()[1:]
+
+    def _display_cell(self, rendered: str, *, display_x: int, display_y: int) -> str:
+        return self._display_symbols(rendered, display_y)[display_x - 1]
+
+    def _with_enemy(self, state, *, enemy_id: str, position: Position):
+        enemy = create_enemy_combat_state(
+            enemy_id=enemy_id,
+            tier=SrsEnemyTier.TIER2,
+            position=position,
+        )
+        return replace(
+            state,
+            combat_state=SrsCombatState(
+                enemies={enemy_id: enemy},
+                player_attack_target_id=enemy_id,
+            ),
+        )
+
+    def _build_baseline_snapshot_state(self):
+        state = replace(make_state(), player_position=Position(6, 3))
+
+        barrier_positions = [Position(8, y) for y in range(6)]
+        floor_positions = [
+            Position(3, 6),
+            Position(4, 6),
+            Position(5, 6),
+            Position(3, 5),
+            Position(4, 5),
+            Position(5, 5),
+            Position(6, 5),
+            Position(7, 5),
+            Position(3, 4),
+            Position(4, 4),
+            Position(5, 4),
+            Position(6, 4),
+            Position(7, 4),
+            Position(3, 3),
+            Position(4, 3),
+            Position(5, 3),
+            Position(6, 3),
+            Position(7, 3),
+            Position(3, 2),
+            Position(5, 2),
+            Position(6, 2),
+            Position(7, 2),
+            Position(2, 1),
+            Position(3, 1),
+            Position(4, 1),
+            Position(5, 1),
+            Position(6, 1),
+            Position(7, 1),
+        ]
+        warp_positions = [Position(x, 0) for x in range(2, 8)]
+        known_positions = set(floor_positions)
+        known_positions.update(barrier_positions)
+        known_positions.update(warp_positions)
+        known_positions.add(Position(4, 2))
+        known_positions.add(Position(4, 4))
+
+        for position in barrier_positions:
+            state = self._replace_cell(
+                state,
+                position,
+                terrain=SrsTerrainType.RIFT_BARRIER,
+                warp_flags=frozenset(),
+            )
+        for position in warp_positions:
+            state = self._replace_cell(state, position, warp_flags=frozenset({Direction.S}))
+
+        state = place_object(state, Position(4, 2), SrsObjectType.SALVAGE, "salvage-a")
+        state = self._with_enemy(state, enemy_id="enemy-1", position=Position(4, 4))
+        state = reveal_positions(state, known_positions)
+        return state
 
     def test_known_render_unknown_cells_are_question_marks(self) -> None:
         rendered = render_known_map(make_state())
@@ -87,22 +201,7 @@ class SrsRenderTests(unittest.TestCase):
         self.assertEqual(rendered.splitlines()[self._row_for_internal_y(height=9, y=2)][2], "s")
 
     def test_known_render_warp_symbols(self) -> None:
-        state = make_state()
-        rows = [list(row) for row in state.actual_map.cells]
-        cell = rows[1][1]
-        rows[1][1] = SrsCell(
-            terrain=cell.terrain,
-            object_id=cell.object_id,
-            actor_id=cell.actor_id,
-            warp_flags=frozenset({Direction.N, Direction.E}),
-        )
-        state = replace(
-            state,
-            actual_map=replace(
-                state.actual_map,
-                cells=tuple(tuple(row) for row in rows),
-            ),
-        )
+        state = self._replace_cell(make_state(), Position(1, 1), warp_flags=frozenset({Direction.N, Direction.E}))
         state = reveal_positions(state, [Position(1, 1)])
 
         rendered = render_known_map(state)
@@ -157,3 +256,160 @@ class SrsRenderTests(unittest.TestCase):
         self.assertEqual(lines[0], "? ? ? ? ? ? ? ? ?")
         self.assertEqual(lines[8], ". . . . @ . . . .")
         self.assertEqual([len(row) for row in lines], [17] * 9)
+
+    def test_display_map_shape_uses_axis_labels_and_blank_separator(self) -> None:
+        rendered = render_display_map(make_state())
+        lines = rendered.splitlines()
+
+        self.assertEqual(len(lines), 11)
+        self.assertEqual([line.split()[0] for line in lines[:9]], [str(y) for y in range(9, 0, -1)])
+        self.assertEqual(lines[9], "")
+        self.assertEqual(lines[10], "    1 2 3 4 5 6 7 8 9")
+
+    def test_display_map_uses_display_coordinate_row_order(self) -> None:
+        state = reveal_positions(make_state(), [Position(3, 8), Position(4, 0)])
+
+        rendered = render_display_map(state)
+
+        self.assertEqual(self._display_cell(rendered, display_x=4, display_y=9), ".")
+        self.assertEqual(self._display_cell(rendered, display_x=5, display_y=1), "@")
+        self.assertEqual(to_display_position(Position(3, 8)), (4, 9))
+        self.assertEqual(from_display_position(5, 1), Position(4, 0))
+
+    def test_display_map_player_uses_at_mark_at_display_coordinate(self) -> None:
+        state = replace(make_state(), player_position=Position(6, 3))
+        state = reveal_positions(state, [Position(6, 3)])
+
+        rendered = render_display_map(state)
+
+        self.assertEqual(self._display_cell(rendered, display_x=7, display_y=4), "@")
+
+    def test_display_map_enemy_overlay_uses_e_for_known_cell(self) -> None:
+        state = reveal_positions(make_state(), [Position(4, 4)])
+        state = self._with_enemy(state, enemy_id="enemy-1", position=Position(4, 4))
+
+        rendered = render_display_map(state)
+
+        self.assertEqual(self._display_cell(rendered, display_x=5, display_y=5), "e")
+
+    def test_display_map_hides_enemy_on_unknown_cell(self) -> None:
+        state = self._with_enemy(make_state(), enemy_id="enemy-1", position=Position(4, 4))
+
+        rendered = render_display_map(state)
+
+        self.assertEqual(self._display_cell(rendered, display_x=5, display_y=5), "?")
+
+    def test_display_map_overlay_priority_player_over_enemy(self) -> None:
+        state = reveal_positions(make_state(), [Position(4, 4)])
+        state = replace(state, player_position=Position(4, 4))
+        state = self._with_enemy(state, enemy_id="enemy-1", position=Position(4, 4))
+
+        rendered = render_display_map(state)
+
+        self.assertEqual(self._display_cell(rendered, display_x=5, display_y=5), "@")
+
+    def test_display_map_overlay_priority_enemy_over_object_warp_and_terrain(self) -> None:
+        state = replace_cell_terrain(make_state(), Position(4, 4), SrsTerrainType.ASTEROID)
+        state = place_object(state, Position(4, 4), SrsObjectType.SALVAGE, "salvage-a")
+        state = self._replace_cell(state, Position(4, 4), warp_flags=frozenset({Direction.N}))
+        state = reveal_positions(state, [Position(4, 4)])
+        state = self._with_enemy(state, enemy_id="enemy-1", position=Position(4, 4))
+
+        rendered = render_display_map(state)
+
+        self.assertEqual(self._display_cell(rendered, display_x=5, display_y=5), "e")
+
+    def test_display_map_object_symbols_follow_contract(self) -> None:
+        positions = [
+            (Position(0, 4), SrsObjectType.SALVAGE, "$", False),
+            (Position(1, 4), SrsObjectType.SALVAGE, "s", True),
+            (Position(2, 4), SrsObjectType.RESOURCE_CACHE, "R", False),
+            (Position(3, 4), SrsObjectType.RESOURCE_CACHE, "r", True),
+            (Position(4, 4), SrsObjectType.STATION, "S", False),
+            (Position(5, 4), SrsObjectType.STAR, "*", False),
+            (Position(6, 4), SrsObjectType.PLANET, "o", False),
+        ]
+        state = make_state()
+        for index, (position, object_type, _, consumed) in enumerate(positions, start=1):
+            object_id = f"object-{index}"
+            state = place_object(state, position, object_type, object_id)
+            if consumed:
+                state = replace(
+                    state,
+                    objects={
+                        **state.objects,
+                        object_id: replace(state.objects[object_id], consumed=True),
+                    },
+                )
+        state = reveal_positions(state, [position for position, *_ in positions])
+
+        rendered = render_display_map(state)
+
+        self.assertEqual(
+            self._display_symbols(rendered, 5)[:7],
+            ["$", "s", "R", "r", "S", "*", "o"],
+        )
+
+    def test_display_map_warp_symbols_follow_contract(self) -> None:
+        state = make_state()
+        cases = [
+            (Position(0, 4), frozenset({Direction.N}), "^"),
+            (Position(1, 4), frozenset({Direction.E}), ">"),
+            (Position(2, 4), frozenset({Direction.S}), "v"),
+            (Position(3, 4), frozenset({Direction.W}), "<"),
+            (Position(4, 4), frozenset({Direction.N, Direction.E}), "+"),
+        ]
+        for position, warp_flags, _ in cases:
+            state = self._replace_cell(state, position, warp_flags=warp_flags)
+        state = reveal_positions(state, [position for position, *_ in cases])
+
+        rendered = render_display_map(state)
+
+        self.assertEqual(
+            self._display_symbols(rendered, 5)[:5],
+            ["^", ">", "v", "<", "+"],
+        )
+
+    def test_display_map_impassable_terrain_uses_hash(self) -> None:
+        state = self._replace_cell(make_state(), Position(4, 4), terrain=SrsTerrainType.ASTEROID, warp_flags=frozenset())
+        state = self._replace_cell(state, Position(5, 4), terrain=SrsTerrainType.RIFT_BARRIER, warp_flags=frozenset())
+        state = reveal_positions(state, [Position(4, 4), Position(5, 4)])
+
+        rendered = render_display_map(state)
+
+        self.assertEqual(self._display_symbols(rendered, 5)[4:6], ["#", "#"])
+
+    def test_display_map_keeps_unknown_cell_secrecy_for_terrain_object_enemy_and_warp(self) -> None:
+        state = replace_cell_terrain(make_state(), Position(4, 4), SrsTerrainType.ASTEROID)
+        state = place_object(state, Position(4, 4), SrsObjectType.STAR, "star-a")
+        state = self._replace_cell(state, Position(4, 4), warp_flags=frozenset({Direction.N}))
+        state = self._with_enemy(state, enemy_id="enemy-1", position=Position(4, 4))
+
+        rendered = render_display_map(state)
+
+        self.assertEqual(self._display_cell(rendered, display_x=5, display_y=5), "?")
+        self.assertNotIn("*", rendered)
+        self.assertNotIn("^", rendered)
+        self.assertNotIn("e", rendered)
+
+    def test_display_map_snapshot_matches_issue_baseline_shape(self) -> None:
+        rendered = render_display_map(self._build_baseline_snapshot_state())
+
+        self.assertEqual(
+            rendered,
+            "\n".join(
+                [
+                    " 9  ? ? ? ? ? ? ? ? ?",
+                    " 8  ? ? ? ? ? ? ? ? ?",
+                    " 7  ? ? ? . . . ? ? ?",
+                    " 6  ? ? ? . . . . . #",
+                    " 5  ? ? ? . e . . . #",
+                    " 4  ? ? ? . . . @ . #",
+                    " 3  ? ? ? . $ . . . #",
+                    " 2  ? ? . . . . . . #",
+                    " 1  ? ? v v v v v v #",
+                    "",
+                    "    1 2 3 4 5 6 7 8 9",
+                ]
+            ),
+        )

--- a/experiments/galactic_exodus/srs/test_run_manual_eval.py
+++ b/experiments/galactic_exodus/srs/test_run_manual_eval.py
@@ -29,14 +29,16 @@ class SrsRunManualEvalTests(unittest.TestCase):
 
         rendered = _render_known_map_spaced_for_manual_eval(state)
 
-        self.assertEqual(rendered.splitlines()[self._row_for_internal_y(height=9, y=1)], ". . . . @ . . . .")
+        self.assertEqual(rendered.splitlines()[self._row_for_internal_y(height=9, y=1)], " 2  . . . . @ . . . .")
+        self.assertEqual(rendered.splitlines()[9], "")
+        self.assertEqual(rendered.splitlines()[10], "    1 2 3 4 5 6 7 8 9")
 
     def test_manual_eval_render_shows_player_beside_warp_symbol(self) -> None:
         state = reveal_positions(make_state(), [Position(4, 0)])
 
         rendered = _render_known_map_spaced_for_manual_eval(state)
 
-        self.assertEqual(rendered.splitlines()[self._row_for_internal_y(height=9, y=0)], "? ? ? ? v@? ? ? ?")
+        self.assertEqual(rendered.splitlines()[self._row_for_internal_y(height=9, y=0)], " 1  ? ? ? ? v@? ? ? ?")
 
     def test_manual_eval_render_shows_player_beside_salvage_symbol(self) -> None:
         state = place_object(make_state(), Position(4, 2), SrsObjectType.SALVAGE, "salvage-a")
@@ -52,14 +54,14 @@ class SrsRunManualEvalTests(unittest.TestCase):
 
         rendered = _render_known_map_spaced_for_manual_eval(state)
 
-        self.assertEqual(rendered.splitlines()[self._row_for_internal_y(height=9, y=2)], "? ? ? ? s@? ? ? ?")
+        self.assertEqual(rendered.splitlines()[self._row_for_internal_y(height=9, y=2)], " 3  ? ? ? ? s@? ? ? ?")
 
     def test_manual_eval_render_uses_left_space_at_right_edge(self) -> None:
         state = reveal_positions(make_state(entry_edge=Direction.E), [Position(8, 4)])
 
         rendered = _render_known_map_spaced_for_manual_eval(state)
 
-        self.assertEqual(rendered.splitlines()[self._row_for_internal_y(height=9, y=4)], "? ? ? ? ? ? ? ?@>")
+        self.assertEqual(rendered.splitlines()[self._row_for_internal_y(height=9, y=4)], " 5  ? ? ? ? ? ? ? ?@>")
 
     def test_player_cell_text_includes_object_and_warp_details(self) -> None:
         state = place_object(make_state(), Position(4, 0), SrsObjectType.SALVAGE, "salvage-a")
@@ -107,7 +109,7 @@ class SrsRunManualEvalTests(unittest.TestCase):
         )
         self.assertEqual(
             _render_known_map_spaced_for_manual_eval(result.final_state).splitlines()[self._row_for_internal_y(height=9, y=7)],
-            "? . r@. ? ? ? ? ?",
+            " 8  ? . r@. ? ? ? ? ?",
         )
 
     def test_event_summary_station_includes_refuel_and_activation(self) -> None:


### PR DESCRIPTION
## 概要

Closes #1232

SRS local map の normal play / display sample 向け renderer として `render_display_map()` を追加し、manual eval の通常 map 表示を axis label 付き display map に切り替えました。

## 変更内容

- `experiments/galactic_exodus/srs/render.py`
  - `render_display_map(state)` を追加
  - player / enemy / object / warp / terrain の display overlay 優先順位を display renderer 用 helper に分離
  - 既存 `render_known_map()` / `render_known_map_spaced()` は維持
- `experiments/galactic_exodus/srs/run_manual_eval.py`
  - 通常 map 表示を `render_display_map()` ベースへ変更
  - 足元記号を残す manual eval 専用 overlay は維持
- `experiments/galactic_exodus/srs/test_render.py`
  - display map の shape、座標順、overlay、unknown secrecy、記号契約、baseline snapshot を追加
- `experiments/galactic_exodus/srs/test_run_manual_eval.py`
  - manual eval が axis label 付き display map を使うことを確認するよう更新
- `experiments/galactic_exodus/srs/__init__.py`
  - `render_display_map` を export

## 確認

- `python -m unittest experiments.galactic_exodus.srs.test_render`
- `python -m unittest experiments.galactic_exodus.srs.test_run_manual_eval`
- `python experiments/galactic_exodus/srs/validate_phase2_results.py experiments/galactic_exodus/srs/fixtures/phase2_reference.json`
- `python -m unittest discover experiments/galactic_exodus/srs`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`

## 補足

- `python -m unittest discover experiments/galactic_exodus` は今回の変更箇所と無関係な既存失敗で落ちます
  - `srs.test_evaluate_policies.EvaluatePoliciesCliTests.test_same_cli_equivalent_processing_is_fully_reproducible`
  - `srs.test_evaluate_policies.EvaluatePoliciesCliTests.test_main_returns_non_zero_on_write_failure`
