### PR TITLE
TBX Next: WordIdと公開済みword定義集合を追加

### DIFF
--- a/crates/tbx-next/src/lib.rs
+++ b/crates/tbx-next/src/lib.rs
@@ -11,8 +11,9 @@ mod stack;
 #[allow(dead_code)]
 mod name;
 
-// Phase B for ADR #1368 keeps published executable word definitions separate
-// from name binding, primitive bootstrap, and mutable VM execution state.
+// Phase B for ADR #1368/#1369 keeps published executable word definitions
+// separate from name binding, primitive bootstrap, builders, and mutable VM
+// execution state.
 #[allow(dead_code)]
 mod word;
 

--- a/crates/tbx-next/src/lib.rs
+++ b/crates/tbx-next/src/lib.rs
@@ -11,6 +11,11 @@ mod stack;
 #[allow(dead_code)]
 mod name;
 
+// Phase B for ADR #1368 keeps published executable word definitions separate
+// from name binding, primitive bootstrap, and mutable VM execution state.
+#[allow(dead_code)]
+mod word;
+
 pub const STATUS_MESSAGE: &str =
     "TBX Next is under development; language features are not implemented yet.";
 

--- a/crates/tbx-next/src/word.rs
+++ b/crates/tbx-next/src/word.rs
@@ -74,6 +74,11 @@ pub(crate) enum WordLookupError {
 /// outside this responsibility: callers may add a new published definition and
 /// later look it up by `WordId`, but they cannot rewrite older IDs or expose
 /// unpublished definitions through normal lookup.
+///
+/// ADR #1369 makes `WordId` issuance part of the construction-to-publication
+/// boundary: callers must pass only completed, executable definitions to `add`.
+/// In-progress code, failed builds, and unreferenced instruction fragments must
+/// remain outside this collection so ordinary `Call(WordId)` cannot reach them.
 #[derive(Debug, Default)]
 pub(crate) struct PublishedWords {
     definitions: Vec<WordDefinition>,
@@ -110,7 +115,6 @@ impl PublishedWords {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::value::Value;
 
     fn primitive(slot: usize) -> WordDefinition {
         WordDefinition::Primitive {
@@ -237,15 +241,6 @@ mod tests {
         assert_eq!(words.get(second_id), Ok(&compiled(20)));
         assert_eq!(words.get(third_id), Ok(&primitive(30)));
         assert_eq!(words.get(fourth_id), Ok(&compiled(40)));
-    }
-
-    #[test]
-    fn word_ids_are_not_runtime_values() {
-        let runtime_value = Value::integer(1);
-        let word_id = WordId::test_invalid(1);
-
-        assert_eq!(runtime_value.as_integer(), 1);
-        assert_ne!(format!("{runtime_value:?}"), format!("{word_id:?}"));
     }
 
     #[test]

--- a/crates/tbx-next/src/word.rs
+++ b/crates/tbx-next/src/word.rs
@@ -1,0 +1,261 @@
+/// Absolute address into the shared TBX Next instruction sequence.
+///
+/// ADR #1367 defines instruction addresses as VM-control identifiers, not
+/// runtime values. The concrete backing type is intentionally private and must
+/// not become a serialized or public ABI contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct InstructionAddress {
+    index: usize,
+}
+
+impl InstructionAddress {
+    pub(crate) const fn from_index(index: usize) -> Self {
+        Self { index }
+    }
+
+    pub(crate) const fn as_index(self) -> usize {
+        self.index
+    }
+}
+
+/// Internal identifier for a published executable word definition.
+///
+/// ADR #1368 requires old definitions to remain executable after redefinition,
+/// so IDs are allocated monotonically, never reused, and never exposed as
+/// runtime `Value`s. This type identifies an entry in `PublishedWords` without
+/// exposing the backing collection layout as a contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct WordId {
+    slot: usize,
+}
+
+impl WordId {
+    #[cfg(test)]
+    const fn test_invalid(slot: usize) -> Self {
+        Self { slot }
+    }
+}
+
+/// Minimal primitive implementation identity.
+///
+/// The final primitive handler signature belongs to the VM call implementation.
+/// This ID is only enough for the published word collection to distinguish and
+/// retain primitive definitions without adding primitive-specific instructions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct PrimitiveId {
+    slot: usize,
+}
+
+impl PrimitiveId {
+    pub(crate) const fn from_slot(slot: usize) -> Self {
+        Self { slot }
+    }
+
+    pub(crate) const fn as_slot(self) -> usize {
+        self.slot
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WordDefinition {
+    Primitive { primitive: PrimitiveId },
+    Compiled { entry: InstructionAddress },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WordLookupError {
+    InvalidWordId { id: WordId },
+}
+
+/// Monotonic collection of published, executable word definitions.
+///
+/// This collection deliberately has no removal, replacement, arbitrary insert,
+/// or mutable-definition access API. ADR #1368 keeps name binding and VM state
+/// outside this responsibility: callers may add a new published definition and
+/// later look it up by `WordId`, but they cannot rewrite older IDs or expose
+/// unpublished definitions through normal lookup.
+#[derive(Debug, Default)]
+pub(crate) struct PublishedWords {
+    definitions: Vec<WordDefinition>,
+}
+
+impl PublishedWords {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn add(&mut self, definition: WordDefinition) -> WordId {
+        let id = WordId {
+            slot: self.definitions.len(),
+        };
+        self.definitions.push(definition);
+        id
+    }
+
+    pub(crate) fn get(&self, id: WordId) -> Result<&WordDefinition, WordLookupError> {
+        self.definitions
+            .get(id.slot)
+            .ok_or(WordLookupError::InvalidWordId { id })
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.definitions.len()
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.definitions.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::value::Value;
+
+    fn primitive(slot: usize) -> WordDefinition {
+        WordDefinition::Primitive {
+            primitive: PrimitiveId::from_slot(slot),
+        }
+    }
+
+    fn compiled(index: usize) -> WordDefinition {
+        WordDefinition::Compiled {
+            entry: InstructionAddress::from_index(index),
+        }
+    }
+
+    #[test]
+    fn empty_collection_accepts_first_definition() {
+        let mut words = PublishedWords::new();
+
+        let id = words.add(primitive(0));
+
+        assert_eq!(words.len(), 1);
+        assert!(!words.is_empty());
+        assert_eq!(words.get(id), Ok(&primitive(0)));
+    }
+
+    #[test]
+    fn added_definitions_receive_distinct_ids_and_keep_identity() {
+        let mut words = PublishedWords::new();
+
+        let first_id = words.add(primitive(7));
+        let second_id = words.add(compiled(12));
+        let third_id = words.add(primitive(9));
+
+        assert_ne!(first_id, second_id);
+        assert_ne!(first_id, third_id);
+        assert_ne!(second_id, third_id);
+        assert_eq!(words.get(first_id), Ok(&primitive(7)));
+        assert_eq!(words.get(second_id), Ok(&compiled(12)));
+        assert_eq!(words.get(third_id), Ok(&primitive(9)));
+    }
+
+    #[test]
+    fn later_additions_do_not_change_previous_ids() {
+        let mut words = PublishedWords::new();
+
+        let old_id = words.add(compiled(3));
+        let old_definition = *words.get(old_id).expect("old id should be valid");
+
+        let new_id = words.add(compiled(99));
+
+        assert_eq!(words.get(old_id), Ok(&old_definition));
+        assert_eq!(words.get(new_id), Ok(&compiled(99)));
+    }
+
+    #[test]
+    fn primitive_and_compiled_definitions_are_distinguishable_after_lookup() {
+        let mut words = PublishedWords::new();
+
+        let primitive_id = words.add(primitive(5));
+        let compiled_id = words.add(compiled(42));
+
+        match words
+            .get(primitive_id)
+            .expect("primitive id should be valid")
+        {
+            WordDefinition::Primitive { primitive } => {
+                assert_eq!(primitive.as_slot(), 5);
+            }
+            WordDefinition::Compiled { .. } => panic!("primitive id returned compiled word"),
+        }
+
+        match words.get(compiled_id).expect("compiled id should be valid") {
+            WordDefinition::Compiled { entry } => {
+                assert_eq!(entry.as_index(), 42);
+            }
+            WordDefinition::Primitive { .. } => panic!("compiled id returned primitive word"),
+        }
+    }
+
+    #[test]
+    fn lookup_rejects_invalid_ids_without_mutating_collection() {
+        let mut words = PublishedWords::new();
+
+        let empty_id = WordId::test_invalid(0);
+        assert_eq!(
+            words.get(empty_id),
+            Err(WordLookupError::InvalidWordId { id: empty_id })
+        );
+        assert_eq!(words.len(), 0);
+        assert!(words.is_empty());
+
+        let valid_id = words.add(primitive(1));
+        let out_of_range_id = WordId::test_invalid(2);
+        let max_id = WordId::test_invalid(usize::MAX);
+
+        assert_eq!(
+            words.get(out_of_range_id),
+            Err(WordLookupError::InvalidWordId {
+                id: out_of_range_id
+            })
+        );
+        assert_eq!(
+            words.get(max_id),
+            Err(WordLookupError::InvalidWordId { id: max_id })
+        );
+        assert_eq!(words.len(), 1);
+        assert_eq!(words.get(valid_id), Ok(&primitive(1)));
+    }
+
+    #[test]
+    fn old_definitions_remain_accessible_after_multiple_additions() {
+        let mut words = PublishedWords::new();
+
+        let first_id = words.add(primitive(10));
+        let second_id = words.add(compiled(20));
+        let third_id = words.add(primitive(30));
+
+        assert_eq!(words.get(first_id), Ok(&primitive(10)));
+        assert_eq!(words.get(second_id), Ok(&compiled(20)));
+        assert_eq!(words.get(third_id), Ok(&primitive(30)));
+
+        let fourth_id = words.add(compiled(40));
+
+        assert_eq!(words.get(first_id), Ok(&primitive(10)));
+        assert_eq!(words.get(second_id), Ok(&compiled(20)));
+        assert_eq!(words.get(third_id), Ok(&primitive(30)));
+        assert_eq!(words.get(fourth_id), Ok(&compiled(40)));
+    }
+
+    #[test]
+    fn word_ids_are_not_runtime_values() {
+        let runtime_value = Value::integer(1);
+        let word_id = WordId::test_invalid(1);
+
+        assert_eq!(runtime_value.as_integer(), 1);
+        assert_ne!(format!("{runtime_value:?}"), format!("{word_id:?}"));
+    }
+
+    #[test]
+    fn definitions_do_not_require_names_or_vm_state() {
+        let mut words = PublishedWords::new();
+
+        let primitive_id = words.add(primitive(0));
+        let compiled_id = words.add(compiled(8));
+
+        assert_eq!(words.get(primitive_id), Ok(&primitive(0)));
+        assert_eq!(words.get(compiled_id), Ok(&compiled(8)));
+    }
+}


### PR DESCRIPTION
## Summary

- `tbx-next`にcrate内部専用の`word` moduleを追加
- `WordId`、`InstructionAddress`、`PrimitiveId`、`WordDefinition`、`PublishedWords`、lookup errorを追加
- 公開済みword定義の単調追加、旧定義保持、不正ID拒否、primitive/compiled識別をunit testで検証

## Notes

- ADR #1369は採用済みであり、本PRの`PublishedWords`は完成済みかつ実行可能な定義だけに`WordId`を発行するPhase B境界として実装しています。
- compiled wordのentryは、ADR #1367の共有命令列上の絶対address契約と、ADR #1369の完成済みentry address保持契約に沿った最小型として保持しています。
- 名前binding、primitive bootstrap、VM `Call`、再定義、builderは対象外として未実装です。
- 構築中コード、検証失敗済みコード、未参照命令断片、名前bindingによる公開コミットは後続issueの責務です。

## Verification

- `cargo test -p tbx-next`
- `cargo clippy -p tbx-next --all-targets -- -D warnings`
- `cargo fmt --check`
- `cargo test --workspace`
- `cargo clippy --all-targets -- -D warnings`

Closes #1381
