### PR TITLE
Galactic Exodus: document integrated CLI non-EXIT commands

### DIFF
--- a/experiments/galactic_exodus/docs/specs/README.md
+++ b/experiments/galactic_exodus/docs/specs/README.md
@@ -85,7 +85,7 @@ B. spec file 反映用の後続 issue が作成済みで、そのリンクが本
 | [`srs_movement.md`](srs_movement.md) | #1083, #1089 | #1267 で追加 |
 | `srs_encounter.md` | #1178, #1194 | 後続候補 |
 | `srs_combat.md` | #1178, #1194 | 後続候補 |
-| `integrated_cli.md` | #1241, #1242, #1243, #1244, #1245 | #1268 と連動 |
+| [`integrated_cli.md`](integrated_cli.md) | #1241, #1242, #1243, #1244, #1245 | #1268 / #1279 で追加・補完 |
 | `display.md` | #1076, #1214, #1218, #1230-#1235 | 後続候補 |
 | `balance.md` | #1178, #1194, #1257 | 後続候補 |
 

--- a/experiments/galactic_exodus/docs/specs/integrated_cli.md
+++ b/experiments/galactic_exodus/docs/specs/integrated_cli.md
@@ -3,10 +3,11 @@
 Source issue: #1241
 Implementation issues: #1242, #1243, #1244, #1245, #1250, #1252, #1255
 Traceability audit: #1260
-Follow-up: #1268
+Follow-up: #1268, #1279
 
 この文書は、Galactic Exodus integrated command-response CLI の正本仕様である。
-#1268 では特に `EXIT <dir>` 制約の implemented / deferred を明確化する。
+#1268 では特に `EXIT <dir>` 制約の implemented / deferred を明確化した。
+#1279 では non-EXIT command surface を補完し、SRS移動入力を `MOVE <route>` に一本化する方針を正本化する。
 
 ## CLIの基本方針
 
@@ -46,11 +47,10 @@ LOG  optional
 - control character / backspaceを入力処理で吸収
 ```
 
-現行command:
+CLI command surface:
 
 | Command | 意味 | LRS position change | SRS position change |
 |---|---|---:|---:|
-| `N` / `E` / `S` / `W` | SRS内1step移動 | no | yes, if accepted |
 | `MOVE <route>` | SRS内route移動 | no | yes, if accepted |
 | `INTERACT` | SRS object interaction | no | no |
 | `EXIT <dir>` | SRSから隣接LRS sectorへ移動 | yes, if accepted | yes, new sector entry |
@@ -58,9 +58,196 @@ LOG  optional
 | `STATUS` | 状態を見る | no | no |
 | `HELP` | command help | no | no |
 | `Q` / `QUIT` | session終了 | no | no |
+| unknown command | 未知command / parser error | no | no |
 
-直接方向commandおよび `MOVE` は SRS movement専用である。
+`MOVE <route>` は SRS movement専用である。
 LRS positionを変更するのは `EXIT <dir>` のみである。
+
+`N` / `E` / `S` / `W` は direction token としては有効だが、standalone CLI command としては受け付けない。
+
+```text
+MOVE N        accepted as MOVE route=(N)
+MOVE N E W S  accepted as MOVE route=(N,E,W,S)
+N             rejected as unknown command or explicit rejected standalone direction
+E             rejected as unknown command or explicit rejected standalone direction
+S             rejected as unknown command or explicit rejected standalone direction
+W             rejected as unknown command or explicit rejected standalone direction
+```
+
+理由:
+
+```text
+- Phase 2 baselineでは movement_points_per_turn = 4
+- 1 accepted movement command = 1 SRS turn
+- `N` を4回入力すると4 SRS turnを消費し、1turnに最大4step移動できる設計と直感的にずれる
+- `MOVE <route>` に一本化すると、ユーザー入力単位とSRS turn境界が一致する
+- 単独方向入力を後から1turnにまとめる方式は、入力途中状態 / cancel / partial preview / encounter timing が複雑になる
+```
+
+現行実装では、`parse_integrated_command(...)` が `N/E/S/W` 単独入力を `COMMAND_MOVE` として受け付ける。
+これは後続実装issueで `COMMAND_UNKNOWN` または explicit rejected command へ変更する。
+
+## non-EXIT commands
+
+### LOOK
+
+`LOOK` は現在状態を再表示するcommandである。
+
+```text
+accepted = true
+LRS position change = no
+SRS position change = no
+SRS turn change = no
+```
+
+### STATUS
+
+`STATUS` は現在のship / sector状態を確認するcommandである。
+
+```text
+accepted = true
+LRS position change = no
+SRS position change = no
+SRS turn change = no
+```
+
+現行minimal CLIでは、`STATUS` の詳細はHUD表示に寄せている。
+必要なら後続で、status専用summaryを拡張する。
+
+### HELP
+
+`HELP` は使用可能commandを案内するcommandである。
+
+```text
+accepted = true
+LRS position change = no
+SRS position change = no
+SRS turn change = no
+```
+
+HELPは、canonical commandとして `MOVE <route>` を案内する。
+`N/E/S/W` 単独commandは案内しない。
+
+### Q / QUIT
+
+`Q` / `QUIT` はsessionを終了するcommandである。
+
+```text
+accepted = true
+should_quit = true
+LRS position change = no
+SRS position change = no
+SRS turn change = no
+```
+
+### INTERACT
+
+`INTERACT` は、現在のSRS positionに対して object interaction を試行するcommandである。
+
+対象objectとrange条件は `srs_movement.md` を正本とする。
+
+```text
+RESOURCE_CACHE  SAME_CELL
+SALVAGE         SAME_CELL
+STATION         ADJACENT
+```
+
+accepted interaction は 1 SRS turn を消費する。
+rejected interaction は SRS turn を消費しない。
+
+現行minimal integrated CLIでは、target object idをCLI引数では指定しない。
+現在位置・隣接位置から候補を探し、優先順で1つを選ぶ。
+候補がない場合はrejectする。
+
+### MOVE <route>
+
+`MOVE <route>` は、SRS内movementのcanonical CLI commandである。
+
+```text
+MOVE <dir> [<dir> ...]
+```
+
+`<dir>` は direction token の列である。
+
+```text
+N
+E
+S
+W
+```
+
+commaはspaceへ正規化されるため、次は同じrouteとして扱う。
+
+```text
+MOVE E,E,N
+MOVE E E N
+```
+
+Phase 2 baselineでは、通常床で最大4stepまでを1 SRS turnとして解決する。
+terrain movement cost、impassable cell、movement budgetにより途中停止する場合がある。
+詳細は `srs_movement.md` の `MOVE_ROUTE` を正本とする。
+
+受理例:
+
+```text
+MOVE N
+MOVE N E
+MOVE N E W S
+```
+
+reject例:
+
+```text
+MOVE
+MOVE X
+MOVE N X
+```
+
+invalid directionを含む場合はrejectし、LRS / SRS positionを変更しない。
+
+### standalone direction token
+
+`N` / `E` / `S` / `W` 単独入力は、CLI commandとしては非対応とする。
+
+```text
+N  rejected
+E  rejected
+S  rejected
+W  rejected
+```
+
+ただし、これらは `MOVE <route>` と `EXIT <dir>` の direction token としては引き続き有効である。
+
+```text
+MOVE N
+EXIT N
+```
+
+この区別により、SRS engine側の `MOVE_ROUTE` direction token仕様と、integrated CLI command surfaceを分離する。
+
+### unknown command / parser error
+
+未知commandや parser がcommandとして解釈できない入力はrejectする。
+
+```text
+accepted = false
+LRS position change = no
+SRS position change = no
+SRS turn change = no
+```
+
+ユーザー向けsummaryは次を基本とする。
+
+```text
+COMMAND rejected: unknown command
+```
+
+standalone direction tokenを unknown command に丸めるか、次のような明示rejectにするかは後続実装issueで決める。
+
+```text
+MOVE rejected: use MOVE <route> instead of standalone direction
+COMMAND rejected: use MOVE <route> for SRS movement
+```
 
 ## 初期状態
 
@@ -148,9 +335,11 @@ REJECTED_ENEMY_PRESENCE
 
 ## deferred constraints
 
-#1268時点で、次は意図的に deferred とする。
+#1268 / #1279時点で、次は意図的に deferred とする。
 
 ```text
+- integrated CLI parserからstandalone `N/E/S/W` commandを廃止する実装
+- HELP summaryからstandalone `N/E/S/W` を外し、`MOVE <route>` を案内する実装
 - EXIT時のLRS fuel消費
 - EXIT時のdurability / ship status制約
 - full combat phaseとintegrated CLI command loopの完全統合
@@ -165,5 +354,6 @@ REJECTED_ENEMY_PRESENCE
 
 | Spec | 関係 |
 |---|---|
+| `srs_movement.md` | `MOVE_ROUTE`, movement points, terrain movement cost, interaction lifecycleのSRS側正本。 |
 | `srs_warp.md` | `warp_flags` と RIFT_BARRIER / blocked edgeのSRS側正本。 |
 | `srs_map_generation.md` | minimal SRS generation と full terrain-count profile deferred範囲。 |


### PR DESCRIPTION
## 概要

- `experiments/galactic_exodus/docs/specs/integrated_cli.md` に non-EXIT command 仕様を追記
- `MOVE <route>` を canonical SRS movement command として正本化
- `N/E/S/W` は direction token としては有効だが、standalone CLI command としては受け付けない方針を記録
- `LOOK`, `STATUS`, `HELP`, `QUIT/Q`, `INTERACT`, unknown command / parser error の扱いを補完
- specs README から `integrated_cli.md` へリンクし、#1268 / #1279 で追加・補完済みとして更新

## 範囲

Documentation-only の変更です。

現行 `integrated_play.py` の parser はまだ `N/E/S/W` 単独入力を `COMMAND_MOVE` として受け付けるため、実装差分は後続issueへ切り出します。

実行コード、fixtures、snapshots、数値バランスは変更していません。

## 確認

この環境では未実行です。Markdownのみの変更です。

ローカル確認時の推奨コマンド:

```bash
cargo fmt --check
cargo clippy --all-targets -- -D warnings
cargo test
```

Closes #1279