### PR TITLE
TBX Nextの初期workspace構成を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
               with:
                   toolchain: stable
             - uses: Swatinem/rust-cache@v2
-            - run: cargo check --all-targets
+            - run: cargo check --workspace --all-targets
 
     test:
         name: Test
@@ -31,7 +31,7 @@ jobs:
               with:
                   toolchain: stable
             - uses: Swatinem/rust-cache@v2
-            - run: cargo test
+            - run: cargo test --workspace
 
     clippy:
         name: Clippy
@@ -43,7 +43,7 @@ jobs:
                   toolchain: stable
                   components: clippy
             - uses: Swatinem/rust-cache@v2
-            - run: cargo clippy --all-targets
+            - run: cargo clippy --workspace --all-targets
 
     fmt:
         name: Format
@@ -54,4 +54,4 @@ jobs:
               with:
                   toolchain: stable
                   components: rustfmt
-            - run: cargo fmt --check
+            - run: cargo fmt --all --check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,6 +307,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "tbx-next"
+version = "0.1.0"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,13 @@ edition = "2021"
 rust-version = "1.76"
 description = "Tiny BASIC eXtensible - a bootstrappable BASIC interpreter"
 
+[workspace]
+members = [
+    ".",
+    "crates/tbx-next",
+]
+resolver = "2"
+
 [lib]
 name = "tbx"
 path = "src/lib.rs"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,20 @@
 TBX は Tiny BASIC の構文と Forth 的な自己拡張性を組み合わせた処理系です。
 Rust で実装された最小限のプリミティブセットを土台として、言語自身を用いて段階的にブートストラップします。
 
+## 現行 TBX と TBX Next
+
+現行実装はルート package `tbx` です。ADR #1358 に基づき、次世代実装の入口として独立 package `tbx-next` を `crates/tbx-next` に追加しています。TBX Next は現行 `tbx` に依存せず、現時点では開発中であることを示す最小 crate です。
+
+TBX Next の案内は [`crates/tbx-next/README.md`](./crates/tbx-next/README.md) と [`docs/next/README.md`](./docs/next/README.md) を参照してください。実装事実の正本はコードとテストで、非自明な why はソースコードコメントに記録します。
+
+```sh
+cargo build -p tbx
+cargo test -p tbx
+cargo build -p tbx-next
+cargo test -p tbx-next
+cargo run -p tbx-next --bin tbx-next
+```
+
 ## アーキテクチャの概要
 
 | 要素 | 説明 |

--- a/crates/tbx-next/Cargo.toml
+++ b/crates/tbx-next/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "tbx-next"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.76"
+publish = false
+description = "Next-generation TBX implementation placeholder"
+
+[lib]
+name = "tbx_next"
+path = "src/lib.rs"
+
+[[bin]]
+name = "tbx-next"
+path = "src/main.rs"
+
+[dependencies]

--- a/crates/tbx-next/README.md
+++ b/crates/tbx-next/README.md
@@ -1,0 +1,18 @@
+# TBX Next
+
+TBX Next は、現行 `tbx` package とは独立した次世代実装用 crate です。
+この crate は ADR #1358 に基づくリポジトリ境界を置くための最小コードベースであり、現時点では VM、lexer、parser、compiler、辞書、値型、スタック、変数、ワード定義などの言語機能を実装していません。
+
+現行実装はルート package `tbx` です。TBX Next は package `tbx-next`、library `tbx_next`、binary `tbx-next` として分離されています。新旧 crate 間の dependency はありません。
+
+## Source of Truth
+
+実装事実の正本はコードとテストです。設計判断の根拠は ADR #1358 を参照し、非自明な why は実装時にソースコードコメントへ記録します。
+
+## Commands
+
+```sh
+cargo build -p tbx-next
+cargo test -p tbx-next
+cargo run -p tbx-next --bin tbx-next
+```

--- a/crates/tbx-next/src/lib.rs
+++ b/crates/tbx-next/src/lib.rs
@@ -1,0 +1,16 @@
+pub const STATUS_MESSAGE: &str =
+    "TBX Next is under development; language features are not implemented yet.";
+
+pub fn status_message() -> &'static str {
+    STATUS_MESSAGE
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn status_message_reports_development_state() {
+        assert!(status_message().contains("under development"));
+    }
+}

--- a/crates/tbx-next/src/main.rs
+++ b/crates/tbx-next/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("{}", tbx_next::status_message());
+}

--- a/docs/next/README.md
+++ b/docs/next/README.md
@@ -1,0 +1,20 @@
+# TBX Next
+
+TBX Next は、現行 `tbx` package と同じリポジトリに置かれた独立 package です。
+根拠 ADR は #1358 です。
+
+- 現行実装: ルート package `tbx`
+- 次世代実装: `crates/tbx-next` の package `tbx-next`
+- 実装事実の正本: コードとテスト
+- 非自明な why: ソースコードコメントに記録
+
+## Commands
+
+```sh
+cargo build -p tbx
+cargo test -p tbx
+cargo build -p tbx-next
+cargo test -p tbx-next
+cargo run -p tbx-next --bin tbx-next
+cargo test --workspace
+```

--- a/src/array_ref.rs
+++ b/src/array_ref.rs
@@ -158,7 +158,7 @@ impl ArrayRef {
 /// semantics for arrays, which are out of scope for this issue.
 impl std::fmt::Debug for ArrayRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "ArrayRef({:?}, {:?})", self.shape, &*self.inner.borrow())
+        write!(f, "ArrayRef({:?}, {:?})", self.shape, *self.inner.borrow())
     }
 }
 


### PR DESCRIPTION
## 概要

Closes #1359

- ルート `tbx` package を維持したまま Cargo workspace root 化
- 独立 crate `crates/tbx-next` を追加し、library `tbx_next` / binary `tbx-next` の最小入口を追加
- TBX Next の案内 README と `docs/next/README.md` を追加
- CI の Cargo コマンドを workspace 対象に更新

## 確認

- `cargo build -p tbx`
- `cargo test -p tbx`
- `cargo build -p tbx-next`
- `cargo test -p tbx-next`
- `cargo run -p tbx-next --bin tbx-next`
- `cargo test --workspace`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all --check`
