### PR TITLE
Galactic Exodus: add counterattack dropped SALVAGE fixture regression

### DIFF
--- a/experiments/galactic_exodus/srs/fixtures/combat_counterattack_salvage_drop_object_tier2_9x9.json
+++ b/experiments/galactic_exodus/srs/fixtures/combat_counterattack_salvage_drop_object_tier2_9x9.json
@@ -1,0 +1,75 @@
+{
+  "fixture_id": "combat_counterattack_salvage_drop_object_tier2_9x9",
+  "description": "A counterattack kill spawns a dropped tier2 SALVAGE object without immediate reward.",
+  "sector": {
+    "sector_id": "normal-9113",
+    "sector_type": "NORMAL",
+    "sector_seed": 9113,
+    "entry_edge": "S",
+    "blocked_edges": []
+  },
+  "initial": {
+    "reveal": {"mode": "FULL"},
+    "player_position": [1, 4],
+    "combat": {
+      "phase": "ENEMY_ACTION",
+      "enemies": [
+        {"enemy_id": "enemy-2", "tier": "TIER2", "position": [2, 4], "drop_salvage": true, "durability": 1}
+      ]
+    }
+  },
+  "commands": [
+    {
+      "command_type": "COMBAT_STEP",
+      "enemy_reactions": {
+        "enemy-2": "COUNTERATTACK"
+      }
+    }
+  ],
+  "expect": {
+    "event_types": ["COMBAT_TRANSITIONED"],
+    "combat_phase": "PLAYER_MOVEMENT",
+    "combat_turn": 1,
+    "enemy_presence": false,
+    "player_salvage": 0,
+    "combat_player_durability": 93,
+    "combat_player_energy": 6,
+    "combat_player_torpedo_ammo": 6,
+    "combat_enemy_positions": {},
+    "combat_enemy_durabilities": {},
+    "enemy_actions": [
+      {
+        "enemy_id": "enemy-2",
+        "start_position": [2, 4],
+        "target_attackable_position": [2, 4],
+        "planned_path": [],
+        "moved_path": [],
+        "final_position": [2, 4],
+        "movement_power": 3,
+        "movement_cost": 0,
+        "attacked_player": true,
+        "can_attack_before_move": true,
+        "can_attack_after_move": true,
+        "reaction": {
+          "selected_reaction": "COUNTERATTACK",
+          "resolved_reaction": "COUNTERATTACK",
+          "counterattack_available": true,
+          "fallback_to_defend": false,
+          "damage_to_player": 7,
+          "counterattack_damage": 1,
+          "enemy_destroyed": true,
+          "salvage_drop": {
+            "reward_source": "ENEMY_DROP",
+            "object_id": "enemy-drop-salvage-enemy-2",
+            "position": [2, 4],
+            "enemy_id": "enemy-2",
+            "enemy_tier": "TIER2",
+            "salvage_value": 1,
+            "spawned": true
+          }
+        }
+      }
+    ],
+    "outcome": "ACCEPTED"
+  }
+}

--- a/experiments/galactic_exodus/srs/test_fixture_regression.py
+++ b/experiments/galactic_exodus/srs/test_fixture_regression.py
@@ -167,6 +167,29 @@ class SrsFixtureRegressionTests(unittest.TestCase):
         self.assertEqual(result.final_state.combat_state.player.energy, 5)
         self.assertEqual(result.final_state.combat_state.enemies["enemy-1"].durability, 4)
 
+    def test_combat_counterattack_salvage_drop_object_tier2(self) -> None:
+        result = run_named_fixture("combat_counterattack_salvage_drop_object_tier2_9x9")
+
+        self.assertFalse(result.final_state.combat_state.enemy_presence)
+        self.assertEqual(result.final_state.player_state.salvage, 0)
+        self.assertEqual(
+            result.final_state.actual_map.cell_at(Position(2, 4)).object_id,
+            "enemy-drop-salvage-enemy-2",
+        )
+        self.assertEqual(
+            result.summary["enemy_actions"][0]["reaction"]["salvage_drop"],
+            {
+                "reward_source": "ENEMY_DROP",
+                "object_id": "enemy-drop-salvage-enemy-2",
+                "position": [2, 4],
+                "enemy_id": "enemy-2",
+                "enemy_tier": "TIER2",
+                "salvage_value": 1,
+                "spawned": True,
+            },
+        )
+        self.assertTrue(result.summary["enemy_actions"][0]["reaction"]["enemy_destroyed"])
+
     def test_combat_salvage_drop_object_tier3(self) -> None:
         result = run_named_fixture("combat_salvage_drop_object_tier3_9x9")
 

--- a/experiments/galactic_exodus/srs/test_fixtures.py
+++ b/experiments/galactic_exodus/srs/test_fixtures.py
@@ -46,6 +46,7 @@ REQUIRED_FIXTURES = {
     "combat_enemy_movement_tiebreak_9x9.json",
     "combat_torpedo_destroy_no_counterattack_9x9.json",
     "combat_phaser_attack_damage_9x9.json",
+    "combat_counterattack_salvage_drop_object_tier2_9x9.json",
     "combat_salvage_drop_object_tier3_9x9.json",
     "combat_salvage_drop_then_interact_9x9.json",
     "combat_salvage_drop_occupied_cell_skip_9x9.json",


### PR DESCRIPTION
Closes #1303
Related: #1275, #1276, #1296

## Summary

- add a fixture covering dropped SALVAGE object spawn from a counterattack kill
- add fixture regression assertions for `enemy_actions[].reaction.salvage_drop`
- confirm the drop remains object-lifecycle based and does not grant immediate reward

## Tests

- `python -m unittest discover experiments/galactic_exodus`
