### PR TITLE
TBX Nextのword名前解決境界を追加

### DIFF
--- a/crates/tbx-next/src/lib.rs
+++ b/crates/tbx-next/src/lib.rs
@@ -37,8 +37,8 @@ mod redefinition;
 #[allow(dead_code)]
 mod word_lookup;
 
-// Phase G for ADR #1368 connects source word references to the current word
-// binding and freezes the resolved `WordId` in a minimal compiled form.
+// Phase G1 for ADR #1368 resolves source word names through the current word
+// binding without introducing compiler or VM execution dependencies.
 #[allow(dead_code)]
 mod word_resolution;
 

--- a/crates/tbx-next/src/lib.rs
+++ b/crates/tbx-next/src/lib.rs
@@ -37,6 +37,11 @@ mod redefinition;
 #[allow(dead_code)]
 mod word_lookup;
 
+// Phase G for ADR #1368 connects source word references to the current word
+// binding and freezes the resolved `WordId` in a minimal compiled form.
+#[allow(dead_code)]
+mod word_resolution;
+
 pub const STATUS_MESSAGE: &str =
     "TBX Next is under development; language features are not implemented yet.";
 

--- a/crates/tbx-next/src/word_resolution.rs
+++ b/crates/tbx-next/src/word_resolution.rs
@@ -1,0 +1,271 @@
+use crate::binding::{Binding, Bindings};
+use crate::name::{NameError, NormalizedName};
+use crate::word::WordId;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WordResolutionError {
+    InvalidWordName,
+    UndefinedName,
+    TargetIsNotWord,
+}
+
+/// Minimal compiled representation for an already-resolved word reference.
+///
+/// This stores only the `WordId` selected at compile time. Keeping names,
+/// normalized names, or binding-table handles here would move name lookup into
+/// VM execution and would make later redefinitions affect existing code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CompiledWordReference {
+    target: WordId,
+}
+
+impl CompiledWordReference {
+    pub(crate) const fn target(self) -> WordId {
+        self.target
+    }
+}
+
+pub(crate) fn compile_word_reference(
+    bindings: &Bindings,
+    source_name: &str,
+) -> Result<CompiledWordReference, WordResolutionError> {
+    let target = resolve_word_name(bindings, source_name)?;
+    Ok(CompiledWordReference { target })
+}
+
+pub(crate) fn resolve_word_name(
+    bindings: &Bindings,
+    source_name: &str,
+) -> Result<WordId, WordResolutionError> {
+    let name = NormalizedName::new(source_name).map_err(WordResolutionError::from)?;
+    resolve_normalized_word(bindings, &name)
+}
+
+pub(crate) fn resolve_normalized_word(
+    bindings: &Bindings,
+    name: &NormalizedName,
+) -> Result<WordId, WordResolutionError> {
+    match bindings.get(name) {
+        Some(Binding::Word(id)) => Ok(*id),
+        None => Err(WordResolutionError::UndefinedName),
+    }
+}
+
+impl From<NameError> for WordResolutionError {
+    fn from(error: NameError) -> Self {
+        match error {
+            NameError::InvalidWordName => Self::InvalidWordName,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::binding::{Binding, Bindings};
+    use crate::bootstrap::register_primitive;
+    use crate::name::NormalizedName;
+    use crate::redefinition::redefine_word;
+    use crate::word::{InstructionAddress, PrimitiveId, PublishedWords, WordDefinition, WordId};
+    use crate::word_lookup::PublishedWordLookup;
+
+    fn name(input: &str) -> NormalizedName {
+        NormalizedName::new(input).expect("test input should be a valid word name")
+    }
+
+    fn primitive(slot: usize) -> WordDefinition {
+        WordDefinition::Primitive {
+            primitive: PrimitiveId::from_slot(slot),
+        }
+    }
+
+    fn compiled(index: usize) -> WordDefinition {
+        WordDefinition::Compiled {
+            entry: InstructionAddress::from_index(index),
+        }
+    }
+
+    fn publish_initial(
+        words: &mut PublishedWords,
+        bindings: &mut Bindings,
+        input: &str,
+        definition: WordDefinition,
+    ) -> WordId {
+        let id = words.add(definition);
+        bindings
+            .insert_new(name(input), Binding::Word(id))
+            .expect("initial test binding should register");
+        id
+    }
+
+    #[test]
+    fn source_word_name_resolves_through_normalized_binding_identity() {
+        let mut words = PublishedWords::new();
+        let mut bindings = Bindings::new();
+        let id = publish_initial(&mut words, &mut bindings, "foo", primitive(1));
+
+        assert_eq!(resolve_word_name(&bindings, "foo"), Ok(id));
+        assert_eq!(resolve_word_name(&bindings, "Foo"), Ok(id));
+        assert_eq!(resolve_word_name(&bindings, "FOO"), Ok(id));
+    }
+
+    #[test]
+    fn predicate_word_name_resolves_after_case_normalization() {
+        let mut words = PublishedWords::new();
+        let mut bindings = Bindings::new();
+        let id = publish_initial(&mut words, &mut bindings, "ready?", primitive(2));
+
+        assert_eq!(resolve_word_name(&bindings, "ready?"), Ok(id));
+        assert_eq!(resolve_word_name(&bindings, "Ready?"), Ok(id));
+        assert_eq!(resolve_word_name(&bindings, "READY?"), Ok(id));
+    }
+
+    #[test]
+    fn invalid_source_name_is_rejected_by_normalized_name_contract() {
+        let bindings = Bindings::new();
+
+        for invalid in ["", "1ABC", "A-B", "READY??", "NAMEé"] {
+            assert_eq!(
+                resolve_word_name(&bindings, invalid),
+                Err(WordResolutionError::InvalidWordName),
+                "{invalid:?} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn undefined_name_is_rejected_without_mutation() {
+        let mut words = PublishedWords::new();
+        let mut bindings = Bindings::new();
+        let id = publish_initial(&mut words, &mut bindings, "KNOWN", primitive(3));
+        let compiled_output = Vec::<CompiledWordReference>::new();
+
+        assert_eq!(
+            resolve_word_name(&bindings, "MISSING"),
+            Err(WordResolutionError::UndefinedName)
+        );
+        assert_eq!(words.len(), 1);
+        assert_eq!(bindings.len(), 1);
+        assert_eq!(bindings.get(&name("KNOWN")), Some(&Binding::Word(id)));
+        assert!(compiled_output.is_empty());
+    }
+
+    #[test]
+    fn primitive_and_compiled_words_use_the_same_binding_path() {
+        let mut words = PublishedWords::new();
+        let mut bindings = Bindings::new();
+        let primitive_id = publish_initial(&mut words, &mut bindings, "PRIM", primitive(4));
+        let compiled_id = publish_initial(&mut words, &mut bindings, "USER_WORD", compiled(10));
+        let lookup = PublishedWordLookup::new(&words);
+
+        assert_eq!(resolve_word_name(&bindings, "prim"), Ok(primitive_id));
+        assert_eq!(resolve_word_name(&bindings, "user_word"), Ok(compiled_id));
+        assert_eq!(lookup.lookup_word(primitive_id), Ok(&primitive(4)));
+        assert_eq!(lookup.lookup_word(compiled_id), Ok(&compiled(10)));
+    }
+
+    #[test]
+    fn compile_word_reference_stores_only_the_resolved_word_id() {
+        let mut words = PublishedWords::new();
+        let mut bindings = Bindings::new();
+        let first = publish_initial(&mut words, &mut bindings, "FIRST", primitive(5));
+        let second = publish_initial(&mut words, &mut bindings, "SECOND", compiled(20));
+
+        let references = [
+            compile_word_reference(&bindings, "first").expect("first should resolve"),
+            compile_word_reference(&bindings, "SECOND").expect("second should resolve"),
+        ];
+
+        assert_eq!(references[0].target(), first);
+        assert_eq!(references[1].target(), second);
+    }
+
+    #[test]
+    fn existing_compiled_reference_keeps_old_word_id_after_redefinition() {
+        let mut words = PublishedWords::new();
+        let mut bindings = Bindings::new();
+        let old_definition = primitive(6);
+        let new_definition = compiled(30);
+        let old = publish_initial(&mut words, &mut bindings, "TARGET", old_definition);
+
+        let old_reference =
+            compile_word_reference(&bindings, "target").expect("old target should resolve");
+        let redefinition =
+            redefine_word(&mut words, &mut bindings, &name("TARGET"), new_definition)
+                .expect("existing word should redefine");
+        let new_reference =
+            compile_word_reference(&bindings, "target").expect("new target should resolve");
+        let lookup = PublishedWordLookup::new(&words);
+
+        assert_eq!(old_reference.target(), old);
+        assert_eq!(old_reference.target(), redefinition.previous());
+        assert_eq!(new_reference.target(), redefinition.current());
+        assert_ne!(old_reference.target(), new_reference.target());
+        assert_eq!(
+            lookup.lookup_word(old_reference.target()),
+            Ok(&old_definition)
+        );
+        assert_eq!(
+            lookup.lookup_word(new_reference.target()),
+            Ok(&new_definition)
+        );
+    }
+
+    #[test]
+    fn same_kind_redefinition_only_changes_future_resolutions() {
+        let mut words = PublishedWords::new();
+        let mut bindings = Bindings::new();
+        let old_definition = compiled(40);
+        let new_definition = compiled(41);
+        publish_initial(&mut words, &mut bindings, "CHAIN", old_definition);
+
+        let old_reference =
+            compile_word_reference(&bindings, "CHAIN").expect("old target should resolve");
+        let redefinition = redefine_word(&mut words, &mut bindings, &name("CHAIN"), new_definition)
+            .expect("existing word should redefine");
+        let new_reference =
+            compile_word_reference(&bindings, "CHAIN").expect("new target should resolve");
+        let lookup = PublishedWordLookup::new(&words);
+
+        assert_eq!(old_reference.target(), redefinition.previous());
+        assert_eq!(new_reference.target(), redefinition.current());
+        assert_eq!(
+            lookup.lookup_word(old_reference.target()),
+            Ok(&old_definition)
+        );
+        assert_eq!(
+            lookup.lookup_word(new_reference.target()),
+            Ok(&new_definition)
+        );
+    }
+
+    #[test]
+    fn unpublished_word_definition_is_not_resolved_by_name() {
+        let mut words = PublishedWords::new();
+        let bindings = Bindings::new();
+        let unpublished = words.add(compiled(50));
+
+        assert_eq!(
+            resolve_word_name(&bindings, "UNPUBLISHED"),
+            Err(WordResolutionError::UndefinedName)
+        );
+        assert_eq!(words.get(unpublished), Ok(&compiled(50)));
+        assert_eq!(words.len(), 1);
+        assert!(bindings.is_empty());
+    }
+
+    #[test]
+    fn primitive_bootstrap_words_resolve_like_ordinary_words() {
+        let mut words = PublishedWords::new();
+        let mut bindings = Bindings::new();
+        let id = register_primitive(
+            &mut words,
+            &mut bindings,
+            name("BOOTSTRAPPED"),
+            PrimitiveId::from_slot(60),
+        )
+        .expect("primitive should bootstrap");
+
+        assert_eq!(resolve_word_name(&bindings, "bootstrapped"), Ok(id));
+    }
+}

--- a/crates/tbx-next/src/word_resolution.rs
+++ b/crates/tbx-next/src/word_resolution.rs
@@ -9,30 +9,12 @@ pub(crate) enum WordResolutionError {
     TargetIsNotWord,
 }
 
-/// Minimal compiled representation for an already-resolved word reference.
+/// Resolves a source word name through the current published binding only.
 ///
-/// This stores only the `WordId` selected at compile time. Keeping names,
-/// normalized names, or binding-table handles here would move name lookup into
-/// VM execution and would make later redefinitions affect existing code.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct CompiledWordReference {
-    target: WordId,
-}
-
-impl CompiledWordReference {
-    pub(crate) const fn target(self) -> WordId {
-        self.target
-    }
-}
-
-pub(crate) fn compile_word_reference(
-    bindings: &Bindings,
-    source_name: &str,
-) -> Result<CompiledWordReference, WordResolutionError> {
-    let target = resolve_word_name(bindings, source_name)?;
-    Ok(CompiledWordReference { target })
-}
-
+/// The resolver returns the `WordId` selected at lookup time and does not retain
+/// names, scan published definitions, or create fallback bindings. Future
+/// compiler paths must store this ID in their real compiled representation so
+/// later redefinitions only affect future resolutions.
 pub(crate) fn resolve_word_name(
     bindings: &Bindings,
     source_name: &str,
@@ -138,7 +120,6 @@ mod tests {
         let mut words = PublishedWords::new();
         let mut bindings = Bindings::new();
         let id = publish_initial(&mut words, &mut bindings, "KNOWN", primitive(3));
-        let compiled_output = Vec::<CompiledWordReference>::new();
 
         assert_eq!(
             resolve_word_name(&bindings, "MISSING"),
@@ -147,7 +128,6 @@ mod tests {
         assert_eq!(words.len(), 1);
         assert_eq!(bindings.len(), 1);
         assert_eq!(bindings.get(&name("KNOWN")), Some(&Binding::Word(id)));
-        assert!(compiled_output.is_empty());
     }
 
     #[test]
@@ -165,50 +145,28 @@ mod tests {
     }
 
     #[test]
-    fn compile_word_reference_stores_only_the_resolved_word_id() {
-        let mut words = PublishedWords::new();
-        let mut bindings = Bindings::new();
-        let first = publish_initial(&mut words, &mut bindings, "FIRST", primitive(5));
-        let second = publish_initial(&mut words, &mut bindings, "SECOND", compiled(20));
-
-        let references = [
-            compile_word_reference(&bindings, "first").expect("first should resolve"),
-            compile_word_reference(&bindings, "SECOND").expect("second should resolve"),
-        ];
-
-        assert_eq!(references[0].target(), first);
-        assert_eq!(references[1].target(), second);
-    }
-
-    #[test]
-    fn existing_compiled_reference_keeps_old_word_id_after_redefinition() {
+    fn saved_resolution_keeps_old_word_id_after_redefinition() {
         let mut words = PublishedWords::new();
         let mut bindings = Bindings::new();
         let old_definition = primitive(6);
         let new_definition = compiled(30);
         let old = publish_initial(&mut words, &mut bindings, "TARGET", old_definition);
 
-        let old_reference =
-            compile_word_reference(&bindings, "target").expect("old target should resolve");
+        let old_resolution =
+            resolve_word_name(&bindings, "target").expect("old target should resolve");
         let redefinition =
             redefine_word(&mut words, &mut bindings, &name("TARGET"), new_definition)
                 .expect("existing word should redefine");
-        let new_reference =
-            compile_word_reference(&bindings, "target").expect("new target should resolve");
+        let new_resolution =
+            resolve_word_name(&bindings, "target").expect("new target should resolve");
         let lookup = PublishedWordLookup::new(&words);
 
-        assert_eq!(old_reference.target(), old);
-        assert_eq!(old_reference.target(), redefinition.previous());
-        assert_eq!(new_reference.target(), redefinition.current());
-        assert_ne!(old_reference.target(), new_reference.target());
-        assert_eq!(
-            lookup.lookup_word(old_reference.target()),
-            Ok(&old_definition)
-        );
-        assert_eq!(
-            lookup.lookup_word(new_reference.target()),
-            Ok(&new_definition)
-        );
+        assert_eq!(old_resolution, old);
+        assert_eq!(old_resolution, redefinition.previous());
+        assert_eq!(new_resolution, redefinition.current());
+        assert_ne!(old_resolution, new_resolution);
+        assert_eq!(lookup.lookup_word(old_resolution), Ok(&old_definition));
+        assert_eq!(lookup.lookup_word(new_resolution), Ok(&new_definition));
     }
 
     #[test]
@@ -219,24 +177,18 @@ mod tests {
         let new_definition = compiled(41);
         publish_initial(&mut words, &mut bindings, "CHAIN", old_definition);
 
-        let old_reference =
-            compile_word_reference(&bindings, "CHAIN").expect("old target should resolve");
+        let old_resolution =
+            resolve_word_name(&bindings, "CHAIN").expect("old target should resolve");
         let redefinition = redefine_word(&mut words, &mut bindings, &name("CHAIN"), new_definition)
             .expect("existing word should redefine");
-        let new_reference =
-            compile_word_reference(&bindings, "CHAIN").expect("new target should resolve");
+        let new_resolution =
+            resolve_word_name(&bindings, "CHAIN").expect("new target should resolve");
         let lookup = PublishedWordLookup::new(&words);
 
-        assert_eq!(old_reference.target(), redefinition.previous());
-        assert_eq!(new_reference.target(), redefinition.current());
-        assert_eq!(
-            lookup.lookup_word(old_reference.target()),
-            Ok(&old_definition)
-        );
-        assert_eq!(
-            lookup.lookup_word(new_reference.target()),
-            Ok(&new_definition)
-        );
+        assert_eq!(old_resolution, redefinition.previous());
+        assert_eq!(new_resolution, redefinition.current());
+        assert_eq!(lookup.lookup_word(old_resolution), Ok(&old_definition));
+        assert_eq!(lookup.lookup_word(new_resolution), Ok(&new_definition));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `crates/tbx-next` に source word名から現在の `Binding::Word(WordId)` を解決する内部境界を追加
- `NormalizedName` の検証・ASCII大文字正規化を再利用し、未定義名を明示的な resolver error として拒否
- primitive/compiled共通経路、bootstrap済みprimitive、未公開word拒否、再定義前後の resolver 結果をunit testで検証

Closes #1393

## Verification

- `cargo fmt --check`
- `cargo test -p tbx-next`
- `cargo clippy -p tbx-next --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo clippy --all-targets -- -D warnings`
