### PR TITLE
Galactic Exodus: audit encounter spawn balance after warp flag expansion

### DIFF
--- a/experiments/galactic_exodus/srs/encounter_balance_notes.md
+++ b/experiments/galactic_exodus/srs/encounter_balance_notes.md
@@ -32,8 +32,8 @@ This document records the #1257 audit result for encounter spawn candidates and 
 
 - all `FLOOR` 9x9 / player center (`Position(4, 4)`)
   - candidate count = 32
-  - north = 9
-  - south = 9
+  - y_min = 9
+  - y_max = 9
   - west = 7
   - east = 7
   - corners = 4
@@ -46,10 +46,10 @@ This document records the #1257 audit result for encounter spawn candidates and 
 - `SectorType.RIFT`, `blocked_edges = {N, W}`, player center
   - candidate count = 15
   - blocked edge 側の candidate は除外される
-  - north = 8, south = 0, west = 0, east = 7, corners = 2
+  - y_min = 8, y_max = 0, west = 0, east = 7, corners = 1
   - 残る candidate の Chebyshev 距離はすべて 4
 
-west / east の件数は corner を別集計に分離しており、外周分布を二重計上しないための分析用 summary である。
+`y_min` / `y_max` は座標ベースの集計であり、`Direction.N` / `Direction.S` とは意図的に切り分けている。west / east の件数は corner を別集計に分離しており、外周分布を二重計上しないための分析用 summary である。
 
 ## 4. Spawn result checks
 

--- a/experiments/galactic_exodus/srs/encounter_balance_notes.md
+++ b/experiments/galactic_exodus/srs/encounter_balance_notes.md
@@ -1,0 +1,102 @@
+# Galactic Exodus SRS encounter spawn balance notes
+
+Source issue: #1257
+Related: #1088, #1178, #1194, #1254, PR #1256
+Base branch: `integration/882-galactic-exodus`
+
+This document records the #1257 audit result for encounter spawn candidates and initial combat distance after the #1254 warp flag expansion. It is an analysis note, not a gameplay source of truth.
+
+## 1. Scope
+
+このメモは `spawn_candidate_points()` と `spawn_enemies_for_encounter()` の現行挙動を、deterministic なテストで確認した結果をまとめる。
+
+対象は次に限定する。
+
+- all `FLOOR` 9x9 での warp candidate 分布
+- player が edge 近傍にいる場合の neighbor ring 除外
+- `SectorType.RIFT` + blocked edge の candidate 除外
+- fixed composition spawn の enemy id / tier / position
+- representative fixture における初期 combat distance
+
+この PR では gameplay constants、encounter chance、movement power、tier composition、damage、durability は変更しない。
+
+## 2. Baseline after #1254
+
+#1254 / PR #1256 により warp flag は「各辺中央4点」ではなく、外周 `FLOOR` と 2x2 `FLOOR` cluster 条件に基づく配置へ広がった。
+
+その結果、all `FLOOR` 9x9 では外周全体が spawn candidate になりうる。candidate 数は増えたが、candidate 順序・spawn cap・tier 正規化の仕様は今回の PR では変更していない。
+
+## 3. Candidate distribution checks
+
+`test_encounter_balance.py` で確認した代表ケースは次の通り。
+
+- all `FLOOR` 9x9 / player center (`Position(4, 4)`)
+  - candidate count = 32
+  - north = 9
+  - south = 9
+  - west = 7
+  - east = 7
+  - corners = 4
+  - 全 candidate の Chebyshev 距離 = 4
+- all `FLOOR` 9x9 / player edge-near (`Position(7, 4)`)
+  - player の neighbor ring に入る `Position(8, 3)`, `Position(8, 4)`, `Position(8, 5)` は除外される
+  - それ以外の外周 candidate は残る
+  - candidate count = 29
+  - 最短 Chebyshev 距離 = 2
+- `SectorType.RIFT`, `blocked_edges = {N, W}`, player center
+  - candidate count = 15
+  - blocked edge 側の candidate は除外される
+  - north = 8, south = 0, west = 0, east = 7, corners = 2
+  - 残る candidate の Chebyshev 距離はすべて 4
+
+west / east の件数は corner を別集計に分離しており、外周分布を二重計上しないための分析用 summary である。
+
+## 4. Spawn result checks
+
+固定 composition `(TIER2, TIER1, TIER1)` を all `FLOOR` 9x9 / center player に与えると、spawn 結果は次で安定する。
+
+- `enemy-1`: `TIER1` at `Position(0, 0)`
+- `enemy-2`: `TIER1` at `Position(1, 0)`
+- `enemy-3`: `TIER2` at `Position(2, 0)`
+
+つまり、
+
+- enemy id 採番は deterministic
+- tier は現行仕様通り昇順に正規化される
+- position は candidate 順序に従って deterministic に選ばれる
+
+既存 fixture `combat_encounter_spawn_cap_9x9.json` でも、最終位置は `Position(1, 0)`, `Position(2, 0)`, `Position(3, 0)` で固定される。
+
+## 5. Distance / pressure assessment
+
+center player の代表 9x9 ケースでは、all `FLOOR` / RIFT fixture のどちらでも spawn 直後の敵距離は Chebyshev 4 でそろっている。
+
+これは次を意味する。
+
+- #1254 後に candidate は増えた
+- ただし player center ケースでは「外周多数 candidate = すぐ隣に spawn」にはなっていない
+- player edge 近傍でも neighbor ring 除外により、少なくとも距離 1 の即時近接 spawn は抑制されている
+
+現行の `player movement_power = 4`、`enemy movement_power = 3` 前提に対し、今回確認した representative ケースでは初期 distance pressure が直ちに破綻している証拠は見つからない。
+
+## 6. Balance conclusion
+
+Conclusion:
+
+#1254 後の warp flag 増加により spawn candidate は増えたが、player neighbor ring 除外と外周 spawn により、代表 9x9 ケースでは初期距離は概ね維持されている。既存 #1194 / #1178 の初期バランス前提と即時に矛盾する evidence はない。数値調整は行わない。
+
+## 7. Follow-up
+
+今回の分析では follow-up issue が必要なほどの明確な balance break は確認できなかった。
+
+non-scope を再掲する。
+
+- `BASE_ENCOUNTER_CHANCE_PER_SRS_TURN` の変更
+- `EXPECTED_SRS_TURNS` の変更
+- `ENCOUNTERS_PER_LRS_STEP` の変更
+- enemy / player `movement_power` の変更
+- tier composition / group budget の変更
+- combat damage / durability / defense / evasion の変更
+- spawn candidate ordering の仕様変更
+- spawn cap の仕様変更
+- `integrated_play.py` への encounter / combat 接続

--- a/experiments/galactic_exodus/srs/test_encounter_balance.py
+++ b/experiments/galactic_exodus/srs/test_encounter_balance.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import unittest
+from dataclasses import replace
+from pathlib import Path
+
+from experiments.galactic_exodus.srs.contracts import load_default_contracts
+from experiments.galactic_exodus.srs.encounter import (
+    spawn_candidate_points,
+    spawn_enemies_for_encounter,
+)
+from experiments.galactic_exodus.srs.model import (
+    Direction,
+    Position,
+    SectorDescriptor,
+    SectorType,
+    SrsEnemyTier,
+)
+from experiments.galactic_exodus.srs.run_fixture import FIXTURES_DIR, run_fixture
+from experiments.galactic_exodus.srs.test_engine_movement import make_state
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def chebyshev_distance(a: Position, b: Position) -> int:
+    return max(abs(a.x - b.x), abs(a.y - b.y))
+
+
+def candidate_summary(state) -> dict[str, int]:
+    candidates = spawn_candidate_points(state)
+    corners = {
+        Position(0, 0),
+        Position(state.actual_map.width - 1, 0),
+        Position(0, state.actual_map.height - 1),
+        Position(state.actual_map.width - 1, state.actual_map.height - 1),
+    }
+    return {
+        "count": len(candidates),
+        "north": sum(position.y == 0 for position in candidates),
+        "south": sum(position.y == state.actual_map.height - 1 for position in candidates),
+        "west": sum(position.x == 0 and position not in corners for position in candidates),
+        "east": sum(
+            position.x == state.actual_map.width - 1 and position not in corners
+            for position in candidates
+        ),
+        "corners": sum(position in corners for position in candidates),
+        "min_distance": min(chebyshev_distance(state.player_position, position) for position in candidates),
+        "max_distance": max(chebyshev_distance(state.player_position, position) for position in candidates),
+    }
+
+
+class SrsEncounterBalanceTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.contracts = load_default_contracts(REPO_ROOT)
+
+    def test_all_floor_center_player_candidate_distribution_after_warp_flag_expansion(self) -> None:
+        state = replace(make_state(), player_position=Position(4, 4))
+
+        self.assertEqual(
+            candidate_summary(state),
+            {
+                "count": 32,
+                "north": 9,
+                "south": 9,
+                "west": 7,
+                "east": 7,
+                "corners": 4,
+                "min_distance": 4,
+                "max_distance": 4,
+            },
+        )
+
+    def test_edge_near_player_excludes_neighbor_ring_but_keeps_other_edge_candidates(self) -> None:
+        state = replace(make_state(), player_position=Position(7, 4))
+        candidates = spawn_candidate_points(state)
+
+        self.assertLess(len(candidates), len(spawn_candidate_points(replace(make_state(), player_position=Position(4, 4)))))
+        self.assertNotIn(Position(8, 3), candidates)
+        self.assertNotIn(Position(8, 4), candidates)
+        self.assertNotIn(Position(8, 5), candidates)
+        self.assertIn(Position(0, 0), candidates)
+        self.assertIn(Position(4, 0), candidates)
+        self.assertIn(Position(8, 0), candidates)
+        self.assertIn(Position(0, 8), candidates)
+        self.assertGreaterEqual(
+            min(chebyshev_distance(state.player_position, position) for position in candidates),
+            2,
+        )
+
+    def test_rift_blocked_edges_remove_blocked_edge_candidates(self) -> None:
+        descriptor = SectorDescriptor(
+            sector_id="rift-9201",
+            sector_type=SectorType.RIFT,
+            sector_seed=9201,
+            entry_edge=Direction.S,
+            blocked_edges=frozenset({Direction.N, Direction.W}),
+        )
+        state = make_state(
+            sector_type=descriptor.sector_type,
+            sector_seed=descriptor.sector_seed,
+            entry_edge=descriptor.entry_edge,
+            blocked_edges=descriptor.blocked_edges,
+        )
+        state = replace(state, descriptor=descriptor, player_position=Position(4, 4))
+
+        self.assertEqual(
+            candidate_summary(state),
+            {
+                "count": 15,
+                "north": 8,
+                "south": 0,
+                "west": 0,
+                "east": 7,
+                "corners": 1,
+                "min_distance": 4,
+                "max_distance": 4,
+            },
+        )
+
+    def test_fixed_composition_spawn_positions_keep_initial_distance_pressure(self) -> None:
+        state = replace(make_state(), player_position=Position(4, 4))
+
+        enemies = spawn_enemies_for_encounter(
+            state,
+            danger_score=4,
+            composition=(
+                SrsEnemyTier.TIER2,
+                SrsEnemyTier.TIER1,
+                SrsEnemyTier.TIER1,
+            ),
+        )
+
+        self.assertEqual(
+            [(enemy.enemy_id, enemy.tier, enemy.position) for enemy in enemies],
+            [
+                ("enemy-1", SrsEnemyTier.TIER1, Position(0, 0)),
+                ("enemy-2", SrsEnemyTier.TIER1, Position(1, 0)),
+                ("enemy-3", SrsEnemyTier.TIER2, Position(2, 0)),
+            ],
+        )
+        self.assertEqual(
+            [chebyshev_distance(state.player_position, enemy.position) for enemy in enemies],
+            [4, 4, 4],
+        )
+
+    def test_combat_encounter_spawn_cap_fixture_documents_current_spawn_positions(self) -> None:
+        result = run_fixture(FIXTURES_DIR / "combat_encounter_spawn_cap_9x9.json", contracts=self.contracts)
+        player_position = result.final_state.player_position
+        enemies = result.final_state.combat_state.enemies
+
+        self.assertEqual(len(enemies), 3)
+        self.assertEqual(
+            result.summary["combat_enemy_positions"],
+            {
+                "enemy-1": [1, 0],
+                "enemy-2": [2, 0],
+                "enemy-3": [3, 0],
+            },
+        )
+        self.assertEqual(
+            {
+                enemy_id: chebyshev_distance(player_position, enemy.position)
+                for enemy_id, enemy in enemies.items()
+            },
+            {
+                "enemy-1": 4,
+                "enemy-2": 4,
+                "enemy-3": 4,
+            },
+        )

--- a/experiments/galactic_exodus/srs/test_encounter_balance.py
+++ b/experiments/galactic_exodus/srs/test_encounter_balance.py
@@ -37,8 +37,8 @@ def candidate_summary(state) -> dict[str, int]:
     }
     return {
         "count": len(candidates),
-        "north": sum(position.y == 0 for position in candidates),
-        "south": sum(position.y == state.actual_map.height - 1 for position in candidates),
+        "y_min": sum(position.y == 0 for position in candidates),
+        "y_max": sum(position.y == state.actual_map.height - 1 for position in candidates),
         "west": sum(position.x == 0 and position not in corners for position in candidates),
         "east": sum(
             position.x == state.actual_map.width - 1 and position not in corners
@@ -62,8 +62,8 @@ class SrsEncounterBalanceTests(unittest.TestCase):
             candidate_summary(state),
             {
                 "count": 32,
-                "north": 9,
-                "south": 9,
+                "y_min": 9,
+                "y_max": 9,
                 "west": 7,
                 "east": 7,
                 "corners": 4,
@@ -109,8 +109,8 @@ class SrsEncounterBalanceTests(unittest.TestCase):
             candidate_summary(state),
             {
                 "count": 15,
-                "north": 8,
-                "south": 0,
+                "y_min": 8,
+                "y_max": 0,
                 "west": 0,
                 "east": 7,
                 "corners": 1,


### PR DESCRIPTION
Closes #1257

## Summary

- add `test_encounter_balance.py` to audit candidate distribution, blocked-edge filtering, deterministic spawn order, and initial combat distance after the #1254 warp flag expansion
- add `encounter_balance_notes.md` to record the representative findings and confirm that this PR does not change gameplay constants or encounter behavior
- keep implementation behavior unchanged and limit the work to analysis, tests, and notes

## Tests

- `python -m unittest experiments.galactic_exodus.srs.test_encounter`
- `python -m unittest experiments.galactic_exodus.srs.test_encounter_balance`
- `python -m unittest discover experiments/galactic_exodus/srs`
  - fails in the current repository state because `experiments/galactic_exodus/srs/phase2_initial_model.md` and `experiments/galactic_exodus/srs/phase2_srs_spec.md` are missing before this change
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
