### PR TITLE
TBX Next: 複数 code-space の read-only execution lookup を追加

### DIFF
--- a/crates/tbx-next/src/instruction.rs
+++ b/crates/tbx-next/src/instruction.rs
@@ -63,6 +63,13 @@ pub(crate) struct CodeLocation {
 }
 
 impl CodeLocation {
+    pub(crate) const fn new(code_space: CodeSpaceId, address: InstructionAddress) -> Self {
+        Self {
+            code_space,
+            address,
+        }
+    }
+
     pub(crate) const fn code_space(self) -> CodeSpaceId {
         self.code_space
     }
@@ -103,6 +110,31 @@ pub(crate) enum InstructionAddressError {
         actual: CodeSpaceId,
         address: InstructionAddress,
     },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CodeSpaceLookupError {
+    UnknownCodeSpace { code_space: CodeSpaceId },
+    DuplicateCodeSpace { code_space: CodeSpaceId },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum InstructionLookupError {
+    UnknownCodeSpace { code_space: CodeSpaceId },
+    Address { source: InstructionAddressError },
+}
+
+impl From<CodeSpaceLookupError> for InstructionLookupError {
+    fn from(error: CodeSpaceLookupError) -> Self {
+        match error {
+            CodeSpaceLookupError::UnknownCodeSpace { code_space } => {
+                Self::UnknownCodeSpace { code_space }
+            }
+            CodeSpaceLookupError::DuplicateCodeSpace { code_space } => {
+                Self::UnknownCodeSpace { code_space }
+            }
+        }
+    }
 }
 
 /// Owner for one instruction sequence.
@@ -165,6 +197,104 @@ impl Default for InstructionSequence {
 pub(crate) struct InstructionView<'a> {
     code_space: CodeSpaceId,
     instructions: &'a [Instruction],
+}
+
+/// Read-only lookup over multiple instruction owners.
+///
+/// The lookup stores only `InstructionView`s, so consumers can fetch and
+/// validate existing code locations without gaining append, truncate, or
+/// replacement authority over any owner.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct CodeSpaceLookup<'a> {
+    views: &'a [InstructionView<'a>],
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum InstructionLookup<'a> {
+    Single(InstructionView<'a>),
+    Multiple(CodeSpaceLookup<'a>),
+}
+
+impl<'a> CodeSpaceLookup<'a> {
+    pub(crate) fn new(views: &'a [InstructionView<'a>]) -> Result<Self, CodeSpaceLookupError> {
+        for (index, view) in views.iter().enumerate() {
+            if views[index + 1..]
+                .iter()
+                .any(|other| other.code_space() == view.code_space())
+            {
+                return Err(CodeSpaceLookupError::DuplicateCodeSpace {
+                    code_space: view.code_space(),
+                });
+            }
+        }
+
+        Ok(Self { views })
+    }
+
+    pub(crate) fn view_for(
+        self,
+        code_space: CodeSpaceId,
+    ) -> Result<InstructionView<'a>, CodeSpaceLookupError> {
+        self.views
+            .iter()
+            .copied()
+            .find(|view| view.code_space() == code_space)
+            .ok_or(CodeSpaceLookupError::UnknownCodeSpace { code_space })
+    }
+}
+
+impl<'a> From<InstructionView<'a>> for InstructionLookup<'a> {
+    fn from(view: InstructionView<'a>) -> Self {
+        Self::Single(view)
+    }
+}
+
+impl<'a> From<CodeSpaceLookup<'a>> for InstructionLookup<'a> {
+    fn from(lookup: CodeSpaceLookup<'a>) -> Self {
+        Self::Multiple(lookup)
+    }
+}
+
+impl<'a> InstructionLookup<'a> {
+    pub(crate) fn view_for(
+        self,
+        code_space: CodeSpaceId,
+    ) -> Result<InstructionView<'a>, CodeSpaceLookupError> {
+        match self {
+            Self::Single(view) if view.code_space() == code_space => Ok(view),
+            Self::Single(_) => Err(CodeSpaceLookupError::UnknownCodeSpace { code_space }),
+            Self::Multiple(lookup) => lookup.view_for(code_space),
+        }
+    }
+
+    pub(crate) fn get_location(
+        self,
+        location: CodeLocation,
+    ) -> Result<&'a Instruction, InstructionLookupError> {
+        self.view_for(location.code_space())?
+            .get_location(location)
+            .map_err(|source| InstructionLookupError::Address { source })
+    }
+
+    pub(crate) fn validate_location(
+        self,
+        location: CodeLocation,
+    ) -> Result<InstructionAddress, InstructionLookupError> {
+        self.view_for(location.code_space())?
+            .validate_location(location)
+            .map_err(|source| InstructionLookupError::Address { source })
+    }
+
+    pub(crate) fn checked_next_location(
+        self,
+        location: CodeLocation,
+    ) -> Result<CodeLocation, InstructionLookupError> {
+        let view = self.view_for(location.code_space())?;
+        view.validate_location(location)
+            .and_then(|address| view.checked_next_address(address))
+            .map(|address| view.location(address))
+            .map_err(|source| InstructionLookupError::Address { source })
+    }
 }
 
 impl<'a> InstructionView<'a> {
@@ -254,6 +384,10 @@ mod tests {
 
     fn address(index: usize) -> InstructionAddress {
         InstructionAddress::from_index(index)
+    }
+
+    fn address_lookup_error(source: InstructionAddressError) -> InstructionLookupError {
+        InstructionLookupError::Address { source }
     }
 
     #[test]
@@ -493,5 +627,132 @@ mod tests {
         assert_eq!(view.validate_address(target), Ok(target));
         assert_eq!(view.get(jump), Ok(&Instruction::Jump(target)));
         assert_eq!(view.get(jump_if_zero), Ok(&Instruction::JumpIfZero(target)));
+    }
+
+    #[test]
+    fn code_space_lookup_resolves_registered_views_by_code_space_id() {
+        let mut first = InstructionSequence::new();
+        let first_entry = first.append(push(10));
+        let mut second = InstructionSequence::new();
+        let second_entry = second.append(push(20));
+        let views = [first.view(), second.view()];
+        let lookup = CodeSpaceLookup::new(&views).expect("views should be distinct");
+        let first_view = lookup
+            .view_for(first.code_space())
+            .expect("first code space should be registered");
+        let second_view = lookup
+            .view_for(second.code_space())
+            .expect("second code space should be registered");
+
+        assert_eq!(first_view.get(first_entry), Ok(&push(10)));
+        assert_eq!(second_view.get(second_entry), Ok(&push(20)));
+    }
+
+    #[test]
+    fn instruction_lookup_does_not_fallback_to_same_local_index_in_another_space() {
+        let mut registered = InstructionSequence::new();
+        let registered_entry = registered.append(push(10));
+        let mut unregistered = InstructionSequence::new();
+        let unregistered_entry = unregistered.append(push(99));
+        let views = [registered.view()];
+        let lookup = InstructionLookup::from(
+            CodeSpaceLookup::new(&views).expect("single registered view is valid"),
+        );
+
+        assert_eq!(registered_entry.as_index(), unregistered_entry.as_index());
+        assert_eq!(
+            lookup.get_location(unregistered.view().location(unregistered_entry)),
+            Err(InstructionLookupError::UnknownCodeSpace {
+                code_space: unregistered.code_space()
+            })
+        );
+    }
+
+    #[test]
+    fn instruction_lookup_keeps_same_local_index_separate_between_spaces() {
+        let mut first = InstructionSequence::new();
+        let first_entry = first.append(push(1));
+        let mut second = InstructionSequence::new();
+        let second_entry = second.append(push(2));
+        let views = [second.view(), first.view()];
+        let lookup = InstructionLookup::from(
+            CodeSpaceLookup::new(&views).expect("views should be distinct"),
+        );
+
+        assert_eq!(first_entry.as_index(), second_entry.as_index());
+        assert_eq!(
+            lookup.get_location(first.view().location(first_entry)),
+            Ok(&push(1))
+        );
+        assert_eq!(
+            lookup.get_location(second.view().location(second_entry)),
+            Ok(&push(2))
+        );
+    }
+
+    #[test]
+    fn instruction_lookup_distinguishes_unknown_space_from_invalid_local_address() {
+        let mut registered = InstructionSequence::new();
+        registered.append(Instruction::Halt);
+        let unregistered = InstructionSequence::new();
+        let views = [registered.view()];
+        let lookup = InstructionLookup::from(
+            CodeSpaceLookup::new(&views).expect("single registered view is valid"),
+        );
+        let end = registered.view().location(address(1));
+        let out_of_range = registered.view().location(address(2));
+        let unknown = unregistered.view().location(address(1));
+
+        assert_eq!(
+            lookup.validate_location(end),
+            Err(address_lookup_error(InstructionAddressError::EndAddress {
+                address: end.address()
+            }))
+        );
+        assert_eq!(
+            lookup.validate_location(out_of_range),
+            Err(address_lookup_error(
+                InstructionAddressError::InvalidAddress {
+                    address: out_of_range.address()
+                }
+            ))
+        );
+        assert_eq!(
+            lookup.validate_location(unknown),
+            Err(InstructionLookupError::UnknownCodeSpace {
+                code_space: unregistered.code_space()
+            })
+        );
+    }
+
+    #[test]
+    fn instruction_lookup_reports_end_for_empty_registered_space() {
+        let empty = InstructionSequence::new();
+        let views = [empty.view()];
+        let lookup = InstructionLookup::from(
+            CodeSpaceLookup::new(&views).expect("single registered view is valid"),
+        );
+        let location = empty.view().location(address(0));
+
+        assert_eq!(
+            lookup.get_location(location),
+            Err(address_lookup_error(InstructionAddressError::EndAddress {
+                address: location.address()
+            }))
+        );
+    }
+
+    #[test]
+    fn code_space_lookup_rejects_duplicate_registered_spaces() {
+        let mut code = InstructionSequence::new();
+        code.append(Instruction::Halt);
+        let views = [code.view(), code.view()];
+
+        assert_eq!(
+            CodeSpaceLookup::new(&views).expect_err("duplicate code spaces should be rejected"),
+            CodeSpaceLookupError::DuplicateCodeSpace {
+                code_space: code.code_space()
+            }
+        );
     }
 }

--- a/crates/tbx-next/src/source_processor.rs
+++ b/crates/tbx-next/src/source_processor.rs
@@ -1,5 +1,8 @@
 use crate::binding::Bindings;
-use crate::instruction::{Instruction, InstructionAddress, InstructionSequence};
+use crate::instruction::{
+    CodeSpaceLookup, CodeSpaceLookupError, Instruction, InstructionAddress, InstructionSequence,
+    InstructionView,
+};
 use crate::lexer::{LexError, Lexer, Token, TokenKind};
 use crate::primitive::PrimitiveLookup;
 use crate::source::{SourceError, SourceId, SourceSpan, SourceView};
@@ -29,6 +32,7 @@ pub(crate) struct SourceCompileContext<'a> {
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct SourceExecutionContext<'a> {
     compile: SourceCompileContext<'a>,
+    code_spaces: &'a [InstructionView<'a>],
     words: PublishedWordLookup<'a>,
     primitives: PrimitiveLookup<'a>,
 }
@@ -45,6 +49,7 @@ pub(crate) enum SourceProcessorError {
     Source(SourceError),
     Lex(LexError),
     Compile(CompileError),
+    CodeSpaceLookup(CodeSpaceLookupError),
     Vm(VmError),
 }
 
@@ -83,6 +88,12 @@ impl From<CompileError> for SourceProcessorError {
 impl From<VmError> for SourceProcessorError {
     fn from(error: VmError) -> Self {
         Self::Vm(error)
+    }
+}
+
+impl From<CodeSpaceLookupError> for SourceProcessorError {
+    fn from(error: CodeSpaceLookupError) -> Self {
+        Self::CodeSpaceLookup(error)
     }
 }
 
@@ -159,8 +170,11 @@ fn run_unit(
     context: SourceExecutionContext<'_>,
 ) -> Result<SourceRunResult, SourceProcessorError> {
     let mut vm = Vm::new(unit.instructions.view(), unit.entry)?;
-    let execution = ExecutionView::new(
-        unit.instructions.view(),
+    let mut code_spaces = Vec::with_capacity(context.code_spaces().len() + 1);
+    code_spaces.push(unit.instructions.view());
+    code_spaces.extend_from_slice(context.code_spaces());
+    let execution = ExecutionView::with_code_spaces(
+        CodeSpaceLookup::new(&code_spaces)?,
         context.words(),
         context.primitives(),
     );
@@ -292,6 +306,21 @@ impl<'a> SourceExecutionContext<'a> {
     ) -> Self {
         Self {
             compile: SourceCompileContext::new(bindings),
+            code_spaces: &[],
+            words,
+            primitives,
+        }
+    }
+
+    pub(crate) const fn with_code_spaces(
+        bindings: &'a Bindings,
+        code_spaces: &'a [InstructionView<'a>],
+        words: PublishedWordLookup<'a>,
+        primitives: PrimitiveLookup<'a>,
+    ) -> Self {
+        Self {
+            compile: SourceCompileContext::new(bindings),
+            code_spaces,
             words,
             primitives,
         }
@@ -299,6 +328,10 @@ impl<'a> SourceExecutionContext<'a> {
 
     pub(crate) const fn compile(self) -> SourceCompileContext<'a> {
         self.compile
+    }
+
+    pub(crate) const fn code_spaces(self) -> &'a [InstructionView<'a>] {
+        self.code_spaces
     }
 
     pub(crate) const fn words(self) -> PublishedWordLookup<'a> {
@@ -854,6 +887,39 @@ mod tests {
 
         assert_eq!(result.outcome(), RunOutcome::Halted);
         assert_eq!(result.data_stack(), [value(7)]);
+        assert_eq!(result.instruction_count(), 2);
+    }
+
+    #[test]
+    fn compiled_word_call_runs_with_temporary_and_published_code_spaces() {
+        let mut words = PublishedWords::new();
+        let mut bindings = Bindings::new();
+        let primitives = PrimitiveRegistry::new();
+        let mut published_code = InstructionSequence::new();
+        publish_initial(
+            &mut words,
+            &mut bindings,
+            "USER_WORD",
+            completed_compiled(&mut published_code, 10),
+        );
+        published_code.append(Instruction::Return);
+        let (sources, source_id) = source("user_word");
+        let published_views = [published_code.view()];
+
+        let result = run_source(
+            sources.view(),
+            source_id,
+            SourceExecutionContext::with_code_spaces(
+                &bindings,
+                &published_views,
+                PublishedWordLookup::new(&words),
+                primitives.lookup(),
+            ),
+        )
+        .expect("published compiled word should run");
+
+        assert_eq!(result.outcome(), RunOutcome::Halted);
+        assert_eq!(result.data_stack(), [value(10)]);
         assert_eq!(result.instruction_count(), 2);
     }
 

--- a/crates/tbx-next/src/vm.rs
+++ b/crates/tbx-next/src/vm.rs
@@ -1,5 +1,6 @@
 use crate::instruction::{
-    CodeLocation, Instruction, InstructionAddress, InstructionAddressError, InstructionView,
+    CodeLocation, CodeSpaceLookup, Instruction, InstructionAddress, InstructionLookup,
+    InstructionLookupError, InstructionView,
 };
 use crate::primitive::{PrimitiveContext, PrimitiveError, PrimitiveLookup, PrimitiveLookupError};
 use crate::stack::{DataStack, ReturnFrame, ReturnStack, StackError};
@@ -41,10 +42,10 @@ pub(crate) struct VmError {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum VmErrorKind {
     InstructionFetch {
-        source: InstructionAddressError,
+        source: InstructionLookupError,
     },
     UnexpectedEndOfCode {
-        source: InstructionAddressError,
+        source: InstructionLookupError,
     },
     DataStackUnderflow {
         source: StackError,
@@ -53,10 +54,10 @@ pub(crate) enum VmErrorKind {
         source: StackError,
     },
     InvalidJumpTarget {
-        source: InstructionAddressError,
+        source: InstructionLookupError,
     },
     InvalidReturnTarget {
-        source: InstructionAddressError,
+        source: InstructionLookupError,
     },
     InvalidWordId {
         source: WordLookupError,
@@ -69,20 +70,28 @@ pub(crate) enum VmErrorKind {
         source: PrimitiveError,
     },
     InvalidCompiledEntry {
-        source: InstructionAddressError,
+        source: InstructionLookupError,
     },
 }
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct ExecutionView<'a> {
-    instructions: InstructionView<'a>,
+    instructions: InstructionLookup<'a>,
     words: PublishedWordLookup<'a>,
     primitives: PrimitiveLookup<'a>,
 }
 
 impl<'a> ExecutionView<'a> {
-    pub(crate) const fn new(
+    pub(crate) fn new(
         instructions: InstructionView<'a>,
+        words: PublishedWordLookup<'a>,
+        primitives: PrimitiveLookup<'a>,
+    ) -> Self {
+        Self::with_instruction_lookup(instructions.into(), words, primitives)
+    }
+
+    pub(crate) const fn with_instruction_lookup(
+        instructions: InstructionLookup<'a>,
         words: PublishedWordLookup<'a>,
         primitives: PrimitiveLookup<'a>,
     ) -> Self {
@@ -93,7 +102,15 @@ impl<'a> ExecutionView<'a> {
         }
     }
 
-    pub(crate) const fn instructions(self) -> InstructionView<'a> {
+    pub(crate) fn with_code_spaces(
+        code_spaces: CodeSpaceLookup<'a>,
+        words: PublishedWordLookup<'a>,
+        primitives: PrimitiveLookup<'a>,
+    ) -> Self {
+        Self::with_instruction_lookup(code_spaces.into(), words, primitives)
+    }
+
+    pub(crate) const fn instructions(self) -> InstructionLookup<'a> {
         self.instructions
     }
 
@@ -107,7 +124,7 @@ impl<'a> ExecutionView<'a> {
 }
 
 pub(crate) trait VmExecutionView<'a>: Copy {
-    fn instructions(self) -> InstructionView<'a>;
+    fn instructions(self) -> InstructionLookup<'a>;
 
     fn lookup_word(self, id: WordId) -> Result<WordDefinition, WordLookupError>;
 
@@ -118,7 +135,7 @@ pub(crate) trait VmExecutionView<'a>: Copy {
 }
 
 impl<'a> VmExecutionView<'a> for ExecutionView<'a> {
-    fn instructions(self) -> InstructionView<'a> {
+    fn instructions(self) -> InstructionLookup<'a> {
         self.instructions()
     }
 
@@ -135,8 +152,8 @@ impl<'a> VmExecutionView<'a> for ExecutionView<'a> {
 }
 
 impl<'a> VmExecutionView<'a> for InstructionView<'a> {
-    fn instructions(self) -> InstructionView<'a> {
-        self
+    fn instructions(self) -> InstructionLookup<'a> {
+        self.into()
     }
 
     fn lookup_word(self, id: WordId) -> Result<WordDefinition, WordLookupError> {
@@ -164,7 +181,15 @@ impl Vm {
         instructions: InstructionView<'_>,
         entry: CodeLocation,
     ) -> Result<Self, VmError> {
-        instructions
+        Self::new_at_location_in(instructions, entry)
+    }
+
+    pub(crate) fn new_at_location_in<'a, E: VmExecutionView<'a>>(
+        execution: E,
+        entry: CodeLocation,
+    ) -> Result<Self, VmError> {
+        execution
+            .instructions()
             .validate_location(entry)
             .map_err(|source| VmError {
                 location: entry,
@@ -257,7 +282,7 @@ impl Vm {
 
     fn step_push(
         &mut self,
-        instructions: InstructionView<'_>,
+        instructions: InstructionLookup<'_>,
         location: CodeLocation,
         value: Value,
     ) -> Result<StepOutcome, VmError> {
@@ -271,7 +296,7 @@ impl Vm {
 
     fn step_jump(
         &mut self,
-        instructions: InstructionView<'_>,
+        instructions: InstructionLookup<'_>,
         location: CodeLocation,
         target: InstructionAddress,
     ) -> Result<StepOutcome, VmError> {
@@ -331,7 +356,7 @@ impl Vm {
                         location,
                         kind: VmErrorKind::InvalidCompiledEntry { source },
                     })
-                    .map(|address| instructions.location(address))?;
+                    .map(|_| entry)?;
 
                 self.return_stack.push(ReturnFrame::new(next));
                 self.instruction_pointer = entry;
@@ -343,7 +368,7 @@ impl Vm {
 
     fn step_jump_if_zero(
         &mut self,
-        instructions: InstructionView<'_>,
+        instructions: InstructionLookup<'_>,
         location: CodeLocation,
         target: InstructionAddress,
     ) -> Result<StepOutcome, VmError> {
@@ -372,7 +397,7 @@ impl Vm {
 
     fn step_return(
         &mut self,
-        instructions: InstructionView<'_>,
+        instructions: InstructionLookup<'_>,
         location: CodeLocation,
     ) -> Result<StepOutcome, VmError> {
         let frame = self.return_stack.peek().map_err(|source| VmError {
@@ -391,13 +416,11 @@ impl Vm {
 
     fn valid_next_location(
         &self,
-        instructions: InstructionView<'_>,
+        instructions: InstructionLookup<'_>,
         location: CodeLocation,
     ) -> Result<CodeLocation, VmError> {
         instructions
-            .validate_location(location)
-            .and_then(|address| instructions.checked_next_address(address))
-            .map(|address| instructions.location(address))
+            .checked_next_location(location)
             .map_err(|source| VmError {
                 location,
                 kind: VmErrorKind::UnexpectedEndOfCode { source },
@@ -406,14 +429,14 @@ impl Vm {
 
     fn valid_jump_target(
         &self,
-        instructions: InstructionView<'_>,
+        instructions: InstructionLookup<'_>,
         location: CodeLocation,
         target: InstructionAddress,
     ) -> Result<CodeLocation, VmError> {
-        let target = instructions.location(target);
+        let target = CodeLocation::new(location.code_space(), target);
         instructions
             .validate_location(target)
-            .map(|address| instructions.location(address))
+            .map(|_| target)
             .map_err(|source| VmError {
                 location,
                 kind: VmErrorKind::InvalidJumpTarget { source },
@@ -422,13 +445,13 @@ impl Vm {
 
     fn valid_return_target(
         &self,
-        instructions: InstructionView<'_>,
+        instructions: InstructionLookup<'_>,
         location: CodeLocation,
         target: CodeLocation,
     ) -> Result<CodeLocation, VmError> {
         instructions
             .validate_location(target)
-            .map(|address| instructions.location(address))
+            .map(|_| target)
             .map_err(|source| VmError {
                 location,
                 kind: VmErrorKind::InvalidReturnTarget { source },
@@ -453,6 +476,7 @@ impl VmError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::instruction::InstructionAddressError;
     use crate::instruction::InstructionSequence;
     use crate::primitive::{PrimitiveLookupError, PrimitiveRegistry};
     use crate::word::{CompletedWordDefinition, PrimitiveId, PublishedWords, WordLookupError};
@@ -464,6 +488,10 @@ mod tests {
 
     fn address(index: usize) -> InstructionAddress {
         InstructionAddress::from_index(index)
+    }
+
+    fn address_lookup_error(source: InstructionAddressError) -> InstructionLookupError {
+        InstructionLookupError::Address { source }
     }
 
     fn new_vm(code: &InstructionSequence, entry: InstructionAddress) -> Vm {
@@ -560,14 +588,16 @@ mod tests {
             VmError {
                 location: location(&code, entry),
                 kind: VmErrorKind::InstructionFetch {
-                    source: InstructionAddressError::EndAddress { address: entry }
+                    source: address_lookup_error(InstructionAddressError::EndAddress {
+                        address: entry,
+                    })
                 }
             }
         );
     }
 
     #[test]
-    fn new_at_location_rejects_cross_owner_entry_without_index_fallback() {
+    fn new_at_location_rejects_unregistered_entry_code_space_without_index_fallback() {
         let mut source = InstructionSequence::new();
         let source_entry = source.append(Instruction::Halt);
         let mut target = InstructionSequence::new();
@@ -580,10 +610,8 @@ mod tests {
             VmError {
                 location: entry,
                 kind: VmErrorKind::InstructionFetch {
-                    source: InstructionAddressError::CodeSpaceMismatch {
-                        expected: target.view().code_space(),
-                        actual: source.view().code_space(),
-                        address: source_entry,
+                    source: InstructionLookupError::UnknownCodeSpace {
+                        code_space: source.view().code_space(),
                     }
                 }
             }
@@ -645,9 +673,9 @@ mod tests {
             Err(VmError {
                 location: location(&code, entry),
                 kind: VmErrorKind::UnexpectedEndOfCode {
-                    source: InstructionAddressError::EndAddress {
+                    source: address_lookup_error(InstructionAddressError::EndAddress {
                         address: address(1)
-                    }
+                    })
                 }
             })
         );
@@ -656,7 +684,7 @@ mod tests {
     }
 
     #[test]
-    fn step_rejects_invalid_current_instruction_pointer_without_mutation() {
+    fn step_rejects_unregistered_current_code_space_without_mutation() {
         let mut code = InstructionSequence::new();
         let entry = code.append(Instruction::Halt);
         let other = InstructionSequence::new();
@@ -669,10 +697,8 @@ mod tests {
             Err(VmError {
                 location: location(&code, entry),
                 kind: VmErrorKind::InstructionFetch {
-                    source: InstructionAddressError::CodeSpaceMismatch {
-                        expected: other.view().code_space(),
-                        actual: code.view().code_space(),
-                        address: entry
+                    source: InstructionLookupError::UnknownCodeSpace {
+                        code_space: code.view().code_space(),
                     }
                 }
             })
@@ -719,9 +745,9 @@ mod tests {
             Err(VmError {
                 location: location(&code, entry),
                 kind: VmErrorKind::InvalidJumpTarget {
-                    source: InstructionAddressError::InvalidAddress {
+                    source: address_lookup_error(InstructionAddressError::InvalidAddress {
                         address: address(10)
-                    }
+                    })
                 }
             })
         );
@@ -743,7 +769,9 @@ mod tests {
             Err(VmError {
                 location: location(&code, entry),
                 kind: VmErrorKind::InvalidJumpTarget {
-                    source: InstructionAddressError::EndAddress { address: end }
+                    source: address_lookup_error(InstructionAddressError::EndAddress {
+                        address: end,
+                    })
                 }
             })
         );
@@ -822,9 +850,9 @@ mod tests {
             Err(VmError {
                 location: location(&code, branch),
                 kind: VmErrorKind::InvalidJumpTarget {
-                    source: InstructionAddressError::InvalidAddress {
+                    source: address_lookup_error(InstructionAddressError::InvalidAddress {
                         address: address(99)
-                    }
+                    })
                 }
             })
         );
@@ -848,9 +876,9 @@ mod tests {
             Err(VmError {
                 location: location(&code, branch),
                 kind: VmErrorKind::UnexpectedEndOfCode {
-                    source: InstructionAddressError::EndAddress {
+                    source: address_lookup_error(InstructionAddressError::EndAddress {
                         address: address(2)
-                    }
+                    })
                 }
             })
         );
@@ -935,7 +963,9 @@ mod tests {
             Err(VmError {
                 location: location(&code, entry),
                 kind: VmErrorKind::InvalidReturnTarget {
-                    source: InstructionAddressError::EndAddress { address: end }
+                    source: address_lookup_error(InstructionAddressError::EndAddress {
+                        address: end,
+                    })
                 }
             })
         );
@@ -961,7 +991,9 @@ mod tests {
             Err(VmError {
                 location: location(&code, entry),
                 kind: VmErrorKind::InvalidReturnTarget {
-                    source: InstructionAddressError::InvalidAddress { address: invalid }
+                    source: address_lookup_error(InstructionAddressError::InvalidAddress {
+                        address: invalid,
+                    })
                 }
             })
         );
@@ -972,7 +1004,7 @@ mod tests {
     }
 
     #[test]
-    fn return_rejects_target_missing_from_current_instruction_view() {
+    fn return_rejects_unregistered_target_code_space_without_mutation() {
         let mut full_code = InstructionSequence::new();
         let target = full_code.append(Instruction::Halt);
         let mut shorter_code = InstructionSequence::new();
@@ -987,10 +1019,8 @@ mod tests {
             Err(VmError {
                 location: location(&shorter_code, entry),
                 kind: VmErrorKind::InvalidReturnTarget {
-                    source: InstructionAddressError::CodeSpaceMismatch {
-                        expected: shorter_code.view().code_space(),
-                        actual: full_code.view().code_space(),
-                        address: target
+                    source: InstructionLookupError::UnknownCodeSpace {
+                        code_space: full_code.view().code_space(),
                     }
                 }
             })
@@ -1161,9 +1191,9 @@ mod tests {
             Err(VmError {
                 location: location(&code, entry),
                 kind: VmErrorKind::UnexpectedEndOfCode {
-                    source: InstructionAddressError::EndAddress {
+                    source: address_lookup_error(InstructionAddressError::EndAddress {
                         address: address(1)
-                    }
+                    })
                 }
             })
         );
@@ -1260,9 +1290,9 @@ mod tests {
         let error = VmError {
             location: location(&code, failing_branch),
             kind: VmErrorKind::InvalidJumpTarget {
-                source: InstructionAddressError::InvalidAddress {
+                source: address_lookup_error(InstructionAddressError::InvalidAddress {
                     address: address(99),
-                },
+                }),
             },
         };
         assert_eq!(result, Err(error));
@@ -1282,7 +1312,7 @@ mod tests {
     }
 
     #[test]
-    fn compiled_call_revalidates_entry_against_current_instruction_view() {
+    fn compiled_call_rejects_unregistered_entry_code_space() {
         let primitives = PrimitiveRegistry::new();
         let mut words = PublishedWords::new();
         let mut full_code = InstructionSequence::new();
@@ -1308,10 +1338,8 @@ mod tests {
             Err(VmError {
                 location: location(&short_code, call),
                 kind: VmErrorKind::InvalidCompiledEntry {
-                    source: InstructionAddressError::CodeSpaceMismatch {
-                        expected: short_code.code_space(),
-                        actual: full_code.code_space(),
-                        address: compiled_entry,
+                    source: InstructionLookupError::UnknownCodeSpace {
+                        code_space: full_code.code_space(),
                     }
                 }
             })
@@ -1520,7 +1548,9 @@ mod tests {
             Err(VmError {
                 location: location(&code, bad_return),
                 kind: VmErrorKind::InvalidReturnTarget {
-                    source: InstructionAddressError::InvalidAddress { address: invalid }
+                    source: address_lookup_error(InstructionAddressError::InvalidAddress {
+                        address: invalid,
+                    })
                 }
             })
         );
@@ -1545,9 +1575,9 @@ mod tests {
             Err(VmError {
                 location: location(&code, bad_branch),
                 kind: VmErrorKind::UnexpectedEndOfCode {
-                    source: InstructionAddressError::EndAddress {
+                    source: address_lookup_error(InstructionAddressError::EndAddress {
                         address: address(2)
-                    }
+                    })
                 }
             })
         );


### PR DESCRIPTION
## Summary

- `CodeSpaceId` から `InstructionView` を引く read-only lookup 境界を追加
- VM の命令 fetch / next / jump / return / compiled entry validation を `CodeLocation` 基準の lookup に変更
- source processor の execution context に temporary code と published code の同時登録 fixture を追加

## Verification

- `cargo fmt --check`
- `cargo test -p tbx-next`
- `cargo clippy -p tbx-next --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo clippy --all-targets -- -D warnings`

Closes #1426
