### PR TITLE
integrated CLI に SRS movement command を接続

### DIFF
--- a/experiments/galactic_exodus/integrated_play.py
+++ b/experiments/galactic_exodus/integrated_play.py
@@ -15,8 +15,15 @@ if __package__ in (None, ""):
 from experiments.galactic_exodus import engine as lrs_engine
 from experiments.galactic_exodus.display import render_lrs_border_light_map
 from experiments.galactic_exodus.hud import CompactHudContext, render_compact_hud
+from experiments.galactic_exodus.srs import engine as srs_engine
+from experiments.galactic_exodus.srs import event_format as srs_event_format
+from experiments.galactic_exodus.srs.contracts import load_default_contracts
 from experiments.galactic_exodus.srs import model as srs_model
 from experiments.galactic_exodus.srs.render import render_display_map
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRS_CONTRACTS = load_default_contracts(REPO_ROOT)
 
 
 COMMAND_LOOK = "LOOK"
@@ -115,7 +122,7 @@ def parse_integrated_command(raw: str) -> IntegratedCommand:
     tokens = normalized.split()
     if len(tokens) == 1 and tokens[0] in _COMMAND_DIRECTIONS:
         return IntegratedCommand(kind=COMMAND_MOVE, directions=(tokens[0],), raw=normalized)
-    if tokens and tokens[0] == "MOVE" and _all_directions(tokens[1:]):
+    if tokens and tokens[0] == "MOVE" and tokens[1:]:
         return IntegratedCommand(kind=COMMAND_MOVE, directions=tuple(tokens[1:]), raw=normalized)
     if tokens and tokens[0] == "EXIT" and _all_directions(tokens[1:]) and len(tokens[1:]) == 1:
         return IntegratedCommand(kind=COMMAND_EXIT, directions=(tokens[1],), raw=normalized)
@@ -167,11 +174,7 @@ def execute_integrated_command(
             should_quit=True,
         )
     if command.kind == COMMAND_MOVE:
-        return IntegratedCommandResult(
-            accepted=False,
-            command_type=COMMAND_MOVE,
-            summary_lines=("MOVE  rejected: movement is not implemented in integrated CLI yet",),
-        )
+        return _execute_move_command(state, command)
     if command.kind == COMMAND_INTERACT:
         return IntegratedCommandResult(
             accepted=False,
@@ -263,6 +266,56 @@ def _normalize_command_text(raw: str) -> str:
 
 def _all_directions(tokens: Sequence[str]) -> bool:
     return bool(tokens) and all(token in _COMMAND_DIRECTIONS for token in tokens)
+
+
+def _execute_move_command(
+    state: IntegratedGameState,
+    command: IntegratedCommand,
+) -> IntegratedCommandResult:
+    if not _all_directions(command.directions):
+        summary = "MOVE  rejected: invalid direction"
+        state.last_event_summary = summary
+        return IntegratedCommandResult(
+            accepted=False,
+            command_type=COMMAND_MOVE,
+            summary_lines=(summary,),
+            changed_lrs_position=False,
+            changed_srs_position=False,
+        )
+
+    route = tuple(_DIRECTION_ENUM[direction] for direction in command.directions)
+    previous_position = state.srs_state.player_position
+    result = srs_engine.apply_srs_command(
+        state.srs_state,
+        srs_model.SrsCommand(command_type="MOVE_ROUTE", route=route),
+        contracts=SRS_CONTRACTS,
+    )
+    state.srs_state = result.state
+
+    summary_lines = tuple(_format_summary_lines(result.events))
+    if summary_lines:
+        state.last_event_summary = summary_lines[0]
+
+    return IntegratedCommandResult(
+        accepted=_movement_result_accepted(result),
+        command_type=COMMAND_MOVE,
+        summary_lines=summary_lines,
+        changed_lrs_position=False,
+        changed_srs_position=result.state.player_position != previous_position,
+    )
+
+
+def _format_summary_lines(events: Sequence[srs_model.SrsTurnEvent]) -> list[str]:
+    summary_lines: list[str] = []
+    for event in events:
+        summary_lines.extend(srs_event_format.format_srs_event_summary_lines(event))
+    return summary_lines
+
+
+def _movement_result_accepted(result: srs_model.SrsCommandResult) -> bool:
+    if not result.events:
+        return False
+    return result.events[0].event_type != srs_engine.MOVE_REJECTED
 
 
 def _sector_type_for_lrs_symbol(symbol: str | None) -> srs_model.SectorType:

--- a/experiments/galactic_exodus/test_integrated_play.py
+++ b/experiments/galactic_exodus/test_integrated_play.py
@@ -160,7 +160,7 @@ class IntegratedPlayCliTests(unittest.TestCase):
         self.assertEqual(state.srs_state.player_position, old_srs)
         self.assertIn("COMMAND rejected: unknown command", result.summary_lines[0])
 
-    def test_move_currently_rejected_without_changing_positions(self) -> None:
+    def test_direction_command_moves_only_srs(self) -> None:
         state = integrated_play.create_integrated_game(42)
         old_lrs = state.lrs_state.player_position
         old_srs = state.srs_state.player_position
@@ -170,11 +170,89 @@ class IntegratedPlayCliTests(unittest.TestCase):
             integrated_play.parse_integrated_command("E"),
         )
 
-        self.assertFalse(result.accepted)
+        self.assertTrue(result.accepted)
+        self.assertEqual(result.command_type, integrated_play.COMMAND_MOVE)
+        self.assertFalse(result.changed_lrs_position)
+        self.assertTrue(result.changed_srs_position)
+        self.assertEqual(state.lrs_state.player_position, old_lrs)
+        self.assertEqual(state.srs_state.player_position, srs_model.Position(old_srs.x + 1, old_srs.y))
+        self.assertTrue(result.summary_lines[0].startswith("MOVE  accepted"))
+
+    def test_repeated_direction_commands_never_move_lrs(self) -> None:
+        state = integrated_play.create_integrated_game(42)
+        old_lrs = state.lrs_state.player_position
+
+        first = integrated_play.execute_integrated_command(
+            state,
+            integrated_play.parse_integrated_command("E"),
+        )
+        second = integrated_play.execute_integrated_command(
+            state,
+            integrated_play.parse_integrated_command("E"),
+        )
+
+        self.assertTrue(first.accepted)
+        self.assertTrue(second.accepted)
+        self.assertEqual(state.lrs_state.player_position, old_lrs)
+
+    def test_move_route_comma_syntax_moves_only_srs(self) -> None:
+        state = integrated_play.create_integrated_game(42)
+        old_lrs = state.lrs_state.player_position
+
+        result = integrated_play.execute_integrated_command(
+            state,
+            integrated_play.parse_integrated_command("MOVE E,E,N"),
+        )
+
+        self.assertTrue(result.accepted)
         self.assertEqual(result.command_type, integrated_play.COMMAND_MOVE)
         self.assertEqual(state.lrs_state.player_position, old_lrs)
+        self.assertEqual(state.srs_state.player_position, srs_model.Position(6, 5))
+        self.assertTrue(result.summary_lines[0].startswith("MOVE  accepted"))
+
+    def test_move_route_whitespace_syntax_moves_only_srs(self) -> None:
+        state = integrated_play.create_integrated_game(42)
+        old_lrs = state.lrs_state.player_position
+
+        result = integrated_play.execute_integrated_command(
+            state,
+            integrated_play.parse_integrated_command("MOVE E E N"),
+        )
+
+        self.assertTrue(result.accepted)
+        self.assertEqual(result.command_type, integrated_play.COMMAND_MOVE)
+        self.assertEqual(state.lrs_state.player_position, old_lrs)
+        self.assertEqual(state.srs_state.player_position, srs_model.Position(6, 5))
+        self.assertTrue(result.summary_lines[0].startswith("MOVE  accepted"))
+
+    def test_move_invalid_direction_rejected_without_changing_positions(self) -> None:
+        state = integrated_play.create_integrated_game(42)
+        old_lrs = state.lrs_state.player_position
+        old_srs = state.srs_state.player_position
+
+        result = integrated_play.execute_integrated_command(
+            state,
+            integrated_play.parse_integrated_command("MOVE X"),
+        )
+
+        self.assertFalse(result.accepted)
+        self.assertEqual(result.command_type, integrated_play.COMMAND_MOVE)
+        self.assertFalse(result.changed_lrs_position)
+        self.assertFalse(result.changed_srs_position)
+        self.assertEqual(state.lrs_state.player_position, old_lrs)
         self.assertEqual(state.srs_state.player_position, old_srs)
-        self.assertIn("movement is not implemented", result.summary_lines[0])
+        self.assertIn("invalid direction", result.summary_lines[0])
+
+    def test_hud_last_updates_after_move(self) -> None:
+        state = integrated_play.create_integrated_game(42)
+
+        result = integrated_play.execute_integrated_command(
+            state,
+            integrated_play.parse_integrated_command("E"),
+        )
+        rendered = integrated_play.render_integrated_response(state, result)
+
+        self.assertIn("LAST    MOVE  accepted", rendered)
 
     def test_exit_currently_rejected_without_changing_positions(self) -> None:
         state = integrated_play.create_integrated_game(42)


### PR DESCRIPTION
Closes #1243

## 概要

- `integrated_play.py` の `MOVE` 分岐を SRS engine の `MOVE_ROUTE` に接続
- `N/E/S/W` と `MOVE <route>` を SRS 内移動として実行し、LRS position は変更しないように維持
- SRS event formatter の summary を `RESULT` と `HUD LAST` に反映
- `MOVE X` のような不正 direction を `MOVE  rejected: invalid direction` として処理
- integrated CLI の移動系テストを追加

## 確認

- `python -m unittest experiments.galactic_exodus.test_integrated_play` : OK
- `python -m unittest experiments.galactic_exodus.srs.test_render` : OK
- `python -m unittest experiments.galactic_exodus.srs.test_event_format` : OK
- `python -m unittest discover experiments/galactic_exodus/srs` : OK
- `python -m unittest discover experiments/galactic_exodus` : FAILED
  - `srs.test_evaluate_policies.EvaluatePoliciesCliTests.test_same_cli_equivalent_processing_is_fully_reproducible`
  - `srs.test_evaluate_policies.EvaluatePoliciesCliTests.test_main_returns_non_zero_on_write_failure`
  - いずれも `experiments/galactic_exodus/srs/test_evaluate_policies.py` の既存失敗で、今回の `integrated_play.py` / `test_integrated_play.py` 変更とは無関係
- `cargo fmt --check` : OK
- `cargo clippy --all-targets -- -D warnings` : OK
- `cargo test` : OK
