### PR TITLE
Galactic Exodus: archive the Phase 1 reference fixture plan

### DIFF
--- a/experiments/galactic_exodus/docs/archive/README.md
+++ b/experiments/galactic_exodus/docs/archive/README.md
@@ -1,0 +1,25 @@
+# Galactic Exodus archived documents
+
+## Authority
+
+- archive配下は履歴資料であり current source ではない
+- gameplay specification の CURRENT_SOURCE は `../specs/`
+- active implementation plan として使用しない
+- archive と current spec が異なる場合は `docs/specs` を優先する
+
+## Phase 1
+
+### `phase1_reference_fixture_plan.md`
+
+- former role: PR #1077 向け reference fixture 実装計画
+- related issue / PR: #1059 / #1077
+- status: implemented and archived
+- reason retained: fixture注入・再生設計の実装経緯を保存するため
+- current references: code / fixtures / tests
+
+## Retention policy
+
+- 完了済みで履歴価値のある設計・実装計画を保持する
+- 未完了のactive planはarchiveへ置かない
+- archive文書を仕様正本として参照しない
+- 削除判断は重複性と履歴価値を別途確認して行う

--- a/experiments/galactic_exodus/docs/archive/phase1_reference_fixture_plan.md
+++ b/experiments/galactic_exodus/docs/archive/phase1_reference_fixture_plan.md
@@ -1,5 +1,14 @@
 # Phase 1参照fixture実装計画
 
+> **文書区分:** 履歴資料 — 完了済み実装計画
+>
+> この文書は PR #1077 の実装計画を保存するための履歴資料です。現行の gameplay 仕様や active plan ではありません。現行仕様は `experiments/galactic_exodus/docs/specs/`、現行挙動はコード・fixtures・testsを参照してください。
+
+- Former path: `experiments/galactic_exodus/reference_fixture_plan.md`
+- Related issue: #1059
+- Implemented by: PR #1077
+- Archived by: #1316
+
 ## 1. 対象範囲
 
 通常の生成ゲーム挙動を変更せず、Python参照実装へ決定的なfixture注入・再生機能を追加する。

--- a/experiments/galactic_exodus/docs/spec_traceability.md
+++ b/experiments/galactic_exodus/docs/spec_traceability.md
@@ -212,6 +212,7 @@ status は #1314 の定義に従い、`MIGRATED` / `PARTIAL` / `MISSING` / `CONF
 
 | inventory path | classification | final destination | status | note |
 |---|---|---|---|---|
+| `experiments/galactic_exodus/reference_fixture_plan.md` | `HISTORICAL_IMPLEMENTATION_PLAN` | `experiments/galactic_exodus/docs/archive/phase1_reference_fixture_plan.md` | `archived` | former path。PR #1077 の実装経緯を保存する履歴資料。follow-up issue: #1316 |
 | `experiments/galactic_exodus/docs/evaluations/phase1_prototype_playtest.md` | `EVALUATION` | `experiments/galactic_exodus/docs/evaluations/phase1_prototype_playtest.md` | `current` | Phase 1B の手動/自動評価の統合レポート。 |
 | `experiments/galactic_exodus/docs/evaluations/phase1_fuel_comparison_low_initial_seed_1_1000.md` | `EVALUATION` | `experiments/galactic_exodus/docs/evaluations/phase1_fuel_comparison_low_initial_seed_1_1000.md` | `current` | 低 initial fuel 候補の比較レポート。 |
 | `experiments/galactic_exodus/docs/evaluations/phase1_fuel_comparison_seed_1_1000.md` | `EVALUATION` | `experiments/galactic_exodus/docs/evaluations/phase1_fuel_comparison_seed_1_1000.md` | `current` | 高 initial fuel 候補の比較レポート。 |


### PR DESCRIPTION
Closes #1316
Related: #1059, #1077, #1307, #1313, #1314, #1317, #1318

## Summary

- move `reference_fixture_plan.md` to `experiments/galactic_exodus/docs/archive/phase1_reference_fixture_plan.md`
- add archive authority note and metadata to the archived plan
- add `experiments/galactic_exodus/docs/archive/README.md`
- record the archived destination in `experiments/galactic_exodus/docs/spec_traceability.md`

## Testing

- not run (documentation-only)
