### PR TITLE
Galactic Exodus: fix Phase 1B validator ResourceWarning

### DIFF
--- a/experiments/galactic_exodus/test_validate_phase1b_results.py
+++ b/experiments/galactic_exodus/test_validate_phase1b_results.py
@@ -121,7 +121,8 @@ class Phase1BValidationTests(unittest.TestCase):
             validator.validate_summary(self.summary, run_counts)
 
     def test_validate_findings_requires_all_questions(self) -> None:
-        rows = list(csv.DictReader(self.findings.open(encoding="utf-8", newline="")))
+        with self.findings.open(encoding="utf-8", newline="") as file:
+            rows = list(csv.DictReader(file))
         with self.findings.open("w", encoding="utf-8", newline="") as file:
             writer = csv.DictWriter(file, fieldnames=validator.FINDING_FIELDS)
             writer.writeheader()


### PR DESCRIPTION
## Summary

- Fix the `ResourceWarning` in `test_validate_phase1b_results.py` by closing the findings CSV file explicitly.
- The warning was caused by passing `Path.open()` directly to `csv.DictReader`, leaving the file handle without context-manager ownership.
- Use `with self.findings.open(...) as file` so the handle is closed deterministically after rows are read.

## Verification

- `python -Wd -m unittest experiments.galactic_exodus.test_validate_phase1b_results`
- `python -Wd -m unittest discover experiments/galactic_exodus`
- `python -Wd -m unittest discover experiments/galactic_exodus/srs`
- `git diff --check`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
