### PR TITLE
TBX Nextのword再定義境界を追加

### DIFF
--- a/crates/tbx-next/src/binding.rs
+++ b/crates/tbx-next/src/binding.rs
@@ -19,6 +19,13 @@ pub(crate) enum BindingInsertError {
     NameConflict,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BindingReplaceError {
+    MissingName,
+    TargetIsNotWord,
+    CurrentWordMismatch { actual: WordId },
+}
+
 /// Crate-internal map from normalized names to their current published binding.
 ///
 /// This registry owns only name-to-binding state. It deliberately does not own
@@ -50,6 +57,34 @@ impl Bindings {
 
     pub(crate) fn get(&self, name: &NormalizedName) -> Option<&Binding> {
         self.entries.get(name)
+    }
+
+    pub(crate) fn current_word(
+        &self,
+        name: &NormalizedName,
+    ) -> Result<WordId, BindingReplaceError> {
+        match self.entries.get(name) {
+            Some(Binding::Word(id)) => Ok(*id),
+            None => Err(BindingReplaceError::MissingName),
+        }
+    }
+
+    pub(crate) fn replace_word(
+        &mut self,
+        name: &NormalizedName,
+        expected: WordId,
+        replacement: WordId,
+    ) -> Result<(), BindingReplaceError> {
+        match self.entries.get_mut(name) {
+            Some(Binding::Word(current)) if *current == expected => {
+                *current = replacement;
+                Ok(())
+            }
+            Some(Binding::Word(actual)) => {
+                Err(BindingReplaceError::CurrentWordMismatch { actual: *actual })
+            }
+            None => Err(BindingReplaceError::MissingName),
+        }
     }
 
     pub(crate) fn len(&self) -> usize {
@@ -278,5 +313,71 @@ mod tests {
             Err(BindingInsertError::NameConflict)
         );
         assert_eq!(bindings.get(&name("SAME")), Some(&binding));
+    }
+
+    #[test]
+    fn replace_word_updates_only_the_expected_existing_word_binding() {
+        let mut words = PublishedWords::new();
+        let old = add_word(&mut words, 40);
+        let new = add_word(&mut words, 41);
+        let other = add_word(&mut words, 42);
+        let mut bindings = Bindings::new();
+
+        bindings
+            .insert_new(name("TARGET"), Binding::Word(old))
+            .expect("new name should register");
+        bindings
+            .insert_new(name("OTHER"), Binding::Word(other))
+            .expect("new name should register");
+
+        assert_eq!(bindings.current_word(&name("TARGET")), Ok(old));
+        assert_eq!(bindings.replace_word(&name("TARGET"), old, new), Ok(()));
+
+        assert_eq!(bindings.current_word(&name("TARGET")), Ok(new));
+        assert_eq!(bindings.get(&name("OTHER")), Some(&Binding::Word(other)));
+        assert_eq!(bindings.len(), 2);
+    }
+
+    #[test]
+    fn replace_word_rejects_missing_name_without_mutation() {
+        let mut words = PublishedWords::new();
+        let existing = add_word(&mut words, 50);
+        let replacement = add_word(&mut words, 51);
+        let mut bindings = Bindings::new();
+
+        bindings
+            .insert_new(name("EXISTING"), Binding::Word(existing))
+            .expect("new name should register");
+
+        assert_eq!(
+            bindings.replace_word(&name("MISSING"), existing, replacement),
+            Err(BindingReplaceError::MissingName)
+        );
+        assert_eq!(
+            bindings.current_word(&name("MISSING")),
+            Err(BindingReplaceError::MissingName)
+        );
+        assert_eq!(bindings.current_word(&name("EXISTING")), Ok(existing));
+        assert_eq!(bindings.len(), 1);
+    }
+
+    #[test]
+    fn replace_word_rejects_unexpected_current_word_without_mutation() {
+        let mut words = PublishedWords::new();
+        let expected = add_word(&mut words, 60);
+        let actual = add_word(&mut words, 61);
+        let replacement = add_word(&mut words, 62);
+        let mut bindings = Bindings::new();
+
+        bindings
+            .insert_new(name("TARGET"), Binding::Word(actual))
+            .expect("new name should register");
+
+        assert_eq!(
+            bindings.replace_word(&name("TARGET"), expected, replacement),
+            Err(BindingReplaceError::CurrentWordMismatch { actual })
+        );
+        assert_eq!(bindings.current_word(&name("TARGET")), Ok(actual));
+        assert_eq!(bindings.len(), 1);
     }
 }

--- a/crates/tbx-next/src/lib.rs
+++ b/crates/tbx-next/src/lib.rs
@@ -27,6 +27,11 @@ mod binding;
 #[allow(dead_code)]
 mod bootstrap;
 
+// Phase E for ADR #1368/#1369 coordinates explicit word redefinition as a
+// separate publication boundary from ordinary registration and bootstrap.
+#[allow(dead_code)]
+mod redefinition;
+
 pub const STATUS_MESSAGE: &str =
     "TBX Next is under development; language features are not implemented yet.";
 

--- a/crates/tbx-next/src/redefinition.rs
+++ b/crates/tbx-next/src/redefinition.rs
@@ -1,0 +1,297 @@
+use crate::binding::{BindingReplaceError, Bindings};
+use crate::name::NormalizedName;
+use crate::word::{PublishedWords, WordDefinition, WordId};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct WordRedefinition {
+    previous: WordId,
+    current: WordId,
+}
+
+impl WordRedefinition {
+    pub(crate) const fn previous(self) -> WordId {
+        self.previous
+    }
+
+    pub(crate) const fn current(self) -> WordId {
+        self.current
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WordRedefinitionError {
+    UndefinedName,
+    TargetIsNotWord,
+    BindingCommitInvariantViolated,
+}
+
+/// Publishes a completed replacement definition for an existing word name.
+///
+/// ADR #1368 requires fully early-bound redefinition: old `WordId`s and their
+/// definitions stay executable, and only future name lookup moves to the new
+/// `WordId`. ADR #1369 makes the binding update the publication commit point,
+/// so all ordinary preconditions are checked before the monotonic word append.
+pub(crate) fn redefine_word(
+    words: &mut PublishedWords,
+    bindings: &mut Bindings,
+    name: &NormalizedName,
+    definition: WordDefinition,
+) -> Result<WordRedefinition, WordRedefinitionError> {
+    let previous = bindings
+        .current_word(name)
+        .map_err(WordRedefinitionError::from_precheck_error)?;
+
+    let current = words.add(definition);
+
+    bindings
+        .replace_word(name, previous, current)
+        .map_err(WordRedefinitionError::from_commit_error)?;
+
+    Ok(WordRedefinition { previous, current })
+}
+
+impl WordRedefinitionError {
+    fn from_precheck_error(error: BindingReplaceError) -> Self {
+        match error {
+            BindingReplaceError::MissingName => Self::UndefinedName,
+            BindingReplaceError::TargetIsNotWord => Self::TargetIsNotWord,
+            BindingReplaceError::CurrentWordMismatch { .. } => Self::BindingCommitInvariantViolated,
+        }
+    }
+
+    fn from_commit_error(error: BindingReplaceError) -> Self {
+        match error {
+            BindingReplaceError::MissingName
+            | BindingReplaceError::TargetIsNotWord
+            | BindingReplaceError::CurrentWordMismatch { .. } => {
+                Self::BindingCommitInvariantViolated
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::binding::{Binding, Bindings};
+    use crate::word::{InstructionAddress, PrimitiveId};
+
+    fn name(input: &str) -> NormalizedName {
+        NormalizedName::new(input).expect("test input should be a valid word name")
+    }
+
+    fn primitive(slot: usize) -> WordDefinition {
+        WordDefinition::Primitive {
+            primitive: PrimitiveId::from_slot(slot),
+        }
+    }
+
+    fn compiled(index: usize) -> WordDefinition {
+        WordDefinition::Compiled {
+            entry: InstructionAddress::from_index(index),
+        }
+    }
+
+    fn publish_initial(
+        words: &mut PublishedWords,
+        bindings: &mut Bindings,
+        input: &str,
+        definition: WordDefinition,
+    ) -> WordId {
+        let id = words.add(definition);
+        bindings
+            .insert_new(name(input), Binding::Word(id))
+            .expect("initial test binding should register");
+        id
+    }
+
+    fn assert_word_binding(bindings: &Bindings, input: &str, expected: WordId) {
+        assert_eq!(bindings.get(&name(input)), Some(&Binding::Word(expected)));
+    }
+
+    fn assert_redefinition(
+        words: &PublishedWords,
+        bindings: &Bindings,
+        input: &str,
+        result: WordRedefinition,
+        old_definition: WordDefinition,
+        new_definition: WordDefinition,
+    ) {
+        assert_ne!(result.previous(), result.current());
+        assert_word_binding(bindings, input, result.current());
+        assert_eq!(words.get(result.previous()), Ok(&old_definition));
+        assert_eq!(words.get(result.current()), Ok(&new_definition));
+    }
+
+    #[test]
+    fn primitive_word_can_be_redefined_as_primitive_word() {
+        let mut words = PublishedWords::new();
+        let mut bindings = Bindings::new();
+        let old_definition = primitive(1);
+        let new_definition = primitive(2);
+        let old = publish_initial(&mut words, &mut bindings, "PRINT", old_definition);
+
+        let result = redefine_word(&mut words, &mut bindings, &name("PRINT"), new_definition)
+            .expect("existing word should redefine");
+
+        assert_eq!(result.previous(), old);
+        assert_redefinition(
+            &words,
+            &bindings,
+            "PRINT",
+            result,
+            old_definition,
+            new_definition,
+        );
+    }
+
+    #[test]
+    fn primitive_word_can_be_redefined_as_compiled_word() {
+        let mut words = PublishedWords::new();
+        let mut bindings = Bindings::new();
+        let old_definition = primitive(3);
+        let new_definition = compiled(100);
+        let old = publish_initial(&mut words, &mut bindings, "ABS", old_definition);
+
+        let result = redefine_word(&mut words, &mut bindings, &name("ABS"), new_definition)
+            .expect("existing word should redefine");
+
+        assert_eq!(result.previous(), old);
+        assert_redefinition(
+            &words,
+            &bindings,
+            "ABS",
+            result,
+            old_definition,
+            new_definition,
+        );
+    }
+
+    #[test]
+    fn compiled_word_can_be_redefined_as_primitive_word() {
+        let mut words = PublishedWords::new();
+        let mut bindings = Bindings::new();
+        let old_definition = compiled(200);
+        let new_definition = primitive(4);
+        let old = publish_initial(&mut words, &mut bindings, "RUN", old_definition);
+
+        let result = redefine_word(&mut words, &mut bindings, &name("RUN"), new_definition)
+            .expect("existing word should redefine");
+
+        assert_eq!(result.previous(), old);
+        assert_redefinition(
+            &words,
+            &bindings,
+            "RUN",
+            result,
+            old_definition,
+            new_definition,
+        );
+    }
+
+    #[test]
+    fn compiled_word_can_be_redefined_as_compiled_word() {
+        let mut words = PublishedWords::new();
+        let mut bindings = Bindings::new();
+        let old_definition = compiled(300);
+        let new_definition = compiled(301);
+        let old = publish_initial(&mut words, &mut bindings, "LOOP", old_definition);
+
+        let result = redefine_word(&mut words, &mut bindings, &name("LOOP"), new_definition)
+            .expect("existing word should redefine");
+
+        assert_eq!(result.previous(), old);
+        assert_redefinition(
+            &words,
+            &bindings,
+            "LOOP",
+            result,
+            old_definition,
+            new_definition,
+        );
+    }
+
+    #[test]
+    fn undefined_name_is_rejected_before_issuing_word_id() {
+        let mut words = PublishedWords::new();
+        let mut bindings = Bindings::new();
+        let other_definition = primitive(5);
+        let other = publish_initial(&mut words, &mut bindings, "OTHER", other_definition);
+
+        let result = redefine_word(&mut words, &mut bindings, &name("MISSING"), compiled(400));
+
+        assert_eq!(result, Err(WordRedefinitionError::UndefinedName));
+        assert_eq!(words.len(), 1);
+        assert_eq!(bindings.len(), 1);
+        assert_word_binding(&bindings, "OTHER", other);
+        assert_eq!(words.get(other), Ok(&other_definition));
+    }
+
+    #[test]
+    fn case_variant_redefinition_updates_the_existing_binding() {
+        let mut words = PublishedWords::new();
+        let mut bindings = Bindings::new();
+        let old_definition = primitive(6);
+        let new_definition = compiled(500);
+        let old = publish_initial(&mut words, &mut bindings, "foo", old_definition);
+
+        let result = redefine_word(&mut words, &mut bindings, &name("FOO"), new_definition)
+            .expect("case-equivalent word should redefine");
+
+        assert_eq!(result.previous(), old);
+        assert_eq!(bindings.len(), 1);
+        assert_redefinition(
+            &words,
+            &bindings,
+            "Foo",
+            result,
+            old_definition,
+            new_definition,
+        );
+    }
+
+    #[test]
+    fn repeated_redefinitions_keep_all_previous_definitions_addressable() {
+        let mut words = PublishedWords::new();
+        let mut bindings = Bindings::new();
+        let first_definition = primitive(7);
+        let second_definition = compiled(600);
+        let third_definition = primitive(8);
+        let fourth_definition = compiled(601);
+        let first = publish_initial(&mut words, &mut bindings, "CHAIN", first_definition);
+
+        let second = redefine_word(&mut words, &mut bindings, &name("CHAIN"), second_definition)
+            .expect("second definition should publish")
+            .current();
+        let third = redefine_word(&mut words, &mut bindings, &name("CHAIN"), third_definition)
+            .expect("third definition should publish")
+            .current();
+        let fourth = redefine_word(&mut words, &mut bindings, &name("CHAIN"), fourth_definition)
+            .expect("fourth definition should publish")
+            .current();
+
+        assert_ne!(first, second);
+        assert_ne!(second, third);
+        assert_ne!(third, fourth);
+        assert_word_binding(&bindings, "CHAIN", fourth);
+        assert_eq!(words.get(first), Ok(&first_definition));
+        assert_eq!(words.get(second), Ok(&second_definition));
+        assert_eq!(words.get(third), Ok(&third_definition));
+        assert_eq!(words.get(fourth), Ok(&fourth_definition));
+        assert_eq!(words.len(), 4);
+        assert_eq!(bindings.len(), 1);
+    }
+
+    #[test]
+    fn redefinition_does_not_require_vm_state_or_handler_table() {
+        let mut words = PublishedWords::new();
+        let mut bindings = Bindings::new();
+        publish_initial(&mut words, &mut bindings, "BOUNDARY", primitive(9));
+
+        let result = redefine_word(&mut words, &mut bindings, &name("BOUNDARY"), compiled(700))
+            .expect("completed definition should publish without VM state");
+
+        assert_word_binding(&bindings, "BOUNDARY", result.current());
+        assert_eq!(words.len(), 2);
+    }
+}


### PR DESCRIPTION
## Summary

- `Bindings` に word 限定の `current_word` / `replace_word` API を追加し、通常登録用 `insert_new` の非上書き契約は維持
- 完成済み `WordDefinition` を既存 word 名へ再公開する `redefine_word` 境界を追加
- primitive/compiled の全組み合わせ、未定義名、case-insensitive 同一性、複数回再定義、early binding 保持を unit test で確認

Closes #1387

## Verification

- `cargo fmt --check`
- `cargo test -p tbx-next`
- `cargo clippy -p tbx-next --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo clippy --all-targets -- -D warnings`
