### PR TITLE
TBX Next: source mappingをCodeLocation対応へ移行する

### DIFF
--- a/crates/tbx-next/src/lib.rs
+++ b/crates/tbx-next/src/lib.rs
@@ -62,6 +62,11 @@ mod word_resolution;
 #[allow(dead_code)]
 mod source;
 
+// ADR #1421 keeps source mappings owner-qualified by code space without adding
+// source spans to runtime values, instruction operands, or VM state.
+#[allow(dead_code)]
+mod source_mapping;
+
 // ADR #1412 keeps non-incremental lexical analysis as a crate-internal source
 // processing boundary that emits token categories and source spans only.
 #[allow(dead_code)]

--- a/crates/tbx-next/src/source_mapping.rs
+++ b/crates/tbx-next/src/source_mapping.rs
@@ -1,0 +1,387 @@
+use crate::instruction::{CodeLocation, CodeSpaceId, InstructionAddress, InstructionAddressError};
+use crate::source::SourceSpan;
+
+/// Owner for source spans keyed by one instruction sequence's code space.
+///
+/// `spans[index]` describes the instruction at local `InstructionAddress`
+/// `index` for this owner. `None` is a valid existing instruction with no
+/// source mapping; missing indexes are invalid runtime locations.
+#[derive(Debug)]
+pub(crate) struct InstructionSourceMapping {
+    code_space: CodeSpaceId,
+    spans: Vec<Option<SourceSpan>>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct InstructionSourceMappingView<'a> {
+    code_space: CodeSpaceId,
+    spans: &'a [Option<SourceSpan>],
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SourceMappingLookup<'a> {
+    views: &'a [InstructionSourceMappingView<'a>],
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SourceMappingLookupError {
+    UnknownCodeSpace { code_space: CodeSpaceId },
+    DuplicateCodeSpace { code_space: CodeSpaceId },
+    Address { source: InstructionAddressError },
+}
+
+impl InstructionSourceMapping {
+    pub(crate) fn new(code_space: CodeSpaceId) -> Self {
+        Self {
+            code_space,
+            spans: Vec::new(),
+        }
+    }
+
+    pub(crate) fn append_mapped(
+        &mut self,
+        address: InstructionAddress,
+        span: SourceSpan,
+    ) -> Result<(), SourceMappingAppendError> {
+        self.append(address, Some(span))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn append_unmapped(
+        &mut self,
+        address: InstructionAddress,
+    ) -> Result<(), SourceMappingAppendError> {
+        self.append(address, None)
+    }
+
+    pub(crate) fn view(&self) -> InstructionSourceMappingView<'_> {
+        InstructionSourceMappingView {
+            code_space: self.code_space,
+            spans: &self.spans,
+        }
+    }
+
+    pub(crate) fn code_space(&self) -> CodeSpaceId {
+        self.code_space
+    }
+
+    fn append(
+        &mut self,
+        address: InstructionAddress,
+        span: Option<SourceSpan>,
+    ) -> Result<(), SourceMappingAppendError> {
+        let expected = InstructionAddress::from_index(self.spans.len());
+        if address != expected {
+            return Err(SourceMappingAppendError::OutOfOrder {
+                expected,
+                actual: address,
+            });
+        }
+
+        self.spans.push(span);
+        Ok(())
+    }
+}
+
+impl<'a> InstructionSourceMappingView<'a> {
+    pub(crate) fn source_span(
+        self,
+        location: CodeLocation,
+    ) -> Result<Option<SourceSpan>, SourceMappingLookupError> {
+        self.validate_location(location)?;
+        Ok(self.spans[location.address().as_index()])
+    }
+
+    pub(crate) fn validate_location(
+        self,
+        location: CodeLocation,
+    ) -> Result<InstructionAddress, SourceMappingLookupError> {
+        if location.code_space() != self.code_space {
+            return Err(SourceMappingLookupError::Address {
+                source: InstructionAddressError::CodeSpaceMismatch {
+                    expected: self.code_space,
+                    actual: location.code_space(),
+                    address: location.address(),
+                },
+            });
+        }
+
+        let address = location.address();
+        if address.as_index() < self.spans.len() {
+            Ok(address)
+        } else {
+            Err(SourceMappingLookupError::Address {
+                source: self.address_error(address),
+            })
+        }
+    }
+
+    pub(crate) const fn code_space(self) -> CodeSpaceId {
+        self.code_space
+    }
+
+    pub(crate) fn len(self) -> usize {
+        self.spans.len()
+    }
+
+    fn address_error(self, address: InstructionAddress) -> InstructionAddressError {
+        if address.as_index() == self.spans.len() {
+            InstructionAddressError::EndAddress { address }
+        } else {
+            InstructionAddressError::InvalidAddress { address }
+        }
+    }
+}
+
+impl<'a> SourceMappingLookup<'a> {
+    pub(crate) fn new(
+        views: &'a [InstructionSourceMappingView<'a>],
+    ) -> Result<Self, SourceMappingLookupError> {
+        for (index, view) in views.iter().enumerate() {
+            if views[index + 1..]
+                .iter()
+                .any(|other| other.code_space() == view.code_space())
+            {
+                return Err(SourceMappingLookupError::DuplicateCodeSpace {
+                    code_space: view.code_space(),
+                });
+            }
+        }
+
+        Ok(Self { views })
+    }
+
+    pub(crate) fn source_span(
+        self,
+        location: CodeLocation,
+    ) -> Result<Option<SourceSpan>, SourceMappingLookupError> {
+        self.view_for(location.code_space())?.source_span(location)
+    }
+
+    fn view_for(
+        self,
+        code_space: CodeSpaceId,
+    ) -> Result<InstructionSourceMappingView<'a>, SourceMappingLookupError> {
+        self.views
+            .iter()
+            .copied()
+            .find(|view| view.code_space() == code_space)
+            .ok_or(SourceMappingLookupError::UnknownCodeSpace { code_space })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SourceMappingAppendError {
+    OutOfOrder {
+        expected: InstructionAddress,
+        actual: InstructionAddress,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::instruction::{Instruction, InstructionSequence};
+    use crate::source::{SourceId, SourceTexts, SourceView};
+
+    fn source(text: &str) -> (SourceTexts, SourceId) {
+        let mut sources = SourceTexts::new();
+        let id = sources.register(text);
+        (sources, id)
+    }
+
+    fn span(view: SourceView<'_>, source_id: SourceId, start: usize, end: usize) -> SourceSpan {
+        view.span(source_id, start, end)
+            .expect("test span should be valid")
+    }
+
+    fn address(index: usize) -> InstructionAddress {
+        InstructionAddress::from_index(index)
+    }
+
+    #[test]
+    fn mapping_owner_keeps_code_space_identity() {
+        let code = InstructionSequence::new();
+        let mapping = InstructionSourceMapping::new(code.code_space());
+
+        assert_eq!(mapping.code_space(), code.code_space());
+        assert_eq!(mapping.view().code_space(), code.code_space());
+    }
+
+    #[test]
+    fn mapped_location_returns_source_span() {
+        let (sources, source_id) = source("10");
+        let mut code = InstructionSequence::new();
+        let entry = code.append(Instruction::Halt);
+        let location = code.view().location(entry);
+        let mut mapping = InstructionSourceMapping::new(code.code_space());
+        let expected = span(sources.view(), source_id, 0, 2);
+        mapping
+            .append_mapped(entry, expected)
+            .expect("mapping should append");
+
+        assert_eq!(mapping.view().source_span(location), Ok(Some(expected)));
+    }
+
+    #[test]
+    fn same_local_index_is_separate_per_code_space() {
+        let (mut sources, first_source) = source("A");
+        let second_source = sources.register("B");
+        let mut first_code = InstructionSequence::new();
+        let mut second_code = InstructionSequence::new();
+        let first_address = first_code.append(Instruction::Halt);
+        let second_address = second_code.append(Instruction::Halt);
+        let first_span = span(sources.view(), first_source, 0, 1);
+        let second_span = span(sources.view(), second_source, 0, 1);
+        let mut first_mapping = InstructionSourceMapping::new(first_code.code_space());
+        let mut second_mapping = InstructionSourceMapping::new(second_code.code_space());
+        first_mapping
+            .append_mapped(first_address, first_span)
+            .expect("first mapping should append");
+        second_mapping
+            .append_mapped(second_address, second_span)
+            .expect("second mapping should append");
+        let views = [first_mapping.view(), second_mapping.view()];
+        let lookup = SourceMappingLookup::new(&views).expect("mapping spaces are distinct");
+
+        assert_eq!(first_address.as_index(), second_address.as_index());
+        assert_eq!(
+            lookup.source_span(first_code.view().location(first_address)),
+            Ok(Some(first_span))
+        );
+        assert_eq!(
+            lookup.source_span(second_code.view().location(second_address)),
+            Ok(Some(second_span))
+        );
+    }
+
+    #[test]
+    fn lookup_does_not_fallback_to_same_local_index_in_another_space() {
+        let (sources, source_id) = source("A");
+        let mut registered_code = InstructionSequence::new();
+        let registered_address = registered_code.append(Instruction::Halt);
+        let mut other_code = InstructionSequence::new();
+        let other_address = other_code.append(Instruction::Halt);
+        let mut mapping = InstructionSourceMapping::new(registered_code.code_space());
+        mapping
+            .append_mapped(registered_address, span(sources.view(), source_id, 0, 1))
+            .expect("mapping should append");
+        let views = [mapping.view()];
+        let lookup = SourceMappingLookup::new(&views).expect("single mapping is valid");
+
+        assert_eq!(registered_address.as_index(), other_address.as_index());
+        assert_eq!(
+            lookup.source_span(other_code.view().location(other_address)),
+            Err(SourceMappingLookupError::UnknownCodeSpace {
+                code_space: other_code.code_space()
+            })
+        );
+    }
+
+    #[test]
+    fn valid_unmapped_location_is_distinct_from_unknown_and_invalid() {
+        let mut mapped_code = InstructionSequence::new();
+        let mapped = mapped_code.append(Instruction::Halt);
+        let unmapped = mapped_code.append(Instruction::Halt);
+        let mut unknown_code = InstructionSequence::new();
+        let unknown = unknown_code.append(Instruction::Halt);
+        let (sources, source_id) = source("A");
+        let mut mapping = InstructionSourceMapping::new(mapped_code.code_space());
+        mapping
+            .append_mapped(mapped, span(sources.view(), source_id, 0, 1))
+            .expect("mapped source should append");
+        mapping
+            .append_unmapped(unmapped)
+            .expect("unmapped source should append");
+        let views = [mapping.view()];
+        let lookup = SourceMappingLookup::new(&views).expect("single mapping is valid");
+        let end = mapped_code.view().location(address(2));
+        let out_of_range = mapped_code.view().location(address(3));
+
+        assert_eq!(
+            lookup.source_span(mapped_code.view().location(unmapped)),
+            Ok(None)
+        );
+        assert_eq!(
+            lookup.source_span(unknown_code.view().location(unknown)),
+            Err(SourceMappingLookupError::UnknownCodeSpace {
+                code_space: unknown_code.code_space()
+            })
+        );
+        assert_eq!(
+            lookup.source_span(end),
+            Err(SourceMappingLookupError::Address {
+                source: InstructionAddressError::EndAddress {
+                    address: end.address()
+                }
+            })
+        );
+        assert_eq!(
+            lookup.source_span(out_of_range),
+            Err(SourceMappingLookupError::Address {
+                source: InstructionAddressError::InvalidAddress {
+                    address: out_of_range.address()
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn append_requires_instruction_order() {
+        let mut code = InstructionSequence::new();
+        code.append(Instruction::Halt);
+        let (sources, source_id) = source("A");
+        let mut mapping = InstructionSourceMapping::new(code.code_space());
+
+        assert_eq!(
+            mapping.append_mapped(address(1), span(sources.view(), source_id, 0, 1)),
+            Err(SourceMappingAppendError::OutOfOrder {
+                expected: address(0),
+                actual: address(1),
+            })
+        );
+    }
+
+    #[test]
+    fn published_code_mapping_uses_code_owner_not_source_owner() {
+        let (mut sources, first_source) = source("A");
+        let second_source = sources.register("B");
+        let mut published_code = InstructionSequence::new();
+        let entry = published_code.append(Instruction::Halt);
+        let first_span = span(sources.view(), first_source, 0, 1);
+        let second_same_offset = span(sources.view(), second_source, 0, 1);
+        let mut mapping = InstructionSourceMapping::new(published_code.code_space());
+        mapping
+            .append_mapped(entry, first_span)
+            .expect("published mapping should append");
+
+        assert_ne!(first_span, second_same_offset);
+        assert_eq!(
+            mapping
+                .view()
+                .source_span(published_code.view().location(entry)),
+            Ok(Some(first_span))
+        );
+        assert_ne!(
+            mapping
+                .view()
+                .source_span(published_code.view().location(entry)),
+            Ok(Some(second_same_offset))
+        );
+    }
+
+    #[test]
+    fn duplicate_mapping_spaces_are_rejected() {
+        let code = InstructionSequence::new();
+        let first = InstructionSourceMapping::new(code.code_space());
+        let second = InstructionSourceMapping::new(code.code_space());
+        let views = [first.view(), second.view()];
+
+        assert_eq!(
+            SourceMappingLookup::new(&views).expect_err("duplicate mapping spaces should fail"),
+            SourceMappingLookupError::DuplicateCodeSpace {
+                code_space: code.code_space()
+            }
+        );
+    }
+}

--- a/crates/tbx-next/src/source_mapping.rs
+++ b/crates/tbx-next/src/source_mapping.rs
@@ -46,7 +46,6 @@ impl InstructionSourceMapping {
         self.append(address, Some(span))
     }
 
-    #[cfg(test)]
     pub(crate) fn append_unmapped(
         &mut self,
         address: InstructionAddress,

--- a/crates/tbx-next/src/source_processor.rs
+++ b/crates/tbx-next/src/source_processor.rs
@@ -1,11 +1,15 @@
 use crate::binding::Bindings;
 use crate::instruction::{
-    CodeSpaceLookup, CodeSpaceLookupError, Instruction, InstructionAddress, InstructionSequence,
-    InstructionView,
+    CodeLocation, CodeSpaceLookup, CodeSpaceLookupError, Instruction, InstructionAddress,
+    InstructionSequence, InstructionView,
 };
 use crate::lexer::{LexError, Lexer, Token, TokenKind};
 use crate::primitive::PrimitiveLookup;
 use crate::source::{SourceError, SourceId, SourceSpan, SourceView};
+use crate::source_mapping::{
+    InstructionSourceMapping, InstructionSourceMappingView, SourceMappingAppendError,
+    SourceMappingLookupError,
+};
 use crate::value::Value;
 use crate::vm::{ExecutionView, RunOutcome, Vm, VmError};
 use crate::word_lookup::PublishedWordLookup;
@@ -14,14 +18,8 @@ use crate::word_resolution::{resolve_word_name, WordResolutionError};
 #[derive(Debug)]
 pub(crate) struct TemporaryExecutionUnit {
     instructions: InstructionSequence,
-    spans: Vec<InstructionSource>,
+    mapping: InstructionSourceMapping,
     entry: InstructionAddress,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct InstructionSource {
-    address: InstructionAddress,
-    span: SourceSpan,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -50,6 +48,7 @@ pub(crate) enum SourceProcessorError {
     Lex(LexError),
     Compile(CompileError),
     CodeSpaceLookup(CodeSpaceLookupError),
+    SourceMappingAppend(SourceMappingAppendError),
     Vm(VmError),
 }
 
@@ -97,6 +96,12 @@ impl From<CodeSpaceLookupError> for SourceProcessorError {
     }
 }
 
+impl From<SourceMappingAppendError> for SourceProcessorError {
+    fn from(error: SourceMappingAppendError) -> Self {
+        Self::SourceMappingAppend(error)
+    }
+}
+
 pub(crate) fn compile_source(
     view: SourceView<'_>,
     source_id: SourceId,
@@ -104,7 +109,7 @@ pub(crate) fn compile_source(
 ) -> Result<TemporaryExecutionUnit, SourceProcessorError> {
     let mut lexer = Lexer::new(view, source_id)?;
     let mut instructions = InstructionSequence::new();
-    let mut spans = Vec::new();
+    let mut mapping = InstructionSourceMapping::new(instructions.code_space());
 
     loop {
         let token = lexer.next_token()?;
@@ -114,28 +119,28 @@ pub(crate) fn compile_source(
                 let value = compile_integer_literal(view, token)?;
                 append_mapped(
                     &mut instructions,
-                    &mut spans,
+                    &mut mapping,
                     Instruction::Push(Value::integer(value)),
                     token.span(),
-                );
+                )?;
             }
             TokenKind::Name => {
                 let id = compile_word_reference(view, token, context)?;
                 append_mapped(
                     &mut instructions,
-                    &mut spans,
+                    &mut mapping,
                     Instruction::Call(id),
                     token.span(),
-                );
+                )?;
             }
             TokenKind::LineBoundary => {}
             TokenKind::Eof => {
                 append_mapped(
                     &mut instructions,
-                    &mut spans,
+                    &mut mapping,
                     Instruction::Halt,
                     token.span(),
-                );
+                )?;
                 break;
             }
             TokenKind::Minus => {
@@ -151,7 +156,7 @@ pub(crate) fn compile_source(
     let entry = InstructionAddress::from_index(0);
     Ok(TemporaryExecutionUnit {
         instructions,
-        spans,
+        mapping,
         entry,
     })
 }
@@ -247,13 +252,13 @@ fn parse_unsigned_i16(source: &str, span: SourceSpan) -> Result<i16, CompileErro
 
 fn append_mapped(
     instructions: &mut InstructionSequence,
-    spans: &mut Vec<InstructionSource>,
+    mapping: &mut InstructionSourceMapping,
     instruction: Instruction,
     span: SourceSpan,
-) -> InstructionAddress {
+) -> Result<InstructionAddress, SourceMappingAppendError> {
     let address = instructions.append(instruction);
-    spans.push(InstructionSource { address, span });
-    address
+    mapping.append_mapped(address, span)?;
+    Ok(address)
 }
 
 fn drain_data_stack(vm: &mut Vm) -> Vec<Value> {
@@ -272,19 +277,27 @@ impl TemporaryExecutionUnit {
         self.entry
     }
 
+    pub(crate) fn entry_location(&self) -> CodeLocation {
+        self.instructions.view().location(self.entry)
+    }
+
     pub(crate) fn instructions(&self) -> crate::instruction::InstructionView<'_> {
         self.instructions.view()
+    }
+
+    pub(crate) fn source_mapping(&self) -> InstructionSourceMappingView<'_> {
+        self.mapping.view()
     }
 
     pub(crate) fn len(&self) -> usize {
         self.instructions.len()
     }
 
-    pub(crate) fn source_span(&self, address: InstructionAddress) -> Option<SourceSpan> {
-        self.spans
-            .iter()
-            .find(|source| source.address == address)
-            .map(|source| source.span)
+    pub(crate) fn source_span(
+        &self,
+        location: CodeLocation,
+    ) -> Result<Option<SourceSpan>, SourceMappingLookupError> {
+        self.mapping.view().source_span(location)
     }
 }
 
@@ -377,6 +390,7 @@ mod tests {
     use crate::primitive::{PrimitiveContext, PrimitiveError, PrimitiveRegistry};
     use crate::redefinition::redefine_word;
     use crate::source::SourceTexts;
+    use crate::source_mapping::{SourceMappingLookup, SourceMappingLookupError};
     use crate::word::{CompletedWordDefinition, PrimitiveId, PublishedWords, WordId};
     use crate::word_lookup::PublishedWordLookup;
 
@@ -443,6 +457,10 @@ mod tests {
         InstructionAddress::from_index(index)
     }
 
+    fn location(unit: &TemporaryExecutionUnit, index: usize) -> CodeLocation {
+        unit.instructions().location(address(index))
+    }
+
     fn name(input: &str) -> NormalizedName {
         NormalizedName::new(input).expect("test input should be a valid word name")
     }
@@ -495,9 +513,13 @@ mod tests {
         let view = sources.view();
 
         assert_eq!(unit.entry(), address(0));
+        assert_eq!(unit.entry_location(), location(&unit, 0));
         assert_eq!(unit.len(), 1);
         assert_eq!(unit.instructions().get(address(0)), Ok(&Instruction::Halt));
-        assert_eq!(unit.source_span(address(0)), Some(span(view, id, 0, 0)));
+        assert_eq!(
+            unit.source_span(location(&unit, 0)),
+            Ok(Some(span(view, id, 0, 0)))
+        );
 
         let words = PublishedWords::new();
         let bindings = Bindings::new();
@@ -525,8 +547,8 @@ mod tests {
             assert_eq!(unit.len(), 1);
             assert_eq!(unit.instructions().get(address(0)), Ok(&Instruction::Halt));
             assert_eq!(
-                unit.source_span(address(0)),
-                Some(span(sources.view(), id, eof, eof)),
+                unit.source_span(location(&unit, 0)),
+                Ok(Some(span(sources.view(), id, eof, eof))),
                 "{source:?} should map Halt to EOF"
             );
         }
@@ -556,11 +578,26 @@ mod tests {
             Ok(&Instruction::Push(value(32767)))
         );
         assert_eq!(unit.instructions().get(address(4)), Ok(&Instruction::Halt));
-        assert_eq!(unit.source_span(address(0)), Some(span(view, id, 0, 1)));
-        assert_eq!(unit.source_span(address(1)), Some(span(view, id, 2, 3)));
-        assert_eq!(unit.source_span(address(2)), Some(span(view, id, 4, 6)));
-        assert_eq!(unit.source_span(address(3)), Some(span(view, id, 7, 12)));
-        assert_eq!(unit.source_span(address(4)), Some(span(view, id, 12, 12)));
+        assert_eq!(
+            unit.source_span(location(&unit, 0)),
+            Ok(Some(span(view, id, 0, 1)))
+        );
+        assert_eq!(
+            unit.source_span(location(&unit, 1)),
+            Ok(Some(span(view, id, 2, 3)))
+        );
+        assert_eq!(
+            unit.source_span(location(&unit, 2)),
+            Ok(Some(span(view, id, 4, 6)))
+        );
+        assert_eq!(
+            unit.source_span(location(&unit, 3)),
+            Ok(Some(span(view, id, 7, 12)))
+        );
+        assert_eq!(
+            unit.source_span(location(&unit, 4)),
+            Ok(Some(span(view, id, 12, 12)))
+        );
     }
 
     #[test]
@@ -700,20 +737,72 @@ mod tests {
         let (_sources, _id, unit) = compile("10 20");
 
         assert_eq!(
-            unit.spans
-                .iter()
-                .map(|source| source.address)
-                .collect::<Vec<_>>(),
-            [address(0), address(1), address(2)]
+            unit.source_mapping().code_space(),
+            unit.instructions().code_space()
         );
-        assert_eq!(unit.len(), unit.spans.len());
+        assert_eq!(unit.source_mapping().len(), unit.len());
         assert_eq!(
-            unit.spans
-                .iter()
-                .enumerate()
-                .map(|(index, source)| source.address.as_index() == index)
+            (0..unit.len())
+                .map(|index| unit.source_span(location(&unit, index)).is_ok())
                 .collect::<Vec<_>>(),
             [true, true, true]
+        );
+    }
+
+    #[test]
+    fn temporary_mapping_location_uses_unit_code_space_identity() {
+        let (first_sources, first_source_id, first_unit) = compile("10");
+        let (second_sources, second_source_id, second_unit) = compile("20");
+        let first_span = span(first_sources.view(), first_source_id, 0, 2);
+        let second_span = span(second_sources.view(), second_source_id, 0, 2);
+        let mapping_views = [first_unit.source_mapping(), second_unit.source_mapping()];
+        let lookup = SourceMappingLookup::new(&mapping_views).expect("unit mappings are distinct");
+
+        assert_eq!(
+            first_unit.source_mapping().code_space(),
+            first_unit.instructions().code_space()
+        );
+        assert_eq!(
+            first_unit
+                .instructions()
+                .location(address(0))
+                .address()
+                .as_index(),
+            second_unit
+                .instructions()
+                .location(address(0))
+                .address()
+                .as_index()
+        );
+        assert_ne!(
+            first_unit.instructions().code_space(),
+            second_unit.instructions().code_space()
+        );
+        assert_eq!(
+            lookup.source_span(first_unit.instructions().location(address(0))),
+            Ok(Some(first_span))
+        );
+        assert_eq!(
+            lookup.source_span(second_unit.instructions().location(address(0))),
+            Ok(Some(second_span))
+        );
+    }
+
+    #[test]
+    fn temporary_mapping_rejects_other_code_space_without_index_fallback() {
+        let (_sources, _source_id, unit) = compile("10");
+        let mut other_code = InstructionSequence::new();
+        let other_address = other_code.append(Instruction::Halt);
+
+        assert_eq!(
+            unit.source_span(other_code.view().location(other_address)),
+            Err(SourceMappingLookupError::Address {
+                source: crate::instruction::InstructionAddressError::CodeSpaceMismatch {
+                    expected: unit.source_mapping().code_space(),
+                    actual: other_code.code_space(),
+                    address: other_address,
+                }
+            })
         );
     }
 
@@ -748,9 +837,18 @@ mod tests {
             Ok(&Instruction::Call(second))
         );
         assert_eq!(unit.instructions().get(address(3)), Ok(&Instruction::Halt));
-        assert_eq!(unit.source_span(address(0)), Some(span(view, id, 0, 5)));
-        assert_eq!(unit.source_span(address(1)), Some(span(view, id, 6, 8)));
-        assert_eq!(unit.source_span(address(2)), Some(span(view, id, 9, 14)));
+        assert_eq!(
+            unit.source_span(location(&unit, 0)),
+            Ok(Some(span(view, id, 0, 5)))
+        );
+        assert_eq!(
+            unit.source_span(location(&unit, 1)),
+            Ok(Some(span(view, id, 6, 8)))
+        );
+        assert_eq!(
+            unit.source_span(location(&unit, 2)),
+            Ok(Some(span(view, id, 9, 14)))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Added an owner-qualified source mapping boundary keyed by `CodeLocation`.
- Migrated `TemporaryExecutionUnit` source-span lookup from local `InstructionAddress` to code-space-aware lookup.
- Added fixtures covering temporary mappings, published-code mappings, duplicate/unknown spaces, invalid addresses, unmapped instructions, and same-local-index separation.

Closes #1428

## Verification

- `cargo fmt --check`
- `cargo test -p tbx-next`
- `cargo clippy -p tbx-next --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo clippy --all-targets -- -D warnings`
