### PR TITLE
#1076-4 compact HUD block を実装する

### DIFF
--- a/experiments/galactic_exodus/hud.py
+++ b/experiments/galactic_exodus/hud.py
@@ -1,0 +1,291 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from experiments.galactic_exodus import engine
+from experiments.galactic_exodus.srs import model as srs_model
+from experiments.galactic_exodus.srs.render import to_display_position
+
+
+_DIRECTION_ORDER = (
+    srs_model.Direction.N,
+    srs_model.Direction.E,
+    srs_model.Direction.S,
+    srs_model.Direction.W,
+)
+
+_LRS_SYMBOL_TO_SECTOR_TYPE = {
+    ".": "NORMAL",
+    "N": "NEBULA",
+    "A": "ASTEROID",
+    "@": "GRAVITY",
+    "B": "BASE",
+    "R": "RESOURCE",
+    "S": "START",
+    "H": "HOME",
+    "?": "UNKNOWN",
+}
+
+_REWARD_LABELS = {
+    srs_model.SrsObjectType.SALVAGE: "SALVAGE",
+    srs_model.SrsObjectType.RESOURCE_CACHE: "CACHE",
+    srs_model.SrsObjectType.STATION: "STATION",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class CompactHudContext:
+    lrs_state: engine.GameState | None = None
+    srs_state: srs_model.SrsGameState | None = None
+    last_event_summary: str | None = None
+    status: str | None = None
+    cost_mode: str | None = None
+
+
+def render_compact_hud(context: CompactHudContext) -> str:
+    """Render the #1076 compact HUD block for normal display."""
+    lines = [
+        _render_sector_line(context),
+        _render_turn_line(context),
+        _render_fuel_line(context),
+        _render_player_line(context),
+        _render_combat_line(context),
+        _render_warp_line(context),
+        _render_reward_line(context),
+        _render_last_line(context),
+    ]
+    return "\n".join(lines)
+
+
+def _render_sector_line(context: CompactHudContext) -> str:
+    lrs_coord = _lrs_coordinate_text(context.lrs_state)
+    sector_type = _sector_type_text(context)
+    srs_coord = _srs_coordinate_text(context.srs_state)
+    sensor = _sensor_range_text(context.srs_state)
+    return (
+        f"SECTOR  LRS={_pad(lrs_coord, 5)}  "
+        f"TYPE={_pad(sector_type, 4)}  "
+        f"SRS={_pad(srs_coord, 5)}  "
+        f"SENSOR={sensor}"
+    )
+
+
+def _render_turn_line(context: CompactHudContext) -> str:
+    lrs_turn = "-" if context.lrs_state is None else str(context.lrs_state.turn_count)
+    srs_turn = "-" if context.srs_state is None else str(context.srs_state.srs_turn)
+    cost_mode = _cost_mode_text(context)
+    return (
+        f"TURN    LRS={_pad(lrs_turn, 5)}  "
+        f"SRS={_pad(srs_turn, 5)}  "
+        f"COST={cost_mode}"
+    )
+
+
+def _render_fuel_line(context: CompactHudContext) -> str:
+    fuel = _fuel_text(context)
+    status = _status_text(context)
+    return f"FUEL    {_pad(fuel, 9)}  STATUS={status}"
+
+
+def _render_player_line(context: CompactHudContext) -> str:
+    player = None if context.srs_state is None else context.srs_state.player_state
+    if player is None:
+        return "PLAYER  DUR=-      EN=-      TORP=-      SALVAGE=-"
+    return (
+        f"PLAYER  DUR={_pad(f'{player.durability}/{player.durability_capacity}', 5)}  "
+        f"EN={_pad(f'{player.energy}/{player.energy_capacity}', 5)}  "
+        f"TORP={_pad(f'{player.photon_torpedo_ammo}/{player.photon_torpedo_ammo_capacity}', 5)}  "
+        f"SALVAGE={player.salvage}"
+    )
+
+
+def _render_combat_line(context: CompactHudContext) -> str:
+    combat_state = None if context.srs_state is None else context.srs_state.combat_state
+    if combat_state is None or not combat_state.enemies:
+        return "COMBAT  none"
+    enemy = _select_enemy(combat_state)
+    enemy_position = _display_position_text(enemy.position)
+    return (
+        f"COMBAT  PHASE={combat_state.phase.value}  "
+        f"ENEMY={enemy.enemy_id} {enemy.tier.value} "
+        f"hp={enemy.durability} at SRS={enemy_position}"
+    )
+
+
+def _render_warp_line(context: CompactHudContext) -> str:
+    summary = _warp_summary_text(context.srs_state)
+    return f"WARP    {summary}"
+
+
+def _render_reward_line(context: CompactHudContext) -> str:
+    summary = _reward_summary_text(context.srs_state)
+    return f"REWARD  {summary}"
+
+
+def _render_last_line(context: CompactHudContext) -> str:
+    return f"LAST    {context.last_event_summary or '-'}"
+
+
+def _lrs_coordinate_text(state: engine.GameState | None) -> str:
+    if state is None:
+        return "-"
+    return f"({state.player_position[0]},{state.player_position[1]})"
+
+
+def _sector_type_text(context: CompactHudContext) -> str:
+    if context.srs_state is not None:
+        return context.srs_state.descriptor.sector_type.value
+    if context.lrs_state is None:
+        return "-"
+    symbol = context.lrs_state.known_cells.get(context.lrs_state.player_position)
+    if symbol is None:
+        return "UNKNOWN"
+    return _LRS_SYMBOL_TO_SECTOR_TYPE.get(symbol, "UNKNOWN")
+
+
+def _srs_coordinate_text(state: srs_model.SrsGameState | None) -> str:
+    if state is None:
+        return "-"
+    return _display_position_text(state.player_position)
+
+
+def _sensor_range_text(state: srs_model.SrsGameState | None) -> str:
+    if state is None:
+        return "-"
+    if state.descriptor.sector_type is srs_model.SectorType.NEBULA:
+        return "3x3"
+    return "5x5"
+
+
+def _cost_mode_text(context: CompactHudContext) -> str:
+    if context.cost_mode is not None:
+        return context.cost_mode
+    return "-"
+
+
+def _fuel_text(context: CompactHudContext) -> str:
+    if context.srs_state is not None:
+        return f"{context.srs_state.fuel}/{context.srs_state.max_fuel}"
+    if context.lrs_state is not None:
+        return f"{context.lrs_state.remaining_fuel}/{context.lrs_state.settings.max_fuel}"
+    return "-"
+
+
+def _status_text(context: CompactHudContext) -> str:
+    if context.status is not None:
+        return context.status
+    if context.lrs_state is not None or context.srs_state is not None:
+        return "EXPLORING"
+    return "-"
+
+
+def _select_enemy(combat_state: srs_model.SrsCombatState) -> srs_model.SrsEnemyCombatState:
+    target_id = combat_state.player_attack_target_id
+    if target_id is not None and target_id in combat_state.enemies:
+        return combat_state.enemies[target_id]
+    return next(iter(combat_state.enemies.values()))
+
+
+def _warp_summary_text(state: srs_model.SrsGameState | None) -> str:
+    if state is None:
+        return "-"
+    cell = state.known_state.known_cells.get(state.player_position)
+    if cell is not None and cell.warp_flags:
+        directions = _direction_text(cell.warp_flags)
+        return f"{directions} available at SRS={_display_position_text(state.player_position)}"
+    blocked_direction = _visible_blocked_direction(state)
+    if blocked_direction is not None:
+        return f"{blocked_direction} blocked by RIFT_BARRIER"
+    return "-"
+
+
+def _visible_blocked_direction(state: srs_model.SrsGameState) -> str | None:
+    player = state.player_position
+    for direction in _DIRECTION_ORDER:
+        neighbor = _step_position(player, direction)
+        if not state.actual_map.contains(neighbor):
+            if direction in state.descriptor.blocked_edges:
+                return direction.value
+            continue
+        if neighbor not in state.known_state.discovered_cells:
+            continue
+        if state.known_state.known_cells[neighbor].terrain is srs_model.SrsTerrainType.RIFT_BARRIER:
+            return direction.value
+    return None
+
+
+def _reward_summary_text(state: srs_model.SrsGameState | None) -> str:
+    if state is None:
+        return "-"
+    player_cell = state.known_state.known_cells.get(state.player_position)
+    if player_cell is not None:
+        player_reward = _visible_reward_object(state, player_cell.object_id)
+        if player_reward is not None:
+            return _reward_detection_text(player_reward)
+
+    candidates: list[srs_model.SrsObjectState] = []
+    for position in state.known_state.discovered_cells:
+        cell = state.known_state.known_cells.get(position)
+        if cell is None:
+            continue
+        reward = _visible_reward_object(state, cell.object_id)
+        if reward is not None:
+            candidates.append(reward)
+    if not candidates:
+        return "-"
+
+    player = state.player_position
+    reward = min(
+        candidates,
+        key=lambda item: (
+            abs(item.position.x - player.x) + abs(item.position.y - player.y),
+            item.object_id,
+        ),
+    )
+    return _reward_detection_text(reward)
+
+
+def _visible_reward_object(
+    state: srs_model.SrsGameState,
+    object_id: str | None,
+) -> srs_model.SrsObjectState | None:
+    if object_id is None or object_id not in state.objects:
+        return None
+    object_state = state.objects[object_id]
+    if object_state.consumed:
+        return None
+    if object_state.object_type not in _REWARD_LABELS:
+        return None
+    return object_state
+
+
+def _reward_detection_text(object_state: srs_model.SrsObjectState) -> str:
+    label = _REWARD_LABELS[object_state.object_type]
+    return f"{label} detected at SRS={_display_position_text(object_state.position)}"
+
+
+def _display_position_text(position: srs_model.Position) -> str:
+    display_x, display_y = to_display_position(position)
+    return f"({display_x},{display_y})"
+
+
+def _direction_text(directions: frozenset[srs_model.Direction]) -> str:
+    return ",".join(direction.value for direction in _DIRECTION_ORDER if direction in directions)
+
+
+def _step_position(
+    position: srs_model.Position,
+    direction: srs_model.Direction,
+) -> srs_model.Position:
+    deltas = {
+        srs_model.Direction.N: (0, 1),
+        srs_model.Direction.E: (1, 0),
+        srs_model.Direction.S: (0, -1),
+        srs_model.Direction.W: (-1, 0),
+    }
+    dx, dy = deltas[direction]
+    return srs_model.Position(position.x + dx, position.y + dy)
+
+
+def _pad(value: str, min_width: int) -> str:
+    return value.ljust(max(min_width, len(value)))

--- a/experiments/galactic_exodus/play.py
+++ b/experiments/galactic_exodus/play.py
@@ -12,6 +12,7 @@ if __package__ in (None, ""):
 
 from experiments.galactic_exodus import engine, simulate
 from experiments.galactic_exodus.display import render_lrs_border_light_map
+from experiments.galactic_exodus.hud import CompactHudContext, render_compact_hud
 
 ABORTED_BY_USER = engine.FINAL_OUTCOME_ABORTED_NO_POLICY_ACTION
 KNOWN_TERRAIN_SYMBOLS = {".", "N", "A", "@", "B", "R"}
@@ -102,6 +103,9 @@ def main(
 def render_state(state: engine.GameState, output: TextIO) -> None:
     output.write("MAP:\n")
     output.write(render_lrs_border_light_map(state))
+    output.write("\n")
+    output.write("HUD:\n")
+    output.write(render_compact_hud(CompactHudContext(lrs_state=state)))
     output.write("\n")
     output.write(
         f"SEED: requested={state.requested_seed} effective={state.effective_seed} rerolls={state.reroll_count}\n"

--- a/experiments/galactic_exodus/srs/run_manual_eval.py
+++ b/experiments/galactic_exodus/srs/run_manual_eval.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Iterable, Mapping, Sequence
 
+from experiments.galactic_exodus.hud import CompactHudContext, render_compact_hud
 from experiments.galactic_exodus.srs.model import Position, SrsGameState
 from experiments.galactic_exodus.srs.render import render_display_map, render_row_for_internal_y, to_display_position
 from experiments.galactic_exodus.srs.run_fixture import FIXTURES_DIR, SrsFixtureRunResult, run_fixture
@@ -369,6 +370,20 @@ def _player_cell_text(state: SrsGameState) -> str:
     return "- " + ", ".join(details)
 
 
+def _compact_hud_text(result: SrsFixtureRunResult) -> str:
+    last_event_summary = None
+    event_lines = _event_summary_lines(result)
+    if event_lines:
+        last_event_summary = event_lines[-1]
+    return render_compact_hud(
+        CompactHudContext(
+            srs_state=result.final_state,
+            last_event_summary=last_event_summary,
+            cost_mode=str(result.summary.get("cost_mode", "-") or "-"),
+        )
+    )
+
+
 def _print_case(result: SrsFixtureRunResult) -> None:
     print("\n" + "=" * 80)
     print(result.fixture_id)
@@ -384,6 +399,8 @@ def _print_case(result: SrsFixtureRunResult) -> None:
     print(_player_cell_text(result.final_state))
     print("\nknown map:")
     print(_render_known_map_spaced_for_manual_eval(result.final_state))
+    print("\ncompact hud:")
+    print(_compact_hud_text(result))
     print("=" * 80)
 
 

--- a/experiments/galactic_exodus/srs/test_run_manual_eval.py
+++ b/experiments/galactic_exodus/srs/test_run_manual_eval.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
+import io
 import unittest
+from contextlib import redirect_stdout
 from dataclasses import replace
 from pathlib import Path
 
 from experiments.galactic_exodus.srs.model import Direction, Position, SrsObjectType, SrsTerrainType
 from experiments.galactic_exodus.srs.run_fixture import run_fixture
 from experiments.galactic_exodus.srs.run_manual_eval import (
+    _compact_hud_text,
     _event_summary_lines,
+    _print_case,
     _player_cell_text,
     _render_known_map_spaced_for_manual_eval,
 )
@@ -149,3 +153,26 @@ class SrsRunManualEvalTests(unittest.TestCase):
             _player_cell_text(result.final_state),
             "- position=(3,8), terrain=FLOOR, object=RESOURCE_CACHE, consumed=true, activated=false",
         )
+
+    def test_compact_hud_uses_display_coordinates_without_internal_debug(self) -> None:
+        result = run_fixture(Path(__file__).resolve().parent / "fixtures" / "resource_cache_single_9x9.json")
+
+        rendered = _compact_hud_text(result)
+
+        self.assertIn("SRS=(3,8)", rendered)
+        self.assertIn("COST=TURN_ONLY", rendered)
+        self.assertNotIn("internal=", rendered)
+        self.assertNotIn("Position(", rendered)
+
+    def test_print_case_includes_compact_hud_section_and_keeps_existing_sections(self) -> None:
+        result = run_fixture(Path(__file__).resolve().parent / "fixtures" / "resource_cache_single_9x9.json")
+
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            _print_case(result)
+        rendered = stdout.getvalue()
+
+        self.assertIn("event summary:\n", rendered)
+        self.assertIn("player cell:\n", rendered)
+        self.assertIn("known map:\n", rendered)
+        self.assertIn("compact hud:\n", rendered)

--- a/experiments/galactic_exodus/test_hud.py
+++ b/experiments/galactic_exodus/test_hud.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import unittest
+from dataclasses import replace
+
+from experiments.galactic_exodus.hud import CompactHudContext, render_compact_hud
+from experiments.galactic_exodus.srs.model import (
+    Direction,
+    Position,
+    SectorType,
+    SrsCell,
+    SrsCombatPhase,
+    SrsCombatState,
+    SrsEnemyTier,
+    SrsObjectType,
+    SrsPlayerCombatState,
+    SrsTerrainType,
+    create_enemy_combat_state,
+)
+from experiments.galactic_exodus.srs.test_engine_movement import make_state as make_srs_state
+from experiments.galactic_exodus.srs.test_engine_movement import place_object, reveal_positions, replace_cell_terrain
+from experiments.galactic_exodus.test_engine import filled_cells, make_actual_map, make_state as make_lrs_state
+
+
+def _all_positions(state: object) -> list[Position]:
+    width = state.actual_map.width
+    height = state.actual_map.height
+    return [Position(x, y) for y in range(height) for x in range(width)]
+
+
+def _set_warp_flags(state, position: Position, warp_flags: frozenset[Direction]):
+    rows = [list(row) for row in state.actual_map.cells]
+    current = state.actual_map.cell_at(position)
+    rows[position.y][position.x] = SrsCell(
+        terrain=current.terrain,
+        object_id=current.object_id,
+        actor_id=current.actor_id,
+        warp_flags=warp_flags,
+    )
+    return replace(
+        state,
+        actual_map=replace(
+            state.actual_map,
+            cells=tuple(tuple(row) for row in rows),
+        ),
+    )
+
+
+class CompactHudTests(unittest.TestCase):
+    def test_minimal_context_shape(self) -> None:
+        rendered = render_compact_hud(CompactHudContext())
+
+        self.assertEqual(
+            rendered,
+            "\n".join(
+                [
+                    "SECTOR  LRS=-      TYPE=-     SRS=-      SENSOR=-",
+                    "TURN    LRS=-      SRS=-      COST=-",
+                    "FUEL    -          STATUS=-",
+                    "PLAYER  DUR=-      EN=-      TORP=-      SALVAGE=-",
+                    "COMBAT  none",
+                    "WARP    -",
+                    "REWARD  -",
+                    "LAST    -",
+                ]
+            ),
+        )
+        self.assertEqual(len(rendered.splitlines()), 8)
+
+    def test_lrs_only_hud_uses_lrs_fields(self) -> None:
+        cells = filled_cells(".")
+        cells[(3, 5)] = "R"
+        lrs_state = make_lrs_state(
+            actual_map=make_actual_map(cells=cells),
+            player_position=(3, 5),
+            remaining_fuel=6,
+            known_cells={(3, 5): "R", (8, 8): "H"},
+            turn_count=18,
+        )
+
+        rendered = render_compact_hud(CompactHudContext(lrs_state=lrs_state))
+
+        self.assertIn("SECTOR  LRS=(3,5)  TYPE=RESOURCE", rendered)
+        self.assertIn("TURN    LRS=18", rendered)
+        self.assertIn("FUEL    6/16", rendered)
+        self.assertIn("SRS=-", rendered)
+        self.assertIn("STATUS=EXPLORING", rendered)
+
+    def test_srs_display_coordinate_only(self) -> None:
+        state = replace(make_srs_state(), player_position=Position(6, 3))
+        state = reveal_positions(state, _all_positions(state))
+
+        rendered = render_compact_hud(CompactHudContext(srs_state=state))
+
+        self.assertIn("SRS=(7,4)", rendered)
+        self.assertNotIn("Position(x=6, y=3)", rendered)
+        self.assertNotIn("internal=", rendered)
+
+    def test_nebula_sensor_range_is_3x3(self) -> None:
+        nebula_state = replace(make_srs_state(sector_type=SectorType.NEBULA), player_position=Position(4, 4))
+        nebula_state = reveal_positions(nebula_state, _all_positions(nebula_state))
+        normal_state = replace(make_srs_state(sector_type=SectorType.NORMAL), player_position=Position(4, 4))
+        normal_state = reveal_positions(normal_state, _all_positions(normal_state))
+
+        self.assertIn("SENSOR=3x3", render_compact_hud(CompactHudContext(srs_state=nebula_state)))
+        self.assertIn("SENSOR=5x5", render_compact_hud(CompactHudContext(srs_state=normal_state)))
+
+    def test_player_stats_and_combat_target_summary(self) -> None:
+        player_state = SrsPlayerCombatState(
+            durability=100,
+            durability_capacity=100,
+            energy=6,
+            energy_capacity=6,
+            photon_torpedo_ammo=6,
+            photon_torpedo_ammo_capacity=6,
+            salvage=1,
+        )
+        enemy_1 = create_enemy_combat_state(
+            enemy_id="enemy-1",
+            tier=SrsEnemyTier.TIER2,
+            position=Position(4, 4),
+        )
+        enemy_2 = create_enemy_combat_state(
+            enemy_id="enemy-2",
+            tier=SrsEnemyTier.TIER1,
+            position=Position(3, 3),
+        )
+        state = replace(
+            make_srs_state(
+                sector_type=SectorType.RIFT,
+                blocked_edges=frozenset({Direction.W}),
+                fuel=6,
+                max_fuel=9,
+            ),
+            player_position=Position(6, 3),
+            player_state=player_state,
+            combat_state=SrsCombatState(
+                player=player_state,
+                enemies={"enemy-1": enemy_1, "enemy-2": enemy_2},
+                phase=SrsCombatPhase.PLAYER_MOVEMENT,
+                player_attack_target_id="enemy-1",
+            ),
+        )
+        state = reveal_positions(state, _all_positions(state))
+
+        rendered = render_compact_hud(
+            CompactHudContext(
+                srs_state=state,
+                last_event_summary="MOVE_ACCEPTED route=E,E",
+                cost_mode="TURN_ONLY",
+            )
+        )
+
+        self.assertIn("PLAYER  DUR=100/100  EN=6/6", rendered)
+        self.assertIn("TORP=6/6", rendered)
+        self.assertIn("SALVAGE=1", rendered)
+        self.assertIn(
+            "COMBAT  PHASE=PLAYER_MOVEMENT  ENEMY=enemy-1 TIER2 hp=5 at SRS=(5,5)",
+            rendered,
+        )
+        self.assertIn("LAST    MOVE_ACCEPTED route=E,E", rendered)
+
+    def test_warp_summary_uses_player_cell_flags_in_nesw_order(self) -> None:
+        state = replace(make_srs_state(), player_position=Position(4, 0))
+        state = _set_warp_flags(state, Position(4, 0), frozenset({Direction.S, Direction.N, Direction.E}))
+        state = reveal_positions(state, _all_positions(state))
+
+        rendered = render_compact_hud(CompactHudContext(srs_state=state))
+
+        self.assertIn("WARP    N,E,S available at SRS=(5,1)", rendered)
+
+    def test_warp_summary_uses_visible_rift_barrier_when_no_warp(self) -> None:
+        state = replace(make_srs_state(), player_position=Position(4, 4))
+        state = replace_cell_terrain(state, Position(4, 5), terrain=SrsTerrainType.RIFT_BARRIER)
+        state = reveal_positions(state, _all_positions(state))
+
+        rendered = render_compact_hud(CompactHudContext(srs_state=state))
+
+        self.assertIn("WARP    N blocked by RIFT_BARRIER", rendered)
+
+    def test_reward_summary_prefers_nearest_unconsumed_reward(self) -> None:
+        state = replace(make_srs_state(), player_position=Position(4, 3))
+        state = place_object(state, Position(4, 2), SrsObjectType.SALVAGE, "salvage-a")
+        state = place_object(state, Position(5, 3), SrsObjectType.RESOURCE_CACHE, "cache-a")
+        state = place_object(state, Position(3, 3), SrsObjectType.STAR, "star-a")
+        state = replace(
+            state,
+            objects={
+                **state.objects,
+                "cache-a": replace(state.objects["cache-a"], consumed=True),
+            },
+        )
+        state = reveal_positions(state, _all_positions(state))
+
+        rendered = render_compact_hud(CompactHudContext(srs_state=state))
+
+        self.assertIn("REWARD  SALVAGE detected at SRS=(5,3)", rendered)
+        self.assertNotIn("CACHE detected", rendered)
+        self.assertNotIn("STAR", rendered)
+
+    def test_normal_hud_excludes_debug_strings(self) -> None:
+        state = replace(make_srs_state(), player_position=Position(4, 3))
+        state = reveal_positions(state, _all_positions(state))
+
+        rendered = render_compact_hud(
+            CompactHudContext(
+                srs_state=state,
+                last_event_summary="MOVE_ACCEPTED route=E,E center=(5,4)",
+            )
+        )
+
+        for forbidden in ("internal=", "raw", "roll", "consumed_object_ids", "activated_object_ids", "before", "after"):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experiments/galactic_exodus/test_play.py
+++ b/experiments/galactic_exodus/test_play.py
@@ -76,6 +76,7 @@ class PlayCliTests(unittest.TestCase):
 
         self.assertEqual(exit_code, 0)
         self.assertEqual(stdout.count("MAP:\n"), 1)
+        self.assertEqual(stdout.count("HUD:\n"), 1)
         self.assertIn("TURN: 0\n", stdout)
         self.assertTrue(stdout.endswith("COMMAND> "))
 
@@ -249,6 +250,20 @@ class PlayCliTests(unittest.TestCase):
         self.assertIn("MAP:\n  +---+---+---+---+---+---+---+---+\n", rendered)
         self.assertNotIn("y=8 ", rendered)
         self.assertIn("1 | @   ?   ?   ?   ?   ?   ?   ? |\n", rendered)
+
+    def test_render_state_includes_hud_after_map_and_keeps_legacy_lines(self) -> None:
+        state = make_state(actual_map=make_actual_map(cells=filled_cells(".")))
+
+        stdout = io.StringIO()
+        play.render_state(state, stdout)
+        rendered = stdout.getvalue()
+
+        self.assertIn("\nHUD:\nSECTOR", rendered)
+        self.assertLess(rendered.index("MAP:\n"), rendered.index("HUD:\n"))
+        self.assertLess(rendered.index("HUD:\n"), rendered.index("SEED:"))
+        self.assertIn("POSITION: (1,1)\n", rendered)
+        self.assertIn("FUEL: 16/16\n", rendered)
+        self.assertIn("STATUS: IN PROGRESS\n", rendered)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 概要

Closes #1233

Galactic Exodus Phase 2 の normal play 向け compact HUD block を追加しました。

## 変更内容

- `experiments/galactic_exodus/hud.py` を追加し、LRS/SRS 両方から使える `CompactHudContext` と `render_compact_hud()` を実装
- HUD の 8 行固定表示で、SECTOR / TURN / FUEL / PLAYER / COMBAT / WARP / REWARD / LAST を整形
- `play.render_state()` の MAP 直後に `HUD:` セクションを追加し、既存の `SEED` / `POSITION` / `FUEL` / `STATUS` などの互換表示は維持
- `srs/run_manual_eval.py` の known map の下に `compact hud:` セクションを追加し、fixture summary から cost mode と last event summary を渡すようにした
- LRS 専用・SRS 専用・combat / warp / reward / manual eval 連携の表示テストを追加

## 確認

- `python -m unittest experiments.galactic_exodus.test_hud`
- `python -m unittest experiments.galactic_exodus.test_play`
- `python -m unittest experiments.galactic_exodus.srs.test_run_manual_eval`
- `python -m unittest discover experiments/galactic_exodus`
- `python -m unittest discover experiments/galactic_exodus/srs`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
