### PR TITLE
integrated CLI に INTERACT command を接続

### DIFF
--- a/experiments/galactic_exodus/README.md
+++ b/experiments/galactic_exodus/README.md
@@ -282,9 +282,9 @@ JSON ログの用途:
 python experiments/galactic_exodus/integrated_play.py --seed 42
 ```
 
-このCLIでは `N/E/S/W` は最終的に SRS内の移動として扱います。LRS座標は `EXIT N/E/S/W` が成功した場合だけ変化します。
+このCLIでは `N/E/S/W` と `MOVE <route>` は SRS 内移動として実行され、`EXIT N/E/S/W` が成功した場合だけ LRS 座標が変化します。
 
-この issue 時点では、`N/E/S/W` / `MOVE` / `INTERACT` / `EXIT` は parser のみ先行し、実行は後続 issue で追加します。
+`INTERACT` は minimal SRS builder 上の `RESOURCE_CACHE` / `STATION` と接続されており、既存 SRS interaction を integrated CLI から試せます。
 
 既存 `play.py` は LRS-only prototype として残しています。
 

--- a/experiments/galactic_exodus/integrated_play.py
+++ b/experiments/galactic_exodus/integrated_play.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import re
 import sys
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Sequence, TextIO
@@ -41,6 +42,8 @@ _DEFAULT_SENSOR_SIZE = 5
 _SRS_MAP_WIDTH = 9
 _SRS_MAP_HEIGHT = 9
 _SRS_CENTER = srs_model.Position(4, 4)
+_DEFAULT_SRS_FUEL = 3
+_DEFAULT_SRS_MAX_FUEL = 9
 _ENTRY_POSITIONS = {
     "N": srs_model.Position(4, 8),
     "E": srs_model.Position(8, 4),
@@ -59,6 +62,18 @@ _ALL_EXIT_WARP_FLAGS = {
     _ENTRY_POSITIONS["E"]: frozenset({_DIRECTION_ENUM["E"]}),
     _ENTRY_POSITIONS["S"]: frozenset({_DIRECTION_ENUM["S"]}),
     _ENTRY_POSITIONS["W"]: frozenset({_DIRECTION_ENUM["W"]}),
+}
+_MINIMAL_OBJECT_SPECS = {
+    "R": (
+        "resource-cache-1",
+        srs_model.SrsObjectType.RESOURCE_CACHE,
+        srs_model.Position(4, 5),
+    ),
+    "B": (
+        "station-1",
+        srs_model.SrsObjectType.STATION,
+        srs_model.Position(4, 5),
+    ),
 }
 
 
@@ -183,11 +198,7 @@ def execute_integrated_command(
     if command.kind == COMMAND_MOVE:
         return _execute_move_command(state, command)
     if command.kind == COMMAND_INTERACT:
-        return IntegratedCommandResult(
-            accepted=False,
-            command_type=COMMAND_INTERACT,
-            summary_lines=("INTERACT rejected: interaction is not implemented in integrated CLI yet",),
-        )
+        return _execute_interact_command(state)
     if command.kind == COMMAND_EXIT:
         return _execute_exit_command(state, command)
     return IntegratedCommandResult(
@@ -308,6 +319,40 @@ def _execute_move_command(
     )
 
 
+def _execute_interact_command(
+    state: IntegratedGameState,
+) -> IntegratedCommandResult:
+    target_object_id = _find_interaction_target_object_id(state.srs_state)
+    if target_object_id is None:
+        summary = f"INTERACT rejected: no object at SRS={_display_srs_position(state.srs_state.player_position)}"
+        state.last_event_summary = summary
+        return IntegratedCommandResult(
+            accepted=False,
+            command_type=COMMAND_INTERACT,
+            summary_lines=(summary,),
+            changed_lrs_position=False,
+            changed_srs_position=False,
+        )
+
+    result = srs_engine.apply_srs_command(
+        state.srs_state,
+        srs_model.SrsCommand(command_type="INTERACT", target_object_id=target_object_id),
+        contracts=SRS_CONTRACTS,
+    )
+    state.srs_state = result.state
+    summary_lines = tuple(_format_summary_lines(result.events))
+    if summary_lines:
+        state.last_event_summary = summary_lines[-1]
+
+    return IntegratedCommandResult(
+        accepted=_interaction_result_accepted(result),
+        command_type=COMMAND_INTERACT,
+        summary_lines=summary_lines,
+        changed_lrs_position=False,
+        changed_srs_position=False,
+    )
+
+
 def _format_summary_lines(events: Sequence[srs_model.SrsTurnEvent]) -> list[str]:
     summary_lines: list[str] = []
     for event in events:
@@ -319,6 +364,61 @@ def _movement_result_accepted(result: srs_model.SrsCommandResult) -> bool:
     if not result.events:
         return False
     return result.events[0].event_type != srs_engine.MOVE_REJECTED
+
+
+def _interaction_result_accepted(result: srs_model.SrsCommandResult) -> bool:
+    if not result.events:
+        return False
+    return result.events[0].event_type != srs_engine.INTERACT_REJECTED
+
+
+def _find_interaction_target_object_id(
+    state: srs_model.SrsGameState,
+) -> str | None:
+    player_position = state.player_position
+    candidates: list[tuple[int, int, int, str]] = []
+    for object_id, object_state in state.objects.items():
+        interaction_range = _interaction_range_for_object(object_state.object_type)
+        if interaction_range is None:
+            continue
+        if not _object_is_interactable_from_player(
+            player_position=player_position,
+            object_position=object_state.position,
+            interaction_range=interaction_range,
+        ):
+            continue
+        priority = 0 if object_state.position == player_position else 1
+        candidates.append((priority, object_state.position.y, object_state.position.x, object_id))
+
+    if not candidates:
+        return None
+    candidates.sort()
+    return candidates[0][3]
+
+
+def _interaction_range_for_object(
+    object_type: srs_model.SrsObjectType,
+) -> str | None:
+    contract = SRS_CONTRACTS.movement.interaction.get(object_type.value)
+    if not isinstance(contract, Mapping):
+        return None
+    interaction_range = contract.get("range")
+    return interaction_range if isinstance(interaction_range, str) else None
+
+
+def _object_is_interactable_from_player(
+    *,
+    player_position: srs_model.Position,
+    object_position: srs_model.Position,
+    interaction_range: str,
+) -> bool:
+    if interaction_range == "SAME_CELL":
+        return object_position == player_position
+    if interaction_range == "ADJACENT":
+        dx = abs(object_position.x - player_position.x)
+        dy = abs(object_position.y - player_position.y)
+        return dx + dy == 1
+    return False
 
 
 def _execute_exit_command(
@@ -490,7 +590,14 @@ def _create_minimal_srs_for_sector(
     sector_type = _sector_type_for_lrs_symbol(sector_symbol)
     player_position = _player_position_for_entry(entry_direction)
     warp_flags = _warp_flags_for_entry(entry_direction)
-    rows = _make_floor_rows(warp_flags)
+    objects = _minimal_objects_for_sector(sector_symbol)
+    rows = _make_floor_rows(
+        warp_flags,
+        object_positions={
+            object_state.position: object_id
+            for object_id, object_state in objects.items()
+        },
+    )
     actual_map = srs_model.SrsActualMap(
         width=_SRS_MAP_WIDTH,
         height=_SRS_MAP_HEIGHT,
@@ -531,12 +638,28 @@ def _create_minimal_srs_for_sector(
         ),
         persistent_state=persistent_state,
         player_position=player_position,
-        objects={},
+        objects=objects,
         combat_state=None,
         srs_turn=0,
-        fuel=0,
-        max_fuel=0,
+        fuel=_DEFAULT_SRS_FUEL,
+        max_fuel=_DEFAULT_SRS_MAX_FUEL,
     )
+
+
+def _minimal_objects_for_sector(
+    sector_symbol: str | None,
+) -> dict[str, srs_model.SrsObjectState]:
+    spec = _MINIMAL_OBJECT_SPECS.get(sector_symbol or "")
+    if spec is None:
+        return {}
+    object_id, object_type, position = spec
+    return {
+        object_id: srs_model.SrsObjectState(
+            object_id=object_id,
+            object_type=object_type,
+            position=position,
+        )
+    }
 
 
 def _player_position_for_entry(entry_direction: str | None) -> srs_model.Position:
@@ -553,6 +676,8 @@ def _warp_flags_for_entry(
 
 def _make_floor_rows(
     warp_flags: dict[srs_model.Position, frozenset[srs_model.Direction]],
+    *,
+    object_positions: Mapping[srs_model.Position, str],
 ) -> list[list[srs_model.SrsCell]]:
     rows: list[list[srs_model.SrsCell]] = []
     for y in range(_SRS_MAP_HEIGHT):
@@ -562,6 +687,7 @@ def _make_floor_rows(
             row.append(
                 srs_model.SrsCell(
                     terrain=srs_model.SrsTerrainType.FLOOR,
+                    object_id=object_positions.get(position),
                     warp_flags=warp_flags.get(position, frozenset()),
                 )
             )

--- a/experiments/galactic_exodus/test_integrated_play.py
+++ b/experiments/galactic_exodus/test_integrated_play.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+from dataclasses import replace
 from pathlib import Path
 import subprocess
 import unittest
@@ -410,7 +411,39 @@ class IntegratedPlayCliTests(unittest.TestCase):
             frozenset({srs_model.Direction.N}),
         )
 
-    def test_interact_currently_rejected_without_changing_positions(self) -> None:
+    def test_resource_sector_places_resource_cache_at_fixed_position(self) -> None:
+        state = integrated_play.create_integrated_game(42)
+        state.srs_state = integrated_play._create_minimal_srs_for_sector(
+            seed=state.lrs_state.effective_seed,
+            lrs_position=state.lrs_state.player_position,
+            sector_symbol="R",
+        )
+
+        cache_cell = state.srs_state.actual_map.cell_at(srs_model.Position(4, 5))
+
+        self.assertEqual(cache_cell.object_id, "resource-cache-1")
+        self.assertEqual(
+            state.srs_state.objects["resource-cache-1"].object_type,
+            srs_model.SrsObjectType.RESOURCE_CACHE,
+        )
+
+    def test_base_sector_places_station_at_fixed_position(self) -> None:
+        state = integrated_play.create_integrated_game(42)
+        state.srs_state = integrated_play._create_minimal_srs_for_sector(
+            seed=state.lrs_state.effective_seed,
+            lrs_position=state.lrs_state.player_position,
+            sector_symbol="B",
+        )
+
+        station_cell = state.srs_state.actual_map.cell_at(srs_model.Position(4, 5))
+
+        self.assertEqual(station_cell.object_id, "station-1")
+        self.assertEqual(
+            state.srs_state.objects["station-1"].object_type,
+            srs_model.SrsObjectType.STATION,
+        )
+
+    def test_interact_rejected_without_object_or_position_change(self) -> None:
         state = integrated_play.create_integrated_game(42)
         old_lrs = state.lrs_state.player_position
         old_srs = state.srs_state.player_position
@@ -424,7 +457,111 @@ class IntegratedPlayCliTests(unittest.TestCase):
         self.assertEqual(result.command_type, integrated_play.COMMAND_INTERACT)
         self.assertEqual(state.lrs_state.player_position, old_lrs)
         self.assertEqual(state.srs_state.player_position, old_srs)
-        self.assertIn("interaction is not implemented", result.summary_lines[0])
+        self.assertIn("no object", result.summary_lines[0])
+
+    def test_resource_cache_interact_accepted_without_changing_lrs(self) -> None:
+        state = integrated_play.create_integrated_game(42)
+        state.srs_state = integrated_play._create_minimal_srs_for_sector(
+            seed=state.lrs_state.effective_seed,
+            lrs_position=state.lrs_state.player_position,
+            sector_symbol="R",
+        )
+        state.srs_state = replace(
+            state.srs_state,
+            player_position=srs_model.Position(4, 5),
+            fuel=3,
+            max_fuel=9,
+        )
+        old_lrs = state.lrs_state.player_position
+
+        result = integrated_play.execute_integrated_command(
+            state,
+            integrated_play.parse_integrated_command("INTERACT"),
+        )
+        rendered = integrated_play.render_integrated_response(state, result)
+
+        self.assertTrue(result.accepted)
+        self.assertEqual(result.command_type, integrated_play.COMMAND_INTERACT)
+        self.assertEqual(state.lrs_state.player_position, old_lrs)
+        self.assertIn("resource-cache-1", state.srs_state.persistent_state.consumed_object_ids)
+        self.assertTrue(state.srs_state.objects["resource-cache-1"].consumed)
+        self.assertTrue(any("CACHE acquired" in line for line in result.summary_lines))
+        self.assertIn("LAST    CACHE acquired", rendered)
+
+    def test_station_interact_accepted_without_changing_lrs(self) -> None:
+        state = integrated_play.create_integrated_game(42)
+        state.srs_state = integrated_play._create_minimal_srs_for_sector(
+            seed=state.lrs_state.effective_seed,
+            lrs_position=state.lrs_state.player_position,
+            sector_symbol="B",
+        )
+        state.srs_state = replace(state.srs_state, fuel=2, max_fuel=9)
+        old_lrs = state.lrs_state.player_position
+        old_srs = state.srs_state.player_position
+
+        result = integrated_play.execute_integrated_command(
+            state,
+            integrated_play.parse_integrated_command("INTERACT"),
+        )
+        rendered = integrated_play.render_integrated_response(state, result)
+
+        self.assertTrue(result.accepted)
+        self.assertEqual(state.lrs_state.player_position, old_lrs)
+        self.assertEqual(state.srs_state.player_position, old_srs)
+        self.assertIn("station-1", state.srs_state.persistent_state.activated_object_ids)
+        self.assertTrue(state.srs_state.objects["station-1"].activated)
+        self.assertTrue(any("BASE station activated" in line for line in result.summary_lines))
+        self.assertIn("LAST    BASE station activated", rendered)
+
+    def test_repeated_resource_cache_interact_is_rejected_after_consumption(self) -> None:
+        state = integrated_play.create_integrated_game(42)
+        state.srs_state = integrated_play._create_minimal_srs_for_sector(
+            seed=state.lrs_state.effective_seed,
+            lrs_position=state.lrs_state.player_position,
+            sector_symbol="R",
+        )
+        state.srs_state = replace(
+            state.srs_state,
+            player_position=srs_model.Position(4, 5),
+            fuel=3,
+            max_fuel=9,
+        )
+
+        first = integrated_play.execute_integrated_command(
+            state,
+            integrated_play.parse_integrated_command("INTERACT"),
+        )
+        second = integrated_play.execute_integrated_command(
+            state,
+            integrated_play.parse_integrated_command("INTERACT"),
+        )
+
+        self.assertTrue(first.accepted)
+        self.assertFalse(second.accepted)
+        self.assertIn("already consumed", second.summary_lines[0])
+
+    def test_consumed_resource_cache_symbol_is_visible_after_player_moves_off_cell(self) -> None:
+        state = integrated_play.create_integrated_game(42)
+        state.srs_state = integrated_play._create_minimal_srs_for_sector(
+            seed=state.lrs_state.effective_seed,
+            lrs_position=state.lrs_state.player_position,
+            sector_symbol="R",
+        )
+        state.srs_state = replace(
+            state.srs_state,
+            player_position=srs_model.Position(4, 5),
+            fuel=3,
+            max_fuel=9,
+        )
+
+        result = integrated_play.execute_integrated_command(
+            state,
+            integrated_play.parse_integrated_command("INTERACT"),
+        )
+        state.srs_state = self._replace_srs_position(state.srs_state, srs_model.Position(4, 4))
+        rendered = integrated_play.render_integrated_response(state, result)
+
+        self.assertIn(" 6  ? ? . . r . . ? ?", rendered)
 
     def test_response_section_order(self) -> None:
         state = integrated_play.create_integrated_game(42)


### PR DESCRIPTION
## 概要

Closes #1245

- integrated CLI の `INTERACT` を既存 SRS interaction に接続
- minimal SRS builder に `RESOURCE_CACHE` / `STATION` の固定配置を追加
- consumed / activated 状態と HUD LAST の更新を integrated CLI テストで検証
- README の integrated CLI 説明を現状に合わせて更新

## 確認

- `python -m unittest experiments.galactic_exodus.test_integrated_play` : OK
- `python -m unittest experiments.galactic_exodus.srs.test_event_format` : OK
- `python -m unittest experiments.galactic_exodus.srs.test_render` : OK
- `python -m unittest discover experiments/galactic_exodus` : OK
- `cargo fmt --check` : OK
- `cargo clippy --all-targets -- -D warnings` : OK
- `cargo test` : OK
