### PR TITLE
Galactic Exodus: document dropped SALVAGE object lifecycle

### DIFF
--- a/experiments/galactic_exodus/docs/specs/srs_objects.md
+++ b/experiments/galactic_exodus/docs/specs/srs_objects.md
@@ -55,7 +55,7 @@ RECOVER_DURABILITY は SALVAGE pickup では非対応にし、durability recover
 
 この文書は #1277 の仕様判断を反映した source-of-truth である。
 
-注意: #1277 Step 1 は documentation-only であり、実装・fixture・snapshot はまだ B 方針へ同期しない。実装同期は #1277 Step 2 で扱う。
+#1277 / #1292 により、実装・fixture・test は B 方針へ同期済み。
 
 ## Map SALVAGE pickup
 
@@ -87,8 +87,7 @@ RECOVER_DURABILITY
 
 `RECOVER_DURABILITY` が SALVAGE reward choice として指定された場合は、暗黙に `STORE_ONLY` へ丸めず、明示的に reject する。
 
-reject reason 名は実装PRで確定する。
-候補:
+reject reason:
 
 ```text
 REJECTED_UNSUPPORTED_SALVAGE_CHOICE
@@ -184,8 +183,7 @@ RECOVER_DURABILITY
 
 `RECOVER_DURABILITY` が dropped SALVAGE pickup の `salvage_choice` として指定された場合も、暗黙に `STORE_ONLY` へ丸めず、明示的に reject する。
 
-reject reason 名は実装PRで確定する。
-候補:
+reject reason:
 
 ```text
 REJECTED_UNSUPPORTED_SALVAGE_CHOICE
@@ -287,19 +285,19 @@ SALVAGE pickup does not provide durability recovery.
 
 ## Fixture regression references
 
-#1266 / #1288 時点で確認済みの fixture regression:
+#1292 時点で確認済みの fixture regression:
 
 ```text
 test_salvage_placeholder
-test_salvage_recover_durability
+test_salvage_reject_recover_durability
+test_salvage_recover_energy
+test_salvage_recover_photon_torpedo_ammo
 test_base_upgrade_defense
 test_combat_salvage_drop_tier3_energy
 test_combat_salvage_no_drop_tier1
 ```
 
-#1277 により、`test_salvage_recover_durability` は後続の実装同期で更新または置換される。
-
-この spec 更新では fixture を変更しない。fixture は実装済み挙動の regression 固定であり、spec変更に合わせた更新は別PRで行う。
+#1293 は documentation-only であり、fixture は変更しない。dropped SALVAGE object lifecycle の fixture 更新は #1294 で扱う。
 
 ## Deferred / follow-up issues
 
@@ -338,7 +336,7 @@ Durability recovery:
 Implementation sync:
 
 ```text
-#1277 Step 2 updates engine.py / model.py / fixtures / tests to match this spec.
+#1277 / #1292 updated engine.py / fixtures / tests to match this spec.
 ```
 
 ### #1278
@@ -362,7 +360,7 @@ once drop_salvage is true, #1276 object lifecycle applies.
 
 ```text
 1. #1277 Step 1 records the B decision in the source-of-truth spec.
-2. #1277 Step 2 synchronizes implementation / fixtures / tests with the B decision.
+2. #1277 / #1292 synchronized implementation / fixtures / tests with the B decision.
 3. #1276 replaces immediate enemy drop reward with dropped SALVAGE object lifecycle.
 4. #1278 randomizes drop/no-drop decision without conflicting with #1276.
 5. #1275 should be integrated into the same spawn-based lifecycle after #1276.

--- a/experiments/galactic_exodus/docs/specs/srs_objects.md
+++ b/experiments/galactic_exodus/docs/specs/srs_objects.md
@@ -357,7 +357,7 @@ once drop_salvage is true, #1276 object lifecycle applies.
 ## Follow-up ordering memo
 
 ```text
-1. #1277 Step 1 records the B decision in the source-of-truth spec.
+1. #1277 records the B decision in the source-of-truth spec.
 2. #1277 / #1292 synchronized implementation / fixtures / tests with the B decision.
 3. #1276 replaces immediate enemy drop reward with dropped SALVAGE object lifecycle.
 4. #1278 randomizes drop/no-drop decision without conflicting with #1276.

--- a/experiments/galactic_exodus/docs/specs/srs_objects.md
+++ b/experiments/galactic_exodus/docs/specs/srs_objects.md
@@ -53,8 +53,6 @@ SALVAGE取得時の即時回復は:
 RECOVER_DURABILITY は SALVAGE pickup では非対応にし、durability recovery は BASE / STATION に寄せる。
 ```
 
-この文書は #1277 の仕様判断を反映した source-of-truth である。
-
 #1277 / #1292 により、実装・fixture・test は B 方針へ同期済み。
 
 ## Map SALVAGE pickup

--- a/experiments/galactic_exodus/docs/specs/srs_objects.md
+++ b/experiments/galactic_exodus/docs/specs/srs_objects.md
@@ -15,21 +15,24 @@ Included:
 - map上の SALVAGE pickup
 - SALVAGE reward common flow
 - salvage_choice / recovery choice
-- enemy dropped SALVAGE の現行挙動
+- enemy dropped SALVAGE object lifecycle
+- dropped SALVAGE spawn
+- dropped SALVAGE pickup through `INTERACT`
+- drop payload / skip payload
 - base station interaction
 - base upgrade と salvage消費
 - persistent_state / SRS turn / fuel / player_state への副作用
-- #1275〜#1278 の deferred / follow-up
+- #1275 / #1278 との follow-up関係
 
 Excluded:
 
 - gameplay実装変更
 - fixture / snapshot 更新
 - SALVAGE効果量の再バランス
-- enemy drop randomization 実装
-- enemy drop map object化 実装
-- counterattack kill reward 実装
+- enemy drop randomization 実装 (#1278)
+- counterattack実装変更 (#1275)
 - integrated CLI入力UI実装
+- 近傍空きcell探索ルール
 
 ## Current Phase 2 initial behavior
 
@@ -106,19 +109,57 @@ REJECTED_UNSUPPORTED_SALVAGE_CHOICE
 
 durability recovery は BASE / STATION recovery 側で扱う。
 
-## Enemy dropped SALVAGE current behavior
+## Enemy dropped SALVAGE object lifecycle
 
-現行仕様:
+Before #1276:
 
-- player attack phase で target enemy を破壊したとき、`target_enemy.drop_salvage` が `true` なら SALVAGE reward を即時適用する
+```text
+player attack kill with target_enemy.drop_salvage=true applied ENEMY_DROP reward immediately.
+no map object was generated.
+INTERACT was not required.
+```
+
+After #1276:
+
+```text
+enemy kill with drop_salvage=true spawns a SALVAGE object at the destroyed enemy position.
+player inventory is not updated at kill time.
+reward is applied when the dropped object is picked up with INTERACT.
+```
+
+仕様:
+
+- 対象 enemy の `drop_salvage` が `true` の場合のみ drop候補になる
+- `drop_salvage` が `false` の場合、object は生成しない
+- object_type は `SALVAGE`
+- position は destroyed enemy の position
 - `reward_source` は `ENEMY_DROP`
-- map object は生成しない
-- `INTERACT` は不要
-- `consumed_object_ids` / `activated_object_ids` は更新しない
-- reward payload は `player_action.salvage_reward` に入る
-- drop量は enemy tier に依存する
+- `salvage_value` は enemy tier から解決する
+- generated dropped SALVAGE は map上の initial SALVAGE と同じ `INTERACT` lifecycle で取得する
+- player inventory は kill 時点では更新しない
+- successful pickup で SRS turn `+1`
+- fuel は変化しない
+- object は consumed になる
+- `persistent_state.consumed_object_ids` に `object_id` を追加する
+- `player_state` / `combat_state.player` に reward を反映する
+- reward payload には `salvage_before` / `salvage_after` / `selected_salvage_choice` / 各delta が含まれる
 
-Current drop value:
+Dropped SALVAGE metadata / payload meaning:
+
+```text
+reward_source: ENEMY_DROP
+dropped_by_enemy_id
+dropped_by_enemy_tier
+salvage_value
+recovery_profile or enemy_tier
+```
+
+補足:
+
+- 実装上の保持形式は Step 2 (#1294) で決めてよい
+- ただし `INTERACT` 時に value / recovery amount を再現できることが必要
+
+Drop value by enemy tier:
 
 ```text
 TIER1: salvage +1
@@ -127,7 +168,30 @@ TIER3: salvage +2
 TIER4: salvage +3
 ```
 
-Current drop recovery amount for supported choices:
+Supported recovery choices for dropped SALVAGE:
+
+```text
+RECOVER_ENERGY
+RECOVER_PHOTON_TORPEDO_AMMO
+STORE_ONLY
+```
+
+Unsupported recovery choices for dropped SALVAGE:
+
+```text
+RECOVER_DURABILITY
+```
+
+`RECOVER_DURABILITY` が dropped SALVAGE pickup の `salvage_choice` として指定された場合も、暗黙に `STORE_ONLY` へ丸めず、明示的に reject する。
+
+reject reason 名は実装PRで確定する。
+候補:
+
+```text
+REJECTED_UNSUPPORTED_SALVAGE_CHOICE
+```
+
+Recovery amount by enemy tier:
 
 ```text
 TIER1:
@@ -151,13 +215,51 @@ TIER4:
   STORE_ONLY: 0
 ```
 
-Unsupported enemy drop recovery choice:
+Occupied-cell skip policy:
 
 ```text
-RECOVER_DURABILITY
+destroyed enemy position の cell.object_id が None の場合のみ dropped SALVAGE を生成する
+cell.object_id が既にある場合は生成しない
+近傍空きcell探索はしない
+payload に spawned=false と skip_reason を記録する
 ```
 
-注意: 現行実装・fixture はまだ `RECOVER_DURABILITY` を扱っている可能性がある。#1277 Step 2 で実装・fixture・test をこの仕様へ同期する。
+推奨 skip reason:
+
+```text
+OCCUPIED_CELL
+```
+
+実装PRで別名にする場合は、PR本文に理由を書く。
+
+Event payload meaning:
+
+```text
+player attack phase:
+  COMBAT_TRANSITIONED.payload.player_action.salvage_drop
+
+counterattack reaction:
+  COMBAT_TRANSITIONED.payload.enemy_actions[].reaction.salvage_drop
+```
+
+payload に含める情報:
+
+```text
+reward_source: ENEMY_DROP
+object_id
+position
+enemy_id
+enemy_tier
+salvage_value
+spawned
+skip_reason, if spawned=false
+```
+
+注意:
+
+- #1293 は payload shape の意味を正本化する
+- 実際の exact key name は #1294 で実装に合わせて最終化してよい
+- ただし PR本文で specとの差分があれば明記する
 
 ## Base station / upgrade
 
@@ -205,32 +307,11 @@ test_combat_salvage_no_drop_tier1
 
 `#1275 counterattack撃破時にも enemy dropped SALVAGE を適用する`
 
-Current:
+Follow-up:
 
 ```text
-player attack kill only applies immediate ENEMY_DROP reward.
-```
-
-Deferred:
-
-```text
-counterattack kill reward is handled by #1275, but may be superseded or absorbed by #1276.
-```
-
-### #1276
-
-`#1276 enemy dropped SALVAGE を即時取得ではなく map object として生成する`
-
-Current:
-
-```text
-enemy drop is immediate reward; no map object is generated.
-```
-
-Deferred:
-
-```text
-#1276 may replace immediate reward with dropped SALVAGE object lifecycle.
+counterattack kill should use the same dropped SALVAGE object spawn helper.
+immediate ENEMY_DROP reward should not be reintroduced.
 ```
 
 ### #1277
@@ -273,7 +354,8 @@ enemy.drop_salvage bool determines drop/no-drop.
 Deferred:
 
 ```text
-#1278 may introduce tier-based random drop chance during encounter/spawn.
+randomization should decide drop_salvage or drop/no-drop before combat reward resolution.
+once drop_salvage is true, #1276 object lifecycle applies.
 ```
 
 ## Follow-up ordering memo
@@ -281,7 +363,7 @@ Deferred:
 ```text
 1. #1277 Step 1 records the B decision in the source-of-truth spec.
 2. #1277 Step 2 synchronizes implementation / fixtures / tests with the B decision.
-3. #1276 may replace immediate enemy drop reward with map object lifecycle.
+3. #1276 replaces immediate enemy drop reward with dropped SALVAGE object lifecycle.
 4. #1278 randomizes drop/no-drop decision without conflicting with #1276.
-5. #1275 should be integrated into or re-scoped after #1276 if #1276 is adopted.
+5. #1275 should be integrated into the same spawn-based lifecycle after #1276.
 ```

--- a/experiments/galactic_exodus/docs/specs/srs_objects.md
+++ b/experiments/galactic_exodus/docs/specs/srs_objects.md
@@ -53,6 +53,8 @@ SALVAGE取得時の即時回復は:
 RECOVER_DURABILITY は SALVAGE pickup では非対応にし、durability recovery は BASE / STATION に寄せる。
 ```
 
+この文書は #1277 の仕様判断を反映した source-of-truth である。
+
 #1277 / #1292 により、実装・fixture・test は B 方針へ同期済み。
 
 ## Map SALVAGE pickup


### PR DESCRIPTION
Closes #1293
Related: #1276, #1294

## Summary

- Promote #1276 dropped SALVAGE object lifecycle from deferred follow-up to source-of-truth behavior
- Document enemy drop object spawn, metadata, pickup lifecycle, occupied-cell skip behavior, and payload meaning
- Clarify #1275 / #1278 follow-up relationship after #1276
- Keep this PR documentation-only

## Tests

Tests not run: documentation-only change.
