### PR TITLE
Galactic Exodus: integrated CLI に EXIT command / LRS移動を接続する

### DIFF
--- a/experiments/galactic_exodus/integrated_play.py
+++ b/experiments/galactic_exodus/integrated_play.py
@@ -53,6 +53,13 @@ _DIRECTION_ENUM = {
     "S": srs_model.Direction.S,
     "W": srs_model.Direction.W,
 }
+_LRS_DIRECTION_DELTAS = lrs_engine.COMMAND_DELTAS
+_ALL_EXIT_WARP_FLAGS = {
+    _ENTRY_POSITIONS["N"]: frozenset({_DIRECTION_ENUM["N"]}),
+    _ENTRY_POSITIONS["E"]: frozenset({_DIRECTION_ENUM["E"]}),
+    _ENTRY_POSITIONS["S"]: frozenset({_DIRECTION_ENUM["S"]}),
+    _ENTRY_POSITIONS["W"]: frozenset({_DIRECTION_ENUM["W"]}),
+}
 
 
 class CliArgumentParser(argparse.ArgumentParser):
@@ -124,7 +131,7 @@ def parse_integrated_command(raw: str) -> IntegratedCommand:
         return IntegratedCommand(kind=COMMAND_MOVE, directions=(tokens[0],), raw=normalized)
     if tokens and tokens[0] == "MOVE" and tokens[1:]:
         return IntegratedCommand(kind=COMMAND_MOVE, directions=tuple(tokens[1:]), raw=normalized)
-    if tokens and tokens[0] == "EXIT" and _all_directions(tokens[1:]) and len(tokens[1:]) == 1:
+    if tokens and tokens[0] == "EXIT" and len(tokens[1:]) == 1:
         return IntegratedCommand(kind=COMMAND_EXIT, directions=(tokens[1],), raw=normalized)
     return IntegratedCommand(kind=COMMAND_UNKNOWN, raw=normalized)
 
@@ -182,11 +189,7 @@ def execute_integrated_command(
             summary_lines=("INTERACT rejected: interaction is not implemented in integrated CLI yet",),
         )
     if command.kind == COMMAND_EXIT:
-        return IntegratedCommandResult(
-            accepted=False,
-            command_type=COMMAND_EXIT,
-            summary_lines=("EXIT  rejected: exit is not implemented in integrated CLI yet",),
-        )
+        return _execute_exit_command(state, command)
     return IntegratedCommandResult(
         accepted=False,
         command_type=COMMAND_UNKNOWN,
@@ -318,6 +321,150 @@ def _movement_result_accepted(result: srs_model.SrsCommandResult) -> bool:
     return result.events[0].event_type != srs_engine.MOVE_REJECTED
 
 
+def _execute_exit_command(
+    state: IntegratedGameState,
+    command: IntegratedCommand,
+) -> IntegratedCommandResult:
+    direction = command.directions[0] if command.directions else ""
+    if direction not in _COMMAND_DIRECTIONS:
+        summary = "EXIT  rejected: invalid direction"
+        state.last_event_summary = summary
+        return IntegratedCommandResult(
+            accepted=False,
+            command_type=COMMAND_EXIT,
+            summary_lines=(summary,),
+            changed_lrs_position=False,
+            changed_srs_position=False,
+        )
+
+    previous_srs_position = state.srs_state.player_position
+    warp_result = srs_engine.apply_srs_command(
+        state.srs_state,
+        srs_model.SrsCommand(command_type="WARP_EXIT", exit_direction=_DIRECTION_ENUM[direction]),
+        contracts=SRS_CONTRACTS,
+    )
+    if not _warp_exit_result_accepted(warp_result):
+        summary = _warp_exit_rejected_summary(direction, previous_srs_position)
+        state.last_event_summary = summary
+        return IntegratedCommandResult(
+            accepted=False,
+            command_type=COMMAND_EXIT,
+            summary_lines=(summary,),
+            changed_lrs_position=False,
+            changed_srs_position=False,
+        )
+
+    lrs_state = state.lrs_state
+    old_lrs_position = lrs_state.player_position
+    new_lrs_position = _exit_destination(old_lrs_position, direction)
+    if not lrs_engine.is_inside_board(new_lrs_position):
+        summary = f"EXIT  rejected: {direction} would leave LRS map"
+        state.last_event_summary = summary
+        return IntegratedCommandResult(
+            accepted=False,
+            command_type=COMMAND_EXIT,
+            summary_lines=(summary,),
+            changed_lrs_position=False,
+            changed_srs_position=False,
+        )
+
+    edge = _normalize_lrs_edge(old_lrs_position, new_lrs_position)
+    if lrs_state.known_routes.get(edge) == lrs_engine.ROUTE_RIFT:
+        summary = f"EXIT  rejected: {direction} edge is blocked by RIFT"
+        state.last_event_summary = summary
+        return IntegratedCommandResult(
+            accepted=False,
+            command_type=COMMAND_EXIT,
+            summary_lines=(summary,),
+            changed_lrs_position=False,
+            changed_srs_position=False,
+        )
+
+    old_position, moved_position = _apply_lrs_exit_move(lrs_state, direction)
+    sector_symbol = state.lrs_state.known_cells.get(moved_position)
+    state.srs_state = _create_minimal_srs_for_sector(
+        seed=state.lrs_state.effective_seed,
+        lrs_position=moved_position,
+        sector_symbol=sector_symbol,
+        entry_direction=_opposite_direction(direction),
+    )
+
+    entered_sector_type = state.srs_state.descriptor.sector_type.value
+    summary_lines = (
+        f"EXIT  {direction} accepted from SRS={_display_srs_position(previous_srs_position)}",
+        f"LRS   moved {direction}: LRS={_display_lrs_position(old_position)} -> LRS={_display_lrs_position(moved_position)}",
+        f"SRS   entered sector TYPE={entered_sector_type} at SRS={_display_srs_position(state.srs_state.player_position)}",
+    )
+    state.last_event_summary = summary_lines[-1]
+    return IntegratedCommandResult(
+        accepted=True,
+        command_type=COMMAND_EXIT,
+        summary_lines=summary_lines,
+        changed_lrs_position=old_position != moved_position,
+        changed_srs_position=state.srs_state.player_position != previous_srs_position,
+    )
+
+
+def _warp_exit_result_accepted(result: srs_model.SrsCommandResult) -> bool:
+    if not result.events:
+        return False
+    return result.events[0].event_type == srs_engine.WARP_EXIT_ACCEPTED
+
+
+def _warp_exit_rejected_summary(
+    direction: str,
+    position: srs_model.Position,
+) -> str:
+    return f"EXIT  rejected: no {direction} warp point at SRS={_display_srs_position(position)}"
+
+
+def _apply_lrs_exit_move(
+    state: lrs_engine.GameState,
+    direction: str,
+) -> tuple[tuple[int, int], tuple[int, int]]:
+    old_position = state.player_position
+    new_position = _exit_destination(old_position, direction)
+    edge = _normalize_lrs_edge(old_position, new_position)
+
+    state.player_position = new_position
+    state.visited_cells.add(new_position)
+    state.known_routes[edge] = lrs_engine.ROUTE_OPEN
+    state.turn_count += 1
+    state.path.append(new_position)
+    lrs_engine.reveal_neighborhood(state, new_position)
+    state.game_status = lrs_engine.determine_game_status(state)
+    return old_position, new_position
+
+
+def _exit_destination(position: tuple[int, int], direction: str) -> tuple[int, int]:
+    return lrs_engine.move_position(position, _LRS_DIRECTION_DELTAS[direction])
+
+
+def _normalize_lrs_edge(
+    start: tuple[int, int],
+    goal: tuple[int, int],
+) -> tuple[tuple[int, int], tuple[int, int]]:
+    return lrs_engine.simulate.normalize_edge(start, goal)
+
+
+def _opposite_direction(direction: str) -> str:
+    opposites = {
+        "N": "S",
+        "E": "W",
+        "S": "N",
+        "W": "E",
+    }
+    return opposites[direction]
+
+
+def _display_lrs_position(position: tuple[int, int]) -> str:
+    return f"({position[0]},{position[1]})"
+
+
+def _display_srs_position(position: srs_model.Position) -> str:
+    return f"({position.x + 1},{position.y + 1})"
+
+
 def _sector_type_for_lrs_symbol(symbol: str | None) -> srs_model.SectorType:
     mapping = {
         "N": srs_model.SectorType.NEBULA,
@@ -401,10 +548,7 @@ def _player_position_for_entry(entry_direction: str | None) -> srs_model.Positio
 def _warp_flags_for_entry(
     entry_direction: str | None,
 ) -> dict[srs_model.Position, frozenset[srs_model.Direction]]:
-    if entry_direction is None:
-        return {}
-    direction = _DIRECTION_ENUM[entry_direction]
-    return {_ENTRY_POSITIONS[entry_direction]: frozenset({direction})}
+    return dict(_ALL_EXIT_WARP_FLAGS)
 
 
 def _make_floor_rows(

--- a/experiments/galactic_exodus/test_integrated_play.py
+++ b/experiments/galactic_exodus/test_integrated_play.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import subprocess
 import unittest
 
+from experiments.galactic_exodus import engine as lrs_engine
 from experiments.galactic_exodus import integrated_play
 from experiments.galactic_exodus.srs import model as srs_model
 
@@ -81,6 +82,14 @@ class IntegratedPlayCliTests(unittest.TestCase):
                 kind=integrated_play.COMMAND_EXIT,
                 directions=("E",),
                 raw="EXIT E",
+            ),
+        )
+        self.assertEqual(
+            integrated_play.parse_integrated_command("exit x"),
+            integrated_play.IntegratedCommand(
+                kind=integrated_play.COMMAND_EXIT,
+                directions=("X",),
+                raw="EXIT X",
             ),
         )
         self.assertEqual(
@@ -254,10 +263,11 @@ class IntegratedPlayCliTests(unittest.TestCase):
 
         self.assertIn("LAST    MOVE  accepted", rendered)
 
-    def test_exit_currently_rejected_without_changing_positions(self) -> None:
+    def test_exit_rejected_without_matching_warp_flag(self) -> None:
         state = integrated_play.create_integrated_game(42)
         old_lrs = state.lrs_state.player_position
         old_srs = state.srs_state.player_position
+        state.srs_state = self._replace_srs_position(state.srs_state, srs_model.Position(4, 4))
 
         result = integrated_play.execute_integrated_command(
             state,
@@ -267,8 +277,138 @@ class IntegratedPlayCliTests(unittest.TestCase):
         self.assertFalse(result.accepted)
         self.assertEqual(result.command_type, integrated_play.COMMAND_EXIT)
         self.assertEqual(state.lrs_state.player_position, old_lrs)
+        self.assertEqual(state.srs_state.player_position, srs_model.Position(4, 4))
+        self.assertEqual(old_srs, srs_model.Position(4, 4))
+        self.assertIn("no E warp point", result.summary_lines[0])
+
+    def test_exit_accepted_moves_lrs_east_and_enters_new_srs_from_west(self) -> None:
+        state = integrated_play.create_integrated_game(42)
+        state.lrs_state.player_position = (1, 1)
+        state.srs_state = self._replace_srs_position(state.srs_state, srs_model.Position(8, 4))
+
+        result = integrated_play.execute_integrated_command(
+            state,
+            integrated_play.parse_integrated_command("EXIT E"),
+        )
+
+        self.assertTrue(result.accepted)
+        self.assertTrue(result.changed_lrs_position)
+        self.assertTrue(result.changed_srs_position)
+        self.assertEqual(state.lrs_state.player_position, (2, 1))
+        self.assertEqual(state.srs_state.player_position, srs_model.Position(0, 4))
+        self.assertIn("EXIT  E accepted from SRS=(9,5)", result.summary_lines[0])
+        self.assertIn("LRS   moved E: LRS=(1,1) -> LRS=(2,1)", result.summary_lines[1])
+        self.assertIn("SRS   entered sector TYPE=", result.summary_lines[2])
+        self.assertIn("at SRS=(1,5)", result.summary_lines[2])
+
+    def test_exit_out_of_bounds_rejected(self) -> None:
+        state = integrated_play.create_integrated_game(42)
+        state.lrs_state.player_position = (8, 8)
+        state.srs_state = self._replace_srs_position(state.srs_state, srs_model.Position(8, 4))
+
+        result = integrated_play.execute_integrated_command(
+            state,
+            integrated_play.parse_integrated_command("EXIT E"),
+        )
+
+        self.assertFalse(result.accepted)
+        self.assertEqual(state.lrs_state.player_position, (8, 8))
+        self.assertEqual(state.srs_state.player_position, srs_model.Position(8, 4))
+        self.assertIn("would leave LRS map", result.summary_lines[0])
+
+    def test_exit_known_rift_rejected(self) -> None:
+        state = integrated_play.create_integrated_game(42)
+        state.lrs_state.player_position = (1, 1)
+        blocked_edge = lrs_engine.simulate.normalize_edge((1, 1), (2, 1))
+        state.lrs_state.known_routes[blocked_edge] = lrs_engine.ROUTE_RIFT
+        state.srs_state = self._replace_srs_position(state.srs_state, srs_model.Position(8, 4))
+
+        result = integrated_play.execute_integrated_command(
+            state,
+            integrated_play.parse_integrated_command("EXIT E"),
+        )
+
+        self.assertFalse(result.accepted)
+        self.assertEqual(state.lrs_state.player_position, (1, 1))
+        self.assertEqual(state.srs_state.player_position, srs_model.Position(8, 4))
+        self.assertIn("edge is blocked by RIFT", result.summary_lines[0])
+
+    def test_exit_invalid_direction_rejected_without_changing_positions(self) -> None:
+        state = integrated_play.create_integrated_game(42)
+        old_lrs = state.lrs_state.player_position
+        old_srs = state.srs_state.player_position
+
+        result = integrated_play.execute_integrated_command(
+            state,
+            integrated_play.parse_integrated_command("EXIT X"),
+        )
+
+        self.assertFalse(result.accepted)
+        self.assertEqual(result.command_type, integrated_play.COMMAND_EXIT)
+        self.assertEqual(state.lrs_state.player_position, old_lrs)
         self.assertEqual(state.srs_state.player_position, old_srs)
-        self.assertIn("exit is not implemented", result.summary_lines[0])
+        self.assertIn("invalid direction", result.summary_lines[0])
+
+    def test_hud_last_updates_after_exit(self) -> None:
+        state = integrated_play.create_integrated_game(42)
+        state.lrs_state.player_position = (1, 1)
+        state.srs_state = self._replace_srs_position(state.srs_state, srs_model.Position(8, 4))
+
+        result = integrated_play.execute_integrated_command(
+            state,
+            integrated_play.parse_integrated_command("EXIT E"),
+        )
+        rendered = integrated_play.render_integrated_response(state, result)
+
+        self.assertIn("LAST    SRS   entered sector TYPE=", rendered)
+
+    def test_initial_srs_has_all_four_exit_warp_flags(self) -> None:
+        state = integrated_play.create_integrated_game(42)
+
+        self.assertEqual(
+            state.srs_state.actual_map.cell_at(srs_model.Position(0, 4)).warp_flags,
+            frozenset({srs_model.Direction.W}),
+        )
+        self.assertEqual(
+            state.srs_state.actual_map.cell_at(srs_model.Position(8, 4)).warp_flags,
+            frozenset({srs_model.Direction.E}),
+        )
+        self.assertEqual(
+            state.srs_state.actual_map.cell_at(srs_model.Position(4, 0)).warp_flags,
+            frozenset({srs_model.Direction.S}),
+        )
+        self.assertEqual(
+            state.srs_state.actual_map.cell_at(srs_model.Position(4, 8)).warp_flags,
+            frozenset({srs_model.Direction.N}),
+        )
+
+    def test_new_srs_after_exit_keeps_all_four_exit_warp_flags(self) -> None:
+        state = integrated_play.create_integrated_game(42)
+        state.lrs_state.player_position = (1, 1)
+        state.srs_state = self._replace_srs_position(state.srs_state, srs_model.Position(8, 4))
+
+        integrated_play.execute_integrated_command(
+            state,
+            integrated_play.parse_integrated_command("EXIT E"),
+        )
+
+        self.assertEqual(state.srs_state.player_position, srs_model.Position(0, 4))
+        self.assertEqual(
+            state.srs_state.actual_map.cell_at(srs_model.Position(0, 4)).warp_flags,
+            frozenset({srs_model.Direction.W}),
+        )
+        self.assertEqual(
+            state.srs_state.actual_map.cell_at(srs_model.Position(8, 4)).warp_flags,
+            frozenset({srs_model.Direction.E}),
+        )
+        self.assertEqual(
+            state.srs_state.actual_map.cell_at(srs_model.Position(4, 0)).warp_flags,
+            frozenset({srs_model.Direction.S}),
+        )
+        self.assertEqual(
+            state.srs_state.actual_map.cell_at(srs_model.Position(4, 8)).warp_flags,
+            frozenset({srs_model.Direction.N}),
+        )
 
     def test_interact_currently_rejected_without_changing_positions(self) -> None:
         state = integrated_play.create_integrated_game(42)
@@ -328,3 +468,21 @@ class IntegratedPlayCliTests(unittest.TestCase):
             self.assertNotEqual(next_index, -1, fragment)
             self.assertGreater(next_index, current_index, fragment)
             current_index = next_index
+
+    def _replace_srs_position(
+        self,
+        state: srs_model.SrsGameState,
+        position: srs_model.Position,
+    ) -> srs_model.SrsGameState:
+        return srs_model.SrsGameState(
+            descriptor=state.descriptor,
+            actual_map=state.actual_map,
+            known_state=state.known_state,
+            persistent_state=state.persistent_state,
+            player_position=position,
+            objects=state.objects,
+            combat_state=state.combat_state,
+            srs_turn=state.srs_turn,
+            fuel=state.fuel,
+            max_fuel=state.max_fuel,
+        )


### PR DESCRIPTION
Closes #1244

## 概要

- integrated CLI の `EXIT <dir>` を `WARP_EXIT` と LRS 移動に接続
- EXIT 成功時のみ LRS position を更新し、反対側 entry point の新しい最小 SRS state を生成
- 初期 SRS / EXIT 後 SRS の両方で 4 方向の exit warp flag を維持
- EXIT の受理・拒否ケースと HUD LAST の更新を `test_integrated_play.py` に追加

## 確認

- `python -m unittest experiments.galactic_exodus.test_integrated_play` : OK
- `python -m unittest experiments.galactic_exodus.test_play` : OK
- `python -m unittest experiments.galactic_exodus.test_display` : OK
- `python -m unittest experiments.galactic_exodus.srs.test_render` : OK
- `python -m unittest discover experiments/galactic_exodus` : OK
- `cargo fmt --check` : OK
- `cargo clippy --all-targets -- -D warnings` : OK
- `cargo test` : OK
