### PR TITLE
Galactic Exodus: organize evaluation documents under docs

### DIFF
--- a/experiments/galactic_exodus/README.md
+++ b/experiments/galactic_exodus/README.md
@@ -670,7 +670,7 @@ python experiments/galactic_exodus/fuel_metrics.py \
   --resource-supply 5 \
   --resource-counts 0,1,3 \
   --csv-output experiments/galactic_exodus/results/fuel_comparison_low_initial_seed_1_1000.csv \
-  --markdown-output experiments/galactic_exodus/results/fuel_comparison_low_initial_seed_1_1000.md
+  --markdown-output experiments/galactic_exodus/docs/evaluations/phase1_fuel_comparison_low_initial_seed_1_1000.md
 ```
 
 configuration の並び順は常に次です。

--- a/experiments/galactic_exodus/docs/evaluations/README.md
+++ b/experiments/galactic_exodus/docs/evaluations/README.md
@@ -1,0 +1,37 @@
+# Galactic Exodus evaluation documents
+
+## Authority
+
+- このディレクトリは評価結果・比較・観察・再現手順を保持する。
+- gameplay specification の CURRENT_SOURCE は `../specs/` である。
+- evaluation document と current specification が異なる場合、現行仕様は `docs/specs/` を参照する。
+- 評価結果を仕様へ反映する場合は、対応する仕様 issue / PR を経由する。
+
+## Phase 1
+
+1. [`phase1_prototype_playtest.md`](phase1_prototype_playtest.md)
+   - 対象: Phase 1B の統合プレイテスト
+   - 文書の役割: 手動評価と自動評価を統合した評価レポート
+   - 主な関連issue: #1067, #1068, #1059
+2. [`phase1_fuel_comparison_low_initial_seed_1_1000.md`](phase1_fuel_comparison_low_initial_seed_1_1000.md)
+   - 対象: 低 initial fuel 候補の比較
+   - 文書の役割: 燃料・補給パラメータ比較の評価レポート
+   - 主な関連issue: #1039, #1040
+3. [`phase1_fuel_comparison_seed_1_1000.md`](phase1_fuel_comparison_seed_1_1000.md)
+   - 対象: 高 initial fuel 候補の比較
+   - 文書の役割: 燃料候補の baseline 比較レポート
+   - 主な関連issue: #1040
+
+## Phase 2
+
+1. [`phase2_srs_playtest.md`](phase2_srs_playtest.md)
+   - 対象: Phase 2 SRS の統合評価メモ
+   - 文書の役割: 手動根拠と自動根拠を decision issue へ渡す評価メモ
+   - 主な関連issue: #1162, #1081, #1163
+
+## Reproduction policy
+
+- Markdown は評価レポート本体である。
+- CSV / JSON は既存 `results/` 配下の機械可読成果物である。
+- Markdown の移動に伴って CSV / JSON は移動しない。
+- 再生成時の Markdown 出力先は `docs/evaluations/` を使う。

--- a/experiments/galactic_exodus/docs/evaluations/phase1_fuel_comparison_low_initial_seed_1_1000.md
+++ b/experiments/galactic_exodus/docs/evaluations/phase1_fuel_comparison_low_initial_seed_1_1000.md
@@ -1,5 +1,9 @@
 # Galactic Exodus Fuel Comparison
 
+> **文書区分:** 評価根拠
+>
+> この文書は gameplay 仕様の正本ではありません。現行仕様は `experiments/galactic_exodus/docs/specs/` を参照してください。
+
 ## Reproduction
 
 ```bash
@@ -12,7 +16,7 @@ python experiments/galactic_exodus/fuel_metrics.py \
   --resource-supply 5 \
   --resource-counts 0,1,3 \
   --csv-output experiments/galactic_exodus/results/fuel_comparison_low_initial_seed_1_1000.csv \
-  --markdown-output experiments/galactic_exodus/results/fuel_comparison_low_initial_seed_1_1000.md
+  --markdown-output experiments/galactic_exodus/docs/evaluations/phase1_fuel_comparison_low_initial_seed_1_1000.md
 ```
 
 ## Conclusion

--- a/experiments/galactic_exodus/docs/evaluations/phase1_fuel_comparison_seed_1_1000.md
+++ b/experiments/galactic_exodus/docs/evaluations/phase1_fuel_comparison_seed_1_1000.md
@@ -1,5 +1,9 @@
 # Galactic Exodus Fuel Comparison
 
+> **文書区分:** 評価根拠
+>
+> この文書は gameplay 仕様の正本ではありません。現行仕様は `experiments/galactic_exodus/docs/specs/` を参照してください。
+
 ## Reproduction
 
 ```bash
@@ -12,7 +16,7 @@ python experiments/galactic_exodus/fuel_metrics.py \
   --resource-supply 5 \
   --resource-counts 0,1,3 \
   --csv-output experiments/galactic_exodus/results/fuel_comparison_seed_1_1000.csv \
-  --markdown-output experiments/galactic_exodus/results/fuel_comparison_seed_1_1000.md
+  --markdown-output experiments/galactic_exodus/docs/evaluations/phase1_fuel_comparison_seed_1_1000.md
 ```
 
 ## Conclusion

--- a/experiments/galactic_exodus/docs/evaluations/phase1_prototype_playtest.md
+++ b/experiments/galactic_exodus/docs/evaluations/phase1_prototype_playtest.md
@@ -1,5 +1,9 @@
 # Galactic Exodus Phase 1B 統合プレイテストレポート
 
+> **文書区分:** 評価根拠
+>
+> この文書は gameplay 仕様の正本ではありません。現行仕様は `experiments/galactic_exodus/docs/specs/` を参照してください。
+
 ## 1. 対象範囲とバージョン
 
 本レポートは、TBX実装前のPythonプロトタイプについて、Phase 1B1の手動評価（#1067）とPhase 1B2の決定的方策による自動評価（#1068）を統合したものである。

--- a/experiments/galactic_exodus/docs/evaluations/phase2_srs_playtest.md
+++ b/experiments/galactic_exodus/docs/evaluations/phase2_srs_playtest.md
@@ -1,5 +1,9 @@
 # Galactic Exodus Phase 2 SRS評価統合メモ
 
+> **文書区分:** 評価根拠
+>
+> この文書は gameplay 仕様の正本ではありません。現行仕様は `experiments/galactic_exodus/docs/specs/` を参照してください。
+
 ## 1. 対象と前提
 
 本メモは issue #1162 の成果物として、Phase 2 SRS の移動・探索ルールに関する既存評価結果を decision issue へ渡しやすい形に整理したものである。

--- a/experiments/galactic_exodus/docs/spec_traceability.md
+++ b/experiments/galactic_exodus/docs/spec_traceability.md
@@ -206,6 +206,17 @@ status は #1314 の定義に従い、`MIGRATED` / `PARTIAL` / `MISSING` / `CONF
 | `experiments/galactic_exodus/srs/phase2_srs_generation.md` | `## 5` | `warp_flags` generation / blocked edge / return-cell selection | `docs/specs/srs_warp.md`, `docs/specs/srs_map_generation.md` | WARP / blocked edge / board edge ルールは current docs に移植済み。 | `MIGRATED` | なし | 維持のみ。 | - |
 | `experiments/galactic_exodus/srs/phase2_srs_generation.md` | `## 6-9` | generation order / cluster generation / reachability / seed retry report | `docs/specs/srs_map_generation.md` | 現行 generator 手順と board-edge decision は docs 化済み。 | `PARTIAL` | legacy の retry/report schema を current docs はまだ全面移植していない。 | terrain-count 実装有無と合わせて current generator contract を補完する。 | #1263, #1264 |
 
+## evaluation evidence inventory (#1313 / #1314)
+
+評価文書は gameplay specification の `CURRENT_SOURCE` ではなく、`experiments/galactic_exodus/docs/evaluations/` に集約した `EVALUATION` として扱う。
+
+| inventory path | classification | final destination | status | note |
+|---|---|---|---|---|
+| `experiments/galactic_exodus/docs/evaluations/phase1_prototype_playtest.md` | `EVALUATION` | `experiments/galactic_exodus/docs/evaluations/phase1_prototype_playtest.md` | `current` | Phase 1B の手動/自動評価の統合レポート。 |
+| `experiments/galactic_exodus/docs/evaluations/phase1_fuel_comparison_low_initial_seed_1_1000.md` | `EVALUATION` | `experiments/galactic_exodus/docs/evaluations/phase1_fuel_comparison_low_initial_seed_1_1000.md` | `current` | 低 initial fuel 候補の比較レポート。 |
+| `experiments/galactic_exodus/docs/evaluations/phase1_fuel_comparison_seed_1_1000.md` | `EVALUATION` | `experiments/galactic_exodus/docs/evaluations/phase1_fuel_comparison_seed_1_1000.md` | `current` | 高 initial fuel 候補の比較レポート。 |
+| `experiments/galactic_exodus/docs/evaluations/phase2_srs_playtest.md` | `EVALUATION` | `experiments/galactic_exodus/docs/evaluations/phase2_srs_playtest.md` | `current` | Phase 2 SRS の手動/自動評価統合メモ。 |
+
 ## 棚卸しメモ
 
 - code searchだけを正本にしない。未実装仕様はcode searchでは見つからないため。

--- a/experiments/galactic_exodus/docs/specs/README.md
+++ b/experiments/galactic_exodus/docs/specs/README.md
@@ -13,6 +13,7 @@ Galactic Exodus では、issue comment、設計メモ、fixtures、snapshots、R
 |---|---|
 | issue | 議論・決定ログ。仕様を確定してよいが、issueだけで完了扱いにしない。 |
 | `experiments/galactic_exodus/docs/specs/` | 仕様正本。実装 issue が参照する source of truth。 |
+| `experiments/galactic_exodus/docs/evaluations/` | 評価根拠。比較レポート、観察、再現手順を保持するが、現行仕様正本としては扱わない。 |
 | `experiments/galactic_exodus/docs/design/` | 表示案・比較サンプル・設計メモ。ゲームルール正本としては扱わない。 |
 | fixtures / snapshots | 実装済み挙動の regression 固定。正本仕様と矛盾した場合は正本仕様を優先する。 |
 | README | 実行方法・ユーザー向け説明。詳細仕様は experiments/galactic_exodus/docs/specs へリンクする。 |
@@ -43,6 +44,11 @@ Implementation PR:
 
 `experiments/galactic_exodus/docs/design/galactic_exodus_display_samples.md` のような文書は、表示案や比較サンプルとして扱う。
 ゲームルールを再決定しない。
+
+### 3.5. experiments/galactic_exodus/docs/evaluations は評価根拠
+
+`experiments/galactic_exodus/docs/evaluations/` は、採用判断の根拠となる評価結果・比較・観察・再現手順を集約する。
+この配下の Markdown は現行仕様の正本ではなく、current source は `experiments/galactic_exodus/docs/specs/` を参照する。
 
 ### 4. fixtures / snapshots は regression 固定
 


### PR DESCRIPTION
Closes #1315
Related: #1307, #1313, #1314, #1317, #1318

## Summary

- move the four evaluation Markdown documents under `experiments/galactic_exodus/docs/evaluations/`
- add `docs/evaluations/README.md` as the only evaluation index and document the authority split from `docs/specs/`
- update Markdown output paths and related docs references without changing CSV / JSON / code artifacts

## Testing

- not run (documentation-only)
