### PR TITLE
Galactic Exodus: implement enemy SALVAGE drop randomization

### DIFF
--- a/experiments/galactic_exodus/srs/encounter.py
+++ b/experiments/galactic_exodus/srs/encounter.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections import Counter
 from dataclasses import dataclass
 from enum import Enum
+import random
 from types import MappingProxyType
 from typing import Mapping, Sequence
 
@@ -93,6 +94,15 @@ ENEMY_GROUP_COSTS: Mapping[SrsEnemyTier, int] = _freeze_mapping(
     }
 )
 
+ENEMY_SALVAGE_DROP_CHANCES: Mapping[SrsEnemyTier, float] = _freeze_mapping(
+    {
+        SrsEnemyTier.TIER1: 0.25,
+        SrsEnemyTier.TIER2: 0.35,
+        SrsEnemyTier.TIER3: 0.50,
+        SrsEnemyTier.TIER4: 0.75,
+    }
+)
+
 ENCOUNTER_GROUP_BUDGETS: Mapping[int, tuple[int, int]] = _freeze_mapping(
     {
         0: (1, 1),
@@ -136,6 +146,30 @@ ENCOUNTER_COMPOSITION_TABLE: Mapping[int, tuple[EncounterCompositionOption, ...]
 
 def enemy_group_cost(tier: SrsEnemyTier) -> int:
     return ENEMY_GROUP_COSTS[tier]
+
+
+def enemy_salvage_drop_chance(tier: SrsEnemyTier) -> float:
+    return ENEMY_SALVAGE_DROP_CHANCES[tier]
+
+
+def resolve_enemy_salvage_drop(
+    *,
+    tier: SrsEnemyTier,
+    roll: float,
+) -> tuple[bool, Mapping[str, object]]:
+    if not 0.0 <= roll <= 1.0:
+        raise SrsEncounterError("enemy salvage drop roll must be within 0.0..1.0")
+    chance = enemy_salvage_drop_chance(tier)
+    drop_salvage = roll < chance
+    return (
+        drop_salvage,
+        {
+            "enemy_tier": tier.value,
+            "salvage_drop_chance": chance,
+            "salvage_drop_roll": roll,
+            "drop_salvage": drop_salvage,
+        },
+    )
 
 
 def terrain_encounter_modifier(terrain: SrsTerrainType) -> float:
@@ -210,13 +244,32 @@ def spawn_enemies_for_encounter(
     )
     candidates = spawn_candidate_points(state)
     selected_tiers = apply_spawn_cap(planned_enemies, len(candidates))
+    rng = _enemy_salvage_drop_rng(
+        state,
+        danger_score=danger_score,
+        composition=selected_tiers,
+    )
+    debug_payloads = [
+        resolve_enemy_salvage_drop(tier=tier, roll=rng.random())
+        for tier in selected_tiers
+    ]
     return tuple(
         create_enemy_combat_state(
             enemy_id=f"enemy-{index}",
             tier=tier,
             position=position,
+            drop_salvage=drop_salvage,
+            salvage_drop_chance=payload["salvage_drop_chance"],
+            salvage_drop_roll=payload["salvage_drop_roll"],
         )
-        for index, (tier, position) in enumerate(zip(selected_tiers, candidates[: len(selected_tiers)], strict=True), start=1)
+        for index, ((tier, position), (drop_salvage, payload)) in enumerate(
+            zip(
+                zip(selected_tiers, candidates[: len(selected_tiers)], strict=True),
+                debug_payloads,
+                strict=True,
+            ),
+            start=1,
+        )
     )
 
 
@@ -326,6 +379,17 @@ def resolve_fixed_encounter_roll(
                 "composition": [tier.value for tier in roll.composition],
                 "enemy_spawned": True,
                 "spawned_enemy_ids": sorted(updated_combat_state.enemies),
+                "spawned_enemies": [
+                    {
+                        "enemy_id": enemy.enemy_id,
+                        "enemy_tier": enemy.tier.value,
+                        "position": [enemy.position.x, enemy.position.y],
+                        "salvage_drop_chance": enemy.salvage_drop_chance,
+                        "salvage_drop_roll": enemy.salvage_drop_roll,
+                        "drop_salvage": enemy.drop_salvage,
+                    }
+                    for enemy in updated_combat_state.enemies.values()
+                ],
                 "outcome": "ENCOUNTER_STARTED",
             },
         ),
@@ -375,6 +439,21 @@ def _tier_asc_sort_key(tier: SrsEnemyTier) -> int:
 
 def _tier_desc_sort_key(tier: SrsEnemyTier) -> int:
     return -_tier_asc_sort_key(tier)
+
+
+def _enemy_salvage_drop_rng(
+    state: SrsGameState,
+    *,
+    danger_score: int,
+    composition: Sequence[SrsEnemyTier],
+) -> random.Random:
+    composition_token = ",".join(tier.value for tier in composition)
+    seed = (
+        f"{state.descriptor.sector_id}|{state.descriptor.sector_seed}|"
+        f"{state.srs_turn}|{state.player_position.x},{state.player_position.y}|"
+        f"{danger_score}|{composition_token}"
+    )
+    return random.Random(seed)
 
 
 def _enemy_presence(state: SrsGameState) -> bool:

--- a/experiments/galactic_exodus/srs/fixtures/combat_encounter_spawn_cap_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/combat_encounter_spawn_cap_9x9.json
@@ -33,6 +33,26 @@
       "enemy-2": [2, 0],
       "enemy-3": [3, 0]
     },
+    "combat_enemy_salvage_drops": {
+      "enemy-1": {
+        "enemy_tier": "TIER1",
+        "salvage_drop_chance": 0.25,
+        "salvage_drop_roll": 0.9978751120979634,
+        "drop_salvage": false
+      },
+      "enemy-2": {
+        "enemy_tier": "TIER1",
+        "salvage_drop_chance": 0.25,
+        "salvage_drop_roll": 0.35529620005192497,
+        "drop_salvage": false
+      },
+      "enemy-3": {
+        "enemy_tier": "TIER2",
+        "salvage_drop_chance": 0.35,
+        "salvage_drop_roll": 0.5111271963184837,
+        "drop_salvage": false
+      }
+    },
     "combat_enemy_durabilities": {
       "enemy-1": 3,
       "enemy-2": 3,

--- a/experiments/galactic_exodus/srs/fixtures/combat_encounter_wait_nebula_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/combat_encounter_wait_nebula_9x9.json
@@ -40,6 +40,14 @@
     "combat_enemy_positions": {
       "enemy-1": [0, 0]
     },
+    "combat_enemy_salvage_drops": {
+      "enemy-1": {
+        "enemy_tier": "TIER2",
+        "salvage_drop_chance": 0.35,
+        "salvage_drop_roll": 0.4346763120373218,
+        "drop_salvage": false
+      }
+    },
     "combat_enemy_durabilities": {
       "enemy-1": 5
     },

--- a/experiments/galactic_exodus/srs/model.py
+++ b/experiments/galactic_exodus/srs/model.py
@@ -239,6 +239,8 @@ class SrsEnemyCombatState:
     attack_damage: int
     movement_power: int
     drop_salvage: bool = False
+    salvage_drop_chance: float | None = None
+    salvage_drop_roll: float | None = None
 
     def __post_init__(self) -> None:
         if self.enemy_id == "":
@@ -249,6 +251,10 @@ class SrsEnemyCombatState:
             raise SrsModelError("enemy attack_damage must be positive")
         if self.movement_power <= 0:
             raise SrsModelError("enemy movement_power must be positive")
+        if self.salvage_drop_chance is not None and not 0.0 <= self.salvage_drop_chance <= 1.0:
+            raise SrsModelError("enemy salvage_drop_chance must be within 0.0..1.0")
+        if self.salvage_drop_roll is not None and not 0.0 <= self.salvage_drop_roll <= 1.0:
+            raise SrsModelError("enemy salvage_drop_roll must be within 0.0..1.0")
 
 
 def default_weapon_profiles() -> Mapping[SrsWeaponType, SrsWeaponProfile]:
@@ -294,6 +300,8 @@ def create_enemy_combat_state(
     tier: SrsEnemyTier,
     position: Position,
     drop_salvage: bool = False,
+    salvage_drop_chance: float | None = None,
+    salvage_drop_roll: float | None = None,
 ) -> SrsEnemyCombatState:
     durability, attack_damage, movement_power = enemy_tier_defaults(tier)
     return SrsEnemyCombatState(
@@ -304,6 +312,8 @@ def create_enemy_combat_state(
         attack_damage=attack_damage,
         movement_power=movement_power,
         drop_salvage=drop_salvage,
+        salvage_drop_chance=salvage_drop_chance,
+        salvage_drop_roll=salvage_drop_roll,
     )
 
 

--- a/experiments/galactic_exodus/srs/run_fixture.py
+++ b/experiments/galactic_exodus/srs/run_fixture.py
@@ -299,6 +299,7 @@ def run_fixture_data(data: Mapping[str, Any], *, contracts: SrsContracts) -> Srs
 def fixture_result_to_jsonable(result: SrsFixtureRunResult) -> Mapping[str, Any]:
     final_state = result.final_state
     enemy_positions = _enemy_positions_payload(final_state)
+    enemy_salvage_drops = _enemy_salvage_drop_payload(final_state)
     enemy_actions = _flatten_enemy_actions(result.log)
     return {
         "fixture_id": result.fixture_id,
@@ -326,6 +327,7 @@ def fixture_result_to_jsonable(result: SrsFixtureRunResult) -> Mapping[str, Any]
             "enemy_presence": final_state.combat_state.enemy_presence if final_state.combat_state is not None else False,
             "combat_player_energy": final_state.combat_state.player.energy if final_state.combat_state is not None else None,
             "combat_enemy_positions": enemy_positions,
+            "combat_enemy_salvage_drops": enemy_salvage_drops,
         },
         "log": {
             "events": [
@@ -623,6 +625,7 @@ def _build_summary(
     if log.events:
         primary_outcome = log.events[0].payload.get("outcome")
     enemy_positions = _enemy_positions_payload(final_state)
+    enemy_salvage_drops = _enemy_salvage_drop_payload(final_state)
     enemy_actions = _flatten_enemy_actions(log)
     return {
         "fixture_id": fixture_id,
@@ -658,6 +661,7 @@ def _build_summary(
         ),
         "combat_enemy_positions": enemy_positions,
         "combat_enemy_durabilities": _enemy_durabilities_payload(final_state),
+        "combat_enemy_salvage_drops": enemy_salvage_drops,
         "enemy_actions": enemy_actions,
         "outcome": primary_outcome,
         "render_line_count": len(render.splitlines()),
@@ -673,6 +677,7 @@ def _validate_expectations(expect: Any, result: SrsFixtureRunResult) -> None:
     final_state = result.final_state
     event_types = [event.event_type for event in result.log.events]
     enemy_positions = _enemy_positions_payload(final_state)
+    enemy_salvage_drops = _enemy_salvage_drop_payload(final_state)
     enemy_actions = _flatten_enemy_actions(result.log)
     comparisons = (
         ("srs_turn", final_state.srs_turn),
@@ -702,6 +707,7 @@ def _validate_expectations(expect: Any, result: SrsFixtureRunResult) -> None:
         ),
         ("combat_enemy_positions", enemy_positions),
         ("combat_enemy_durabilities", _enemy_durabilities_payload(final_state)),
+        ("combat_enemy_salvage_drops", enemy_salvage_drops),
         ("enemy_actions", enemy_actions),
         ("outcome", result.summary.get("outcome")),
     )
@@ -736,6 +742,20 @@ def _enemy_durabilities_payload(final_state: SrsGameState) -> Mapping[str, int]:
         return {}
     return {
         enemy_id: enemy.durability
+        for enemy_id, enemy in sorted(final_state.combat_state.enemies.items())
+    }
+
+
+def _enemy_salvage_drop_payload(final_state: SrsGameState) -> Mapping[str, Mapping[str, Any]]:
+    if final_state.combat_state is None:
+        return {}
+    return {
+        enemy_id: {
+            "enemy_tier": enemy.tier.value,
+            "salvage_drop_chance": enemy.salvage_drop_chance,
+            "salvage_drop_roll": enemy.salvage_drop_roll,
+            "drop_salvage": enemy.drop_salvage,
+        }
         for enemy_id, enemy in sorted(final_state.combat_state.enemies.items())
     }
 

--- a/experiments/galactic_exodus/srs/test_encounter.py
+++ b/experiments/galactic_exodus/srs/test_encounter.py
@@ -8,13 +8,16 @@ from experiments.galactic_exodus.srs.contracts import load_default_contracts
 from experiments.galactic_exodus.srs.encounter import (
     BASE_ENCOUNTER_CHANCE_PER_SRS_TURN,
     ENCOUNTERS_PER_LRS_STEP,
+    ENEMY_SALVAGE_DROP_CHANCES,
     EXPECTED_SRS_TURNS,
     EncounterRollDisposition,
     actual_encounter_chance,
     encounter_roll_disposition,
     encounter_composition_options,
     encounter_group_budget_range,
+    enemy_salvage_drop_chance,
     enemy_group_cost,
+    resolve_enemy_salvage_drop,
     spawn_candidate_points,
     spawn_enemies_for_encounter,
     terrain_encounter_modifier,
@@ -74,6 +77,48 @@ class SrsEncounterTests(unittest.TestCase):
                 (5, (SrsEnemyTier.TIER4,)),
             ],
         )
+
+    def test_enemy_salvage_drop_chance_is_tier_monotonic(self) -> None:
+        ordered_tiers = (
+            SrsEnemyTier.TIER1,
+            SrsEnemyTier.TIER2,
+            SrsEnemyTier.TIER3,
+            SrsEnemyTier.TIER4,
+        )
+
+        self.assertEqual(
+            [enemy_salvage_drop_chance(tier) for tier in ordered_tiers],
+            [ENEMY_SALVAGE_DROP_CHANCES[tier] for tier in ordered_tiers],
+        )
+        self.assertLessEqual(enemy_salvage_drop_chance(SrsEnemyTier.TIER1), enemy_salvage_drop_chance(SrsEnemyTier.TIER2))
+        self.assertLessEqual(enemy_salvage_drop_chance(SrsEnemyTier.TIER2), enemy_salvage_drop_chance(SrsEnemyTier.TIER3))
+        self.assertLessEqual(enemy_salvage_drop_chance(SrsEnemyTier.TIER3), enemy_salvage_drop_chance(SrsEnemyTier.TIER4))
+
+    def test_enemy_salvage_drop_roll_success(self) -> None:
+        resolved, payload = resolve_enemy_salvage_drop(tier=SrsEnemyTier.TIER2, roll=0.34)
+
+        self.assertTrue(resolved)
+        self.assertEqual(payload["enemy_tier"], "TIER2")
+        self.assertEqual(payload["salvage_drop_chance"], 0.35)
+        self.assertEqual(payload["salvage_drop_roll"], 0.34)
+        self.assertTrue(payload["drop_salvage"])
+
+    def test_enemy_salvage_drop_roll_failure(self) -> None:
+        resolved, payload = resolve_enemy_salvage_drop(tier=SrsEnemyTier.TIER2, roll=0.36)
+
+        self.assertFalse(resolved)
+        self.assertEqual(payload["salvage_drop_chance"], 0.35)
+        self.assertEqual(payload["salvage_drop_roll"], 0.36)
+        self.assertFalse(payload["drop_salvage"])
+
+    def test_enemy_salvage_drop_roll_boundary_equal_chance_is_failure(self) -> None:
+        resolved, payload = resolve_enemy_salvage_drop(
+            tier=SrsEnemyTier.TIER3,
+            roll=enemy_salvage_drop_chance(SrsEnemyTier.TIER3),
+        )
+
+        self.assertFalse(resolved)
+        self.assertFalse(payload["drop_salvage"])
 
     def test_spawn_candidates_use_all_passable_warp_points_outside_player_neighbor_ring(self) -> None:
         state = replace(make_state(), player_position=Position(4, 4))
@@ -233,6 +278,23 @@ class SrsEncounterTests(unittest.TestCase):
         self.assertEqual(result.log.events[0].event_type, "WAIT_ACCEPTED")
         self.assertEqual(result.log.events[1].event_type, "ENCOUNTER_ROLLED")
         self.assertAlmostEqual(result.log.events[1].payload["actual_encounter_chance"], 0.126)
+        spawned_enemy = result.log.events[1].payload["spawned_enemies"][0]
+        self.assertEqual(spawned_enemy["enemy_id"], "enemy-1")
+        self.assertEqual(spawned_enemy["enemy_tier"], "TIER2")
+        self.assertEqual(spawned_enemy["salvage_drop_chance"], 0.35)
+        self.assertEqual(spawned_enemy["salvage_drop_roll"], 0.4346763120373218)
+        self.assertFalse(spawned_enemy["drop_salvage"])
+        self.assertEqual(
+            result.summary["combat_enemy_salvage_drops"],
+            {
+                "enemy-1": {
+                    "enemy_tier": "TIER2",
+                    "salvage_drop_chance": 0.35,
+                    "salvage_drop_roll": 0.4346763120373218,
+                    "drop_salvage": False,
+                }
+            },
+        )
 
     def test_wait_fixture_suppresses_encounter_when_base_docked(self) -> None:
         result = run_fixture(FIXTURES_DIR / "combat_encounter_wait_base_docked_9x9.json", contracts=self.contracts)

--- a/experiments/galactic_exodus/srs/test_fixtures.py
+++ b/experiments/galactic_exodus/srs/test_fixtures.py
@@ -16,6 +16,7 @@ from experiments.galactic_exodus.srs.run_fixture import (
     fixture_result_to_jsonable,
     load_fixture,
     run_fixture,
+    run_fixture_data,
 )
 from experiments.galactic_exodus.srs.test_engine_movement import make_state
 
@@ -108,6 +109,48 @@ class SrsFixtureTests(unittest.TestCase):
         self.assertEqual(payload["fixture_id"], "resource_cache_single_9x9")
         self.assertEqual(payload["final_state"]["fuel"], 5)
         json.dumps(payload)
+
+    def test_fixture_explicit_drop_salvage_override_bypasses_random_roll(self) -> None:
+        payload = {
+            "fixture_id": "explicit_drop_salvage_override",
+            "sector": {
+                "sector_id": "normal-override",
+                "sector_type": "NORMAL",
+                "sector_seed": 9101,
+                "entry_edge": "S",
+                "blocked_edges": [],
+            },
+            "initial": {
+                "combat": {
+                    "phase": "PLAYER_MOVEMENT",
+                    "enemies": [
+                        {"enemy_id": "enemy-1", "tier": "TIER1", "position": [1, 1], "drop_salvage": True},
+                        {"enemy_id": "enemy-2", "tier": "TIER2", "position": [2, 1], "drop_salvage": False},
+                    ],
+                }
+            },
+            "commands": [],
+        }
+
+        result = run_fixture_data(payload, contracts=self.contracts)
+
+        self.assertEqual(
+            result.summary["combat_enemy_salvage_drops"],
+            {
+                "enemy-1": {
+                    "enemy_tier": "TIER1",
+                    "salvage_drop_chance": None,
+                    "salvage_drop_roll": None,
+                    "drop_salvage": True,
+                },
+                "enemy-2": {
+                    "enemy_tier": "TIER2",
+                    "salvage_drop_chance": None,
+                    "salvage_drop_roll": None,
+                    "drop_salvage": False,
+                },
+            },
+        )
 
     def test_fixture_runner_validates_render_not_contains(self) -> None:
         path = FIXTURES_DIR / "move_route_basic_9x9.json"

--- a/src/array_ref.rs
+++ b/src/array_ref.rs
@@ -158,7 +158,7 @@ impl ArrayRef {
 /// semantics for arrays, which are out of scope for this issue.
 impl std::fmt::Debug for ArrayRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "ArrayRef({:?}, {:?})", self.shape, &*self.inner.borrow())
+        write!(f, "ArrayRef({:?}, {:?})", self.shape, *self.inner.borrow())
     }
 }
 


### PR DESCRIPTION
Closes #1298
Related: #1278, #1297

## Summary

- Add the tier-based enemy SALVAGE drop chance table from the source-of-truth spec (`TIER1=0.25`, `TIER2=0.35`, `TIER3=0.50`, `TIER4=0.75`)
- Resolve `drop_salvage` during encounter spawn with the `roll < chance` boundary and keep combat-time reward handling unchanged
- Preserve explicit fixture `drop_salvage: true / false` overrides without rolling
- Record per-enemy drop chance / roll / result in encounter payloads and fixture summaries
- Keep encounter-spawn fixtures deterministic by deriving the spawn-side RNG from stable encounter state inputs

## Rationale

The adopted chance table comes directly from #1297, which synchronized the source-of-truth spec for #1278. The implementation keeps those values unchanged and only adds the pre-combat resolution step needed to populate `enemy.drop_salvage`.

For fixed encounter fixtures that do not use explicit `drop_salvage`, the implementation uses a deterministic RNG seed derived from sector id, sector seed, SRS turn, player position, danger score, and final spawned composition. This keeps fixture outputs stable while still exercising the randomization path.

## Tests

- `python -m unittest discover experiments/galactic_exodus`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
