### PR TITLE
Galactic Exodus minimal SRS の warp flag 生成を #1088 仕様へ同期

### DIFF
--- a/experiments/galactic_exodus/integrated_play.py
+++ b/experiments/galactic_exodus/integrated_play.py
@@ -62,12 +62,6 @@ _DIRECTION_ENUM = {
     "W": srs_model.Direction.W,
 }
 _LRS_DIRECTION_DELTAS = lrs_engine.COMMAND_DELTAS
-_ALL_EXIT_WARP_FLAGS = {
-    _ENTRY_POSITIONS["N"]: frozenset({_DIRECTION_ENUM["N"]}),
-    _ENTRY_POSITIONS["E"]: frozenset({_DIRECTION_ENUM["E"]}),
-    _ENTRY_POSITIONS["S"]: frozenset({_DIRECTION_ENUM["S"]}),
-    _ENTRY_POSITIONS["W"]: frozenset({_DIRECTION_ENUM["W"]}),
-}
 _MINIMAL_OBJECT_SPECS = {
     "R": (
         "resource-cache-1",
@@ -707,7 +701,48 @@ def _player_position_for_entry(entry_direction: str | None) -> srs_model.Positio
 def _warp_flags_for_entry(
     entry_direction: str | None,
 ) -> dict[srs_model.Position, frozenset[srs_model.Direction]]:
-    return dict(_ALL_EXIT_WARP_FLAGS)
+    del entry_direction
+
+    cells = _make_floor_rows({}, object_positions={})
+    warp_flags: dict[srs_model.Position, frozenset[srs_model.Direction]] = {}
+    for direction in srs_model.Direction:
+        for position in _edge_cells(direction):
+            if not _has_floor_square(cells, position):
+                continue
+            current_flags = warp_flags.get(position, frozenset())
+            warp_flags[position] = current_flags | frozenset({direction})
+    return warp_flags
+
+
+def _edge_cells(direction: srs_model.Direction) -> list[srs_model.Position]:
+    if direction is srs_model.Direction.N:
+        return [srs_model.Position(x, _SRS_MAP_HEIGHT - 1) for x in range(_SRS_MAP_WIDTH)]
+    if direction is srs_model.Direction.E:
+        return [srs_model.Position(_SRS_MAP_WIDTH - 1, y) for y in range(_SRS_MAP_HEIGHT)]
+    if direction is srs_model.Direction.S:
+        return [srs_model.Position(x, 0) for x in range(_SRS_MAP_WIDTH)]
+    return [srs_model.Position(0, y) for y in range(_SRS_MAP_HEIGHT)]
+
+
+def _has_floor_square(
+    cells: Sequence[Sequence[srs_model.SrsCell]],
+    position: srs_model.Position,
+) -> bool:
+    for min_x in range(position.x - 1, position.x + 1):
+        for min_y in range(position.y - 1, position.y + 1):
+            if min_x < 0 or min_y < 0:
+                continue
+            if min_x + 1 >= _SRS_MAP_WIDTH or min_y + 1 >= _SRS_MAP_HEIGHT:
+                continue
+            square = (
+                cells[min_y][min_x],
+                cells[min_y][min_x + 1],
+                cells[min_y + 1][min_x],
+                cells[min_y + 1][min_x + 1],
+            )
+            if all(cell.terrain is srs_model.SrsTerrainType.FLOOR for cell in square):
+                return True
+    return False
 
 
 def _make_floor_rows(

--- a/experiments/galactic_exodus/test_integrated_play.py
+++ b/experiments/galactic_exodus/test_integrated_play.py
@@ -405,53 +405,70 @@ class IntegratedPlayCliTests(unittest.TestCase):
 
         self.assertIn("LAST    SRS   entered sector TYPE=", rendered)
 
-    def test_initial_srs_has_all_four_exit_warp_flags(self) -> None:
+    def test_initial_srs_has_multiple_warp_flags_on_each_edge(self) -> None:
+        state = integrated_play.create_integrated_game(42)
+        edge_positions = {
+            srs_model.Direction.S: [srs_model.Position(x, 0) for x in range(9)],
+            srs_model.Direction.W: [srs_model.Position(0, y) for y in range(9)],
+            srs_model.Direction.N: [srs_model.Position(x, 8) for x in range(9)],
+            srs_model.Direction.E: [srs_model.Position(8, y) for y in range(9)],
+        }
+
+        for direction, positions in edge_positions.items():
+            flagged_positions = [
+                position
+                for position in positions
+                if direction in state.srs_state.actual_map.cell_at(position).warp_flags
+            ]
+            self.assertGreater(len(flagged_positions), 1)
+
+    def test_initial_srs_lower_left_corner_has_s_and_w_warp_flags(self) -> None:
         state = integrated_play.create_integrated_game(42)
 
         self.assertEqual(
-            state.srs_state.actual_map.cell_at(srs_model.Position(0, 4)).warp_flags,
-            frozenset({srs_model.Direction.W}),
-        )
-        self.assertEqual(
-            state.srs_state.actual_map.cell_at(srs_model.Position(8, 4)).warp_flags,
-            frozenset({srs_model.Direction.E}),
-        )
-        self.assertEqual(
-            state.srs_state.actual_map.cell_at(srs_model.Position(4, 0)).warp_flags,
-            frozenset({srs_model.Direction.S}),
-        )
-        self.assertEqual(
-            state.srs_state.actual_map.cell_at(srs_model.Position(4, 8)).warp_flags,
-            frozenset({srs_model.Direction.N}),
+            state.srs_state.actual_map.cell_at(srs_model.Position(0, 0)).warp_flags,
+            frozenset({srs_model.Direction.S, srs_model.Direction.W}),
         )
 
-    def test_new_srs_after_exit_keeps_all_four_exit_warp_flags(self) -> None:
+    def test_exit_from_non_center_edge_warp_is_accepted(self) -> None:
         state = integrated_play.create_integrated_game(42)
         state.lrs_state.player_position = (1, 1)
-        state.srs_state = self._replace_srs_position(state.srs_state, srs_model.Position(8, 4))
+        state.srs_state = self._replace_srs_position(state.srs_state, srs_model.Position(8, 0))
 
-        integrated_play.execute_integrated_command(
+        result = integrated_play.execute_integrated_command(
             state,
             integrated_play.parse_integrated_command("EXIT E"),
         )
 
+        self.assertTrue(result.accepted)
         self.assertEqual(state.srs_state.player_position, srs_model.Position(0, 4))
-        self.assertEqual(
-            state.srs_state.actual_map.cell_at(srs_model.Position(0, 4)).warp_flags,
-            frozenset({srs_model.Direction.W}),
+        self.assertEqual(state.lrs_state.player_position, (2, 1))
+
+    def test_exit_south_from_initial_position_is_rejected_by_lrs_bounds(self) -> None:
+        state = integrated_play.create_integrated_game(42)
+
+        result = integrated_play.execute_integrated_command(
+            state,
+            integrated_play.parse_integrated_command("EXIT S"),
         )
-        self.assertEqual(
-            state.srs_state.actual_map.cell_at(srs_model.Position(8, 4)).warp_flags,
-            frozenset({srs_model.Direction.E}),
+
+        self.assertFalse(result.accepted)
+        self.assertEqual(state.lrs_state.player_position, (1, 1))
+        self.assertEqual(state.srs_state.player_position, srs_model.Position(0, 0))
+        self.assertIn("would leave LRS map", result.summary_lines[0])
+
+    def test_exit_west_from_initial_position_is_rejected_by_lrs_bounds(self) -> None:
+        state = integrated_play.create_integrated_game(42)
+
+        result = integrated_play.execute_integrated_command(
+            state,
+            integrated_play.parse_integrated_command("EXIT W"),
         )
-        self.assertEqual(
-            state.srs_state.actual_map.cell_at(srs_model.Position(4, 0)).warp_flags,
-            frozenset({srs_model.Direction.S}),
-        )
-        self.assertEqual(
-            state.srs_state.actual_map.cell_at(srs_model.Position(4, 8)).warp_flags,
-            frozenset({srs_model.Direction.N}),
-        )
+
+        self.assertFalse(result.accepted)
+        self.assertEqual(state.lrs_state.player_position, (1, 1))
+        self.assertEqual(state.srs_state.player_position, srs_model.Position(0, 0))
+        self.assertIn("would leave LRS map", result.summary_lines[0])
 
     def test_resource_sector_places_resource_cache_at_fixed_position(self) -> None:
         state = integrated_play.create_integrated_game(42)
@@ -653,7 +670,7 @@ class IntegratedPlayCliTests(unittest.TestCase):
             self.assertGreater(next_index, current_index, fragment)
             current_index = next_index
 
-        self.assertIn(" 1  @ . . ? ? ? ? ? ?", stdout)
+        self.assertIn(" 1  @ v v ? ? ? ? ? ?", stdout)
         self.assertIn("SECTOR  LRS=(1,1)  TYPE=NORMAL  SRS=(1,1)  SENSOR=5x5", stdout)
 
     def _replace_srs_position(


### PR DESCRIPTION
## 概要

Closes #1255

`experiments/galactic_exodus/integrated_play.py` の minimal SRS 生成を、4辺中央固定の warp flag から、#1088 仕様に沿った外周 FLOOR セル + 2x2 FLOOR クラスタ判定へ変更しました。

## 変更内容

- `_ALL_EXIT_WARP_FLAGS` の固定4点定義を廃止
- minimal SRS 用に、各辺の外周セルを走査して 2x2 FLOOR クラスタを満たす位置へ方向別 `warp_flags` を付与
- all FLOOR な minimal SRS で各辺に複数の warp 可能セルができることをテスト
- 左下隅 `(0,0)` が `{S, W}` を持つことをテスト
- 辺中央以外の warp cell `(8,0)` からの `EXIT E` が受理されることをテスト
- 初期位置 `(0,0)` から `EXIT S` / `EXIT W` は SRS 側 warp があっても LRS 境界で reject されることをテスト
- 初期スナップショット期待値を新しい warp 表示に更新

## 確認

- `python -m unittest experiments.galactic_exodus.test_integrated_play`
- `python -m unittest discover experiments/galactic_exodus`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
