### PR TITLE
Galactic Exodus統合CLIの土台を追加

### DIFF
--- a/experiments/galactic_exodus/README.md
+++ b/experiments/galactic_exodus/README.md
@@ -274,6 +274,20 @@ JSON ログの用途:
 - `Q` / EOF で終了したセッションは `final_summary.outcome = ABORTED_NO_POLICY_ACTION` になります
 - generation error は通常敗北と分離し、`requested / attempts / last_candidate_seed / reason / message` を表示します
 
+## Integrated command-response CLI prototype
+
+`integrated_play.py` は、LRS / SRS / HUD を command response として表示する統合CLIプロトタイプです。
+
+```bash
+python experiments/galactic_exodus/integrated_play.py --seed 42
+```
+
+このCLIでは `N/E/S/W` は最終的に SRS内の移動として扱います。LRS座標は `EXIT N/E/S/W` が成功した場合だけ変化します。
+
+この issue 時点では、`N/E/S/W` / `MOVE` / `INTERACT` / `EXIT` は parser のみ先行し、実行は後続 issue で追加します。
+
+既存 `play.py` は LRS-only prototype として残しています。
+
 これは Phase 1A のプロトタイプであり、完成ゲーム UI ではありません。
 
 固定 seed のサンプル操作:

--- a/experiments/galactic_exodus/integrated_play.py
+++ b/experiments/galactic_exodus/integrated_play.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence, TextIO
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from experiments.galactic_exodus import engine as lrs_engine
+from experiments.galactic_exodus.display import render_lrs_border_light_map
+from experiments.galactic_exodus.hud import CompactHudContext, render_compact_hud
+from experiments.galactic_exodus.srs import model as srs_model
+from experiments.galactic_exodus.srs.render import render_display_map
+
+
+COMMAND_LOOK = "LOOK"
+COMMAND_STATUS = "STATUS"
+COMMAND_HELP = "HELP"
+COMMAND_QUIT = "QUIT"
+COMMAND_MOVE = "MOVE"
+COMMAND_INTERACT = "INTERACT"
+COMMAND_EXIT = "EXIT"
+COMMAND_UNKNOWN = "UNKNOWN"
+
+_COMMAND_DIRECTIONS = frozenset({"N", "E", "S", "W"})
+_NEBULA_SENSOR_SIZE = 3
+_DEFAULT_SENSOR_SIZE = 5
+_SRS_MAP_WIDTH = 9
+_SRS_MAP_HEIGHT = 9
+_SRS_CENTER = srs_model.Position(4, 4)
+_ENTRY_POSITIONS = {
+    "N": srs_model.Position(4, 8),
+    "E": srs_model.Position(8, 4),
+    "S": srs_model.Position(4, 0),
+    "W": srs_model.Position(0, 4),
+}
+_DIRECTION_ENUM = {
+    "N": srs_model.Direction.N,
+    "E": srs_model.Direction.E,
+    "S": srs_model.Direction.S,
+    "W": srs_model.Direction.W,
+}
+
+
+class CliArgumentParser(argparse.ArgumentParser):
+    def __init__(self, *, stderr: TextIO, **kwargs: object) -> None:
+        super().__init__(**kwargs)
+        self.stderr = stderr
+
+    def _print_message(self, message: str | None, file: TextIO | None = None) -> None:
+        super()._print_message(message, self.stderr)
+
+
+@dataclass(frozen=True, slots=True)
+class IntegratedCommand:
+    kind: str
+    directions: tuple[str, ...] = ()
+    raw: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class IntegratedCommandResult:
+    accepted: bool
+    command_type: str
+    summary_lines: tuple[str, ...]
+    changed_lrs_position: bool = False
+    changed_srs_position: bool = False
+    should_quit: bool = False
+
+
+@dataclass(slots=True)
+class IntegratedGameState:
+    lrs_state: lrs_engine.GameState
+    srs_state: srs_model.SrsGameState
+    last_event_summary: str | None = None
+    session_aborted: bool = False
+
+
+def build_parser(stderr: TextIO) -> argparse.ArgumentParser:
+    parser = CliArgumentParser(
+        stderr=stderr,
+        description="Play the Galactic Exodus integrated command-response prototype.",
+    )
+    parser.add_argument("--seed", type=int, help="Requested seed.")
+    return parser
+
+
+def parse_args(argv: Sequence[str], stderr: TextIO) -> argparse.Namespace:
+    parser = build_parser(stderr)
+    if not any(argument == "--seed" or argument.startswith("--seed=") for argument in argv):
+        parser.print_help(stderr)
+        raise SystemExit(0)
+    return parser.parse_args(argv)
+
+
+def parse_integrated_command(raw: str) -> IntegratedCommand:
+    normalized = _normalize_command_text(raw)
+    if normalized == "HELP":
+        return IntegratedCommand(kind=COMMAND_HELP, raw=normalized)
+    if normalized == "LOOK":
+        return IntegratedCommand(kind=COMMAND_LOOK, raw=normalized)
+    if normalized == "STATUS":
+        return IntegratedCommand(kind=COMMAND_STATUS, raw=normalized)
+    if normalized in {"Q", "QUIT"}:
+        return IntegratedCommand(kind=COMMAND_QUIT, raw=normalized)
+    if normalized == "INTERACT":
+        return IntegratedCommand(kind=COMMAND_INTERACT, raw=normalized)
+
+    tokens = normalized.split()
+    if len(tokens) == 1 and tokens[0] in _COMMAND_DIRECTIONS:
+        return IntegratedCommand(kind=COMMAND_MOVE, directions=(tokens[0],), raw=normalized)
+    if tokens and tokens[0] == "MOVE" and _all_directions(tokens[1:]):
+        return IntegratedCommand(kind=COMMAND_MOVE, directions=tuple(tokens[1:]), raw=normalized)
+    if tokens and tokens[0] == "EXIT" and _all_directions(tokens[1:]) and len(tokens[1:]) == 1:
+        return IntegratedCommand(kind=COMMAND_EXIT, directions=(tokens[1],), raw=normalized)
+    return IntegratedCommand(kind=COMMAND_UNKNOWN, raw=normalized)
+
+
+def create_integrated_game(seed: int) -> IntegratedGameState:
+    lrs_state = lrs_engine.create_game(seed)
+    sector_symbol = lrs_state.known_cells.get(lrs_state.player_position)
+    srs_state = _create_minimal_srs_for_sector(
+        seed=lrs_state.effective_seed,
+        lrs_position=lrs_state.player_position,
+        sector_symbol=sector_symbol,
+    )
+    return IntegratedGameState(
+        lrs_state=lrs_state,
+        srs_state=srs_state,
+        last_event_summary=f"GAME  started seed={lrs_state.effective_seed}",
+    )
+
+
+def execute_integrated_command(
+    state: IntegratedGameState,
+    command: IntegratedCommand,
+) -> IntegratedCommandResult:
+    if command.kind == COMMAND_HELP:
+        return IntegratedCommandResult(
+            accepted=True,
+            command_type=COMMAND_HELP,
+            summary_lines=("HELP  commands: N/E/S/W, MOVE <route>, INTERACT, EXIT <dir>, LOOK, STATUS, Q",),
+        )
+    if command.kind == COMMAND_LOOK:
+        return IntegratedCommandResult(
+            accepted=True,
+            command_type=COMMAND_LOOK,
+            summary_lines=("LOOK  current tactical response",),
+        )
+    if command.kind == COMMAND_STATUS:
+        return IntegratedCommandResult(
+            accepted=True,
+            command_type=COMMAND_STATUS,
+            summary_lines=("STATUS current ship status",),
+        )
+    if command.kind == COMMAND_QUIT:
+        return IntegratedCommandResult(
+            accepted=True,
+            command_type=COMMAND_QUIT,
+            summary_lines=("QUIT  session ended",),
+            should_quit=True,
+        )
+    if command.kind == COMMAND_MOVE:
+        return IntegratedCommandResult(
+            accepted=False,
+            command_type=COMMAND_MOVE,
+            summary_lines=("MOVE  rejected: movement is not implemented in integrated CLI yet",),
+        )
+    if command.kind == COMMAND_INTERACT:
+        return IntegratedCommandResult(
+            accepted=False,
+            command_type=COMMAND_INTERACT,
+            summary_lines=("INTERACT rejected: interaction is not implemented in integrated CLI yet",),
+        )
+    if command.kind == COMMAND_EXIT:
+        return IntegratedCommandResult(
+            accepted=False,
+            command_type=COMMAND_EXIT,
+            summary_lines=("EXIT  rejected: exit is not implemented in integrated CLI yet",),
+        )
+    return IntegratedCommandResult(
+        accepted=False,
+        command_type=COMMAND_UNKNOWN,
+        summary_lines=("COMMAND rejected: unknown command",),
+    )
+
+
+def render_integrated_response(
+    state: IntegratedGameState,
+    result: IntegratedCommandResult,
+) -> str:
+    blocks = [
+        "RESULT",
+        *result.summary_lines,
+        "",
+        "LRS",
+        render_lrs_border_light_map(state.lrs_state),
+        "",
+        "SRS",
+        render_display_map(state.srs_state),
+        "",
+        "HUD",
+        render_compact_hud(
+            CompactHudContext(
+                lrs_state=state.lrs_state,
+                srs_state=state.srs_state,
+                last_event_summary=state.last_event_summary,
+                cost_mode="TURN_ONLY",
+            )
+        ),
+    ]
+    return "\n".join(blocks) + "\n"
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    stdin: TextIO | None = None,
+    stdout: TextIO | None = None,
+    stderr: TextIO | None = None,
+) -> int:
+    effective_argv = list(sys.argv[1:] if argv is None else argv)
+    effective_stdin = sys.stdin if stdin is None else stdin
+    effective_stdout = sys.stdout if stdout is None else stdout
+    effective_stderr = sys.stderr if stderr is None else stderr
+    try:
+        args = parse_args(effective_argv, effective_stderr)
+    except SystemExit as exc:
+        return int(exc.code) if isinstance(exc.code, int) else 1
+
+    state = create_integrated_game(args.seed)
+    initial_summary = state.last_event_summary or f"GAME  started seed={args.seed}"
+    initial_result = IntegratedCommandResult(
+        accepted=True,
+        command_type="INIT",
+        summary_lines=(initial_summary,),
+    )
+    effective_stdout.write(render_integrated_response(state, initial_result))
+    while True:
+        effective_stdout.write("COMMAND> ")
+        effective_stdout.flush()
+        line = effective_stdin.readline()
+        if line == "":
+            break
+        command = parse_integrated_command(line)
+        result = execute_integrated_command(state, command)
+        if result.should_quit:
+            break
+        effective_stdout.write(render_integrated_response(state, result))
+    return 0
+
+
+def _normalize_command_text(raw: str) -> str:
+    stripped = raw.strip().upper().replace(",", " ")
+    return re.sub(r"\s+", " ", stripped)
+
+
+def _all_directions(tokens: Sequence[str]) -> bool:
+    return bool(tokens) and all(token in _COMMAND_DIRECTIONS for token in tokens)
+
+
+def _sector_type_for_lrs_symbol(symbol: str | None) -> srs_model.SectorType:
+    mapping = {
+        "N": srs_model.SectorType.NEBULA,
+        "A": srs_model.SectorType.ASTEROID,
+        "B": srs_model.SectorType.BASE,
+        "R": srs_model.SectorType.RESOURCE,
+        "S": srs_model.SectorType.NORMAL,
+        "H": srs_model.SectorType.NORMAL,
+        ".": srs_model.SectorType.NORMAL,
+    }
+    if symbol == "@" and hasattr(srs_model.SectorType, "GRAVITY"):
+        return srs_model.SectorType.GRAVITY
+    return mapping.get(symbol or "", srs_model.SectorType.NORMAL)
+
+
+def _create_minimal_srs_for_sector(
+    *,
+    seed: int,
+    lrs_position: tuple[int, int],
+    sector_symbol: str | None,
+    entry_direction: str | None = None,
+) -> srs_model.SrsGameState:
+    sector_type = _sector_type_for_lrs_symbol(sector_symbol)
+    player_position = _player_position_for_entry(entry_direction)
+    warp_flags = _warp_flags_for_entry(entry_direction)
+    rows = _make_floor_rows(warp_flags)
+    actual_map = srs_model.SrsActualMap(
+        width=_SRS_MAP_WIDTH,
+        height=_SRS_MAP_HEIGHT,
+        cells=tuple(tuple(row) for row in rows),
+    )
+    discovered_cells = _observed_positions(player_position, sector_type)
+    known_cells = {
+        position: actual_map.cell_at(position)
+        for position in discovered_cells
+    }
+    descriptor = srs_model.SectorDescriptor(
+        sector_id=f"lrs-{lrs_position[0]}-{lrs_position[1]}",
+        sector_type=sector_type,
+        sector_seed=seed,
+        entry_edge=_DIRECTION_ENUM.get(entry_direction or "S", srs_model.Direction.S),
+        blocked_edges=frozenset(),
+    )
+    persistent_state = srs_model.SrsPersistentState(
+        generated_map_id=f"{descriptor.sector_id}:{seed}",
+        generation_schema_version=1,
+        generation_seed=seed,
+        sector_type=sector_type,
+        blocked_edges=frozenset(),
+        warp_flags={
+            position: cell.warp_flags
+            for position, cell in known_cells.items()
+            if cell.warp_flags
+        },
+        discovered_cells=discovered_cells,
+    )
+    return srs_model.SrsGameState(
+        descriptor=descriptor,
+        actual_map=actual_map,
+        known_state=srs_model.SrsKnownState(
+            discovered_cells=discovered_cells,
+            known_cells=known_cells,
+            visited_cells=frozenset({player_position}),
+        ),
+        persistent_state=persistent_state,
+        player_position=player_position,
+        objects={},
+        combat_state=None,
+        srs_turn=0,
+        fuel=0,
+        max_fuel=0,
+    )
+
+
+def _player_position_for_entry(entry_direction: str | None) -> srs_model.Position:
+    if entry_direction is None:
+        return _SRS_CENTER
+    return _ENTRY_POSITIONS[entry_direction]
+
+
+def _warp_flags_for_entry(
+    entry_direction: str | None,
+) -> dict[srs_model.Position, frozenset[srs_model.Direction]]:
+    if entry_direction is None:
+        return {}
+    direction = _DIRECTION_ENUM[entry_direction]
+    return {_ENTRY_POSITIONS[entry_direction]: frozenset({direction})}
+
+
+def _make_floor_rows(
+    warp_flags: dict[srs_model.Position, frozenset[srs_model.Direction]],
+) -> list[list[srs_model.SrsCell]]:
+    rows: list[list[srs_model.SrsCell]] = []
+    for y in range(_SRS_MAP_HEIGHT):
+        row: list[srs_model.SrsCell] = []
+        for x in range(_SRS_MAP_WIDTH):
+            position = srs_model.Position(x, y)
+            row.append(
+                srs_model.SrsCell(
+                    terrain=srs_model.SrsTerrainType.FLOOR,
+                    warp_flags=warp_flags.get(position, frozenset()),
+                )
+            )
+        rows.append(row)
+    return rows
+
+
+def _observed_positions(
+    center: srs_model.Position,
+    sector_type: srs_model.SectorType,
+) -> frozenset[srs_model.Position]:
+    size = _NEBULA_SENSOR_SIZE if sector_type is srs_model.SectorType.NEBULA else _DEFAULT_SENSOR_SIZE
+    radius = size // 2
+    positions = set()
+    for dx in range(-radius, radius + 1):
+        for dy in range(-radius, radius + 1):
+            x = center.x + dx
+            y = center.y + dy
+            if 0 <= x < _SRS_MAP_WIDTH and 0 <= y < _SRS_MAP_HEIGHT:
+                positions.add(srs_model.Position(x, y))
+    return frozenset(positions)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/galactic_exodus/test_integrated_play.py
+++ b/experiments/galactic_exodus/test_integrated_play.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import io
+from pathlib import Path
+import subprocess
+import unittest
+
+from experiments.galactic_exodus import integrated_play
+from experiments.galactic_exodus.srs import model as srs_model
+
+
+class IntegratedPlayCliTests(unittest.TestCase):
+    def run_cli(self, argv: list[str], stdin_text: str) -> tuple[int, str, str]:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        exit_code = integrated_play.main(
+            argv,
+            stdin=io.StringIO(stdin_text),
+            stdout=stdout,
+            stderr=stderr,
+        )
+        return exit_code, stdout.getvalue(), stderr.getvalue()
+
+    def test_script_entrypoint_starts_with_seed_42(self) -> None:
+        result = subprocess.run(
+            ["python", "experiments/galactic_exodus/integrated_play.py", "--seed", "42"],
+            cwd=Path(__file__).resolve().parents[2],
+            input="Q\n",
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stderr, "")
+        self.assertIn("RESULT\n", result.stdout)
+        self.assertIn("GAME  started seed=42", result.stdout)
+        self.assertIn("LRS\n", result.stdout)
+        self.assertIn("SRS\n", result.stdout)
+        self.assertIn("HUD\n", result.stdout)
+        self.assertTrue(result.stdout.endswith("COMMAND> "))
+
+    def test_missing_seed_prints_help_without_starting_game(self) -> None:
+        exit_code, stdout, stderr = self.run_cli([], "")
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(stdout, "")
+        self.assertIn("--seed", stderr)
+
+    def test_invalid_seed_exits_with_argparse_error(self) -> None:
+        exit_code, stdout, stderr = self.run_cli(["--seed", "oops"], "")
+
+        self.assertEqual(exit_code, 2)
+        self.assertEqual(stdout, "")
+        self.assertIn("invalid int value", stderr)
+
+    def test_parser_normalizes_commands(self) -> None:
+        self.assertEqual(
+            integrated_play.parse_integrated_command(" e "),
+            integrated_play.IntegratedCommand(kind=integrated_play.COMMAND_MOVE, directions=("E",), raw="E"),
+        )
+        self.assertEqual(
+            integrated_play.parse_integrated_command("move e,e,n"),
+            integrated_play.IntegratedCommand(
+                kind=integrated_play.COMMAND_MOVE,
+                directions=("E", "E", "N"),
+                raw="MOVE E E N",
+            ),
+        )
+        self.assertEqual(
+            integrated_play.parse_integrated_command("move e e n"),
+            integrated_play.IntegratedCommand(
+                kind=integrated_play.COMMAND_MOVE,
+                directions=("E", "E", "N"),
+                raw="MOVE E E N",
+            ),
+        )
+        self.assertEqual(
+            integrated_play.parse_integrated_command("exit e"),
+            integrated_play.IntegratedCommand(
+                kind=integrated_play.COMMAND_EXIT,
+                directions=("E",),
+                raw="EXIT E",
+            ),
+        )
+        self.assertEqual(
+            integrated_play.parse_integrated_command("quit"),
+            integrated_play.IntegratedCommand(kind=integrated_play.COMMAND_QUIT, raw="QUIT"),
+        )
+        self.assertEqual(
+            integrated_play.parse_integrated_command("foo"),
+            integrated_play.IntegratedCommand(kind=integrated_play.COMMAND_UNKNOWN, raw="FOO"),
+        )
+
+    def test_create_integrated_game_creates_lrs_and_srs(self) -> None:
+        state = integrated_play.create_integrated_game(42)
+
+        self.assertIsNotNone(state.lrs_state)
+        self.assertIsNotNone(state.srs_state)
+        self.assertEqual(state.srs_state.player_position, srs_model.Position(4, 4))
+        self.assertEqual(state.last_event_summary, "GAME  started seed=42")
+
+    def test_look_does_not_change_state(self) -> None:
+        state = integrated_play.create_integrated_game(42)
+        old_lrs = state.lrs_state.player_position
+        old_srs = state.srs_state.player_position
+
+        result = integrated_play.execute_integrated_command(
+            state,
+            integrated_play.IntegratedCommand(kind=integrated_play.COMMAND_LOOK),
+        )
+
+        self.assertTrue(result.accepted)
+        self.assertEqual(state.lrs_state.player_position, old_lrs)
+        self.assertEqual(state.srs_state.player_position, old_srs)
+
+    def test_status_does_not_change_state(self) -> None:
+        state = integrated_play.create_integrated_game(42)
+        old_lrs = state.lrs_state.player_position
+        old_srs = state.srs_state.player_position
+
+        result = integrated_play.execute_integrated_command(
+            state,
+            integrated_play.IntegratedCommand(kind=integrated_play.COMMAND_STATUS),
+        )
+
+        self.assertTrue(result.accepted)
+        self.assertEqual(state.lrs_state.player_position, old_lrs)
+        self.assertEqual(state.srs_state.player_position, old_srs)
+
+    def test_help_does_not_change_state_and_lists_future_commands(self) -> None:
+        state = integrated_play.create_integrated_game(42)
+        old_lrs = state.lrs_state.player_position
+        old_srs = state.srs_state.player_position
+
+        result = integrated_play.execute_integrated_command(
+            state,
+            integrated_play.IntegratedCommand(kind=integrated_play.COMMAND_HELP),
+        )
+
+        self.assertTrue(result.accepted)
+        self.assertEqual(state.lrs_state.player_position, old_lrs)
+        self.assertEqual(state.srs_state.player_position, old_srs)
+        self.assertIn("N/E/S/W", result.summary_lines[0])
+        self.assertIn("EXIT <dir>", result.summary_lines[0])
+
+    def test_unknown_command_rejected_without_crash(self) -> None:
+        state = integrated_play.create_integrated_game(42)
+        old_lrs = state.lrs_state.player_position
+        old_srs = state.srs_state.player_position
+
+        result = integrated_play.execute_integrated_command(
+            state,
+            integrated_play.IntegratedCommand(kind=integrated_play.COMMAND_UNKNOWN, raw="FOO"),
+        )
+
+        self.assertFalse(result.accepted)
+        self.assertEqual(result.command_type, integrated_play.COMMAND_UNKNOWN)
+        self.assertEqual(state.lrs_state.player_position, old_lrs)
+        self.assertEqual(state.srs_state.player_position, old_srs)
+        self.assertIn("COMMAND rejected: unknown command", result.summary_lines[0])
+
+    def test_move_currently_rejected_without_changing_positions(self) -> None:
+        state = integrated_play.create_integrated_game(42)
+        old_lrs = state.lrs_state.player_position
+        old_srs = state.srs_state.player_position
+
+        result = integrated_play.execute_integrated_command(
+            state,
+            integrated_play.parse_integrated_command("E"),
+        )
+
+        self.assertFalse(result.accepted)
+        self.assertEqual(result.command_type, integrated_play.COMMAND_MOVE)
+        self.assertEqual(state.lrs_state.player_position, old_lrs)
+        self.assertEqual(state.srs_state.player_position, old_srs)
+        self.assertIn("movement is not implemented", result.summary_lines[0])
+
+    def test_exit_currently_rejected_without_changing_positions(self) -> None:
+        state = integrated_play.create_integrated_game(42)
+        old_lrs = state.lrs_state.player_position
+        old_srs = state.srs_state.player_position
+
+        result = integrated_play.execute_integrated_command(
+            state,
+            integrated_play.parse_integrated_command("EXIT E"),
+        )
+
+        self.assertFalse(result.accepted)
+        self.assertEqual(result.command_type, integrated_play.COMMAND_EXIT)
+        self.assertEqual(state.lrs_state.player_position, old_lrs)
+        self.assertEqual(state.srs_state.player_position, old_srs)
+        self.assertIn("exit is not implemented", result.summary_lines[0])
+
+    def test_interact_currently_rejected_without_changing_positions(self) -> None:
+        state = integrated_play.create_integrated_game(42)
+        old_lrs = state.lrs_state.player_position
+        old_srs = state.srs_state.player_position
+
+        result = integrated_play.execute_integrated_command(
+            state,
+            integrated_play.parse_integrated_command("INTERACT"),
+        )
+
+        self.assertFalse(result.accepted)
+        self.assertEqual(result.command_type, integrated_play.COMMAND_INTERACT)
+        self.assertEqual(state.lrs_state.player_position, old_lrs)
+        self.assertEqual(state.srs_state.player_position, old_srs)
+        self.assertIn("interaction is not implemented", result.summary_lines[0])
+
+    def test_response_section_order(self) -> None:
+        state = integrated_play.create_integrated_game(42)
+        result = integrated_play.IntegratedCommandResult(
+            accepted=True,
+            command_type="INIT",
+            summary_lines=("GAME  started seed=42",),
+        )
+
+        rendered = integrated_play.render_integrated_response(state, result)
+
+        result_index = rendered.find("RESULT\n")
+        lrs_index = rendered.find("\nLRS\n")
+        srs_index = rendered.find("\nSRS\n")
+        hud_index = rendered.find("\nHUD\n")
+        self.assertTrue(result_index < lrs_index < srs_index < hud_index)
+
+    def test_readme_mentions_integrated_cli(self) -> None:
+        readme = Path("experiments/galactic_exodus/README.md").read_text(encoding="utf-8")
+
+        self.assertIn("integrated_play.py", readme)
+        self.assertIn("python experiments/galactic_exodus/integrated_play.py --seed 42", readme)
+
+    def test_initial_display_snapshot_contains_expected_sections_in_order(self) -> None:
+        _, stdout, _ = self.run_cli(["--seed", "42"], "Q\n")
+
+        expected_fragments = [
+            "RESULT\n",
+            "GAME  started seed=42",
+            "LRS\n",
+            "  +---+---+---+---+---+---+---+---+\n",
+            "SRS\n",
+            " 9  ",
+            "HUD\n",
+            "SECTOR",
+            "COMMAND> ",
+        ]
+        current_index = -1
+        for fragment in expected_fragments:
+            next_index = stdout.find(fragment, current_index + 1)
+            self.assertNotEqual(next_index, -1, fragment)
+            self.assertGreater(next_index, current_index, fragment)
+            current_index = next_index


### PR DESCRIPTION
## 概要

Closes #1242

`experiments/galactic_exodus/integrated_play.py` を追加し、LRS / SRS / HUD をまとめて返す command-response CLI の土台を実装しました。

- `IntegratedCommand` / `IntegratedCommandResult` / `IntegratedGameState` を追加
- `--seed` 必須の CLI 入口、初期表示、`COMMAND> ` ループを追加
- `HELP` / `LOOK` / `STATUS` / `Q` / unknown command を実装
- `N/E/S/W` / `MOVE` / `INTERACT` / `EXIT` は parser で認識し、この段階では rejected として応答
- 現在の LRS セクタ記号から最小 9x9 SRS 状態を構築する helper を `integrated_play.py` 内に集約
- README に統合 CLI の起動方法と現段階の制約を追記
- 新規 `test_integrated_play.py` で parser / state / response / entrypoint の回帰を追加

## 確認

- `python -m unittest experiments.galactic_exodus.test_integrated_play`
- `python -m unittest experiments.galactic_exodus.test_play`
- `python -m unittest experiments.galactic_exodus.test_display`
- `python -m unittest experiments.galactic_exodus.test_hud`
- `python -m unittest experiments.galactic_exodus.test_event_format`
- `python -m unittest experiments.galactic_exodus.srs.test_render`
- `python -m unittest experiments.galactic_exodus.srs.test_event_format`
- `python -m unittest discover experiments/galactic_exodus/srs`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`

## 補足

- `python -m unittest discover experiments/galactic_exodus` は既存の `experiments.galactic_exodus.srs.test_evaluate_policies` 2件失敗のため未通過でした
  - `EvaluatePoliciesCliTests.test_same_cli_equivalent_processing_is_fully_reproducible`
  - `EvaluatePoliciesCliTests.test_main_returns_non_zero_on_write_failure`
