### PR TITLE
TBX Next: 型付き共有命令列とread-only取得境界を追加

### DIFF
--- a/crates/tbx-next/src/binding.rs
+++ b/crates/tbx-next/src/binding.rs
@@ -99,20 +99,16 @@ impl Bindings {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::word::{PrimitiveId, PublishedWords, WordDefinition};
+    use crate::word::{CompletedWordDefinition, PrimitiveId, PublishedWords};
 
     fn name(input: &str) -> NormalizedName {
         NormalizedName::new(input).expect("test input should be a valid word name")
     }
 
-    fn primitive_word(slot: usize) -> WordDefinition {
-        WordDefinition::Primitive {
-            primitive: PrimitiveId::from_slot(slot),
-        }
-    }
-
     fn add_word(words: &mut PublishedWords, primitive_slot: usize) -> WordId {
-        words.add(primitive_word(primitive_slot))
+        words.add(CompletedWordDefinition::primitive(PrimitiveId::from_slot(
+            primitive_slot,
+        )))
     }
 
     fn word_binding(words: &mut PublishedWords, primitive_slot: usize) -> Binding {

--- a/crates/tbx-next/src/bootstrap.rs
+++ b/crates/tbx-next/src/bootstrap.rs
@@ -1,6 +1,6 @@
 use crate::binding::{Binding, BindingInsertError, Bindings};
 use crate::name::NormalizedName;
-use crate::word::{PrimitiveId, PublishedWords, WordDefinition, WordId};
+use crate::word::{CompletedWordDefinition, PrimitiveId, PublishedWords, WordId};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum PrimitiveBootstrapError {
@@ -26,7 +26,7 @@ pub(crate) fn register_primitive(
         return Err(PrimitiveBootstrapError::NameConflict);
     }
 
-    let id = words.add(WordDefinition::Primitive { primitive });
+    let id = words.add(CompletedWordDefinition::primitive(primitive));
 
     bindings
         .insert_new(name, Binding::Word(id))
@@ -46,6 +46,7 @@ impl PrimitiveBootstrapError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::word::WordDefinition;
 
     fn name(input: &str) -> NormalizedName {
         NormalizedName::new(input).expect("test input should be a valid word name")

--- a/crates/tbx-next/src/instruction.rs
+++ b/crates/tbx-next/src/instruction.rs
@@ -1,0 +1,262 @@
+use crate::value::Value;
+
+/// Absolute address into the shared TBX Next instruction sequence.
+///
+/// ADR #1367 defines instruction addresses as VM-control identifiers, not
+/// runtime values. The concrete backing type is intentionally private and must
+/// not become a serialized or public ABI contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct InstructionAddress {
+    index: usize,
+}
+
+impl InstructionAddress {
+    pub(crate) const fn from_index(index: usize) -> Self {
+        Self { index }
+    }
+
+    pub(crate) const fn as_index(self) -> usize {
+        self.index
+    }
+
+    pub(crate) fn checked_next(self) -> Result<Self, InstructionAddressError> {
+        self.index
+            .checked_add(1)
+            .map(Self::from_index)
+            .ok_or(InstructionAddressError::AddressOverflow { address: self })
+    }
+}
+
+/// Crate-internal typed instruction for the future VM execution core.
+///
+/// This is intentionally a small, orthogonal instruction set for Phase 4. Word
+/// calls, returns, stack effects, and primitive dispatch belong to later VM
+/// execution work.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Instruction {
+    Push(Value),
+    Jump(InstructionAddress),
+    JumpIfZero(InstructionAddress),
+    Halt,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum InstructionAddressError {
+    InvalidAddress { address: InstructionAddress },
+    EndAddress { address: InstructionAddress },
+    AddressOverflow { address: InstructionAddress },
+}
+
+/// Owner for the single shared instruction sequence.
+///
+/// The owner is deliberately separate from VM state. Builders may append here,
+/// while the future VM receives only `InstructionView` so it cannot replace,
+/// truncate, or append instructions through its fetch boundary.
+#[derive(Debug, Default)]
+pub(crate) struct InstructionSequence {
+    instructions: Vec<Instruction>,
+}
+
+impl InstructionSequence {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn append(&mut self, instruction: Instruction) -> InstructionAddress {
+        let address = InstructionAddress::from_index(self.instructions.len());
+        self.instructions.push(instruction);
+        address
+    }
+
+    pub(crate) fn view(&self) -> InstructionView<'_> {
+        InstructionView {
+            instructions: &self.instructions,
+        }
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.instructions.len()
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.instructions.is_empty()
+    }
+}
+
+/// Read-only instruction fetch boundary for VM execution.
+///
+/// `code.len()` may be useful as a builder append position, but it is not a
+/// running VM address. Only addresses that point at an existing instruction are
+/// accepted by this view.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct InstructionView<'a> {
+    instructions: &'a [Instruction],
+}
+
+impl<'a> InstructionView<'a> {
+    pub(crate) fn get(
+        self,
+        address: InstructionAddress,
+    ) -> Result<&'a Instruction, InstructionAddressError> {
+        self.instructions
+            .get(address.as_index())
+            .ok_or_else(|| self.address_error(address))
+    }
+
+    pub(crate) fn validate_address(
+        self,
+        address: InstructionAddress,
+    ) -> Result<InstructionAddress, InstructionAddressError> {
+        self.get(address).map(|_| address)
+    }
+
+    pub(crate) fn checked_next_address(
+        self,
+        address: InstructionAddress,
+    ) -> Result<InstructionAddress, InstructionAddressError> {
+        self.validate_address(address)?;
+        let next = address.checked_next()?;
+        self.validate_address(next)
+    }
+
+    pub(crate) fn len(self) -> usize {
+        self.instructions.len()
+    }
+
+    pub(crate) fn is_empty(self) -> bool {
+        self.instructions.is_empty()
+    }
+
+    fn address_error(self, address: InstructionAddress) -> InstructionAddressError {
+        if address.as_index() == self.instructions.len() {
+            InstructionAddressError::EndAddress { address }
+        } else {
+            InstructionAddressError::InvalidAddress { address }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn push(value: i16) -> Instruction {
+        Instruction::Push(Value::integer(value))
+    }
+
+    fn address(index: usize) -> InstructionAddress {
+        InstructionAddress::from_index(index)
+    }
+
+    #[test]
+    fn empty_sequence_rejects_lookup_at_append_position() {
+        let code = InstructionSequence::new();
+        let view = code.view();
+        let zero = address(0);
+
+        assert!(code.is_empty());
+        assert!(view.is_empty());
+        assert_eq!(code.len(), 0);
+        assert_eq!(view.len(), 0);
+        assert_eq!(
+            view.get(zero),
+            Err(InstructionAddressError::EndAddress { address: zero })
+        );
+    }
+
+    #[test]
+    fn append_returns_addresses_for_existing_instructions() {
+        let mut code = InstructionSequence::new();
+
+        let first = code.append(push(10));
+        let second = code.append(push(20));
+        let third = code.append(Instruction::Halt);
+        let view = code.view();
+
+        assert_eq!(first.as_index(), 0);
+        assert_eq!(second.as_index(), 1);
+        assert_eq!(third.as_index(), 2);
+        assert_eq!(view.get(first), Ok(&push(10)));
+        assert_eq!(view.get(second), Ok(&push(20)));
+        assert_eq!(view.get(third), Ok(&Instruction::Halt));
+    }
+
+    #[test]
+    fn lookup_rejects_end_and_out_of_range_addresses() {
+        let mut code = InstructionSequence::new();
+        let first = code.append(push(1));
+        let end = address(1);
+        let out_of_range = address(2);
+        let max = address(usize::MAX);
+        let view = code.view();
+
+        assert_eq!(view.get(first), Ok(&push(1)));
+        assert_eq!(
+            view.get(end),
+            Err(InstructionAddressError::EndAddress { address: end })
+        );
+        assert_eq!(
+            view.get(out_of_range),
+            Err(InstructionAddressError::InvalidAddress {
+                address: out_of_range
+            })
+        );
+        assert_eq!(
+            view.get(max),
+            Err(InstructionAddressError::InvalidAddress { address: max })
+        );
+    }
+
+    #[test]
+    fn checked_next_address_accepts_only_existing_next_instruction() {
+        let mut code = InstructionSequence::new();
+        let first = code.append(push(1));
+        let second = code.append(push(2));
+        let third = code.append(Instruction::Halt);
+        let view = code.view();
+
+        assert_eq!(view.checked_next_address(first), Ok(second));
+        assert_eq!(view.checked_next_address(second), Ok(third));
+        assert_eq!(
+            view.checked_next_address(third),
+            Err(InstructionAddressError::EndAddress {
+                address: address(3)
+            })
+        );
+    }
+
+    #[test]
+    fn checked_next_address_rejects_invalid_current_address() {
+        let mut code = InstructionSequence::new();
+        code.append(Instruction::Halt);
+        let invalid = address(usize::MAX);
+
+        assert_eq!(
+            code.view().checked_next_address(invalid),
+            Err(InstructionAddressError::InvalidAddress { address: invalid })
+        );
+    }
+
+    #[test]
+    fn checked_next_detects_integer_overflow() {
+        let max = address(usize::MAX);
+
+        assert_eq!(
+            max.checked_next(),
+            Err(InstructionAddressError::AddressOverflow { address: max })
+        );
+    }
+
+    #[test]
+    fn jump_instructions_preserve_targets() {
+        let mut code = InstructionSequence::new();
+        let target = code.append(Instruction::Halt);
+        let jump = code.append(Instruction::Jump(target));
+        let jump_if_zero = code.append(Instruction::JumpIfZero(target));
+        let view = code.view();
+
+        assert_eq!(view.validate_address(target), Ok(target));
+        assert_eq!(view.get(jump), Ok(&Instruction::Jump(target)));
+        assert_eq!(view.get(jump_if_zero), Ok(&Instruction::JumpIfZero(target)));
+    }
+}

--- a/crates/tbx-next/src/lib.rs
+++ b/crates/tbx-next/src/lib.rs
@@ -2,6 +2,11 @@
 #[allow(dead_code)]
 mod value;
 
+// Phase 4 for ADR #1367 keeps the typed shared instruction sequence outside
+// mutable VM execution state and exposes only a read-only fetch boundary.
+#[allow(dead_code)]
+mod instruction;
+
 // Phase 2 exposes the internal stack contract before the VM consumes it.
 #[allow(dead_code)]
 mod stack;

--- a/crates/tbx-next/src/redefinition.rs
+++ b/crates/tbx-next/src/redefinition.rs
@@ -1,6 +1,6 @@
 use crate::binding::{BindingReplaceError, Bindings};
 use crate::name::NormalizedName;
-use crate::word::{PublishedWords, WordDefinition, WordId};
+use crate::word::{CompletedWordDefinition, PublishedWords, WordId};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct WordRedefinition {
@@ -35,7 +35,7 @@ pub(crate) fn redefine_word(
     words: &mut PublishedWords,
     bindings: &mut Bindings,
     name: &NormalizedName,
-    definition: WordDefinition,
+    definition: CompletedWordDefinition,
 ) -> Result<WordRedefinition, WordRedefinitionError> {
     let previous = bindings
         .current_word(name)
@@ -74,29 +74,35 @@ impl WordRedefinitionError {
 mod tests {
     use super::*;
     use crate::binding::{Binding, Bindings};
-    use crate::word::{InstructionAddress, PrimitiveId};
+    use crate::instruction::{Instruction, InstructionSequence};
+    use crate::value::Value;
+    use crate::word::{PrimitiveId, WordDefinition};
 
     fn name(input: &str) -> NormalizedName {
         NormalizedName::new(input).expect("test input should be a valid word name")
     }
 
-    fn primitive(slot: usize) -> WordDefinition {
+    fn primitive(slot: usize) -> CompletedWordDefinition {
+        CompletedWordDefinition::primitive(PrimitiveId::from_slot(slot))
+    }
+
+    fn primitive_definition(slot: usize) -> WordDefinition {
         WordDefinition::Primitive {
             primitive: PrimitiveId::from_slot(slot),
         }
     }
 
-    fn compiled(index: usize) -> WordDefinition {
-        WordDefinition::Compiled {
-            entry: InstructionAddress::from_index(index),
-        }
+    fn compiled(code: &mut InstructionSequence, value: i16) -> CompletedWordDefinition {
+        let entry = code.append(Instruction::Push(Value::integer(value)));
+        CompletedWordDefinition::compiled(entry, code.view())
+            .expect("test compiled entry should be valid")
     }
 
     fn publish_initial(
         words: &mut PublishedWords,
         bindings: &mut Bindings,
         input: &str,
-        definition: WordDefinition,
+        definition: CompletedWordDefinition,
     ) -> WordId {
         let id = words.add(definition);
         bindings
@@ -114,13 +120,19 @@ mod tests {
         bindings: &Bindings,
         input: &str,
         result: WordRedefinition,
-        old_definition: WordDefinition,
-        new_definition: WordDefinition,
+        old_definition: CompletedWordDefinition,
+        new_definition: CompletedWordDefinition,
     ) {
         assert_ne!(result.previous(), result.current());
         assert_word_binding(bindings, input, result.current());
-        assert_eq!(words.get(result.previous()), Ok(&old_definition));
-        assert_eq!(words.get(result.current()), Ok(&new_definition));
+        assert_eq!(
+            words.get(result.previous()),
+            Ok(&old_definition.definition())
+        );
+        assert_eq!(
+            words.get(result.current()),
+            Ok(&new_definition.definition())
+        );
     }
 
     #[test]
@@ -147,10 +159,11 @@ mod tests {
 
     #[test]
     fn primitive_word_can_be_redefined_as_compiled_word() {
+        let mut code = InstructionSequence::new();
         let mut words = PublishedWords::new();
         let mut bindings = Bindings::new();
         let old_definition = primitive(3);
-        let new_definition = compiled(100);
+        let new_definition = compiled(&mut code, 100);
         let old = publish_initial(&mut words, &mut bindings, "ABS", old_definition);
 
         let result = redefine_word(&mut words, &mut bindings, &name("ABS"), new_definition)
@@ -169,9 +182,10 @@ mod tests {
 
     #[test]
     fn compiled_word_can_be_redefined_as_primitive_word() {
+        let mut code = InstructionSequence::new();
         let mut words = PublishedWords::new();
         let mut bindings = Bindings::new();
-        let old_definition = compiled(200);
+        let old_definition = compiled(&mut code, 200);
         let new_definition = primitive(4);
         let old = publish_initial(&mut words, &mut bindings, "RUN", old_definition);
 
@@ -191,10 +205,11 @@ mod tests {
 
     #[test]
     fn compiled_word_can_be_redefined_as_compiled_word() {
+        let mut code = InstructionSequence::new();
         let mut words = PublishedWords::new();
         let mut bindings = Bindings::new();
-        let old_definition = compiled(300);
-        let new_definition = compiled(301);
+        let old_definition = compiled(&mut code, 300);
+        let new_definition = compiled(&mut code, 301);
         let old = publish_initial(&mut words, &mut bindings, "LOOP", old_definition);
 
         let result = redefine_word(&mut words, &mut bindings, &name("LOOP"), new_definition)
@@ -218,13 +233,13 @@ mod tests {
         let other_definition = primitive(5);
         let other = publish_initial(&mut words, &mut bindings, "OTHER", other_definition);
 
-        let result = redefine_word(&mut words, &mut bindings, &name("MISSING"), compiled(400));
+        let result = redefine_word(&mut words, &mut bindings, &name("MISSING"), primitive(400));
 
         assert_eq!(result, Err(WordRedefinitionError::UndefinedName));
         assert_eq!(words.len(), 1);
         assert_eq!(bindings.len(), 1);
         assert_word_binding(&bindings, "OTHER", other);
-        assert_eq!(words.get(other), Ok(&other_definition));
+        assert_eq!(words.get(other), Ok(&other_definition.definition()));
     }
 
     #[test]
@@ -232,7 +247,8 @@ mod tests {
         let mut words = PublishedWords::new();
         let mut bindings = Bindings::new();
         let old_definition = primitive(6);
-        let new_definition = compiled(500);
+        let mut code = InstructionSequence::new();
+        let new_definition = compiled(&mut code, 500);
         let old = publish_initial(&mut words, &mut bindings, "foo", old_definition);
 
         let result = redefine_word(&mut words, &mut bindings, &name("FOO"), new_definition)
@@ -252,12 +268,13 @@ mod tests {
 
     #[test]
     fn repeated_redefinitions_keep_all_previous_definitions_addressable() {
+        let mut code = InstructionSequence::new();
         let mut words = PublishedWords::new();
         let mut bindings = Bindings::new();
         let first_definition = primitive(7);
-        let second_definition = compiled(600);
+        let second_definition = compiled(&mut code, 600);
         let third_definition = primitive(8);
-        let fourth_definition = compiled(601);
+        let fourth_definition = compiled(&mut code, 601);
         let first = publish_initial(&mut words, &mut bindings, "CHAIN", first_definition);
 
         let second = redefine_word(&mut words, &mut bindings, &name("CHAIN"), second_definition)
@@ -274,22 +291,28 @@ mod tests {
         assert_ne!(second, third);
         assert_ne!(third, fourth);
         assert_word_binding(&bindings, "CHAIN", fourth);
-        assert_eq!(words.get(first), Ok(&first_definition));
-        assert_eq!(words.get(second), Ok(&second_definition));
-        assert_eq!(words.get(third), Ok(&third_definition));
-        assert_eq!(words.get(fourth), Ok(&fourth_definition));
+        assert_eq!(words.get(first), Ok(&first_definition.definition()));
+        assert_eq!(words.get(second), Ok(&second_definition.definition()));
+        assert_eq!(words.get(third), Ok(&third_definition.definition()));
+        assert_eq!(words.get(fourth), Ok(&fourth_definition.definition()));
         assert_eq!(words.len(), 4);
         assert_eq!(bindings.len(), 1);
     }
 
     #[test]
     fn redefinition_does_not_require_vm_state_or_handler_table() {
+        let mut code = InstructionSequence::new();
         let mut words = PublishedWords::new();
         let mut bindings = Bindings::new();
         publish_initial(&mut words, &mut bindings, "BOUNDARY", primitive(9));
 
-        let result = redefine_word(&mut words, &mut bindings, &name("BOUNDARY"), compiled(700))
-            .expect("completed definition should publish without VM state");
+        let result = redefine_word(
+            &mut words,
+            &mut bindings,
+            &name("BOUNDARY"),
+            compiled(&mut code, 700),
+        )
+        .expect("completed definition should publish without VM state");
 
         assert_word_binding(&bindings, "BOUNDARY", result.current());
         assert_eq!(words.len(), 2);

--- a/crates/tbx-next/src/word.rs
+++ b/crates/tbx-next/src/word.rs
@@ -1,22 +1,6 @@
-/// Absolute address into the shared TBX Next instruction sequence.
-///
-/// ADR #1367 defines instruction addresses as VM-control identifiers, not
-/// runtime values. The concrete backing type is intentionally private and must
-/// not become a serialized or public ABI contract.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub(crate) struct InstructionAddress {
-    index: usize,
-}
+use crate::instruction::{InstructionAddressError, InstructionView};
 
-impl InstructionAddress {
-    pub(crate) const fn from_index(index: usize) -> Self {
-        Self { index }
-    }
-
-    pub(crate) const fn as_index(self) -> usize {
-        self.index
-    }
-}
+pub(crate) use crate::instruction::InstructionAddress;
 
 /// Internal identifier for a published executable word definition.
 ///
@@ -67,6 +51,11 @@ pub(crate) enum WordLookupError {
     InvalidWordId { id: WordId },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WordDefinitionError {
+    InvalidCompiledEntry { error: InstructionAddressError },
+}
+
 /// Monotonic collection of published, executable word definitions.
 ///
 /// This collection deliberately has no removal, replacement, arbitrary insert,
@@ -97,6 +86,15 @@ impl PublishedWords {
         id
     }
 
+    pub(crate) fn add_validated(
+        &mut self,
+        definition: WordDefinition,
+        instructions: InstructionView<'_>,
+    ) -> Result<WordId, WordDefinitionError> {
+        validate_definition(definition, instructions)?;
+        Ok(self.add(definition))
+    }
+
     pub(crate) fn get(&self, id: WordId) -> Result<&WordDefinition, WordLookupError> {
         self.definitions
             .get(id.slot)
@@ -112,9 +110,24 @@ impl PublishedWords {
     }
 }
 
+fn validate_definition(
+    definition: WordDefinition,
+    instructions: InstructionView<'_>,
+) -> Result<(), WordDefinitionError> {
+    match definition {
+        WordDefinition::Primitive { .. } => Ok(()),
+        WordDefinition::Compiled { entry } => instructions
+            .validate_address(entry)
+            .map(|_| ())
+            .map_err(|error| WordDefinitionError::InvalidCompiledEntry { error }),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::instruction::{Instruction, InstructionAddressError, InstructionSequence};
+    use crate::value::Value;
     use crate::word_lookup::PublishedWordLookup;
 
     fn primitive(slot: usize) -> WordDefinition {
@@ -127,6 +140,10 @@ mod tests {
         WordDefinition::Compiled {
             entry: InstructionAddress::from_index(index),
         }
+    }
+
+    fn compiled_entry(entry: InstructionAddress) -> WordDefinition {
+        WordDefinition::Compiled { entry }
     }
 
     #[test]
@@ -285,5 +302,61 @@ mod tests {
 
         assert_eq!(words.get(primitive_id), Ok(&primitive(0)));
         assert_eq!(words.get(compiled_id), Ok(&compiled(8)));
+    }
+
+    #[test]
+    fn validated_add_accepts_compiled_entry_in_the_shared_instruction_sequence() {
+        let mut code = InstructionSequence::new();
+        let entry = code.append(Instruction::Push(Value::integer(42)));
+        code.append(Instruction::Halt);
+        let mut words = PublishedWords::new();
+
+        let id = words
+            .add_validated(compiled_entry(entry), code.view())
+            .expect("compiled entry should point at an existing instruction");
+
+        assert_eq!(words.len(), 1);
+        assert_eq!(words.get(id), Ok(&compiled_entry(entry)));
+    }
+
+    #[test]
+    fn validated_add_rejects_compiled_entry_at_end_without_issuing_word_id() {
+        let mut code = InstructionSequence::new();
+        code.append(Instruction::Halt);
+        let end = InstructionAddress::from_index(code.len());
+        let mut words = PublishedWords::new();
+
+        let result = words.add_validated(compiled_entry(end), code.view());
+
+        assert_eq!(
+            result,
+            Err(WordDefinitionError::InvalidCompiledEntry {
+                error: InstructionAddressError::EndAddress { address: end }
+            })
+        );
+        assert!(words.is_empty());
+    }
+
+    #[test]
+    fn validated_add_rejects_compiled_entry_outside_current_owner_view() {
+        let mut source_code = InstructionSequence::new();
+        source_code.append(Instruction::Push(Value::integer(1)));
+        let source_entry = source_code.append(Instruction::Halt);
+        let target_code = InstructionSequence::new();
+        let mut words = PublishedWords::new();
+
+        // InstructionAddress intentionally has no owner tag. Publication must
+        // validate against the owner view that will back VM execution.
+        let result = words.add_validated(compiled_entry(source_entry), target_code.view());
+
+        assert_eq!(
+            result,
+            Err(WordDefinitionError::InvalidCompiledEntry {
+                error: InstructionAddressError::InvalidAddress {
+                    address: source_entry
+                }
+            })
+        );
+        assert!(words.is_empty());
     }
 }

--- a/crates/tbx-next/src/word.rs
+++ b/crates/tbx-next/src/word.rs
@@ -47,6 +47,35 @@ pub(crate) enum WordDefinition {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CompletedWordDefinition {
+    definition: WordDefinition,
+}
+
+impl CompletedWordDefinition {
+    pub(crate) fn primitive(primitive: PrimitiveId) -> Self {
+        Self {
+            definition: WordDefinition::Primitive { primitive },
+        }
+    }
+
+    pub(crate) fn compiled(
+        entry: InstructionAddress,
+        instructions: InstructionView<'_>,
+    ) -> Result<Self, WordDefinitionError> {
+        instructions
+            .validate_address(entry)
+            .map(|_| Self {
+                definition: WordDefinition::Compiled { entry },
+            })
+            .map_err(|error| WordDefinitionError::InvalidCompiledEntry { error })
+    }
+
+    pub(crate) const fn definition(self) -> WordDefinition {
+        self.definition
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum WordLookupError {
     InvalidWordId { id: WordId },
 }
@@ -65,9 +94,11 @@ pub(crate) enum WordDefinitionError {
 /// unpublished definitions through normal lookup.
 ///
 /// ADR #1369 makes `WordId` issuance part of the construction-to-publication
-/// boundary: callers must pass only completed, executable definitions to `add`.
-/// In-progress code, failed builds, and unreferenced instruction fragments must
-/// remain outside this collection so ordinary `Call(WordId)` cannot reach them.
+/// boundary: callers must pass `CompletedWordDefinition`, whose compiled
+/// variant can only be built after validating its entry address against the
+/// instruction sequence that will back VM execution. In-progress code, failed
+/// builds, and invalid instruction fragments must remain outside this
+/// collection so ordinary `Call(WordId)` cannot reach them.
 #[derive(Debug, Default)]
 pub(crate) struct PublishedWords {
     definitions: Vec<WordDefinition>,
@@ -78,21 +109,12 @@ impl PublishedWords {
         Self::default()
     }
 
-    pub(crate) fn add(&mut self, definition: WordDefinition) -> WordId {
+    pub(crate) fn add(&mut self, definition: CompletedWordDefinition) -> WordId {
         let id = WordId {
             slot: self.definitions.len(),
         };
-        self.definitions.push(definition);
+        self.definitions.push(definition.definition());
         id
-    }
-
-    pub(crate) fn add_validated(
-        &mut self,
-        definition: WordDefinition,
-        instructions: InstructionView<'_>,
-    ) -> Result<WordId, WordDefinitionError> {
-        validate_definition(definition, instructions)?;
-        Ok(self.add(definition))
     }
 
     pub(crate) fn get(&self, id: WordId) -> Result<&WordDefinition, WordLookupError> {
@@ -110,19 +132,6 @@ impl PublishedWords {
     }
 }
 
-fn validate_definition(
-    definition: WordDefinition,
-    instructions: InstructionView<'_>,
-) -> Result<(), WordDefinitionError> {
-    match definition {
-        WordDefinition::Primitive { .. } => Ok(()),
-        WordDefinition::Compiled { entry } => instructions
-            .validate_address(entry)
-            .map(|_| ())
-            .map_err(|error| WordDefinitionError::InvalidCompiledEntry { error }),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -130,19 +139,24 @@ mod tests {
     use crate::value::Value;
     use crate::word_lookup::PublishedWordLookup;
 
-    fn primitive(slot: usize) -> WordDefinition {
+    fn primitive_definition(slot: usize) -> WordDefinition {
         WordDefinition::Primitive {
             primitive: PrimitiveId::from_slot(slot),
         }
     }
 
-    fn compiled(index: usize) -> WordDefinition {
-        WordDefinition::Compiled {
-            entry: InstructionAddress::from_index(index),
-        }
+    fn completed_primitive(slot: usize) -> CompletedWordDefinition {
+        CompletedWordDefinition::primitive(PrimitiveId::from_slot(slot))
     }
 
-    fn compiled_entry(entry: InstructionAddress) -> WordDefinition {
+    fn completed_compiled(
+        entry: InstructionAddress,
+        instructions: InstructionView<'_>,
+    ) -> Result<CompletedWordDefinition, WordDefinitionError> {
+        CompletedWordDefinition::compiled(entry, instructions)
+    }
+
+    fn compiled_entry_definition(entry: InstructionAddress) -> WordDefinition {
         WordDefinition::Compiled { entry }
     }
 
@@ -150,48 +164,66 @@ mod tests {
     fn empty_collection_accepts_first_definition() {
         let mut words = PublishedWords::new();
 
-        let id = words.add(primitive(0));
+        let id = words.add(completed_primitive(0));
 
         assert_eq!(words.len(), 1);
         assert!(!words.is_empty());
-        assert_eq!(words.get(id), Ok(&primitive(0)));
+        assert_eq!(words.get(id), Ok(&primitive_definition(0)));
     }
 
     #[test]
     fn added_definitions_receive_distinct_ids_and_keep_identity() {
         let mut words = PublishedWords::new();
 
-        let first_id = words.add(primitive(7));
-        let second_id = words.add(compiled(12));
-        let third_id = words.add(primitive(9));
+        let mut code = InstructionSequence::new();
+        let second_entry = code.append(Instruction::Halt);
+
+        let first_id = words.add(completed_primitive(7));
+        let second_id = words.add(
+            completed_compiled(second_entry, code.view()).expect("compiled entry should be valid"),
+        );
+        let third_id = words.add(completed_primitive(9));
 
         assert_ne!(first_id, second_id);
         assert_ne!(first_id, third_id);
         assert_ne!(second_id, third_id);
-        assert_eq!(words.get(first_id), Ok(&primitive(7)));
-        assert_eq!(words.get(second_id), Ok(&compiled(12)));
-        assert_eq!(words.get(third_id), Ok(&primitive(9)));
+        assert_eq!(words.get(first_id), Ok(&primitive_definition(7)));
+        assert_eq!(
+            words.get(second_id),
+            Ok(&compiled_entry_definition(second_entry))
+        );
+        assert_eq!(words.get(third_id), Ok(&primitive_definition(9)));
     }
 
     #[test]
     fn later_additions_do_not_change_previous_ids() {
         let mut words = PublishedWords::new();
 
-        let old_id = words.add(compiled(3));
+        let mut code = InstructionSequence::new();
+        let old_entry = code.append(Instruction::Push(Value::integer(3)));
+        let new_entry = code.append(Instruction::Halt);
+
+        let old_id = words
+            .add(completed_compiled(old_entry, code.view()).expect("old entry should be valid"));
         let old_definition = *words.get(old_id).expect("old id should be valid");
 
-        let new_id = words.add(compiled(99));
+        let new_id = words
+            .add(completed_compiled(new_entry, code.view()).expect("new entry should be valid"));
 
         assert_eq!(words.get(old_id), Ok(&old_definition));
-        assert_eq!(words.get(new_id), Ok(&compiled(99)));
+        assert_eq!(words.get(new_id), Ok(&compiled_entry_definition(new_entry)));
     }
 
     #[test]
     fn primitive_and_compiled_definitions_are_distinguishable_after_lookup() {
         let mut words = PublishedWords::new();
 
-        let primitive_id = words.add(primitive(5));
-        let compiled_id = words.add(compiled(42));
+        let mut code = InstructionSequence::new();
+        let entry = code.append(Instruction::Halt);
+
+        let primitive_id = words.add(completed_primitive(5));
+        let compiled_id = words
+            .add(completed_compiled(entry, code.view()).expect("compiled entry should be valid"));
 
         match words
             .get(primitive_id)
@@ -204,8 +236,8 @@ mod tests {
         }
 
         match words.get(compiled_id).expect("compiled id should be valid") {
-            WordDefinition::Compiled { entry } => {
-                assert_eq!(entry.as_index(), 42);
+            WordDefinition::Compiled { entry: actual } => {
+                assert_eq!(*actual, entry);
             }
             WordDefinition::Primitive { .. } => panic!("compiled id returned primitive word"),
         }
@@ -223,7 +255,7 @@ mod tests {
         assert_eq!(words.len(), 0);
         assert!(words.is_empty());
 
-        let valid_id = words.add(primitive(1));
+        let valid_id = words.add(completed_primitive(1));
         let out_of_range_id = WordId::test_invalid(2);
         let max_id = WordId::test_invalid(usize::MAX);
 
@@ -238,7 +270,7 @@ mod tests {
             Err(WordLookupError::InvalidWordId { id: max_id })
         );
         assert_eq!(words.len(), 1);
-        assert_eq!(words.get(valid_id), Ok(&primitive(1)));
+        assert_eq!(words.get(valid_id), Ok(&primitive_definition(1)));
     }
 
     #[test]
@@ -252,7 +284,7 @@ mod tests {
         );
         assert_eq!(words.len(), 0);
 
-        let valid_id = words.add(primitive(1));
+        let valid_id = words.add(completed_primitive(1));
         let out_of_range_id = WordId::test_invalid(2);
         let max_id = WordId::test_invalid(usize::MAX);
 
@@ -269,7 +301,7 @@ mod tests {
         assert_eq!(words.len(), 1);
         assert_eq!(
             PublishedWordLookup::new(&words).lookup_word(valid_id),
-            Ok(&primitive(1))
+            Ok(&primitive_definition(1))
         );
     }
 
@@ -277,56 +309,81 @@ mod tests {
     fn old_definitions_remain_accessible_after_multiple_additions() {
         let mut words = PublishedWords::new();
 
-        let first_id = words.add(primitive(10));
-        let second_id = words.add(compiled(20));
-        let third_id = words.add(primitive(30));
+        let mut code = InstructionSequence::new();
+        let second_entry = code.append(Instruction::Push(Value::integer(20)));
+        let fourth_entry = code.append(Instruction::Halt);
 
-        assert_eq!(words.get(first_id), Ok(&primitive(10)));
-        assert_eq!(words.get(second_id), Ok(&compiled(20)));
-        assert_eq!(words.get(third_id), Ok(&primitive(30)));
+        let first_id = words.add(completed_primitive(10));
+        let second_id = words.add(
+            completed_compiled(second_entry, code.view()).expect("second entry should be valid"),
+        );
+        let third_id = words.add(completed_primitive(30));
 
-        let fourth_id = words.add(compiled(40));
+        assert_eq!(words.get(first_id), Ok(&primitive_definition(10)));
+        assert_eq!(
+            words.get(second_id),
+            Ok(&compiled_entry_definition(second_entry))
+        );
+        assert_eq!(words.get(third_id), Ok(&primitive_definition(30)));
 
-        assert_eq!(words.get(first_id), Ok(&primitive(10)));
-        assert_eq!(words.get(second_id), Ok(&compiled(20)));
-        assert_eq!(words.get(third_id), Ok(&primitive(30)));
-        assert_eq!(words.get(fourth_id), Ok(&compiled(40)));
+        let fourth_id = words.add(
+            completed_compiled(fourth_entry, code.view()).expect("fourth entry should be valid"),
+        );
+
+        assert_eq!(words.get(first_id), Ok(&primitive_definition(10)));
+        assert_eq!(
+            words.get(second_id),
+            Ok(&compiled_entry_definition(second_entry))
+        );
+        assert_eq!(words.get(third_id), Ok(&primitive_definition(30)));
+        assert_eq!(
+            words.get(fourth_id),
+            Ok(&compiled_entry_definition(fourth_entry))
+        );
     }
 
     #[test]
     fn definitions_do_not_require_names_or_vm_state() {
         let mut words = PublishedWords::new();
 
-        let primitive_id = words.add(primitive(0));
-        let compiled_id = words.add(compiled(8));
+        let mut code = InstructionSequence::new();
+        let entry = code.append(Instruction::Halt);
 
-        assert_eq!(words.get(primitive_id), Ok(&primitive(0)));
-        assert_eq!(words.get(compiled_id), Ok(&compiled(8)));
+        let primitive_id = words.add(completed_primitive(0));
+        let compiled_id = words
+            .add(completed_compiled(entry, code.view()).expect("compiled entry should be valid"));
+
+        assert_eq!(words.get(primitive_id), Ok(&primitive_definition(0)));
+        assert_eq!(
+            words.get(compiled_id),
+            Ok(&compiled_entry_definition(entry))
+        );
     }
 
     #[test]
-    fn validated_add_accepts_compiled_entry_in_the_shared_instruction_sequence() {
+    fn completed_compiled_accepts_entry_in_the_shared_instruction_sequence() {
         let mut code = InstructionSequence::new();
         let entry = code.append(Instruction::Push(Value::integer(42)));
         code.append(Instruction::Halt);
         let mut words = PublishedWords::new();
 
-        let id = words
-            .add_validated(compiled_entry(entry), code.view())
-            .expect("compiled entry should point at an existing instruction");
+        let id = words.add(
+            completed_compiled(entry, code.view())
+                .expect("compiled entry should point at an existing instruction"),
+        );
 
         assert_eq!(words.len(), 1);
-        assert_eq!(words.get(id), Ok(&compiled_entry(entry)));
+        assert_eq!(words.get(id), Ok(&compiled_entry_definition(entry)));
     }
 
     #[test]
-    fn validated_add_rejects_compiled_entry_at_end_without_issuing_word_id() {
+    fn completed_compiled_rejects_entry_at_end_before_issuing_word_id() {
         let mut code = InstructionSequence::new();
         code.append(Instruction::Halt);
         let end = InstructionAddress::from_index(code.len());
         let mut words = PublishedWords::new();
 
-        let result = words.add_validated(compiled_entry(end), code.view());
+        let result = completed_compiled(end, code.view()).map(|definition| words.add(definition));
 
         assert_eq!(
             result,
@@ -338,7 +395,7 @@ mod tests {
     }
 
     #[test]
-    fn validated_add_rejects_compiled_entry_outside_current_owner_view() {
+    fn completed_compiled_rejects_entry_outside_current_owner_view() {
         let mut source_code = InstructionSequence::new();
         source_code.append(Instruction::Push(Value::integer(1)));
         let source_entry = source_code.append(Instruction::Halt);
@@ -347,7 +404,8 @@ mod tests {
 
         // InstructionAddress intentionally has no owner tag. Publication must
         // validate against the owner view that will back VM execution.
-        let result = words.add_validated(compiled_entry(source_entry), target_code.view());
+        let result = completed_compiled(source_entry, target_code.view())
+            .map(|definition| words.add(definition));
 
         assert_eq!(
             result,

--- a/crates/tbx-next/src/word_lookup.rs
+++ b/crates/tbx-next/src/word_lookup.rs
@@ -25,9 +25,11 @@ impl<'a> PublishedWordLookup<'a> {
 mod tests {
     use super::*;
     use crate::binding::{Binding, Bindings};
+    use crate::instruction::{Instruction, InstructionSequence};
     use crate::name::NormalizedName;
     use crate::redefinition::redefine_word;
-    use crate::word::{InstructionAddress, PrimitiveId};
+    use crate::value::Value;
+    use crate::word::{CompletedWordDefinition, InstructionAddress, PrimitiveId};
 
     fn name(input: &str) -> NormalizedName {
         NormalizedName::new(input).expect("test input should be a valid word name")
@@ -39,17 +41,25 @@ mod tests {
         }
     }
 
-    fn compiled(index: usize) -> WordDefinition {
-        WordDefinition::Compiled {
-            entry: InstructionAddress::from_index(index),
-        }
+    fn completed_primitive(slot: usize) -> CompletedWordDefinition {
+        CompletedWordDefinition::primitive(PrimitiveId::from_slot(slot))
+    }
+
+    fn compiled_definition(entry: InstructionAddress) -> WordDefinition {
+        WordDefinition::Compiled { entry }
+    }
+
+    fn completed_compiled(code: &mut InstructionSequence, value: i16) -> CompletedWordDefinition {
+        let entry = code.append(Instruction::Push(Value::integer(value)));
+        CompletedWordDefinition::compiled(entry, code.view())
+            .expect("test compiled entry should be valid")
     }
 
     fn publish_initial(
         words: &mut PublishedWords,
         bindings: &mut Bindings,
         input: &str,
-        definition: WordDefinition,
+        definition: CompletedWordDefinition,
     ) -> WordId {
         let id = words.add(definition);
         bindings
@@ -69,9 +79,7 @@ mod tests {
     fn primitive_lookup_preserves_primitive_identity() {
         let mut words = PublishedWords::new();
         let primitive_id = PrimitiveId::from_slot(17);
-        let id = words.add(WordDefinition::Primitive {
-            primitive: primitive_id,
-        });
+        let id = words.add(CompletedWordDefinition::primitive(primitive_id));
         let lookup = PublishedWordLookup::new(&words);
 
         match lookup.lookup_word(id).expect("word id should be valid") {
@@ -82,9 +90,13 @@ mod tests {
 
     #[test]
     fn compiled_lookup_preserves_entry_address() {
+        let mut code = InstructionSequence::new();
         let mut words = PublishedWords::new();
-        let entry = InstructionAddress::from_index(42);
-        let id = words.add(WordDefinition::Compiled { entry });
+        let entry = code.append(Instruction::Halt);
+        let id = words.add(
+            CompletedWordDefinition::compiled(entry, code.view())
+                .expect("compiled entry should be valid"),
+        );
         let lookup = PublishedWordLookup::new(&words);
 
         match lookup.lookup_word(id).expect("word id should be valid") {
@@ -96,36 +108,46 @@ mod tests {
     #[test]
     fn multiple_definitions_lookup_by_their_own_ids() {
         let mut words = PublishedWords::new();
-        let first = words.add(primitive(1));
-        let second = words.add(compiled(20));
-        let third = words.add(primitive(3));
+        let mut code = InstructionSequence::new();
+        let second_definition = completed_compiled(&mut code, 20);
+        let first = words.add(completed_primitive(1));
+        let second = words.add(second_definition);
+        let third = words.add(completed_primitive(3));
         let lookup = PublishedWordLookup::new(&words);
 
         assert_eq!(lookup.lookup_word(first), Ok(&primitive(1)));
-        assert_eq!(lookup.lookup_word(second), Ok(&compiled(20)));
+        assert_eq!(
+            lookup.lookup_word(second),
+            Ok(&second_definition.definition())
+        );
         assert_eq!(lookup.lookup_word(third), Ok(&primitive(3)));
     }
 
     #[test]
     fn later_additions_do_not_change_lookup_for_existing_ids() {
         let mut words = PublishedWords::new();
-        let old = words.add(compiled(10));
+        let mut code = InstructionSequence::new();
+        let old_definition = completed_compiled(&mut code, 10);
+        let new_definition = completed_compiled(&mut code, 99);
+        let old = words.add(old_definition);
         let old_definition = *PublishedWordLookup::new(&words)
             .lookup_word(old)
             .expect("old id should be valid");
 
-        let new = words.add(compiled(99));
+        let new = words.add(new_definition);
         let lookup = PublishedWordLookup::new(&words);
 
         assert_eq!(lookup.lookup_word(old), Ok(&old_definition));
-        assert_eq!(lookup.lookup_word(new), Ok(&compiled(99)));
+        assert_eq!(lookup.lookup_word(new), Ok(&new_definition.definition()));
     }
 
     #[test]
     fn lookup_does_not_require_bindings_or_names() {
         let mut words = PublishedWords::new();
-        let primitive_id = words.add(primitive(11));
-        let compiled_id = words.add(compiled(12));
+        let mut code = InstructionSequence::new();
+        let compiled_definition = completed_compiled(&mut code, 12);
+        let primitive_id = words.add(completed_primitive(11));
+        let compiled_id = words.add(compiled_definition);
         let lookup = PublishedWordLookup::new(&words);
 
         assert_eq!(
@@ -134,7 +156,7 @@ mod tests {
         );
         assert_eq!(
             vm_like_dispatch_target(lookup, compiled_id),
-            Ok(&compiled(12))
+            Ok(&compiled_definition.definition())
         );
     }
 
@@ -142,9 +164,10 @@ mod tests {
     fn lookup_result_is_independent_from_current_name_binding() {
         let mut words = PublishedWords::new();
         let mut bindings = Bindings::new();
+        let mut code = InstructionSequence::new();
         let old_definition = primitive(30);
-        let new_definition = compiled(300);
-        let old = publish_initial(&mut words, &mut bindings, "TARGET", old_definition);
+        let new_definition = completed_compiled(&mut code, 300);
+        let old = publish_initial(&mut words, &mut bindings, "TARGET", completed_primitive(30));
 
         let redefinition =
             redefine_word(&mut words, &mut bindings, &name("TARGET"), new_definition)
@@ -162,7 +185,7 @@ mod tests {
         );
         assert_eq!(
             lookup.lookup_word(redefinition.current()),
-            Ok(&new_definition)
+            Ok(&new_definition.definition())
         );
     }
 }

--- a/crates/tbx-next/src/word_resolution.rs
+++ b/crates/tbx-next/src/word_resolution.rs
@@ -46,9 +46,13 @@ mod tests {
     use super::*;
     use crate::binding::{Binding, Bindings};
     use crate::bootstrap::register_primitive;
+    use crate::instruction::{Instruction, InstructionSequence};
     use crate::name::NormalizedName;
     use crate::redefinition::redefine_word;
-    use crate::word::{InstructionAddress, PrimitiveId, PublishedWords, WordDefinition, WordId};
+    use crate::value::Value;
+    use crate::word::{
+        CompletedWordDefinition, PrimitiveId, PublishedWords, WordDefinition, WordId,
+    };
     use crate::word_lookup::PublishedWordLookup;
 
     fn name(input: &str) -> NormalizedName {
@@ -61,17 +65,21 @@ mod tests {
         }
     }
 
-    fn compiled(index: usize) -> WordDefinition {
-        WordDefinition::Compiled {
-            entry: InstructionAddress::from_index(index),
-        }
+    fn completed_primitive(slot: usize) -> CompletedWordDefinition {
+        CompletedWordDefinition::primitive(PrimitiveId::from_slot(slot))
+    }
+
+    fn completed_compiled(code: &mut InstructionSequence, value: i16) -> CompletedWordDefinition {
+        let entry = code.append(Instruction::Push(Value::integer(value)));
+        CompletedWordDefinition::compiled(entry, code.view())
+            .expect("test compiled entry should be valid")
     }
 
     fn publish_initial(
         words: &mut PublishedWords,
         bindings: &mut Bindings,
         input: &str,
-        definition: WordDefinition,
+        definition: CompletedWordDefinition,
     ) -> WordId {
         let id = words.add(definition);
         bindings
@@ -84,7 +92,7 @@ mod tests {
     fn source_word_name_resolves_through_normalized_binding_identity() {
         let mut words = PublishedWords::new();
         let mut bindings = Bindings::new();
-        let id = publish_initial(&mut words, &mut bindings, "foo", primitive(1));
+        let id = publish_initial(&mut words, &mut bindings, "foo", completed_primitive(1));
 
         assert_eq!(resolve_word_name(&bindings, "foo"), Ok(id));
         assert_eq!(resolve_word_name(&bindings, "Foo"), Ok(id));
@@ -95,7 +103,7 @@ mod tests {
     fn predicate_word_name_resolves_after_case_normalization() {
         let mut words = PublishedWords::new();
         let mut bindings = Bindings::new();
-        let id = publish_initial(&mut words, &mut bindings, "ready?", primitive(2));
+        let id = publish_initial(&mut words, &mut bindings, "ready?", completed_primitive(2));
 
         assert_eq!(resolve_word_name(&bindings, "ready?"), Ok(id));
         assert_eq!(resolve_word_name(&bindings, "Ready?"), Ok(id));
@@ -119,7 +127,7 @@ mod tests {
     fn undefined_name_is_rejected_without_mutation() {
         let mut words = PublishedWords::new();
         let mut bindings = Bindings::new();
-        let id = publish_initial(&mut words, &mut bindings, "KNOWN", primitive(3));
+        let id = publish_initial(&mut words, &mut bindings, "KNOWN", completed_primitive(3));
 
         assert_eq!(
             resolve_word_name(&bindings, "MISSING"),
@@ -134,23 +142,31 @@ mod tests {
     fn primitive_and_compiled_words_use_the_same_binding_path() {
         let mut words = PublishedWords::new();
         let mut bindings = Bindings::new();
-        let primitive_id = publish_initial(&mut words, &mut bindings, "PRIM", primitive(4));
-        let compiled_id = publish_initial(&mut words, &mut bindings, "USER_WORD", compiled(10));
+        let mut code = InstructionSequence::new();
+        let compiled_definition = completed_compiled(&mut code, 10);
+        let primitive_id =
+            publish_initial(&mut words, &mut bindings, "PRIM", completed_primitive(4));
+        let compiled_id =
+            publish_initial(&mut words, &mut bindings, "USER_WORD", compiled_definition);
         let lookup = PublishedWordLookup::new(&words);
 
         assert_eq!(resolve_word_name(&bindings, "prim"), Ok(primitive_id));
         assert_eq!(resolve_word_name(&bindings, "user_word"), Ok(compiled_id));
         assert_eq!(lookup.lookup_word(primitive_id), Ok(&primitive(4)));
-        assert_eq!(lookup.lookup_word(compiled_id), Ok(&compiled(10)));
+        assert_eq!(
+            lookup.lookup_word(compiled_id),
+            Ok(&compiled_definition.definition())
+        );
     }
 
     #[test]
     fn saved_resolution_keeps_old_word_id_after_redefinition() {
         let mut words = PublishedWords::new();
         let mut bindings = Bindings::new();
+        let mut code = InstructionSequence::new();
         let old_definition = primitive(6);
-        let new_definition = compiled(30);
-        let old = publish_initial(&mut words, &mut bindings, "TARGET", old_definition);
+        let new_definition = completed_compiled(&mut code, 30);
+        let old = publish_initial(&mut words, &mut bindings, "TARGET", completed_primitive(6));
 
         let old_resolution =
             resolve_word_name(&bindings, "target").expect("old target should resolve");
@@ -166,15 +182,19 @@ mod tests {
         assert_eq!(new_resolution, redefinition.current());
         assert_ne!(old_resolution, new_resolution);
         assert_eq!(lookup.lookup_word(old_resolution), Ok(&old_definition));
-        assert_eq!(lookup.lookup_word(new_resolution), Ok(&new_definition));
+        assert_eq!(
+            lookup.lookup_word(new_resolution),
+            Ok(&new_definition.definition())
+        );
     }
 
     #[test]
     fn same_kind_redefinition_only_changes_future_resolutions() {
         let mut words = PublishedWords::new();
         let mut bindings = Bindings::new();
-        let old_definition = compiled(40);
-        let new_definition = compiled(41);
+        let mut code = InstructionSequence::new();
+        let old_definition = completed_compiled(&mut code, 40);
+        let new_definition = completed_compiled(&mut code, 41);
         publish_initial(&mut words, &mut bindings, "CHAIN", old_definition);
 
         let old_resolution =
@@ -187,22 +207,24 @@ mod tests {
 
         assert_eq!(old_resolution, redefinition.previous());
         assert_eq!(new_resolution, redefinition.current());
-        assert_eq!(lookup.lookup_word(old_resolution), Ok(&old_definition));
-        assert_eq!(lookup.lookup_word(new_resolution), Ok(&new_definition));
+        assert_eq!(
+            lookup.lookup_word(old_resolution),
+            Ok(&old_definition.definition())
+        );
+        assert_eq!(
+            lookup.lookup_word(new_resolution),
+            Ok(&new_definition.definition())
+        );
     }
 
     #[test]
     fn unpublished_word_definition_is_not_resolved_by_name() {
-        let mut words = PublishedWords::new();
         let bindings = Bindings::new();
-        let unpublished = words.add(compiled(50));
 
         assert_eq!(
             resolve_word_name(&bindings, "UNPUBLISHED"),
             Err(WordResolutionError::UndefinedName)
         );
-        assert_eq!(words.get(unpublished), Ok(&compiled(50)));
-        assert_eq!(words.len(), 1);
         assert!(bindings.is_empty());
     }
 


### PR DESCRIPTION
## Summary

- Add crate-internal typed `Instruction` and `InstructionSequence` owner for the shared TBX Next code sequence.
- Add read-only `InstructionView` fetch and address validation APIs that reject empty, end, out-of-range, and overflow cases.
- Add validated `PublishedWords` publication path for compiled word entries against the same instruction sequence view.

Closes #1399

## Verification

- `cargo test -p tbx-next`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo fmt --check`
