### PR TITLE
Galactic Exodus表示snapshot/fixtureを追加

### DIFF
--- a/experiments/galactic_exodus/display_reference.py
+++ b/experiments/galactic_exodus/display_reference.py
@@ -1,0 +1,363 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+from experiments.galactic_exodus import engine, simulate
+from experiments.galactic_exodus.srs.model import (
+    Direction,
+    Position,
+    SrsCell,
+    SrsCombatState,
+    SrsEnemyTier,
+    SrsObjectType,
+    SrsTerrainType,
+    create_enemy_combat_state,
+)
+from experiments.galactic_exodus.srs.test_engine_movement import make_state as make_srs_state
+from experiments.galactic_exodus.srs.test_engine_movement import place_object, reveal_positions
+from experiments.galactic_exodus.test_engine import filled_cells, make_actual_map, make_state as make_lrs_state
+
+
+def make_lrs_display_snapshot_state() -> engine.GameState:
+    cells = filled_cells(".")
+    cells[(4, 7)] = "N"
+    actual_map = make_actual_map(
+        cells=cells,
+        base_position=(4, 5),
+        resource_positions=((3, 6),),
+    )
+    vertical_rift = simulate.normalize_edge((3, 6), (4, 6))
+    horizontal_rift = simulate.normalize_edge((3, 5), (3, 4))
+    known_cells = {
+        (1, 1): "S",
+        (2, 1): ".",
+        (3, 1): ".",
+        (2, 4): ".",
+        (3, 4): ".",
+        (4, 4): ".",
+        (2, 5): ".",
+        (3, 5): ".",
+        (4, 5): "B",
+        (2, 6): ".",
+        (3, 6): "R",
+        (4, 6): ".",
+        (2, 7): ".",
+        (3, 7): ".",
+        (4, 7): "N",
+        (8, 8): "H",
+    }
+    return make_lrs_state(
+        actual_map=actual_map,
+        player_position=(3, 5),
+        known_cells=known_cells,
+        visited_cells={(1, 1), (3, 5)},
+        known_routes={
+            vertical_rift: engine.ROUTE_RIFT,
+            horizontal_rift: engine.ROUTE_RIFT,
+        },
+        path=[(1, 1), (2, 1), (3, 1), (3, 5)],
+    )
+
+
+def expected_lrs_display_snapshot() -> str:
+    return "\n".join(
+        [
+            "  +---+---+---+---+---+---+---+---+",
+            "8 | ?   ?   ?   ?   ?   ?   ?   H |",
+            "  +                               +",
+            "7 | ?   .   .   N   ?   ?   ?   ? |",
+            "  +           +                   +",
+            "6 | ?   .   R | .   ?   ?   ?   ? |",
+            "  +           +                   +",
+            "5 | ?   .   @   B   ?   ?   ?   ? |",
+            "  +       +---+                   +",
+            "4 | ?   .   .   .   ?   ?   ?   ? |",
+            "  +                               +",
+            "3 | ?   ?   ?   ?   ?   ?   ?   ? |",
+            "  +                               +",
+            "2 | ?   ?   ?   ?   ?   ?   ?   ? |",
+            "  +                               +",
+            "1 | S   .   .   ?   ?   ?   ?   ? |",
+            "  +---+---+---+---+---+---+---+---+",
+            "    1   2   3   4   5   6   7   8",
+        ]
+    )
+
+
+def make_lrs_dense_rift_snapshot_state() -> engine.GameState:
+    cells = filled_cells(".")
+    known_cells = {(x, y): "." for y in range(1, 9) for x in range(1, 9)}
+    known_cells[(1, 1)] = "S"
+    known_cells[(8, 8)] = "H"
+    known_edges = (
+        simulate.normalize_edge((2, 4), (2, 5)),
+        simulate.normalize_edge((3, 4), (3, 5)),
+        simulate.normalize_edge((4, 4), (4, 5)),
+        simulate.normalize_edge((3, 4), (4, 4)),
+        simulate.normalize_edge((3, 5), (4, 5)),
+        simulate.normalize_edge((1, 8), (2, 8)),
+        simulate.normalize_edge((8, 1), (8, 2)),
+    )
+    hidden_edge = simulate.normalize_edge((6, 6), (7, 6))
+    actual_map = make_actual_map(
+        cells=cells,
+        rift_edges=known_edges + (hidden_edge,),
+    )
+    return make_lrs_state(
+        actual_map=actual_map,
+        player_position=(4, 4),
+        known_cells=known_cells,
+        visited_cells={(1, 1), (4, 4)},
+        known_routes={edge: engine.ROUTE_RIFT for edge in known_edges},
+    )
+
+
+def expected_lrs_dense_rift_snapshot() -> str:
+    return "\n".join(
+        [
+            "  +---+---+---+---+---+---+---+---+",
+            "8 | . | .   .   .   .   .   .   H |",
+            "  +   +                           +",
+            "7 | .   .   .   .   .   .   .   . |",
+            "  +                               +",
+            "6 | .   .   .   .   .   .   .   . |",
+            "  +           +                   +",
+            "5 | .   .   . | .   .   .   .   . |",
+            "  +   +---+---+---+               +",
+            "4 | .   .   . | @   .   .   .   . |",
+            "  +           +                   +",
+            "3 | .   .   .   .   .   .   .   . |",
+            "  +                               +",
+            "2 | .   .   .   .   .   .   .   . |",
+            "  +                           +---+",
+            "1 | S   .   .   .   .   .   .   . |",
+            "  +---+---+---+---+---+---+---+---+",
+            "    1   2   3   4   5   6   7   8",
+        ]
+    )
+
+
+def make_srs_display_snapshot_state():
+    state = replace(make_srs_state(), player_position=Position(6, 3))
+
+    barrier_positions = [Position(8, y) for y in range(6)]
+    floor_positions = [
+        Position(3, 6),
+        Position(4, 6),
+        Position(5, 6),
+        Position(3, 5),
+        Position(4, 5),
+        Position(5, 5),
+        Position(6, 5),
+        Position(7, 5),
+        Position(3, 4),
+        Position(4, 4),
+        Position(5, 4),
+        Position(6, 4),
+        Position(7, 4),
+        Position(3, 3),
+        Position(4, 3),
+        Position(5, 3),
+        Position(6, 3),
+        Position(7, 3),
+        Position(3, 2),
+        Position(5, 2),
+        Position(6, 2),
+        Position(7, 2),
+        Position(2, 1),
+        Position(3, 1),
+        Position(4, 1),
+        Position(5, 1),
+        Position(6, 1),
+        Position(7, 1),
+    ]
+    warp_positions = [Position(x, 0) for x in range(2, 8)]
+    known_positions = set(floor_positions)
+    known_positions.update(barrier_positions)
+    known_positions.update(warp_positions)
+    known_positions.add(Position(4, 2))
+    known_positions.add(Position(4, 4))
+
+    for position in barrier_positions:
+        state = _replace_srs_cell(
+            state,
+            position,
+            terrain=SrsTerrainType.RIFT_BARRIER,
+            warp_flags=frozenset(),
+        )
+    for position in warp_positions:
+        state = _replace_srs_cell(state, position, warp_flags=frozenset({Direction.S}))
+
+    state = place_object(state, Position(4, 2), SrsObjectType.SALVAGE, "salvage-a")
+    enemy = create_enemy_combat_state(
+        enemy_id="enemy-1",
+        tier=SrsEnemyTier.TIER2,
+        position=Position(4, 4),
+    )
+    state = replace(
+        state,
+        combat_state=SrsCombatState(
+            enemies={"enemy-1": enemy},
+            player_attack_target_id="enemy-1",
+        ),
+    )
+    return reveal_positions(state, known_positions)
+
+
+def expected_srs_display_snapshot() -> str:
+    return "\n".join(
+        [
+            " 9  ? ? ? ? ? ? ? ? ?",
+            " 8  ? ? ? ? ? ? ? ? ?",
+            " 7  ? ? ? . . . ? ? ?",
+            " 6  ? ? ? . . . . . #",
+            " 5  ? ? ? . e . . . #",
+            " 4  ? ? ? . . . @ . #",
+            " 3  ? ? ? . $ . . . #",
+            " 2  ? ? . . . . . . #",
+            " 1  ? ? v v v v v v #",
+            "",
+            "    1 2 3 4 5 6 7 8 9",
+        ]
+    )
+
+
+def make_srs_symbol_contract_snapshot_state():
+    state = make_srs_state()
+    for y in range(state.actual_map.height):
+        for x in range(state.actual_map.width):
+            state = _replace_srs_cell(state, Position(x, y), warp_flags=frozenset())
+
+    player_position = Position(0, 6)
+    enemy_position = Position(1, 6)
+    hidden_position = Position(0, 8)
+
+    state = _replace_srs_cell(
+        state,
+        player_position,
+        terrain=SrsTerrainType.ASTEROID,
+        warp_flags=frozenset({Direction.N}),
+    )
+    state = place_object(state, player_position, SrsObjectType.STATION, "station-under-player")
+    state = _replace_srs_cell(
+        state,
+        enemy_position,
+        terrain=SrsTerrainType.ASTEROID,
+        warp_flags=frozenset({Direction.E}),
+    )
+    state = place_object(state, enemy_position, SrsObjectType.SALVAGE, "salvage-under-enemy")
+
+    visible_objects = (
+        (Position(2, 6), SrsObjectType.SALVAGE, "salvage-a", False),
+        (Position(3, 6), SrsObjectType.SALVAGE, "salvage-b", True),
+        (Position(4, 6), SrsObjectType.RESOURCE_CACHE, "cache-a", False),
+        (Position(5, 6), SrsObjectType.RESOURCE_CACHE, "cache-b", True),
+        (Position(6, 6), SrsObjectType.STATION, "station-a", False),
+        (Position(7, 6), SrsObjectType.STAR, "star-a", False),
+        (Position(8, 6), SrsObjectType.PLANET, "planet-a", False),
+    )
+    for position, object_type, object_id, consumed in visible_objects:
+        state = place_object(state, position, object_type, object_id)
+        if consumed:
+            state = replace(
+                state,
+                objects={
+                    **state.objects,
+                    object_id: replace(state.objects[object_id], consumed=True),
+                },
+            )
+
+    state = _replace_srs_cell(
+        state,
+        Position(0, 5),
+        terrain=SrsTerrainType.ASTEROID,
+        warp_flags=frozenset(),
+    )
+    warp_cells = (
+        (Position(1, 5), frozenset({Direction.N})),
+        (Position(2, 5), frozenset({Direction.E})),
+        (Position(3, 5), frozenset({Direction.S})),
+        (Position(4, 5), frozenset({Direction.W})),
+        (Position(5, 5), frozenset({Direction.N, Direction.E})),
+    )
+    for position, warp_flags in warp_cells:
+        state = _replace_srs_cell(state, position, warp_flags=warp_flags)
+
+    state = _replace_srs_cell(
+        state,
+        hidden_position,
+        terrain=SrsTerrainType.ASTEROID,
+        warp_flags=frozenset({Direction.S}),
+    )
+    state = place_object(state, hidden_position, SrsObjectType.STAR, "star-hidden")
+
+    discovered = [
+        Position(x, y)
+        for y in range(state.actual_map.height)
+        for x in range(state.actual_map.width)
+        if Position(x, y) != hidden_position
+    ]
+    state = reveal_positions(state, discovered)
+    same_cell_enemy = create_enemy_combat_state(
+        enemy_id="enemy-same",
+        tier=SrsEnemyTier.TIER1,
+        position=player_position,
+    )
+    visible_enemy = create_enemy_combat_state(
+        enemy_id="enemy-1",
+        tier=SrsEnemyTier.TIER2,
+        position=enemy_position,
+    )
+    hidden_enemy = create_enemy_combat_state(
+        enemy_id="enemy-hidden",
+        tier=SrsEnemyTier.TIER1,
+        position=hidden_position,
+    )
+    return replace(
+        state,
+        player_position=player_position,
+        combat_state=SrsCombatState(
+            enemies={
+                "enemy-same": same_cell_enemy,
+                "enemy-1": visible_enemy,
+                "enemy-hidden": hidden_enemy,
+            },
+            player_attack_target_id="enemy-1",
+        ),
+    )
+
+
+def expected_srs_symbol_contract_snapshot() -> str:
+    return "\n".join(
+        [
+            " 9  ? . . . . . . . .",
+            " 8  . . . . . . . . .",
+            " 7  @ e $ s R r S * o",
+            " 6  # ^ > v < + . . .",
+            " 5  . . . . . . . . .",
+            " 4  . . . . . . . . .",
+            " 3  . . . . . . . . .",
+            " 2  . . . . . . . . .",
+            " 1  . . . . . . . . .",
+            "",
+            "    1 2 3 4 5 6 7 8 9",
+        ]
+    )
+
+
+def _replace_srs_cell(state, position: Position, *, terrain=None, object_id=None, warp_flags=None):
+    rows = [list(row) for row in state.actual_map.cells]
+    current = state.actual_map.cell_at(position)
+    rows[position.y][position.x] = SrsCell(
+        terrain=current.terrain if terrain is None else terrain,
+        object_id=current.object_id if object_id is None else object_id,
+        actor_id=current.actor_id,
+        warp_flags=current.warp_flags if warp_flags is None else warp_flags,
+    )
+    return replace(
+        state,
+        actual_map=replace(
+            state.actual_map,
+            cells=tuple(tuple(row) for row in rows),
+        ),
+    )

--- a/experiments/galactic_exodus/srs/test_display_snapshot.py
+++ b/experiments/galactic_exodus/srs/test_display_snapshot.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import unittest
+
+from experiments.galactic_exodus.display_reference import (
+    expected_srs_display_snapshot,
+    expected_srs_symbol_contract_snapshot,
+    make_srs_display_snapshot_state,
+    make_srs_symbol_contract_snapshot_state,
+)
+from experiments.galactic_exodus.srs.render import render_display_map
+
+
+class SrsDisplaySnapshotTests(unittest.TestCase):
+    def test_srs_display_snapshot_matches_1076_baseline(self) -> None:
+        rendered = render_display_map(make_srs_display_snapshot_state())
+
+        self.assertEqual(rendered, expected_srs_display_snapshot())
+
+    def test_srs_symbol_contract_snapshot(self) -> None:
+        rendered = render_display_map(make_srs_symbol_contract_snapshot_state())
+
+        self.assertEqual(rendered, expected_srs_symbol_contract_snapshot())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experiments/galactic_exodus/srs/test_event_format.py
+++ b/experiments/galactic_exodus/srs/test_event_format.py
@@ -211,6 +211,117 @@ class SrsEventFormatTests(unittest.TestCase):
         self.assertEqual(event_format.format_srs_event_summary(event), "EVENT UNKNOWN_EVENT")
         self.assertIn("UNKNOWN_EVENT", event_format.format_srs_debug_event(event))
 
+    def test_srs_event_wording_snapshot(self) -> None:
+        rendered = "\n".join(
+            [
+                event_format.format_srs_event_summary(
+                    make_turn_event(
+                        srs_turn=1,
+                        event_type=log.MOVE_ACCEPTED,
+                        payload={"resolved_route": ["E", "E"], "end_position": [6, 3]},
+                    )
+                ),
+                event_format.format_srs_event_summary(
+                    make_turn_event(
+                        srs_turn=1,
+                        event_type=log.OBSERVATION_UPDATED,
+                        payload={"newly_discovered_count": 6, "total_discovered_count": 34},
+                    )
+                ),
+                event_format.format_srs_event_summary(
+                    make_turn_event(
+                        srs_turn=1,
+                        event_type=log.STOPPED_BEFORE_IMPASSABLE,
+                        payload={"terrain": "RIFT_BARRIER", "blocked_position": [8, 3]},
+                    )
+                ),
+                event_format.format_srs_event_summary(
+                    make_turn_event(
+                        srs_turn=1,
+                        event_type=log.WARP_EXIT_ACCEPTED,
+                        payload={"exit_direction": "S", "start_position": [4, 0]},
+                    )
+                ),
+                event_format.format_srs_event_summary(
+                    make_turn_event(
+                        srs_turn=0,
+                        event_type=log.WARP_EXIT_REJECTED,
+                        payload={"exit_direction": "E", "outcome": "REJECTED_BLOCKED_EDGE"},
+                    )
+                ),
+                event_format.format_srs_event_summary(
+                    make_turn_event(
+                        srs_turn=1,
+                        event_type=log.OBJECT_CONSUMED,
+                        payload={"object_type": "RESOURCE_CACHE", "fuel_delta": 3, "fuel_after": 6, "max_fuel": 9},
+                    )
+                ),
+                event_format.format_srs_event_summary(
+                    make_turn_event(
+                        srs_turn=1,
+                        event_type=log.OBJECT_CONSUMED,
+                        payload={
+                            "object_type": "SALVAGE",
+                            "salvage_after": 1,
+                            "durability_delta": 8,
+                            "durability_after": 100,
+                            "durability_capacity": 100,
+                        },
+                    )
+                ),
+                *event_format.format_srs_event_summary_lines(
+                    make_turn_event(
+                        srs_turn=1,
+                        event_type=log.STATION_ACTIVATED,
+                        payload={"applied_upgrade": "DEFENSE", "salvage_before": 4, "salvage_after": 0},
+                    )
+                ),
+                event_format.format_srs_event_summary(
+                    make_turn_event(
+                        srs_turn=1,
+                        event_type=log.COMBAT_TRANSITIONED,
+                        payload={
+                            "phase_to": "PLAYER_ATTACK",
+                            "player_action": {"target_enemy_id": "enemy-1"},
+                            "target_position": [4, 4],
+                        },
+                    )
+                ),
+                event_format.format_srs_event_summary(
+                    make_turn_event(
+                        srs_turn=1,
+                        event_type=log.ENCOUNTER_ROLLED,
+                        payload={
+                            "roll": 0.12,
+                            "threshold": 0.18,
+                            "enemy_id": "enemy-1",
+                            "enemy_tier": "TIER2",
+                            "spawn_position": [4, 4],
+                        },
+                    )
+                ),
+            ]
+        )
+
+        self.assertEqual(
+            rendered,
+            "\n".join(
+                [
+                    "MOVE  accepted route=E,E to SRS=(7,4)",
+                    "SCAN  5x5 update: +6 known cells, total=34",
+                    "STOP  blocked by RIFT_BARRIER at SRS=(9,4)",
+                    "WARP  S accepted from SRS=(5,1)",
+                    "WARP  rejected: E edge is blocked by RIFT_BARRIER",
+                    "CACHE acquired: fuel +3 -> 6/9",
+                    "SALVAGE acquired: +1 inventory, durability +8 -> 100/100",
+                    "BASE station activated: full recovery complete",
+                    "UPGRADE defense +1, salvage 4 -> 0",
+                    "COMBAT phase=PLAYER_ATTACK target=enemy-1 at SRS=(5,5)",
+                    "ENCOUNTER roll=0.12 threshold=0.18 -> spawned enemy-1 TIER2 at SRS=(5,5)",
+                ]
+            ),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/experiments/galactic_exodus/srs/test_render.py
+++ b/experiments/galactic_exodus/srs/test_render.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import unittest
 from dataclasses import replace
 
+from experiments.galactic_exodus.display_reference import expected_srs_display_snapshot, make_srs_display_snapshot_state
 from experiments.galactic_exodus.srs.model import (
     Direction,
     Position,
@@ -77,60 +78,7 @@ class SrsRenderTests(unittest.TestCase):
         )
 
     def _build_baseline_snapshot_state(self):
-        state = replace(make_state(), player_position=Position(6, 3))
-
-        barrier_positions = [Position(8, y) for y in range(6)]
-        floor_positions = [
-            Position(3, 6),
-            Position(4, 6),
-            Position(5, 6),
-            Position(3, 5),
-            Position(4, 5),
-            Position(5, 5),
-            Position(6, 5),
-            Position(7, 5),
-            Position(3, 4),
-            Position(4, 4),
-            Position(5, 4),
-            Position(6, 4),
-            Position(7, 4),
-            Position(3, 3),
-            Position(4, 3),
-            Position(5, 3),
-            Position(6, 3),
-            Position(7, 3),
-            Position(3, 2),
-            Position(5, 2),
-            Position(6, 2),
-            Position(7, 2),
-            Position(2, 1),
-            Position(3, 1),
-            Position(4, 1),
-            Position(5, 1),
-            Position(6, 1),
-            Position(7, 1),
-        ]
-        warp_positions = [Position(x, 0) for x in range(2, 8)]
-        known_positions = set(floor_positions)
-        known_positions.update(barrier_positions)
-        known_positions.update(warp_positions)
-        known_positions.add(Position(4, 2))
-        known_positions.add(Position(4, 4))
-
-        for position in barrier_positions:
-            state = self._replace_cell(
-                state,
-                position,
-                terrain=SrsTerrainType.RIFT_BARRIER,
-                warp_flags=frozenset(),
-            )
-        for position in warp_positions:
-            state = self._replace_cell(state, position, warp_flags=frozenset({Direction.S}))
-
-        state = place_object(state, Position(4, 2), SrsObjectType.SALVAGE, "salvage-a")
-        state = self._with_enemy(state, enemy_id="enemy-1", position=Position(4, 4))
-        state = reveal_positions(state, known_positions)
-        return state
+        return make_srs_display_snapshot_state()
 
     def test_known_render_unknown_cells_are_question_marks(self) -> None:
         rendered = render_known_map(make_state())
@@ -395,21 +343,4 @@ class SrsRenderTests(unittest.TestCase):
     def test_display_map_snapshot_matches_issue_baseline_shape(self) -> None:
         rendered = render_display_map(self._build_baseline_snapshot_state())
 
-        self.assertEqual(
-            rendered,
-            "\n".join(
-                [
-                    " 9  ? ? ? ? ? ? ? ? ?",
-                    " 8  ? ? ? ? ? ? ? ? ?",
-                    " 7  ? ? ? . . . ? ? ?",
-                    " 6  ? ? ? . . . . . #",
-                    " 5  ? ? ? . e . . . #",
-                    " 4  ? ? ? . . . @ . #",
-                    " 3  ? ? ? . $ . . . #",
-                    " 2  ? ? . . . . . . #",
-                    " 1  ? ? v v v v v v #",
-                    "",
-                    "    1 2 3 4 5 6 7 8 9",
-                ]
-            ),
-        )
+        self.assertEqual(rendered, expected_srs_display_snapshot())

--- a/experiments/galactic_exodus/srs/test_run_manual_eval.py
+++ b/experiments/galactic_exodus/srs/test_run_manual_eval.py
@@ -175,3 +175,30 @@ class SrsRunManualEvalTests(unittest.TestCase):
         self.assertIn("player cell:\n", rendered)
         self.assertIn("known map:\n", rendered)
         self.assertIn("compact hud:\n", rendered)
+
+    def test_manual_eval_output_snapshot_sections_and_key_lines(self) -> None:
+        result = run_fixture(Path(__file__).resolve().parent / "fixtures" / "resource_cache_single_9x9.json")
+
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            _print_case(result)
+        rendered = stdout.getvalue()
+
+        event_index = rendered.index("event summary:\n")
+        player_index = rendered.index("player cell:\n")
+        map_index = rendered.index("known map:\n")
+        hud_index = rendered.index("compact hud:\n")
+
+        self.assertLess(event_index, player_index)
+        self.assertLess(player_index, map_index)
+        self.assertLess(map_index, hud_index)
+        self.assertIn("turn 1: INTERACT accepted: RESOURCE_CACHE at SRS=(3,8)", rendered)
+        self.assertIn("turn 1: CACHE acquired: fuel +3 -> 5", rendered)
+        self.assertIn(
+            "- position=(3,8), terrain=FLOOR, object=RESOURCE_CACHE, consumed=true, activated=false",
+            rendered,
+        )
+        self.assertIn("SECTOR  LRS=-      TYPE=RESOURCE  SRS=(3,8)  SENSOR=5x5", rendered)
+        self.assertIn("LAST    CACHE acquired: fuel +3 -> 5", rendered)
+        self.assertNotIn("internal=", rendered)
+        self.assertNotIn("Position(", rendered)

--- a/experiments/galactic_exodus/test_display.py
+++ b/experiments/galactic_exodus/test_display.py
@@ -3,50 +3,14 @@ from __future__ import annotations
 import unittest
 
 from experiments.galactic_exodus import display, engine, simulate
+from experiments.galactic_exodus.display_reference import expected_lrs_display_snapshot, make_lrs_display_snapshot_state
 from experiments.galactic_exodus.test_engine import filled_cells
 from experiments.galactic_exodus.test_engine import make_actual_map
 from experiments.galactic_exodus.test_engine import make_state
 
 
 def make_snapshot_state() -> engine.GameState:
-    cells = filled_cells(".")
-    cells[(4, 7)] = "N"
-    actual_map = make_actual_map(
-        cells=cells,
-        base_position=(4, 5),
-        resource_positions=((3, 6),),
-    )
-    vertical_rift = simulate.normalize_edge((3, 6), (4, 6))
-    horizontal_rift = simulate.normalize_edge((3, 5), (3, 4))
-    known_cells = {
-        (1, 1): "S",
-        (2, 1): ".",
-        (3, 1): ".",
-        (2, 4): ".",
-        (3, 4): ".",
-        (4, 4): ".",
-        (2, 5): ".",
-        (3, 5): ".",
-        (4, 5): "B",
-        (2, 6): ".",
-        (3, 6): "R",
-        (4, 6): ".",
-        (2, 7): ".",
-        (3, 7): ".",
-        (4, 7): "N",
-        (8, 8): "H",
-    }
-    return make_state(
-        actual_map=actual_map,
-        player_position=(3, 5),
-        known_cells=known_cells,
-        visited_cells={(1, 1), (3, 5)},
-        known_routes={
-            vertical_rift: engine.ROUTE_RIFT,
-            horizontal_rift: engine.ROUTE_RIFT,
-        },
-        path=[(1, 1), (2, 1), (3, 1), (3, 5)],
-    )
+    return make_lrs_display_snapshot_state()
 
 
 class DisplayTests(unittest.TestCase):
@@ -132,31 +96,7 @@ class DisplayTests(unittest.TestCase):
 
         rendered = display.render_lrs_border_light_map(state)
 
-        self.assertEqual(
-            rendered,
-            "\n".join(
-                [
-                    "  +---+---+---+---+---+---+---+---+",
-                    "8 | ?   ?   ?   ?   ?   ?   ?   H |",
-                    "  +                               +",
-                    "7 | ?   .   .   N   ?   ?   ?   ? |",
-                    "  +           +                   +",
-                    "6 | ?   .   R | .   ?   ?   ?   ? |",
-                    "  +           +                   +",
-                    "5 | ?   .   @   B   ?   ?   ?   ? |",
-                    "  +       +---+                   +",
-                    "4 | ?   .   .   .   ?   ?   ?   ? |",
-                    "  +                               +",
-                    "3 | ?   ?   ?   ?   ?   ?   ?   ? |",
-                    "  +                               +",
-                    "2 | ?   ?   ?   ?   ?   ?   ?   ? |",
-                    "  +                               +",
-                    "1 | S   .   .   ?   ?   ?   ?   ? |",
-                    "  +---+---+---+---+---+---+---+---+",
-                    "    1   2   3   4   5   6   7   8",
-                ]
-            ),
-        )
+        self.assertEqual(rendered, expected_lrs_display_snapshot())
 
 
 if __name__ == "__main__":

--- a/experiments/galactic_exodus/test_display_snapshot.py
+++ b/experiments/galactic_exodus/test_display_snapshot.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import unittest
+
+from experiments.galactic_exodus import display
+from experiments.galactic_exodus.display_reference import (
+    expected_lrs_dense_rift_snapshot,
+    expected_lrs_display_snapshot,
+    make_lrs_dense_rift_snapshot_state,
+    make_lrs_display_snapshot_state,
+)
+
+
+class DisplaySnapshotTests(unittest.TestCase):
+    def test_lrs_display_snapshot_matches_1076_baseline(self) -> None:
+        rendered = display.render_lrs_border_light_map(make_lrs_display_snapshot_state())
+
+        self.assertEqual(rendered, expected_lrs_display_snapshot())
+
+    def test_lrs_dense_rift_snapshot_keeps_junctions_and_hides_unknown_rift(self) -> None:
+        rendered = display.render_lrs_border_light_map(make_lrs_dense_rift_snapshot_state())
+        body_rows = rendered.splitlines()[1:16:2]
+        row_six = rendered.splitlines()[5]
+
+        self.assertEqual(rendered, expected_lrs_dense_rift_snapshot())
+        self.assertEqual([len(line) for line in body_rows], [35] * 8)
+        self.assertEqual(row_six.count("|"), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experiments/galactic_exodus/test_event_format.py
+++ b/experiments/galactic_exodus/test_event_format.py
@@ -104,6 +104,55 @@ class LrsEventFormatTests(unittest.TestCase):
         self.assertEqual(event_format.format_lrs_event_summary(event), "EVENT UNKNOWN_EVENT")
         self.assertIn("UNKNOWN_EVENT", event_format.format_lrs_debug_event(event))
 
+    def test_lrs_event_wording_snapshot(self) -> None:
+        moved_state = make_state(actual_map=make_actual_map(cells=filled_cells(".")))
+        blocked_edge = ((1, 1), (1, 2))
+        discovered_rift_state = make_state(
+            actual_map=make_actual_map(cells=filled_cells("."), rift_edges=(blocked_edge,)),
+        )
+        known_rift_state = make_state(
+            actual_map=make_actual_map(cells=filled_cells("."), rift_edges=(blocked_edge,)),
+        )
+        engine.apply_command(known_rift_state, "N")
+        low_fuel_cells = filled_cells(".")
+        low_fuel_cells[(2, 1)] = "A"
+        low_fuel_state = make_state(
+            actual_map=make_actual_map(cells=low_fuel_cells),
+            remaining_fuel=2,
+        )
+        invalid_state = make_state(actual_map=make_actual_map(cells=filled_cells(".")))
+        home_state = make_state(
+            actual_map=make_actual_map(cells=filled_cells(".")),
+            player_position=(8, 7),
+            known_cells={(8, 7): ".", (8, 8): "H"},
+            visited_cells={(8, 7)},
+        )
+
+        rendered = "\n".join(
+            [
+                event_format.format_lrs_event_summary(engine.apply_command(moved_state, "E")),
+                event_format.format_lrs_event_summary(engine.apply_command(discovered_rift_state, "N")),
+                event_format.format_lrs_event_summary(engine.apply_command(known_rift_state, "N")),
+                event_format.format_lrs_event_summary(engine.apply_command(low_fuel_state, "E")),
+                event_format.format_lrs_event_summary(engine.apply_command(invalid_state, "X")),
+                event_format.format_lrs_event_summary(engine.apply_command(home_state, "N")),
+            ]
+        )
+
+        self.assertEqual(
+            rendered,
+            "\n".join(
+                [
+                    "MOVE  accepted to LRS=(2,1)",
+                    "RIFT  discovered: LRS edge (1,1)-N is blocked",
+                    "MOVE  rejected: known RIFT blocks N",
+                    "MOVE  rejected: insufficient fuel",
+                    "MOVE  rejected: invalid command",
+                    "MOVE  accepted to LRS=(8,8)",
+                ]
+            ),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/experiments/galactic_exodus/test_hud.py
+++ b/experiments/galactic_exodus/test_hud.py
@@ -213,6 +213,75 @@ class CompactHudTests(unittest.TestCase):
             with self.subTest(forbidden=forbidden):
                 self.assertNotIn(forbidden, rendered)
 
+    def test_compact_hud_snapshot_matches_1076_baseline(self) -> None:
+        cells = filled_cells(".")
+        cells[(3, 5)] = "R"
+        lrs_state = make_lrs_state(
+            actual_map=make_actual_map(cells=cells),
+            player_position=(3, 5),
+            remaining_fuel=6,
+            known_cells={(3, 5): "R", (8, 8): "H"},
+            turn_count=18,
+        )
+        player_state = SrsPlayerCombatState(
+            durability=100,
+            durability_capacity=100,
+            energy=6,
+            energy_capacity=6,
+            photon_torpedo_ammo=6,
+            photon_torpedo_ammo_capacity=6,
+            salvage=1,
+        )
+        enemy = create_enemy_combat_state(
+            enemy_id="enemy-1",
+            tier=SrsEnemyTier.TIER2,
+            position=Position(4, 4),
+        )
+        state = replace(
+            make_srs_state(
+                sector_type=SectorType.RIFT,
+                blocked_edges=frozenset({Direction.W}),
+                fuel=6,
+                max_fuel=9,
+            ),
+            player_position=Position(6, 3),
+            srs_turn=4,
+            player_state=player_state,
+            combat_state=SrsCombatState(
+                player=player_state,
+                enemies={"enemy-1": enemy},
+                phase=SrsCombatPhase.PLAYER_MOVEMENT,
+                player_attack_target_id="enemy-1",
+            ),
+        )
+        state = place_object(state, Position(4, 2), SrsObjectType.SALVAGE, "salvage-a")
+        state = reveal_positions(state, _all_positions(state))
+
+        rendered = render_compact_hud(
+            CompactHudContext(
+                lrs_state=lrs_state,
+                srs_state=state,
+                last_event_summary="MOVE  accepted route=E,E to SRS=(7,4)",
+                cost_mode="TURN_ONLY",
+            )
+        )
+
+        self.assertEqual(
+            rendered,
+            "\n".join(
+                [
+                    "SECTOR  LRS=(3,5)  TYPE=RIFT  SRS=(7,4)  SENSOR=5x5",
+                    "TURN    LRS=18     SRS=4      COST=TURN_ONLY",
+                    "FUEL    6/9        STATUS=EXPLORING",
+                    "PLAYER  DUR=100/100  EN=6/6    TORP=6/6    SALVAGE=1",
+                    "COMBAT  PHASE=PLAYER_MOVEMENT  ENEMY=enemy-1 TIER2 hp=5 at SRS=(5,5)",
+                    "WARP    -",
+                    "REWARD  SALVAGE detected at SRS=(5,3)",
+                    "LAST    MOVE  accepted route=E,E to SRS=(7,4)",
+                ]
+            ),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 概要

Closes #1235

Galactic Exodus Phase 2 の表示 baseline を snapshot / fixture test として固定しました。production code には手を入れず、display 用の test support と回帰テスト追加に限定しています。

## 変更内容

- `experiments/galactic_exodus/display_reference.py` を追加し、LRS / SRS の deterministic snapshot state と expected string を集約
- LRS / SRS の専用 snapshot test file を追加し、baseline 表示と dense RIFT / symbol contract を完全一致で固定
- compact HUD / LRS event wording / SRS event wording / manual eval 出力の snapshot 回帰テストを追加
- 既存の granular test は残しつつ、重複していた baseline 期待値を helper 参照へ寄せた

## 確認

- `python -m unittest experiments.galactic_exodus.test_display_snapshot`
- `python -m unittest experiments.galactic_exodus.srs.test_display_snapshot`
- `python -m unittest experiments.galactic_exodus.test_display`
- `python -m unittest experiments.galactic_exodus.test_hud`
- `python -m unittest experiments.galactic_exodus.test_event_format`
- `python -m unittest experiments.galactic_exodus.test_play`
- `python -m unittest experiments.galactic_exodus.srs.test_render`
- `python -m unittest experiments.galactic_exodus.srs.test_event_format`
- `python -m unittest experiments.galactic_exodus.srs.test_run_manual_eval`
- `python experiments/galactic_exodus/srs/validate_phase2_results.py experiments/galactic_exodus/srs/fixtures/phase2_reference.json`
- `python -m unittest discover experiments/galactic_exodus/srs`
- `python -m unittest discover experiments/galactic_exodus`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
