### PR TITLE
Galactic Exodus の log/debug event formatter を整理

### DIFF
--- a/experiments/galactic_exodus/event_format.py
+++ b/experiments/galactic_exodus/event_format.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+from experiments.galactic_exodus import engine, simulate
+
+
+def format_lrs_event_summary(event: engine.TurnEvent) -> str:
+    """Format one LRS turn event for normal user-facing output."""
+    if event.outcome == engine.OUTCOME_MOVED:
+        return f"MOVE  accepted to LRS={_format_position(event.to_position)}"
+    if event.outcome == engine.OUTCOME_BLOCKED_UNKNOWN_RIFT:
+        return (
+            "RIFT  discovered: "
+            f"LRS edge {_format_position(event.from_position)}-{_direction_for_event(event)} is blocked"
+        )
+    if event.outcome == engine.OUTCOME_REJECTED_KNOWN_RIFT:
+        return f"MOVE  rejected: known RIFT blocks {_direction_for_event(event)}"
+    if event.outcome == engine.OUTCOME_REJECTED_INSUFFICIENT_FUEL:
+        return "MOVE  rejected: insufficient fuel"
+    if event.outcome == engine.OUTCOME_INVALID_COMMAND:
+        return "MOVE  rejected: invalid command"
+    if event.outcome == engine.OUTCOME_OUT_OF_BOUNDS:
+        return "MOVE  rejected: out of bounds"
+    return f"EVENT {event.outcome}"
+
+
+def format_lrs_debug_event(event: engine.TurnEvent) -> str:
+    """Format one LRS turn event for debug/manual inspection."""
+    tokens = [
+        event.outcome,
+        f"turn={event.turn}",
+        f"from={_format_position(event.from_position)}",
+    ]
+    if event.attempted_position is not None:
+        tokens.append(f"attempted={_format_position(event.attempted_position)}")
+    tokens.extend(
+        [
+            f"to={_format_position(event.to_position)}",
+            f"fuel={event.fuel_before}->{event.fuel_after}",
+            f"spent={event.fuel_spent}",
+        ]
+    )
+    if event.required_fuel is not None:
+        tokens.append(f"required={event.required_fuel}")
+    if event.discovered_cells:
+        tokens.append(f"discovered={len(event.discovered_cells)}")
+        tokens.append(f"cells={_format_discovered_cells(event.discovered_cells)}")
+    if event.discovered_rift:
+        tokens.append("discovered_rift=true")
+    if event.supply_result != engine.SUPPLY_RESULT_NONE:
+        tokens.append(f"supply={event.supply_result}")
+    tokens.append(f"status={event.status_after}")
+    return " ".join(tokens)
+
+
+def _direction_for_event(event: engine.TurnEvent) -> str:
+    if event.attempted_position is None:
+        return "-"
+    dx = event.attempted_position[0] - event.from_position[0]
+    dy = event.attempted_position[1] - event.from_position[1]
+    delta_map = {
+        (0, 1): "N",
+        (1, 0): "E",
+        (0, -1): "S",
+        (-1, 0): "W",
+    }
+    return delta_map.get((dx, dy), "?")
+
+
+def _format_position(position: simulate.Position) -> str:
+    return f"({position[0]},{position[1]})"
+
+
+def _format_discovered_cells(cells: Iterable[engine.DiscoveredCell]) -> str:
+    return ",".join(f"{cell.symbol}@{_format_position(cell.position)}" for cell in cells)

--- a/experiments/galactic_exodus/play.py
+++ b/experiments/galactic_exodus/play.py
@@ -10,7 +10,7 @@ from typing import Sequence, TextIO
 if __package__ in (None, ""):
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from experiments.galactic_exodus import engine, simulate
+from experiments.galactic_exodus import engine, event_format, simulate
 from experiments.galactic_exodus.display import render_lrs_border_light_map
 from experiments.galactic_exodus.hud import CompactHudContext, render_compact_hud
 
@@ -151,38 +151,24 @@ def format_event_messages(
     state: engine.GameState, event: engine.TurnEvent
 ) -> list[str]:
     if event.outcome == engine.OUTCOME_MOVED:
-        messages = [
-            f"MOVED TO {format_position(event.to_position)}, COST {event.fuel_spent}"
-        ]
-        supply_message = format_supply_message(event)
+        messages = [event_format.format_lrs_event_summary(event)]
+        supply_message = format_supply_message(state, event)
         if supply_message is not None:
             messages.append(supply_message)
         if event.status_after == engine.GAME_STATUS_WON:
-            messages.append("YOU REACHED H")
+            messages.append(f"HOME  reached at LRS={format_position(event.to_position)}")
         elif event.status_after == engine.GAME_STATUS_LOST_FUEL:
-            messages.append("NO FURTHER MOVE IS POSSIBLE")
+            messages.append("STATUS fuel depleted: no further move is possible")
         return messages
     if event.outcome == engine.OUTCOME_BLOCKED_UNKNOWN_RIFT:
-        messages = [f"RIFT BLOCKED {direction_for_event(event)}, COST 1"]
+        messages = [event_format.format_lrs_event_summary(event)]
         if event.status_after == engine.GAME_STATUS_LOST_FUEL:
-            messages.append("NO FURTHER MOVE IS POSSIBLE")
+            messages.append("STATUS fuel depleted: no further move is possible")
         return messages
-    if event.outcome == engine.OUTCOME_REJECTED_KNOWN_RIFT:
-        return [f"KNOWN RIFT {direction_for_event(event)}"]
-    if event.outcome == engine.OUTCOME_OUT_OF_BOUNDS:
-        return ["OUT OF BOUNDS"]
-    if event.outcome == engine.OUTCOME_REJECTED_INSUFFICIENT_FUEL:
-        if event.required_fuel is None:
-            raise ValueError("insufficient-fuel event must include required_fuel")
-        return [
-            f"INSUFFICIENT FUEL: NEED {event.required_fuel}, HAVE {event.fuel_before}"
-        ]
-    if event.outcome == engine.OUTCOME_INVALID_COMMAND:
-        return ["INVALID COMMAND"]
-    raise ValueError(f"unexpected outcome: {event.outcome}")
+    return [event_format.format_lrs_event_summary(event)]
 
 
-def format_supply_message(event: engine.TurnEvent) -> str | None:
+def format_supply_message(state: engine.GameState, event: engine.TurnEvent) -> str | None:
     source = event.supply_source
     if event.supply_result == engine.SUPPLY_RESULT_NONE:
         return None
@@ -192,20 +178,24 @@ def format_supply_message(event: engine.TurnEvent) -> str | None:
         raise ValueError("supply event must include fuel_before_supply and fuel_after_supply")
     if event.supply_result == engine.SUPPLY_RESULT_BASE_REFUELED:
         return (
-            f"REFUELED AT B{format_position(source.position)}: "
-            f"{event.fuel_before_supply} -> {event.fuel_after_supply}"
+            "BASE  refueled: "
+            f"{event.fuel_before_supply} -> {event.fuel_after_supply} at LRS={format_position(source.position)}"
         )
     if event.supply_result == engine.SUPPLY_RESULT_BASE_ALREADY_FULL:
-        return f"BASE ALREADY FULL AT B{format_position(source.position)}"
+        return f"BASE  already full at LRS={format_position(source.position)}"
     if event.supply_result == engine.SUPPLY_RESULT_RESOURCE_REFUELED:
+        fuel_after = event.fuel_after_supply
+        if fuel_after is None:
+            raise ValueError("resource refuel event must include fuel_after_supply")
         return (
-            f"REFUELED AT R{format_position(source.position)}: "
-            f"+{event.supply_amount} ({event.fuel_before_supply} -> {event.fuel_after_supply})"
+            "CACHE acquired: "
+            f"fuel +{event.supply_amount} -> {fuel_after}/{state.settings.max_fuel} "
+            f"at LRS={format_position(source.position)}"
         )
     if event.supply_result == engine.SUPPLY_RESULT_RESOURCE_ALREADY_FULL:
-        return f"RESOURCE ALREADY FULL AT R{format_position(source.position)}"
+        return f"CACHE full: no refuel at LRS={format_position(source.position)}"
     if event.supply_result == engine.SUPPLY_RESULT_RESOURCE_ALREADY_USED:
-        return f"RESOURCE ALREADY USED AT R{format_position(source.position)}"
+        return f"CACHE already used at LRS={format_position(source.position)}"
     raise ValueError(f"unexpected supply result: {event.supply_result}")
 
 

--- a/experiments/galactic_exodus/srs/event_format.py
+++ b/experiments/galactic_exodus/srs/event_format.py
@@ -1,0 +1,383 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from experiments.galactic_exodus.srs import log
+from experiments.galactic_exodus.srs.model import Position
+from experiments.galactic_exodus.srs.render import to_display_position
+
+
+def format_srs_event_summary(event: log.SrsTurnEvent) -> str:
+    """Format one SRS turn event for normal user-facing output."""
+    lines = format_srs_event_summary_lines(event)
+    return lines[0]
+
+
+def format_srs_debug_event(event: log.SrsTurnEvent) -> str:
+    """Format one SRS turn event for debug/manual inspection."""
+    payload = dict(event.payload)
+    tokens = [event.event_type]
+    tokens.extend(_debug_position_tokens(payload))
+    tokens.extend(_compact_payload_tokens(payload))
+    return " ".join(tokens)
+
+
+def format_srs_event_summary_lines(event: log.SrsTurnEvent) -> list[str]:
+    """Return one or more normal summary lines for an SRS event."""
+    payload = dict(event.payload)
+    event_type = event.event_type
+
+    if event_type == log.MOVE_ACCEPTED:
+        return [_format_move_accepted(payload)]
+    if event_type == log.MOVE_REJECTED:
+        return [_format_rejected("MOVE", payload)]
+    if event_type == log.STOPPED_BEFORE_IMPASSABLE:
+        return [_format_stopped(payload)]
+    if event_type == log.OBSERVATION_UPDATED:
+        return _format_observation(payload)
+    if event_type == log.INTERACT_ACCEPTED:
+        return [_format_interact_accepted(payload)]
+    if event_type == log.INTERACT_REJECTED:
+        return [_format_rejected("INTERACT", payload)]
+    if event_type == log.OBJECT_CONSUMED:
+        return [_format_object_consumed(payload)]
+    if event_type == log.STATION_ACTIVATED:
+        return _format_station_activated(payload)
+    if event_type == log.WARP_EXIT_ACCEPTED:
+        return [_format_warp_accepted(payload)]
+    if event_type == log.WARP_EXIT_REJECTED:
+        return [_format_warp_rejected(payload)]
+    if event_type == log.COMBAT_TRANSITIONED:
+        return [_format_combat_transitioned(payload)]
+    if event_type == log.COMBAT_REJECTED:
+        return [_format_rejected("COMBAT", payload)]
+    if event_type == log.ENCOUNTER_ROLLED:
+        return [_format_encounter(payload)]
+    return [f"EVENT {event_type}"]
+
+
+def _format_move_accepted(payload: Mapping[str, Any]) -> str:
+    parts = ["MOVE  accepted"]
+    route = _route_text(payload.get("resolved_route") or payload.get("route"))
+    if route is not None:
+        parts.append(f"route={route}")
+    destination = _display_position_text(
+        payload.get("target_position")
+        or payload.get("destination")
+        or payload.get("player_position_after")
+        or payload.get("end_position")
+        or payload.get("to")
+    )
+    if destination is not None:
+        parts.append(f"to SRS={destination}")
+    return " ".join(parts)
+
+
+def _format_rejected(prefix: str, payload: Mapping[str, Any]) -> str:
+    reason = _reason_text(payload)
+    if reason is None:
+        return f"{prefix}  rejected"
+    return f"{prefix}  rejected: {reason}"
+
+
+def _format_stopped(payload: Mapping[str, Any]) -> str:
+    terrain = payload.get("terrain")
+    position = _display_position_text(payload.get("blocked_position") or payload.get("position"))
+    if terrain is not None and position is not None:
+        return f"STOP  blocked by {terrain} at SRS={position}"
+    if position is not None:
+        return f"STOP  blocked at SRS={position}"
+    if terrain is not None:
+        return f"STOP  blocked by {terrain}"
+    return "STOP  blocked"
+
+
+def _format_observation(payload: Mapping[str, Any]) -> list[str]:
+    size = _observation_size_text(payload)
+    update_line = (
+        f"SCAN  {size} update: +{payload.get('newly_discovered_count', '-')} known cells, "
+        f"total={payload.get('total_discovered_count', '-')}"
+    )
+    if payload.get("nebula_interference"):
+        return [
+            "SCAN  NEBULA interference: sensor range reduced to 3x3",
+            update_line,
+        ]
+    return [update_line]
+
+
+def _format_interact_accepted(payload: Mapping[str, Any]) -> str:
+    object_type = payload.get("object_type")
+    position = _display_position_text(payload.get("position"))
+    if object_type is None:
+        return "INTERACT accepted"
+    if position is None:
+        return f"INTERACT accepted: {object_type}"
+    return f"INTERACT accepted: {object_type} at SRS={position}"
+
+
+def _format_object_consumed(payload: Mapping[str, Any]) -> str:
+    object_type = payload.get("object_type")
+    position = _display_position_text(payload.get("position"))
+    if object_type == "RESOURCE_CACHE":
+        fuel_delta = payload.get("fuel_delta")
+        fuel_after = payload.get("fuel_after")
+        fuel_capacity = payload.get("max_fuel") or payload.get("fuel_capacity")
+        target = _with_capacity(fuel_after, fuel_capacity)
+        if fuel_delta is not None and fuel_after is not None:
+            return f"CACHE acquired: fuel +{fuel_delta} -> {target}"
+    if object_type == "SALVAGE":
+        salvage_after = payload.get("salvage_after")
+        durability_delta = payload.get("durability_delta")
+        durability_after = payload.get("durability_after")
+        durability_capacity = payload.get("durability_capacity")
+        if salvage_after is not None and durability_delta is not None and durability_after is not None:
+            durability_text = _with_capacity(durability_after, durability_capacity)
+            return (
+                "SALVAGE acquired: "
+                f"+1 inventory, durability +{durability_delta} -> {durability_text}"
+            )
+    if object_type is not None and position is not None:
+        return f"OBJECT consumed: {object_type} at SRS={position}"
+    if object_type is not None:
+        return f"OBJECT consumed: {object_type}"
+    return "OBJECT consumed"
+
+
+def _format_station_activated(payload: Mapping[str, Any]) -> list[str]:
+    lines = ["BASE station activated: full recovery complete"]
+    applied_upgrade = payload.get("applied_upgrade")
+    salvage_before = payload.get("salvage_before")
+    salvage_after = payload.get("salvage_after")
+    if applied_upgrade is not None and salvage_before is not None and salvage_after is not None:
+        upgrade_label = _upgrade_label(str(applied_upgrade))
+        lines.append(f"UPGRADE {upgrade_label}, salvage {salvage_before} -> {salvage_after}")
+    return lines
+
+
+def _format_warp_accepted(payload: Mapping[str, Any]) -> str:
+    direction = payload.get("exit_direction", "-")
+    start = _display_position_text(payload.get("start_position") or payload.get("from_position"))
+    if start is None:
+        return f"WARP  {direction} accepted"
+    return f"WARP  {direction} accepted from SRS={start}"
+
+
+def _format_warp_rejected(payload: Mapping[str, Any]) -> str:
+    reason = _reason_text(payload)
+    if reason is None:
+        return "WARP  rejected"
+    return f"WARP  rejected: {reason}"
+
+
+def _format_combat_transitioned(payload: Mapping[str, Any]) -> str:
+    phase = payload.get("phase_to") or payload.get("phase") or payload.get("phase_from")
+    summary = f"COMBAT phase={phase}" if phase is not None else "COMBAT"
+    player_action = payload.get("player_action")
+    target_id = None
+    if isinstance(player_action, Mapping):
+        target_id = player_action.get("target_enemy_id")
+    target_position = _display_position_text(
+        payload.get("target_position")
+        or payload.get("enemy_position")
+        or payload.get("position")
+    )
+    if target_id is not None and target_position is not None:
+        return f"{summary} target={target_id} at SRS={target_position}"
+    return summary
+
+
+def _format_encounter(payload: Mapping[str, Any]) -> str:
+    roll = payload.get("roll") or payload.get("encounter_roll") or payload.get("actual_roll")
+    threshold = (
+        payload.get("threshold")
+        or payload.get("actual_encounter_chance")
+        or payload.get("encounter_threshold")
+    )
+    prefix = "ENCOUNTER checked"
+    if roll is not None and threshold is not None:
+        prefix = f"ENCOUNTER roll={_format_number(roll)} threshold={_format_number(threshold)}"
+    spawned_enemy = _spawned_enemy_text(payload)
+    if spawned_enemy is not None:
+        return f"{prefix} -> spawned {spawned_enemy}"
+    return f"{prefix} -> none"
+
+
+def _debug_position_tokens(payload: Mapping[str, Any]) -> list[str]:
+    pairs = (
+        ("position", "position"),
+        ("start_position", "start"),
+        ("end_position", "end"),
+        ("blocked_position", "blocked"),
+        ("target_position", "target"),
+        ("center", "center"),
+    )
+    tokens: list[str] = []
+    for key, label in pairs:
+        if key not in payload:
+            continue
+        internal = _internal_position_text(payload.get(key))
+        display = _display_position_text(payload.get(key))
+        if internal is None or display is None:
+            continue
+        tokens.append(f"{label}_internal={internal}")
+        tokens.append(f"{label}_display={display}")
+    return tokens
+
+
+def _compact_payload_tokens(payload: Mapping[str, Any]) -> list[str]:
+    tokens: list[str] = []
+    for key in sorted(payload):
+        value = payload[key]
+        if value is None:
+            continue
+        if key in {
+            "position",
+            "start_position",
+            "end_position",
+            "blocked_position",
+            "target_position",
+            "center",
+        }:
+            continue
+        if isinstance(value, Mapping):
+            tokens.append(f"{key}={_mapping_debug_summary(value)}")
+            continue
+        if isinstance(value, list):
+            tokens.append(f"{key}={_list_debug_summary(value)}")
+            continue
+        tokens.append(f"{key}={value}")
+    return tokens
+
+
+def _mapping_debug_summary(mapping: Mapping[str, Any]) -> str:
+    compact_parts: list[str] = []
+    for key in sorted(mapping):
+        value = mapping[key]
+        if isinstance(value, Mapping):
+            compact_parts.append(f"{key}=...")
+        elif isinstance(value, list):
+            compact_parts.append(f"{key}=[{len(value)}]")
+        else:
+            compact_parts.append(f"{key}={value}")
+    return "{" + ", ".join(compact_parts) + "}"
+
+
+def _list_debug_summary(values: Sequence[Any]) -> str:
+    if len(values) <= 4 and all(not isinstance(value, Mapping) for value in values):
+        return "[" + ",".join(str(value) for value in values) + "]"
+    return f"[{len(values)}]"
+
+
+def _observation_size_text(payload: Mapping[str, Any]) -> str:
+    size = payload.get("sensor_range") or payload.get("observation_size") or payload.get("size")
+    if size == 3:
+        return "3x3"
+    return "5x5"
+
+
+def _route_text(value: object) -> str | None:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        return None
+    items = [str(item) for item in value]
+    if not items:
+        return None
+    return ",".join(items)
+
+
+def _reason_text(payload: Mapping[str, Any]) -> str | None:
+    explicit_reason = payload.get("reason")
+    if explicit_reason:
+        return str(explicit_reason)
+    outcome = payload.get("outcome")
+    if outcome == "REJECTED_BLOCKED_EDGE":
+        direction = payload.get("exit_direction", "-")
+        return f"{direction} edge is blocked by RIFT_BARRIER"
+    if outcome == "REJECTED_NO_WARP_FLAG":
+        direction = payload.get("exit_direction", "-")
+        return f"{direction} edge has no warp exit"
+    if outcome == "REJECTED_ENEMY_PRESENCE":
+        return "enemy presence blocks warp exit"
+    if outcome == "REJECTED_ALREADY_CONSUMED":
+        return "already consumed"
+    if outcome == "REJECTED_NO_EFFECT":
+        return "no effect"
+    if outcome == "REJECTED_OUT_OF_BOUNDS":
+        return "out of bounds"
+    if outcome == "REJECTED_UNKNOWN_TARGET":
+        return "unknown target"
+    if outcome == "REJECTED_SAME_POSITION":
+        return "same position"
+    if outcome == "REJECTED_UPGRADE_UNAVAILABLE":
+        return "upgrade unavailable"
+    if isinstance(outcome, str) and outcome.startswith("REJECTED_"):
+        return outcome.removeprefix("REJECTED_").replace("_", " ").lower()
+    return None
+
+
+def _spawned_enemy_text(payload: Mapping[str, Any]) -> str | None:
+    enemy_id = payload.get("enemy_id")
+    enemy_tier = payload.get("enemy_tier")
+    spawn_position = (
+        _display_position_text(payload.get("spawn_position"))
+        or _display_position_text(payload.get("enemy_position"))
+        or _display_position_text(payload.get("position"))
+    )
+    if enemy_id is None and enemy_tier is None and spawn_position is None:
+        return None
+    tokens = [str(enemy_id or "enemy")]
+    if enemy_tier is not None:
+        tokens.append(str(enemy_tier))
+    if spawn_position is not None:
+        tokens.append(f"at SRS={spawn_position}")
+    return " ".join(tokens)
+
+
+def _upgrade_label(applied_upgrade: str) -> str:
+    labels = {
+        "DEFENSE": "defense +1",
+        "EVASION": "evasion +1",
+        "PHASER_POWER": "phaser +1",
+        "PHOTON_TORPEDO_POWER": "torpedo +1",
+        "ENERGY_CAPACITY": "energy capacity +1",
+        "PHOTON_TORPEDO_AMMO_CAPACITY": "torpedo capacity +1",
+    }
+    return labels.get(applied_upgrade, applied_upgrade.lower())
+
+
+def _with_capacity(value: object, capacity: object) -> str:
+    if capacity is None:
+        return str(value)
+    return f"{value}/{capacity}"
+
+
+def _format_number(value: object) -> str:
+    if isinstance(value, float):
+        return f"{value:.2f}"
+    return str(value)
+
+
+def _display_position_text(value: object) -> str | None:
+    position = _coerce_position(value)
+    if position is None:
+        return None
+    display_x, display_y = to_display_position(position)
+    return f"({display_x},{display_y})"
+
+
+def _internal_position_text(value: object) -> str | None:
+    position = _coerce_position(value)
+    if position is None:
+        return None
+    return f"({position.x},{position.y})"
+
+
+def _coerce_position(value: object) -> Position | None:
+    if isinstance(value, Position):
+        return value
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)) and len(value) == 2:
+        x, y = value
+        if isinstance(x, int) and isinstance(y, int):
+            return Position(x, y)
+    return None

--- a/experiments/galactic_exodus/srs/run_manual_eval.py
+++ b/experiments/galactic_exodus/srs/run_manual_eval.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Iterable, Mapping, Sequence
 
 from experiments.galactic_exodus.hud import CompactHudContext, render_compact_hud
+from experiments.galactic_exodus.srs import event_format
 from experiments.galactic_exodus.srs.model import Position, SrsGameState
 from experiments.galactic_exodus.srs.render import render_display_map, render_row_for_internal_y, to_display_position
 from experiments.galactic_exodus.srs.run_fixture import FIXTURES_DIR, SrsFixtureRunResult, run_fixture
@@ -279,30 +280,8 @@ def _case_goal_text(fixture_id: str) -> str:
 def _event_summary_lines(result: SrsFixtureRunResult) -> list[str]:
     lines: list[str] = []
     for event in result.log.events:
-        payload = dict(event.payload)
-        prefix = f"turn {event.srs_turn}: {event.event_type}"
-        if event.event_type == "MOVE_ACCEPTED":
-            lines.append(
-                f"{prefix} "
-                f"{payload.get('command_type', '-')} "
-                f"{_format_position(payload.get('start_position'))} -> {_format_position(payload.get('end_position'))} "
-                f"fuel {payload.get('fuel_before', '-')}->{payload.get('fuel_after', '-')}"
-            )
-        elif event.event_type == "OBSERVATION_UPDATED":
-            lines.append(
-                f"{prefix} "
-                f"center={_format_position(payload.get('center'))} "
-                f"new={payload.get('newly_discovered_count', '-')} "
-                f"total={payload.get('total_discovered_count', '-')}"
-            )
-        elif event.event_type in {"INTERACT_ACCEPTED", "INTERACT_REJECTED"}:
-            lines.append(_interaction_event_summary(prefix, payload))
-        elif event.event_type in {"OBJECT_CONSUMED", "STATION_ACTIVATED"}:
-            lines.append(" ".join([prefix, *_interaction_subject_tokens(payload)]))
-        elif "outcome" in payload:
-            lines.append(f"{prefix} outcome={payload.get('outcome')}")
-        else:
-            lines.append(prefix)
+        for summary_line in event_format.format_srs_event_summary_lines(event):
+            lines.append(f"turn {event.srs_turn}: {summary_line}")
     return lines
 
 
@@ -372,9 +351,10 @@ def _player_cell_text(state: SrsGameState) -> str:
 
 def _compact_hud_text(result: SrsFixtureRunResult) -> str:
     last_event_summary = None
-    event_lines = _event_summary_lines(result)
-    if event_lines:
-        last_event_summary = event_lines[-1]
+    for event in result.log.events:
+        summary_lines = event_format.format_srs_event_summary_lines(event)
+        if summary_lines:
+            last_event_summary = summary_lines[-1]
     return render_compact_hud(
         CompactHudContext(
             srs_state=result.final_state,

--- a/experiments/galactic_exodus/srs/test_event_format.py
+++ b/experiments/galactic_exodus/srs/test_event_format.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import unittest
+
+from experiments.galactic_exodus.srs import event_format, log
+from experiments.galactic_exodus.srs.log import make_turn_event
+
+
+class SrsEventFormatTests(unittest.TestCase):
+    def test_move_accepted_uses_display_coordinate(self) -> None:
+        event = make_turn_event(
+            srs_turn=1,
+            event_type=log.MOVE_ACCEPTED,
+            payload={
+                "resolved_route": ["E", "E"],
+                "end_position": [6, 3],
+            },
+        )
+
+        rendered = event_format.format_srs_event_summary(event)
+
+        self.assertEqual(rendered, "MOVE  accepted route=E,E to SRS=(7,4)")
+        self.assertNotIn("internal=", rendered)
+
+    def test_stopped_before_impassable(self) -> None:
+        event = make_turn_event(
+            srs_turn=1,
+            event_type=log.STOPPED_BEFORE_IMPASSABLE,
+            payload={"terrain": "RIFT_BARRIER", "blocked_position": [8, 3]},
+        )
+
+        self.assertEqual(
+            event_format.format_srs_event_summary(event),
+            "STOP  blocked by RIFT_BARRIER at SRS=(9,4)",
+        )
+
+    def test_observation_updated(self) -> None:
+        event = make_turn_event(
+            srs_turn=1,
+            event_type=log.OBSERVATION_UPDATED,
+            payload={"newly_discovered_count": 6, "total_discovered_count": 34},
+        )
+
+        self.assertEqual(
+            event_format.format_srs_event_summary(event),
+            "SCAN  5x5 update: +6 known cells, total=34",
+        )
+
+    def test_nebula_observation_returns_two_lines(self) -> None:
+        event = make_turn_event(
+            srs_turn=1,
+            event_type=log.OBSERVATION_UPDATED,
+            payload={
+                "nebula_interference": True,
+                "sensor_range": 3,
+                "newly_discovered_count": 4,
+                "total_discovered_count": 18,
+            },
+        )
+
+        self.assertEqual(
+            event_format.format_srs_event_summary_lines(event),
+            [
+                "SCAN  NEBULA interference: sensor range reduced to 3x3",
+                "SCAN  3x3 update: +4 known cells, total=18",
+            ],
+        )
+
+    def test_resource_cache_consumed(self) -> None:
+        event = make_turn_event(
+            srs_turn=1,
+            event_type=log.OBJECT_CONSUMED,
+            payload={"object_type": "RESOURCE_CACHE", "fuel_delta": 3, "fuel_after": 6, "max_fuel": 9},
+        )
+
+        self.assertEqual(
+            event_format.format_srs_event_summary(event),
+            "CACHE acquired: fuel +3 -> 6/9",
+        )
+
+    def test_salvage_consumed(self) -> None:
+        event = make_turn_event(
+            srs_turn=1,
+            event_type=log.OBJECT_CONSUMED,
+            payload={
+                "object_type": "SALVAGE",
+                "salvage_after": 1,
+                "durability_delta": 8,
+                "durability_after": 100,
+                "durability_capacity": 100,
+            },
+        )
+
+        self.assertEqual(
+            event_format.format_srs_event_summary(event),
+            "SALVAGE acquired: +1 inventory, durability +8 -> 100/100",
+        )
+
+    def test_station_activated_and_upgrade(self) -> None:
+        event = make_turn_event(
+            srs_turn=1,
+            event_type=log.STATION_ACTIVATED,
+            payload={
+                "applied_upgrade": "DEFENSE",
+                "salvage_before": 4,
+                "salvage_after": 0,
+            },
+        )
+
+        self.assertEqual(
+            event_format.format_srs_event_summary_lines(event),
+            [
+                "BASE station activated: full recovery complete",
+                "UPGRADE defense +1, salvage 4 -> 0",
+            ],
+        )
+
+    def test_warp_accepted_and_rejected(self) -> None:
+        accepted = make_turn_event(
+            srs_turn=1,
+            event_type=log.WARP_EXIT_ACCEPTED,
+            payload={"exit_direction": "S", "start_position": [4, 0]},
+        )
+        rejected = make_turn_event(
+            srs_turn=0,
+            event_type=log.WARP_EXIT_REJECTED,
+            payload={"exit_direction": "E", "outcome": "REJECTED_BLOCKED_EDGE"},
+        )
+
+        self.assertEqual(
+            event_format.format_srs_event_summary(accepted),
+            "WARP  S accepted from SRS=(5,1)",
+        )
+        self.assertEqual(
+            event_format.format_srs_event_summary(rejected),
+            "WARP  rejected: E edge is blocked by RIFT_BARRIER",
+        )
+
+    def test_combat_transitioned_and_rejected(self) -> None:
+        transitioned = make_turn_event(
+            srs_turn=1,
+            event_type=log.COMBAT_TRANSITIONED,
+            payload={
+                "phase_to": "PLAYER_ATTACK",
+                "player_action": {"target_enemy_id": "enemy-1"},
+                "target_position": [4, 4],
+            },
+        )
+        rejected = make_turn_event(
+            srs_turn=1,
+            event_type=log.COMBAT_REJECTED,
+            payload={"reason": "enemy out of range"},
+        )
+
+        self.assertEqual(
+            event_format.format_srs_event_summary(transitioned),
+            "COMBAT phase=PLAYER_ATTACK target=enemy-1 at SRS=(5,5)",
+        )
+        self.assertEqual(
+            event_format.format_srs_event_summary(rejected),
+            "COMBAT  rejected: enemy out of range",
+        )
+
+    def test_encounter_spawned_and_none(self) -> None:
+        spawned = make_turn_event(
+            srs_turn=1,
+            event_type=log.ENCOUNTER_ROLLED,
+            payload={
+                "roll": 0.12,
+                "threshold": 0.18,
+                "enemy_id": "enemy-1",
+                "enemy_tier": "TIER2",
+                "spawn_position": [4, 4],
+            },
+        )
+        none = make_turn_event(
+            srs_turn=1,
+            event_type=log.ENCOUNTER_ROLLED,
+            payload={"roll": 0.42, "threshold": 0.18},
+        )
+
+        self.assertEqual(
+            event_format.format_srs_event_summary(spawned),
+            "ENCOUNTER roll=0.12 threshold=0.18 -> spawned enemy-1 TIER2 at SRS=(5,5)",
+        )
+        self.assertEqual(
+            event_format.format_srs_event_summary(none),
+            "ENCOUNTER roll=0.42 threshold=0.18 -> none",
+        )
+
+    def test_debug_event_includes_internal_display_pair(self) -> None:
+        event = make_turn_event(
+            srs_turn=1,
+            event_type=log.MOVE_ACCEPTED,
+            payload={"start_position": [4, 2], "end_position": [6, 3]},
+        )
+
+        rendered = event_format.format_srs_debug_event(event)
+
+        self.assertIn("MOVE_ACCEPTED", rendered)
+        self.assertIn("start_internal=(4,2)", rendered)
+        self.assertIn("end_display=(7,4)", rendered)
+
+    def test_unknown_event_fallback_does_not_raise(self) -> None:
+        event = make_turn_event(
+            srs_turn=1,
+            event_type="UNKNOWN_EVENT",
+            payload={"payload": "value"},
+        )
+
+        self.assertEqual(event_format.format_srs_event_summary(event), "EVENT UNKNOWN_EVENT")
+        self.assertIn("UNKNOWN_EVENT", event_format.format_srs_debug_event(event))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experiments/galactic_exodus/srs/test_run_manual_eval.py
+++ b/experiments/galactic_exodus/srs/test_run_manual_eval.py
@@ -89,9 +89,8 @@ class SrsRunManualEvalTests(unittest.TestCase):
     def test_event_summary_positions_use_display_coordinates(self) -> None:
         lines = self._summary_lines_for_fixture("move_to_known_9x9.json")
 
-        self.assertIn("turn 1: MOVE_ACCEPTED MOVE_TO (5,1) -> (5,3) fuel 0->0", lines)
-        self.assertIn("turn 1: OBSERVATION_UPDATED center=(5,2) new=0 total=81", lines)
-        self.assertIn("turn 1: OBSERVATION_UPDATED center=(5,3) new=0 total=81", lines)
+        self.assertIn("turn 1: MOVE  accepted route=N,N to SRS=(5,3)", lines)
+        self.assertIn("turn 1: SCAN  5x5 update: +0 known cells, total=81", lines)
 
     def test_event_summary_resource_cache_includes_fuel_and_consumed_state(self) -> None:
         lines = self._summary_lines_for_fixture("resource_cache_single_9x9.json")
@@ -99,8 +98,8 @@ class SrsRunManualEvalTests(unittest.TestCase):
         self.assertEqual(
             lines[-2:],
             [
-                "turn 1: INTERACT_ACCEPTED RESOURCE_CACHE resource-cache-1 outcome=ACCEPTED fuel 2->5 restore=3 consumed=true",
-                "turn 1: OBJECT_CONSUMED RESOURCE_CACHE resource-cache-1",
+                "turn 1: INTERACT accepted: RESOURCE_CACHE at SRS=(3,8)",
+                "turn 1: CACHE acquired: fuel +3 -> 5",
             ],
         )
 
@@ -122,8 +121,8 @@ class SrsRunManualEvalTests(unittest.TestCase):
         self.assertEqual(
             lines[-2:],
             [
-                "turn 1: INTERACT_ACCEPTED STATION station-1 outcome=ACCEPTED fuel 2->9 refuel_to_max=true activated=true",
-                "turn 1: STATION_ACTIVATED STATION station-1",
+                "turn 1: INTERACT accepted: STATION at SRS=(4,1)",
+                "turn 1: BASE station activated: full recovery complete",
             ],
         )
 
@@ -133,8 +132,8 @@ class SrsRunManualEvalTests(unittest.TestCase):
         self.assertEqual(
             lines[-2:],
             [
-                "turn 1: INTERACT_ACCEPTED SALVAGE salvage-1 outcome=ACCEPTED fuel 2->2 placeholder=true consumed=true",
-                "turn 1: OBJECT_CONSUMED SALVAGE salvage-1",
+                "turn 1: INTERACT accepted: SALVAGE at SRS=(5,7)",
+                "turn 1: SALVAGE acquired: +1 inventory, durability +0 -> 100",
             ],
         )
 
@@ -142,7 +141,7 @@ class SrsRunManualEvalTests(unittest.TestCase):
         lines = self._summary_lines_for_fixture("revisit_resource_consumed_9x9.json")
 
         self.assertIn(
-            "turn 0: INTERACT_REJECTED RESOURCE_CACHE resource-cache-1 outcome=REJECTED_ALREADY_CONSUMED fuel 2->2 consumed=true",
+            "turn 0: INTERACT  rejected: already consumed",
             lines,
         )
 

--- a/experiments/galactic_exodus/test_event_format.py
+++ b/experiments/galactic_exodus/test_event_format.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import unittest
+
+from experiments.galactic_exodus import engine
+from experiments.galactic_exodus import event_format
+from experiments.galactic_exodus.test_engine import filled_cells, make_actual_map, make_state
+
+
+class LrsEventFormatTests(unittest.TestCase):
+    def test_moved_summary(self) -> None:
+        state = make_state(actual_map=make_actual_map(cells=filled_cells(".")))
+        event = engine.apply_command(state, "E")
+
+        self.assertEqual(
+            event_format.format_lrs_event_summary(event),
+            "MOVE  accepted to LRS=(2,1)",
+        )
+
+    def test_unknown_rift_summary(self) -> None:
+        blocked_edge = ((1, 1), (1, 2))
+        state = make_state(
+            actual_map=make_actual_map(cells=filled_cells("."), rift_edges=(blocked_edge,)),
+        )
+        event = engine.apply_command(state, "N")
+
+        self.assertEqual(
+            event_format.format_lrs_event_summary(event),
+            "RIFT  discovered: LRS edge (1,1)-N is blocked",
+        )
+
+    def test_known_rift_rejection_summary(self) -> None:
+        blocked_edge = ((1, 1), (1, 2))
+        state = make_state(
+            actual_map=make_actual_map(cells=filled_cells("."), rift_edges=(blocked_edge,)),
+        )
+        engine.apply_command(state, "N")
+        event = engine.apply_command(state, "N")
+
+        self.assertEqual(
+            event_format.format_lrs_event_summary(event),
+            "MOVE  rejected: known RIFT blocks N",
+        )
+
+    def test_insufficient_fuel_summary(self) -> None:
+        cells = filled_cells(".")
+        cells[(2, 1)] = "A"
+        state = make_state(actual_map=make_actual_map(cells=cells), remaining_fuel=2)
+        event = engine.apply_command(state, "E")
+
+        self.assertEqual(
+            event_format.format_lrs_event_summary(event),
+            "MOVE  rejected: insufficient fuel",
+        )
+
+    def test_invalid_and_out_of_bounds_summaries(self) -> None:
+        invalid_state = make_state(actual_map=make_actual_map(cells=filled_cells(".")))
+        invalid_event = engine.apply_command(invalid_state, "X")
+        bounds_state = make_state(actual_map=make_actual_map(cells=filled_cells(".")))
+        bounds_event = engine.apply_command(bounds_state, "S")
+
+        self.assertEqual(
+            event_format.format_lrs_event_summary(invalid_event),
+            "MOVE  rejected: invalid command",
+        )
+        self.assertEqual(
+            event_format.format_lrs_event_summary(bounds_event),
+            "MOVE  rejected: out of bounds",
+        )
+
+    def test_debug_summary_includes_event_type_and_payload(self) -> None:
+        state = make_state(actual_map=make_actual_map(cells=filled_cells(".")))
+        event = engine.apply_command(state, "E")
+
+        rendered = event_format.format_lrs_debug_event(event)
+
+        self.assertIn("MOVED", rendered)
+        self.assertIn("from=(1,1)", rendered)
+        self.assertIn("to=(2,1)", rendered)
+        self.assertIn("fuel=", rendered)
+
+    def test_unknown_event_fallback_does_not_raise(self) -> None:
+        event = engine.TurnEvent(
+            turn=0,
+            command="Q",
+            outcome="UNKNOWN_EVENT",
+            from_position=(1, 1),
+            attempted_position=None,
+            to_position=(1, 1),
+            fuel_before=0,
+            fuel_spent=0,
+            fuel_after=0,
+            required_fuel=None,
+            discovered_cells=(),
+            discovered_rift=False,
+            supply_result=engine.SUPPLY_RESULT_NONE,
+            supply_source=None,
+            fuel_before_supply=None,
+            fuel_after_supply=None,
+            supply_amount=0,
+            status_after=engine.GAME_STATUS_IN_PROGRESS,
+        )
+
+        self.assertEqual(event_format.format_lrs_event_summary(event), "EVENT UNKNOWN_EVENT")
+        self.assertIn("UNKNOWN_EVENT", event_format.format_lrs_debug_event(event))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experiments/galactic_exodus/test_play.py
+++ b/experiments/galactic_exodus/test_play.py
@@ -92,14 +92,14 @@ class PlayCliTests(unittest.TestCase):
         exit_code, stdout, _ = self.run_cli(["--seed", "42"], "  e  \nQ\n")
 
         self.assertEqual(exit_code, 0)
-        self.assertIn("MOVED TO (2,1), COST ", stdout)
+        self.assertIn("MOVE  accepted to LRS=(2,1)", stdout)
         self.assertIn("TURN: 1\n", stdout)
 
     def test_invalid_input_leaves_state_unchanged(self) -> None:
         exit_code, stdout, _ = self.run_cli(["--seed", "42"], "X\nQ\n")
 
         self.assertEqual(exit_code, 0)
-        self.assertIn("INVALID COMMAND\n", stdout)
+        self.assertIn("MOVE  rejected: invalid command\n", stdout)
         self.assertIn("POSITION: (1,1)\n", stdout)
         self.assertIn("TURN: 0\n", stdout)
 
@@ -151,11 +151,17 @@ class PlayCliTests(unittest.TestCase):
         insufficient_state = make_state(actual_map=make_actual_map(cells=cells), remaining_fuel=2)
         insufficient_event = engine.apply_command(insufficient_state, "E")
 
-        self.assertEqual(play.format_event_messages(rift_state, blocked_event), ["RIFT BLOCKED N, COST 1"])
-        self.assertEqual(play.format_event_messages(rift_state, known_event), ["KNOWN RIFT N"])
+        self.assertEqual(
+            play.format_event_messages(rift_state, blocked_event),
+            ["RIFT  discovered: LRS edge (1,1)-N is blocked"],
+        )
+        self.assertEqual(
+            play.format_event_messages(rift_state, known_event),
+            ["MOVE  rejected: known RIFT blocks N"],
+        )
         self.assertEqual(
             play.format_event_messages(insufficient_state, insufficient_event),
-            ["INSUFFICIENT FUEL: NEED 3, HAVE 2"],
+            ["MOVE  rejected: insufficient fuel"],
         )
 
     def test_turn_messages_cover_supply_results(self) -> None:
@@ -173,9 +179,12 @@ class PlayCliTests(unittest.TestCase):
         base_event = engine.apply_command(base_state, "E")
         resource_event = engine.apply_command(resource_state, "E")
 
-        self.assertIn("REFUELED AT B(2,1): 2 -> 5", play.format_event_messages(base_state, base_event))
         self.assertIn(
-            "REFUELED AT R(2,1): +5 (2 -> 7)",
+            "BASE  refueled: 2 -> 5 at LRS=(2,1)",
+            play.format_event_messages(base_state, base_event),
+        )
+        self.assertIn(
+            "CACHE acquired: fuel +5 -> 7/16 at LRS=(2,1)",
             play.format_event_messages(resource_state, resource_event),
         )
 


### PR DESCRIPTION
## 概要

Closes #1234

Galactic Exodus の LRS / SRS event wording を formatter module へ分離し、normal/debug/manual-eval 向けの表示責務を整理しました。

## 変更内容

- `experiments/galactic_exodus/event_format.py` を追加し、LRS event の normal/debug formatter を実装
- `experiments/galactic_exodus/srs/event_format.py` を追加し、SRS event の normal/debug formatter と multi-line summary formatter を実装
- `play.py` の event 表示を LRS formatter 経由へ切り替え、補給・home 到達メッセージを新 wording に更新
- `srs/run_manual_eval.py` の event summary / compact HUD LAST 行を SRS formatter 経由へ切り替え
- formatter 単体テストを新規追加し、`test_play.py` / `test_run_manual_eval.py` を必要最小限更新

## 確認

- `python -m unittest experiments.galactic_exodus.test_event_format`
- `python -m unittest experiments.galactic_exodus.srs.test_event_format`
- `python -m unittest experiments.galactic_exodus.test_play`
- `python -m unittest experiments.galactic_exodus.srs.test_run_manual_eval`
- `python -m unittest discover experiments/galactic_exodus/srs`
- `python -m unittest discover experiments/galactic_exodus`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
