### PR TITLE
Galactic Exodus: integrated_play.py の readline / stdin decode 耐性を追加する

### DIFF
--- a/experiments/galactic_exodus/integrated_play.py
+++ b/experiments/galactic_exodus/integrated_play.py
@@ -10,6 +10,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Sequence, TextIO
 
+try:
+    import readline  # noqa: F401  # Enables line editing/backspace on Unix-like terminals.
+except ImportError:  # pragma: no cover - readline is platform dependent.
+    pass
+
 if __package__ in (None, ""):
     sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
@@ -109,6 +114,10 @@ class IntegratedGameState:
     srs_state: srs_model.SrsGameState
     last_event_summary: str | None = None
     session_aborted: bool = False
+
+
+class CommandInputInterrupted(Exception):
+    """Raised when command input cannot be decoded safely."""
 
 
 def build_parser(stderr: TextIO) -> argparse.ArgumentParser:
@@ -262,8 +271,12 @@ def main(
     while True:
         effective_stdout.write("COMMAND> ")
         effective_stdout.flush()
-        line = effective_stdin.readline()
-        if line == "":
+        try:
+            line = _read_command_line(effective_stdin)
+        except CommandInputInterrupted:
+            effective_stderr.write("input decode error; session ended\n")
+            break
+        if line is None:
             break
         command = parse_integrated_command(line)
         result = execute_integrated_command(state, command)
@@ -276,6 +289,29 @@ def main(
 def _normalize_command_text(raw: str) -> str:
     stripped = raw.strip().upper().replace(",", " ")
     return re.sub(r"\s+", " ", stripped)
+
+
+def _clean_command_input(text: str) -> str:
+    cleaned: list[str] = []
+    for character in text:
+        if character in {"\b", "\x7f"}:
+            if cleaned:
+                cleaned.pop()
+            continue
+        if ord(character) < 32 and character != "\t":
+            continue
+        cleaned.append(character)
+    return "".join(cleaned).strip()
+
+
+def _read_command_line(stdin: TextIO) -> str | None:
+    try:
+        line = stdin.readline()
+    except UnicodeDecodeError as exc:
+        raise CommandInputInterrupted from exc
+    if line == "":
+        return None
+    return _clean_command_input(line)
 
 
 def _all_directions(tokens: Sequence[str]) -> bool:

--- a/experiments/galactic_exodus/test_integrated_play.py
+++ b/experiments/galactic_exodus/test_integrated_play.py
@@ -5,6 +5,7 @@ from dataclasses import replace
 from pathlib import Path
 import subprocess
 import unittest
+from typing import TextIO
 
 from experiments.galactic_exodus import engine as lrs_engine
 from experiments.galactic_exodus import integrated_play
@@ -12,12 +13,13 @@ from experiments.galactic_exodus.srs import model as srs_model
 
 
 class IntegratedPlayCliTests(unittest.TestCase):
-    def run_cli(self, argv: list[str], stdin_text: str) -> tuple[int, str, str]:
+    def run_cli(self, argv: list[str], stdin_text: str | TextIO) -> tuple[int, str, str]:
         stdout = io.StringIO()
         stderr = io.StringIO()
+        stdin = io.StringIO(stdin_text) if isinstance(stdin_text, str) else stdin_text
         exit_code = integrated_play.main(
             argv,
-            stdin=io.StringIO(stdin_text),
+            stdin=stdin,
             stdout=stdout,
             stderr=stderr,
         )
@@ -101,6 +103,26 @@ class IntegratedPlayCliTests(unittest.TestCase):
             integrated_play.parse_integrated_command("foo"),
             integrated_play.IntegratedCommand(kind=integrated_play.COMMAND_UNKNOWN, raw="FOO"),
         )
+
+    def test_clean_command_input_removes_backspace_del_and_control_chars(self) -> None:
+        self.assertEqual(integrated_play._clean_command_input("EN\x7f"), "E")
+        self.assertEqual(integrated_play._clean_command_input("\x00E\r\n"), "E")
+
+    def test_readline_unicode_decode_error_ends_session_without_traceback(self) -> None:
+        class DecodeErrorStdin:
+            def readline(self) -> str:
+                raise UnicodeDecodeError("utf-8", b"\x80", 0, 1, "invalid continuation byte")
+
+        exit_code, stdout, stderr = self.run_cli(["--seed", "42"], DecodeErrorStdin())
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn("RESULT\n", stdout)
+        self.assertIn("GAME  started seed=42", stdout)
+        self.assertIn("LRS\n", stdout)
+        self.assertIn("SRS\n", stdout)
+        self.assertIn("HUD\n", stdout)
+        self.assertTrue(stdout.endswith("COMMAND> "))
+        self.assertEqual(stderr, "input decode error; session ended\n")
 
     def test_create_integrated_game_creates_lrs_and_srs(self) -> None:
         state = integrated_play.create_integrated_game(42)


### PR DESCRIPTION
## 概要

Closes #1250

`experiments/galactic_exodus/integrated_play.py` の command loop に入力清掃と decode error ハンドリングを追加し、端末依存の不正な入力バイト列で traceback せず安全終了するようにしました。

## 変更内容

- `integrated_play.py` に optional `readline` import を追加
- backspace / DEL / 制御文字を除去する `_clean_command_input()` を追加
- `stdin.readline()` を `_read_command_line()` に切り出し、`UnicodeDecodeError` を `CommandInputInterrupted` として扱うように変更
- decode error 発生時は `stderr` に固定文言を出して exit code 0 で終了
- decode error と入力清掃の回帰テストを `test_integrated_play.py` に追加

## 確認

- `python -m unittest experiments.galactic_exodus.test_integrated_play`
- `python -m unittest discover experiments/galactic_exodus`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
