### PR TITLE
Galactic Exodus: document SALVAGE recovery choice decision

### DIFF
--- a/experiments/galactic_exodus/docs/specs/srs_objects.md
+++ b/experiments/galactic_exodus/docs/specs/srs_objects.md
@@ -1,11 +1,12 @@
 # Galactic Exodus SRS objects and rewards
 
 Source issue: #1288
+Decision issue: #1277
 Parent issue: #1266
 Related: #1178, #1185, #1194, #1259, #1275, #1276, #1277, #1278
 Base branch: `integration/882-galactic-exodus`
 
-This document records the Phase 2 initial source-of-truth specification for SRS object interaction, SALVAGE rewards, and RESOURCE / STATION reward timing.
+This document records the Phase 2 source-of-truth specification for SRS object interaction, SALVAGE rewards, and RESOURCE / STATION reward timing.
 
 ## Scope
 
@@ -34,12 +35,28 @@ Excluded:
 
 #1266 の棚卸し結果として、SALVAGE は prototype-only ではなく Phase 2 初期仕様として固定する。
 
-この文書では、現行実装と fixture regression が固定している挙動を正本化する。
-ただし、#1275〜#1278 で変更または再判断され得る項目は `Deferred / follow-up issues` に分けて記録する。
+#1288 / PR #1289 では、現行実装と fixture regression が固定していた挙動を正本化した。
+
+#1277 では、SALVAGE取得時の即時回復対象について B 方針を採用した。
+
+```text
+SALVAGE取得時の即時回復は:
+  - RECOVER_ENERGY
+  - RECOVER_PHOTON_TORPEDO_AMMO
+  - STORE_ONLY
+
+に限定する。
+
+RECOVER_DURABILITY は SALVAGE pickup では非対応にし、durability recovery は BASE / STATION に寄せる。
+```
+
+この文書は #1277 の仕様判断を反映した source-of-truth である。
+
+注意: #1277 Step 1 は documentation-only であり、実装・fixture・snapshot はまだ B 方針へ同期しない。実装同期は #1277 Step 2 で扱う。
 
 ## Map SALVAGE pickup
 
-現行仕様:
+仕様:
 
 - map上の SALVAGE object は `INTERACT` で取得する
 - `reward_source` は `MAP_PICKUP`
@@ -51,18 +68,43 @@ Excluded:
 - `persistent_state.consumed_object_ids` に `object_id` を追加する
 - `player_state` / `combat_state.player` に reward を反映する
 
+Supported immediate effects:
+
+```text
+RECOVER_ENERGY
+RECOVER_PHOTON_TORPEDO_AMMO
+STORE_ONLY
+```
+
+Unsupported immediate effects:
+
+```text
+RECOVER_DURABILITY
+```
+
+`RECOVER_DURABILITY` が SALVAGE reward choice として指定された場合は、暗黙に `STORE_ONLY` へ丸めず、明示的に reject する。
+
+reject reason 名は実装PRで確定する。
+候補:
+
+```text
+REJECTED_UNSUPPORTED_SALVAGE_CHOICE
+```
+
 ## SALVAGE reward common flow
 
-現行仕様:
+仕様:
 
 - choiceなしの場合は `STORE_ONLY`
-- `RECOVER_DURABILITY` は `durability_capacity` まで回復
 - `RECOVER_ENERGY` は `energy_capacity` まで回復
 - `RECOVER_PHOTON_TORPEDO_AMMO` は `photon_torpedo_ammo_capacity` まで回復
-- どのchoiceでも salvage inventory は `salvage_value` 分増える
+- `STORE_ONLY` は即時回復せず、salvage inventory のみ増やす
+- どのsupported choiceでも salvage inventory は `salvage_value` 分増える
 - reward payload には `salvage_before` / `salvage_after` / `selected_salvage_choice` / 各delta が含まれる
 
-`RECOVER_DURABILITY` は現行仕様として記録する。ただし、#1277 により ammo / energy 中心へ再整理される可能性がある。
+`RECOVER_DURABILITY` は SALVAGE pickup immediate effect としては非対応とする。
+
+durability recovery は BASE / STATION recovery 側で扱う。
 
 ## Enemy dropped SALVAGE current behavior
 
@@ -85,37 +127,41 @@ TIER3: salvage +2
 TIER4: salvage +3
 ```
 
-Current drop recovery amount:
+Current drop recovery amount for supported choices:
 
 ```text
 TIER1:
-  RECOVER_DURABILITY: 8
   RECOVER_ENERGY: 2
   RECOVER_PHOTON_TORPEDO_AMMO: 1
   STORE_ONLY: 0
 
 TIER2:
-  RECOVER_DURABILITY: 8
   RECOVER_ENERGY: 2
   RECOVER_PHOTON_TORPEDO_AMMO: 1
   STORE_ONLY: 0
 
 TIER3:
-  RECOVER_DURABILITY: 12
   RECOVER_ENERGY: 3
   RECOVER_PHOTON_TORPEDO_AMMO: 1
   STORE_ONLY: 0
 
 TIER4:
-  RECOVER_DURABILITY: 16
   RECOVER_ENERGY: 4
   RECOVER_PHOTON_TORPEDO_AMMO: 2
   STORE_ONLY: 0
 ```
 
+Unsupported enemy drop recovery choice:
+
+```text
+RECOVER_DURABILITY
+```
+
+注意: 現行実装・fixture はまだ `RECOVER_DURABILITY` を扱っている可能性がある。#1277 Step 2 で実装・fixture・test をこの仕様へ同期する。
+
 ## Base station / upgrade
 
-現行仕様:
+仕様:
 
 - `STATION` interaction は fuel / durability / energy / photon torpedo ammo を回復する
 - successful interaction で SRS turn `+1`
@@ -134,9 +180,12 @@ DEFENSE: 4
 EVASION: 4
 ```
 
+Durability recovery remains supported on BASE / STATION interaction.
+SALVAGE pickup does not provide durability recovery.
+
 ## Fixture regression references
 
-#1266 で確認済みの fixture regression:
+#1266 / #1288 時点で確認済みの fixture regression:
 
 ```text
 test_salvage_placeholder
@@ -146,7 +195,9 @@ test_combat_salvage_drop_tier3_energy
 test_combat_salvage_no_drop_tier1
 ```
 
-この spec では fixture を変更しない。fixture は現行挙動の regression 固定であり、spec変更が必要になった場合は別 issue で fixture / snapshot 更新を行う。
+#1277 により、`test_salvage_recover_durability` は後続の実装同期で更新または置換される。
+
+この spec 更新では fixture を変更しない。fixture は実装済み挙動の regression 固定であり、spec変更に合わせた更新は別PRで行う。
 
 ## Deferred / follow-up issues
 
@@ -186,16 +237,27 @@ Deferred:
 
 `#1277 SALVAGE取得時の即時回復対象を ammo / energy 中心に再整理する`
 
-Current:
+Decision:
 
 ```text
-RECOVER_DURABILITY / RECOVER_ENERGY / RECOVER_PHOTON_TORPEDO_AMMO / STORE_ONLY are supported.
+B を採用する。
+
+Supported:
+  RECOVER_ENERGY
+  RECOVER_PHOTON_TORPEDO_AMMO
+  STORE_ONLY
+
+Unsupported:
+  RECOVER_DURABILITY on SALVAGE pickup
+
+Durability recovery:
+  BASE / STATION recovery側で扱う
 ```
 
-Deferred:
+Implementation sync:
 
 ```text
-#1277 may remove or reject RECOVER_DURABILITY for SALVAGE pickup and keep durability recovery on BASE / STATION side.
+#1277 Step 2 updates engine.py / model.py / fixtures / tests to match this spec.
 ```
 
 ### #1278
@@ -217,8 +279,8 @@ Deferred:
 ## Follow-up ordering memo
 
 ```text
-1. #1288 records current behavior and deferred follow-ups in the source-of-truth spec.
-2. #1277 decides whether SALVAGE pickup keeps RECOVER_DURABILITY.
+1. #1277 Step 1 records the B decision in the source-of-truth spec.
+2. #1277 Step 2 synchronizes implementation / fixtures / tests with the B decision.
 3. #1276 may replace immediate enemy drop reward with map object lifecycle.
 4. #1278 randomizes drop/no-drop decision without conflicting with #1276.
 5. #1275 should be integrated into or re-scoped after #1276 if #1276 is adopted.


### PR DESCRIPTION
Related: #1277

## Summary

- Update `srs_objects.md` to record the #1277 B decision
- Limit SALVAGE pickup immediate recovery choices to energy / photon torpedo ammo / store only
- Mark `RECOVER_DURABILITY` as unsupported for SALVAGE pickup and keep durability recovery on BASE / STATION interaction
- Clarify that implementation / fixture / test synchronization is deferred to #1277 Step 2

## Scope

Documentation-only Step 1 for #1277.

This PR does not change gameplay implementation, fixtures, snapshots, or numeric balance.

## Tests

Tests not run: documentation-only change.