### PR TITLE
Galactic Exodus: SRS sector境界契約を正本仕様へ反映

### DIFF
--- a/experiments/galactic_exodus/docs/specs/srs_map_generation.md
+++ b/experiments/galactic_exodus/docs/specs/srs_map_generation.md
@@ -2,18 +2,18 @@
 
 Source issues: #1085, #1086, #1088
 Traceability audit: #1260
-Follow-up: #1263, #1264
+Follow-up: #1263, #1264, #1350, #1351, #1344
 
 この文書は、Galactic Exodus Phase 2 SRS map generation の正本仕様と、現行prototypeで未実装として残す範囲を記録する。
 
 ## 目的
 
-SRS map generation は、LRS sector type、blocked edge情報、LRS board境界情報から、SRS local map、terrain、objects、warp flags、persistent state を作る。
+SRS map generation は、actual な LRS sector state から構築された `SectorDescriptor` を入力にして、9x9 の SRS local map、terrain、objects、warp flags、persistent generation metadata を作る。
 
 現時点では、WARP / RIFT edge 表現とobject配置は実装済みである。
 一方、#1088 で検討された SectorType別 terrain-count generation profile は、現行prototypeではまだ full implementation にしない。
 
-## 現行prototypeで固定する範囲
+## mapと座標
 
 現行 `experiments/galactic_exodus/srs/generate.py` は、9x9 mapのみを生成する。
 
@@ -24,143 +24,190 @@ MAP_CENTER = internal Position(4, 4)
 ```
 
 SRS internal coordinate は 0-origin lower-left である。
+CLI表示座標は 1-origin lower-left である。
 
 ```text
+internal Position(0, 0) == CLI display (1, 1)
 x increases eastward
 y increases northward
 ```
 
+新規ゲーム開始時の player 位置は次で固定する。
+
+```python
+spawn_position = Position(0, 0)
+```
+
+通常sector遷移では、sourceの退出方向とdestinationの進入側は反対方向になる。
+
+```text
+source EXIT N -> destination ingress S
+source EXIT E -> destination ingress W
+source EXIT S -> destination ingress N
+source EXIT W -> destination ingress E
+```
+
+9x9 mapの進入位置は次で固定する。
+
+```python
+ENTRY_POSITIONS = {
+    Direction.N: Position(4, 8),
+    Direction.E: Position(8, 4),
+    Direction.S: Position(4, 0),
+    Direction.W: Position(0, 4),
+}
+```
+
+`spawn_position` は descriptor の必須fieldであり、進入辺から暗黙導出しない。
+
+## SectorDescriptor contract
+
+SRS生成の正本入力は次の contract とする。
+
+```python
+@dataclass(frozen=True, slots=True)
+class SectorDescriptor:
+    sector_id: str
+    sector_type: SectorType
+    sector_seed: int
+    spawn_position: Position
+    allowed_exit_edges: frozenset[Direction]
+    board_edge_directions: frozenset[Direction]
+    rift_blocked_edges: frozenset[Direction]
+```
+
+`Direction.N/E/S/W` の各方向は、必ず次のいずれか1つに属する。
+
+```text
+allowed_exit_edges
+board_edge_directions
+rift_blocked_edges
+```
+
+3集合は相互排他的であり、和集合は全方向と一致しなければならない。
+未分類方向および重複分類は不正とする。
+
+### `allowed_exit_edges`
+
+`allowed_exit_edges` は、actual に隣接sectorが存在し、RIFTで遮断されていない方向を表す。
+
+```text
+- 対応方向の外周cellは通常terrain
+- 2x2 FLOOR cluster条件を満たす外周cellへwarp flagを生成する
+- 現在sectorからその方向へのEXITを許可する
+- destination側の対応進入方向もallowedの場合のみENTRYを許可する
+```
+
+### `board_edge_directions`
+
+`board_edge_directions` は、LRS board外で隣接sectorが存在しない方向を表す。
+
+```text
+- 外周cellは通行可能
+- RIFT_BARRIERを生成しない
+- warp flagを生成しない
+- WARP_EXITしない
+```
+
+board edgeは壁ではなく、外周cellの先に退出先が存在しない状態である。
+たとえば新規ゲーム開始位置 `Position(0, 0)` はsouth / west側の外周cell上に置けるが、その方向がboard edgeであればEXITは成立しない。
+
+### `rift_blocked_edges`
+
+`rift_blocked_edges` は、actual RIFTによる遮断方向を表す。
+
+```text
+- EXIT不可
+- 対応方向からのENTRY不可
+- 外周一列すべてをRIFT_BARRIERにする
+- warp flagを生成しない
+- 外周cell自体へ進入できない
+```
+
+RIFT blocked edgeは双方向通過不能である。
+
+## SectorType.RIFT consistency
+
+`sector_type` は具体的な遮断方向を決めない。
+遮断方向の正本は `rift_blocked_edges` とする。
+
+```text
+- SectorType.RIFT のsectorは、必ず1方向以上のrift_blocked_edgesを持つ
+- SectorType.RIFT 以外のsectorは、rift_blocked_edgesを持たない
+- sector_typeから具体的な遮断方向を推測しない
+```
+
 ## 生成手順
 
-現行prototypeの生成手順は次の通りである。
+正本仕様としての生成手順は次の通りである。
 
 ```text
-1. 全cellを FLOOR として初期化する
-2. descriptor.blocked_edges に対応する外周へ RIFT_BARRIER を配置する
-3. non-blocked edge へ warp_flags を付与する
-4. entry_edge に対応する固定初期位置へplayerを置く
-5. STAR / PLANET / sector type別extra objectを配置する
-6. persistent_stateへgeneration metadataを保存する
+1. SectorDescriptorを検証する
+2. 全cellを FLOOR として初期化する
+3. rift_blocked_edges に対応する外周一列へ RIFT_BARRIER を配置する
+4. allowed_exit_edges の外周cellへ、2x2 FLOOR cluster条件に従って warp_flags を付与する
+5. spawn_position にplayerを置く
+6. STAR / PLANET / sector type別extra objectを配置する
+7. persistent generation metadataを保存する
 ```
 
-ただし、この手順だけでは LRS board外縁方向を判定できない。
-LRS board外縁方向の扱いは、この文書の「LRS board境界情報」節を正本とする。
+object配置候補、warp flag生成、terrain配置は同じ3方向集合 contract を参照する。
 
-## RIFT / WARP
+## validation責務
 
-WARP の詳細仕様は `srs_warp.md` を正本とする。
-
-この文書では、生成器側の責務だけを扱う。
+共通descriptor / generation validationは次を保証する。
 
 ```text
-- blocked edge方向にはwarp flagを付与しない
-- blocked edge方向の外周にはRIFT_BARRIERを配置する
-- non-blocked edgeでは2x2 FLOOR cluster条件を満たす外周cellへwarp flagを付与する
-- warp flag付きcellにはobjectを配置しない
+- spawn_positionがmap内
+- spawn_positionが生成後に通行可能
+- spawn_positionがRIFT_BARRIER上ではない
+- spawn_positionがobjectと重ならない
+- object配置候補からspawn_positionを除外する
+- 3方向集合が相互排他的かつ全方向を網羅する
+- SectorType.RIFTとrift_blocked_edgesが整合する
 ```
 
-## LRS board境界情報
+通常遷移として正しい外縁位置か、source/destination双方が通過可能かは integrated adapter の責務とする。
 
-### 決定
+## known_routesとの関係
 
-#1264時点では、次を正式方針とする。
+`known_routes` は発見済み情報・表示情報である。
+3方向集合は actual なゲーム状態・SRS生成入力である。
 
 ```text
-Decision:
-  SRS生成は、LRS board外縁方向を blocked edge と同等に扱う。
-
-Preferred implementation:
-  SRS生成の呼び出し側が、現在LRS座標とboard boundsから allowed_exit_edges または blocked_exit_edges を解決し、SectorDescriptor相当の入力へ渡す。
-
-Current prototype status:
-  `create_sector()` は LRS board境界情報を直接持たないため、descriptor.blocked_edges に含まれない方向をopen edgeとして扱う。
+LRS actual state
+  -> integrated adapter
+  -> SectorDescriptor
+  -> SRS generation
 ```
 
-銀河外縁方向にはLRS destinationが存在しないため、SRS cellへその方向の `warp_flags` を付与してはならない。
+`known_routes` を actual generation 入力に使用しない。
+actual RIFTは未発見でも `rift_blocked_edges` に反映する。
+SRS descriptorからLRS route表示を逆算するhelperは設けない。
 
-### 用語
+## persistent metadata
 
-| 用語 | 意味 |
-|---|---|
-| `board edge` | LRS board外縁。隣接sectorが存在しない方向。 |
-| `blocked edge` | RIFT等によりsector間移動が禁止されている方向。 |
-| `allowed_exit_edges` | LRS destinationが存在し、かつRIFT等でblockedされていない方向集合。 |
-| `blocked_exit_edges` | RIFT blocked edge と board edge を合わせた、SRSからexitできない方向集合。 |
-
-### 生成時の解決順
-
-SRS生成時のexit方向は、次の順に解決する。
+persistent metadataへ次を直接保存する。
 
 ```text
-1. 現在LRS座標から、N/E/S/Wそれぞれのdestinationを計算する
-2. destinationがLRS board外なら、その方向を board edge とする
-3. known / generated RIFT edge がある方向を blocked edge とする
-4. board edge と blocked edge を合わせて blocked_exit_edges とする
-5. blocked_exit_edges 方向には warp flag を付与しない
-6. blocked_exit_edges 方向のSRS外周には RIFT_BARRIER 相当の通行不能外周を置く
+sector_type
+generation_seed
+spawn_position
+allowed_exit_edges
+board_edge_directions
+rift_blocked_edges
 ```
 
-`RIFT_BARRIER` というterrain名はRIFT由来だが、Phase 2 prototypeでは「exit不可外周」を表す通行不能terrainとして board edge にも使ってよい。
-必要なら将来、表示上だけ `BOARD_EDGE_BARRIER` などへ分ける。
+restore時にも、metadataとdescriptorの一致、3集合の排他性・網羅性、`SectorType.RIFT` と `rift_blocked_edges` の整合性を検証する。
 
-### 推奨データ契約
-
-将来実装では、`SectorDescriptor` またはその呼び出し元に次のどちらかを追加する。
-
-```text
-Option A:
-  allowed_exit_edges: frozenset[Direction]
-
-Option B:
-  blocked_exit_edges: frozenset[Direction]
-```
-
-推奨は Option A である。
-
-理由:
-
-```text
-- board外・RIFT・将来の一時封鎖を「許可されたexit集合」へ集約できる
-- 生成器は allowed_exit_edges に含まれない方向へwarp flagを付けなければよい
-- EXIT commandの成功条件とも対応しやすい
-```
-
-ただし、現行modelに即して最小変更で実装する場合は、`blocked_edges` に board edge を含めて渡す互換案も許容する。
-その場合、`blocked_edges` が「RIFTのみ」ではなく「exit不可方向」を意味するようになるため、命名またはcommentで明確化する。
-
-### integrated CLIとの関係
-
-現行 `integrated_play.py` の minimal SRS は、全edgeへwarp candidateを付与し、`EXIT <dir>` 実行時にLRS board外をrejectする。
-
-これは安全側のruntime validationではあるが、仕様上は生成時点でboard外方向のwarp flagを出さない方が正しい。
-
-したがって、将来の full SRS generation 統合では次を満たす。
-
-```text
-- LRS board外方向はSRS生成時点でwarp flagを持たない
-- integrated CLIのboard外rejectは、防御的validationとして残してよい
-- 表示上、board外方向はwarp可能に見えてはならない
-```
-
-### #1264時点の実装方針
-
-#1264では、gameplay実装・fixture・snapshotは変更しない。
-
-このissueでは設計を固定し、実装は後続へ送る。
-
-後続実装issueでは、少なくとも次を扱う。
-
-```text
-- SectorDescriptorまたはSRS generation呼び出し元のexit方向contract
-- LRS board boundsからallowed_exit_edgesを計算するhelper
-- srs/generate.py の warp_flags生成
-- integrated_play.py minimal SRS generation
-- test_generate.py / test_integrated_play.py で外縁方向にwarp flagが出ないことの確認
-```
+generation schema versionは #1351 で更新する。
+旧generation schemaのrestoreは明示的にrejectする。
+旧形式を推測変換する互換readerは追加しない。
+既存fixtureは #1351 で新schemaへ一括migrationする。
 
 ## object placement
 
-現行prototypeでは、各sectorに次のobjectを配置する。
+Phase 2 prototypeでは、各sectorに次のobjectを配置する。
 
 ```text
 common:
@@ -177,7 +224,7 @@ sector type別extra:
 object配置候補は次を満たすcellである。
 
 ```text
-- player初期位置ではない
+- spawn_positionではない
 - terrain が FLOOR
 - warp_flags が空
 - object_id が未設定
@@ -202,7 +249,7 @@ resource_cache_restore_values(cache_count):
 - WARP / RIFT edge / EXIT command の整合を先に固定している
 - terrain countを入れると object placement、warp candidate、fixture、snapshotが同時に変化する
 - combat / encounter / movement評価の前提が変わる可能性がある
-- #1264 の LRS外縁情報設計と合わせて扱う方が安全である
+- #1350 の sector boundary contract と合わせて扱う方が安全である
 ```
 
 したがって、#1263時点では次を正式方針とする。
@@ -218,38 +265,24 @@ Future implementation:
   SectorType別terrain count range / limitを実装する場合は、専用issueでgenerator・fixtures・tests・balanceへの影響をまとめて扱う。
 ```
 
-## deferred項目
+## 実装反映先と後続issue
 
-次は未実装として明記する。
+この文書更新では、Pythonコード、fixture、runtime test、snapshot、balance値を変更しない。
 
-```text
-- SectorType別 terrain count range / limit
-- FLOORを残余として扱うterrain composition generation
-- NEBULA / ASTEROID_FIELD / DEBRIS / GRAVITY_FIELD / RIFT_DISTORTION の配置profile
-- terrain countに応じたobject placement候補の再計算
-- terrain countに応じたwarp candidate不足時のfallback / retry policy
-- terrain generation seedの安定化方針
-```
-
-## 実装変更方針
-
-この文書追加では、gameplay実装、fixture、snapshot、balance値を変更しない。
-
-full terrain-count profileを実装する場合は、別issueで次を同時に扱う。
+#1351 では次を同時に扱う。
 
 ```text
-- experiments/galactic_exodus/srs/generate.py
-- experiments/galactic_exodus/srs/test_generate.py
-- fixtures / fixture regression
-- display snapshotがある場合はsnapshot更新
-- encounter / movement balanceへの影響確認
+- Python model / validation / generation の更新
+- generation schema version 更新
+- restore時の新metadata検証と旧schema reject
+- fixture一括migration
+- runtime test / snapshot更新
 ```
 
-## #1264 の結論
+#1344 では次を扱う。
 
-現行 `create_sector()` は LRS board境界情報を直接持たない。
-そのため、`descriptor.blocked_edges` に含まれない方向はopen edgeとして扱う。
-
-#1264では、board外縁方向を生成時にexit不可として扱う方針を固定する。
-ただし、現行prototypeの実装変更は行わない。
-実装は、allowed_exit_edges / blocked_exit_edges contractを決める後続issueで扱う。
+```text
+- integrated adapterでactual LRS stateからSectorDescriptorを構築する
+- 通常sector遷移時のsource/destination通過可否を検証する
+- integrated_play.pyへ新descriptor contractを接続する
+```

--- a/experiments/galactic_exodus/docs/specs/srs_map_generation.md
+++ b/experiments/galactic_exodus/docs/specs/srs_map_generation.md
@@ -10,7 +10,8 @@ Follow-up: #1263, #1264, #1350, #1351, #1344
 
 SRS map generation は、actual な LRS sector state から構築された `SectorDescriptor` を入力にして、9x9 の SRS local map、terrain、objects、warp flags、persistent generation metadata を作る。
 
-現時点では、WARP / RIFT edge 表現とobject配置は実装済みである。
+現行prototypeでは、WARP / RIFT edge 表現とobject配置の一部は旧contractで実装済みである。
+`spawn_position` と3方向集合contractへの同期は #1351 で実装する。
 一方、#1088 で検討された SectorType別 terrain-count generation profile は、現行prototypeではまだ full implementation にしない。
 
 ## mapと座標

--- a/experiments/galactic_exodus/docs/specs/srs_warp.md
+++ b/experiments/galactic_exodus/docs/specs/srs_warp.md
@@ -172,14 +172,22 @@ board edgeは壁ではなく、外周cellの先に退出先が存在しない状
 
 SRSからLRSへ移動するのは `EXIT <dir>` のみである。
 
-`EXIT <dir>` は、少なくとも次を満たす場合に成功する。
+SRS WARP_EXIT の local validation は、少なくとも次を満たす場合に成功する。
 
 ```text
 - 現在playerがいるcellがSRS map内にある
 - 現在cellの warp_flags に <dir> が含まれる
 - <dir> が allowed_exit_edges に含まれる
-- destination側の対応進入方向もallowedである
 - combat等、上位game loop上の移動禁止条件を満たしている
+```
+
+source / destination を組み合わせた sector 遷移の受理は integrated adapter の責務である。
+integrated transition validation は少なくとも次を確認する。
+
+```text
+- source exit directionがsource.allowed_exit_edgesに含まれる
+- destination ingress directionがdestination.allowed_exit_edgesに含まれる
+- destination spawn_positionがENTRY_POSITIONSの対応位置と一致する
 ```
 
 board edge方向は `warp_flags` を持たないため失敗する。

--- a/experiments/galactic_exodus/docs/specs/srs_warp.md
+++ b/experiments/galactic_exodus/docs/specs/srs_warp.md
@@ -3,6 +3,7 @@
 Source issue: #1088
 Related implementation: #1254, #1255
 Traceability audit: #1260
+Boundary contract: #1350
 
 この文書は、Galactic Exodus Phase 2 SRS における WARP / RIFT edge / SRS外周 exit 表現の仕様正本である。
 
@@ -25,8 +26,10 @@ SRS local map から隣接 LRS sector へ移動できる地点を、旧来の固
 | `warp_flags` | SRS cell が持つ方向別 exit flag。値は `N`, `E`, `S`, `W` の集合。 |
 | warp cell | `warp_flags` が空でない passable cell。 |
 | exit direction | `warp_flags` に含まれる LRS移動方向。 |
-| blocked edge | LRS上でRIFT等により通行不能なsector間edge。 |
-| `RIFT_BARRIER` | SRS外周に配置される通行不能terrain。対応するLRS edgeがblockedであることを表す。 |
+| `allowed_exit_edges` | actual に隣接sectorが存在し、RIFTで遮断されていない方向集合。 |
+| `board_edge_directions` | LRS board外で隣接sectorが存在しない方向集合。 |
+| `rift_blocked_edges` | actual RIFT による双方向通過不能edgeの方向集合。 |
+| `RIFT_BARRIER` | RIFT blocked edge のSRS外周一列に配置される通行不能terrain。 |
 
 ## 廃止した表現
 
@@ -41,6 +44,32 @@ SRS local map から隣接 LRS sector へ移動できる地点を、旧来の固
 
 WARPは object / feature ではなく、SRS cell の `warp_flags` で表現する。
 
+## SectorDescriptorとの関係
+
+SRS generation と WARP_EXIT は、同じ3方向集合 contract を参照する。
+
+```python
+@dataclass(frozen=True, slots=True)
+class SectorDescriptor:
+    sector_id: str
+    sector_type: SectorType
+    sector_seed: int
+    spawn_position: Position
+    allowed_exit_edges: frozenset[Direction]
+    board_edge_directions: frozenset[Direction]
+    rift_blocked_edges: frozenset[Direction]
+```
+
+`Direction.N/E/S/W` の各方向は、必ず次のいずれか1つに属する。
+
+```text
+allowed_exit_edges
+board_edge_directions
+rift_blocked_edges
+```
+
+3集合は相互排他的であり、和集合は全方向と一致しなければならない。
+
 ## 基本ルール
 
 ### 1. warp可能cell
@@ -51,7 +80,8 @@ warp可能cellは、次の条件を満たす。
 - terrain が passable である
 - 通常は FLOOR cell として扱う
 - SRS map の外周に接している
-- 対応方向の `warp_flags` を持つ
+- 対応方向が allowed_exit_edges に含まれる
+- 対応方向の warp_flags を持つ
 ```
 
 warp可能cellは、通常の移動対象cellでもある。
@@ -74,12 +104,15 @@ S edgeの場合:
 ### 3. 四隅のmulti-flag
 
 四隅cellは、条件を満たせば2方向のwarp flagを持てる。
+各方向は個別に `allowed_exit_edges` と 2x2 FLOOR cluster 条件を満たす必要がある。
 
 例:
 
 ```text
 south-west corner:
-  `S` と `W` の両方の2x2 FLOOR cluster条件を満たす場合、warp_flags = {S, W} になり得る。
+  S と W の両方が allowed_exit_edges に含まれ、
+  両方向の2x2 FLOOR cluster条件を満たす場合、
+  warp_flags = {S, W} になり得る。
 ```
 
 表示上は、単方向なら `^`, `>`, `v`, `<` などで表し、複数方向を持つcellは `+` で表してよい。
@@ -95,40 +128,45 @@ south-west corner:
 - playerがexit可能なcell上で、RESOURCE_CACHE / SALVAGE / STATION等のinteraction対象と意味が衝突するのを避ける
 ```
 
-## RIFT / blocked edge との関係
+## direction分類ごとの生成規則
 
-### 1. blocked edge 方向はwarp禁止
+### `allowed_exit_edges`
 
-LRS上で対応方向のedgeがblockedの場合、その方向のwarp flagは付与しない。
-
-例:
+`allowed_exit_edges` に含まれる方向だけが warp flag を生成できる。
 
 ```text
-blocked_edges = {E}
-
-SRS cell上の `E` warp flag:
-  付与しない
+- 対応方向の外周cellは通常terrain
+- 2x2 FLOOR cluster条件を満たす外周cellへwarp flagを生成する
+- EXIT <dir> の候補方向になる
 ```
 
-### 2. RIFT_BARRIER配置
+ENTRYは、destination側の対応進入方向もallowedの場合のみ許可する。
 
-blocked edgeに対応するSRS外周には `RIFT_BARRIER` を配置する。
+### `board_edge_directions`
+
+`board_edge_directions` に含まれる方向は、LRS destinationが存在しない。
 
 ```text
-E edge blocked:
-  SRS map の east外周に `RIFT_BARRIER` を配置する
+- warp flagを生成しない
+- RIFT_BARRIERを生成しない
+- 外周cellは通行可能
+- EXIT <dir> は成立しない
 ```
 
-`RIFT_BARRIER` は通行不能terrainである。
-そのため、playerはblocked edge側の外周cellへ移動できず、その方向の `EXIT` も成立しない。
+board edgeは壁ではなく、外周cellの先に退出先が存在しない状態である。
+そのため、playerはboard edge側の外周cellへ移動できるが、その方向へWARP_EXITしない。
 
-### 3. non-blocked edge
+### `rift_blocked_edges`
 
-blockedではない方向では、通常の2x2 FLOOR cluster条件に従ってwarp flagを付与する。
+`rift_blocked_edges` に含まれる方向は、actual RIFT による双方向通過不能edgeである。
 
-ただし、銀河外縁方向はLRS destinationが存在しないため、warp flagを付与してはならない。
-SRS generator単体でLRS board境界情報を持たない場合、その制限は呼び出し側または後続統合で保証する。
-この制限は #1264 で扱う。
+```text
+- warp flagを生成しない
+- 外周一列をRIFT_BARRIERにする
+- 外周cell自体へ進入できない
+- EXIT <dir> は成立しない
+- 対応方向からのENTRYも成立しない
+```
 
 ## EXIT command との関係
 
@@ -138,18 +176,33 @@ SRSからLRSへ移動するのは `EXIT <dir>` のみである。
 
 ```text
 - 現在playerがいるcellがSRS map内にある
-- 現在cellの `warp_flags` に `<dir>` が含まれる
-- `<dir>` が known blocked edge ではない
-- LRS destinationがboard内にある
+- 現在cellの warp_flags に <dir> が含まれる
+- <dir> が allowed_exit_edges に含まれる
+- destination側の対応進入方向もallowedである
 - combat等、上位game loop上の移動禁止条件を満たしている
 ```
 
-この文書では、SRS cell側の `warp_flags` と blocked edge 表現を定義する。
-統合CLI上の実装済み / deferred制約の一覧化は #1268 で扱う。
+board edge方向は `warp_flags` を持たないため失敗する。
+RIFT blocked edge方向も `warp_flags` を持たず、外周一列が `RIFT_BARRIER` であるため失敗する。
+
+## known_routesとの関係
+
+`known_routes` は発見済み情報・表示情報である。
+WARP generation と WARP_EXIT は actual な3方向集合 contract を参照する。
+
+```text
+known_routes:
+  発見済み情報・表示情報
+
+allowed_exit_edges / board_edge_directions / rift_blocked_edges:
+  actualなゲーム状態・SRS生成入力・WARP_EXIT判定入力
+```
+
+actual RIFTは未発見でも `rift_blocked_edges` に反映する。
 
 ## 実装反映先
 
-現行prototypeでは、主に次へ反映されている。
+この仕様は、主に次へ反映される。
 
 ```text
 experiments/galactic_exodus/srs/generate.py
@@ -158,8 +211,8 @@ experiments/galactic_exodus/integrated_play.py
 experiments/galactic_exodus/test_integrated_play.py
 ```
 
-#1254 では `srs/generate.py` の `warp_flags` 生成を #1088 仕様へ同期した。
-#1255 では `integrated_play.py` の minimal SRS `warp_flags` を #1088 仕様へ同期した。
+#1351 では Python model / validation / generation / fixture / test を新しい3方向集合 contract へ同期する。
+#1344 では integrated adapter と `integrated_play.py` を同じ contract へ接続する。
 
 ## 表示との関係
 
@@ -180,6 +233,4 @@ experiments/galactic_exodus/test_integrated_play.py
 ## 後続課題
 
 この文書では、terrain-count generation profile の完全実装は扱わない。
-#1088 の terrain-count generation profile を今すぐ実装するか deferred にするかは #1263 で扱う。
-
-SRS generatorにLRS board外縁情報を渡す設計は #1264 で扱う。
+#1088 の terrain-count generation profile は #1263 で deferred としている。


### PR DESCRIPTION
## 概要

Closes #1350

SRS map generation と WARP 仕様を、`SectorDescriptor` の正本データ契約へ同期しました。

## 変更内容

- `spawn_position`、新規ゲーム開始位置、通常遷移時の進入位置を明記
- `allowed_exit_edges` / `board_edge_directions` / `rift_blocked_edges` の3方向集合による完全分類を正本化
- board edge と actual RIFT の意味、terrain、warp flag、ENTRY/EXIT規則を分離
- `SectorType.RIFT` と `rift_blocked_edges` の整合性規則を追加
- `known_routes` と actual generation 入力の責務分離を明記
- persistent metadata、schema更新、旧schema reject、fixture migration の後続方針を明記
- #1351 と #1344 へ渡す実装責務を整理

## 対象外

- Pythonコード、fixture、runtime test、snapshotは変更していません

## 確認

- `rg -n "\b(entry_edge|spawn_edge|blocked_edges|blocked_exit_edges)\b|Option A|Option B|known / generated|後続で保証|呼び出し側.*保証" experiments/galactic_exodus/docs/specs/srs_map_generation.md experiments/galactic_exodus/docs/specs/srs_warp.md`
- `git diff --check`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
