### PR TITLE
TBX Next README の導線を整理する

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,10 @@ Rust で実装された最小限のプリミティブセットを土台として
 
 ## 現行 TBX と TBX Next
 
-現行実装はルート package `tbx` です。ADR #1358 に基づき、次世代実装の入口として独立 package `tbx-next` を `crates/tbx-next` に追加しています。TBX Next は現行 `tbx` に依存せず、現時点では開発中であることを示す最小 crate です。
+現行実装はルート package `tbx` です。
+`crates/tbx-next/` は開発中の次世代実装であり、現時点では現行 `tbx` との互換性を保証しません。
 
-TBX Next の案内は [`crates/tbx-next/README.md`](./crates/tbx-next/README.md) と [`docs/next/README.md`](./docs/next/README.md) を参照してください。実装事実の正本はコードとテストで、非自明な why はソースコードコメントに記録します。
-
-```sh
-cargo build -p tbx
-cargo test -p tbx
-cargo build -p tbx-next
-cargo test -p tbx-next
-cargo run -p tbx-next --bin tbx-next
-```
+TBX Next の位置付け、設計判断、実装、テスト、開発コマンド、進捗への入口は [`docs/next/README.md`](./docs/next/README.md) を参照してください。
 
 ## アーキテクチャの概要
 

--- a/crates/tbx-next/README.md
+++ b/crates/tbx-next/README.md
@@ -1,13 +1,24 @@
 # TBX Next
 
 TBX Next は、現行 `tbx` package とは独立した次世代実装用 crate です。
-この crate は ADR #1358 に基づくリポジトリ境界を置くための最小コードベースであり、現時点では VM、lexer、parser、compiler、辞書、値型、スタック、変数、ワード定義などの言語機能を実装していません。
+この crate は開発中であり、現時点では完成済み処理系でも、現行 `tbx` の互換実装でもありません。
 
-現行実装はルート package `tbx` です。TBX Next は package `tbx-next`、library `tbx_next`、binary `tbx-next` として分離されています。新旧 crate 間の dependency はありません。
+## Crate Boundary
+
+- package: `tbx-next`
+- library: `tbx_next`
+- binary: `tbx-next`
+- source: [`src/`](./src/)
+- tests: current unit tests in [`src/lib.rs`](./src/lib.rs)
+
+現行実装はルート package `tbx` です。TBX Next と現行 `tbx` の間に crate dependency はありません。
 
 ## Source of Truth
 
-実装事実の正本はコードとテストです。設計判断の根拠は ADR #1358 を参照し、非自明な why は実装時にソースコードコメントへ記録します。
+実装事実と現在の挙動の正本はコードとテストです。
+設計判断の入口は [ADR #1358](https://github.com/kkismd/tbx/issues/1358) を参照してください。
+現在の作業と進捗は [Milestone #17 `TBX-Next`](https://github.com/kkismd/tbx/milestone/17) から追跡します。
+非自明な why、不変条件、契約は、対応するソースコードコメントへ記録します。
 
 ## Commands
 
@@ -16,3 +27,5 @@ cargo build -p tbx-next
 cargo test -p tbx-next
 cargo run -p tbx-next --bin tbx-next
 ```
+
+TBX Next 全体の案内は [`docs/next/README.md`](../../docs/next/README.md) を参照してください。

--- a/docs/next/README.md
+++ b/docs/next/README.md
@@ -1,20 +1,31 @@
 # TBX Next
 
-TBX Next は、現行 `tbx` package と同じリポジトリに置かれた独立 package です。
-根拠 ADR は #1358 です。
+TBX Next は、現行 `tbx` package と同じリポジトリで開発している次世代実装です。
+現時点では初期開発段階であり、完成済み処理系でも、現行 `tbx` の互換実装でもありません。
 
-- 現行実装: ルート package `tbx`
-- 次世代実装: `crates/tbx-next` の package `tbx-next`
-- 実装事実の正本: コードとテスト
-- 非自明な why: ソースコードコメントに記録
+## Scope
+
+- 現行実装はルート package `tbx` です。
+- TBX Next の実装 crate は [`crates/tbx-next/`](../../crates/tbx-next/) です。
+- TBX Next は現行 `tbx` に依存せず、現時点では現行版との互換性を保証しません。
+- 現行の `blueprint.md`、`blueprint-language.md`、`blueprint-compiler.md` は現行 TBX の設計文書であり、TBX Next の仕様ではありません。
+
+## Source of Truth
+
+- 重要な設計判断の正本は ADR issue です。TBX Next の入口となる判断は [ADR #1358](https://github.com/kkismd/tbx/issues/1358) を参照してください。
+- 実装事実と現在の挙動の正本はコードとテストです。
+- 非自明な why、不変条件、契約は、対応するソースコードコメントへ記録します。
+- 現在進行中または計画中の TBX Next 作業は [Milestone #17 `TBX-Next`](https://github.com/kkismd/tbx/milestone/17) から追跡します。
+
+このディレクトリは TBX Next の入口です。包括的な言語仕様書、VM 設計書、compiler 設計書、関連 issue の固定一覧はここへ置きません。
 
 ## Commands
 
 ```sh
-cargo build -p tbx
-cargo test -p tbx
 cargo build -p tbx-next
 cargo test -p tbx-next
 cargo run -p tbx-next --bin tbx-next
 cargo test --workspace
 ```
+
+crate 単位の詳細は [`crates/tbx-next/README.md`](../../crates/tbx-next/README.md) を参照してください。


### PR DESCRIPTION
## Summary

- ルート README の TBX Next 説明をリポジトリ入口としての最小案内に整理
- `docs/next/README.md` を TBX Next 全体の入口として更新し、ADR #1358、Milestone #17、実装 crate、SoT の導線を追加
- `crates/tbx-next/README.md` を crate 利用・開発入口として整理し、package/library/binary、source/test、開発コマンドの導線を明確化

Closes #1362

## Verification

- `cargo build -p tbx-next`
- `cargo test -p tbx-next`
- `cargo run -p tbx-next --bin tbx-next`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo fmt --check`
- `cargo test --workspace`
