### PR TITLE
TBX Next: owner-local行番号backpatch基盤を追加

### DIFF
--- a/crates/tbx-next/src/instruction.rs
+++ b/crates/tbx-next/src/instruction.rs
@@ -159,6 +159,38 @@ impl InstructionSequence {
         address
     }
 
+    pub(crate) fn patch_branch_target(
+        &mut self,
+        branch: InstructionAddress,
+        target: InstructionAddress,
+    ) -> Result<(), BranchTargetPatchError> {
+        self.view()
+            .validate_address(target)
+            .map_err(|source| BranchTargetPatchError::InvalidTarget { source })?;
+
+        let instruction = self
+            .instructions
+            .get(branch.as_index())
+            .copied()
+            .ok_or_else(|| BranchTargetPatchError::InvalidBranch {
+                source: self.view().address_error(branch),
+            })?;
+
+        let patched = match instruction {
+            Instruction::Jump(_) => Instruction::Jump(target),
+            Instruction::JumpIfZero(_) => Instruction::JumpIfZero(target),
+            instruction => {
+                return Err(BranchTargetPatchError::NonBranchInstruction {
+                    address: branch,
+                    instruction,
+                });
+            }
+        };
+
+        self.instructions[branch.as_index()] = patched;
+        Ok(())
+    }
+
     pub(crate) fn view(&self) -> InstructionView<'_> {
         InstructionView {
             code_space: self.code_space,
@@ -186,6 +218,20 @@ impl Default for InstructionSequence {
             instructions: Vec::new(),
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BranchTargetPatchError {
+    InvalidBranch {
+        source: InstructionAddressError,
+    },
+    InvalidTarget {
+        source: InstructionAddressError,
+    },
+    NonBranchInstruction {
+        address: InstructionAddress,
+        instruction: Instruction,
+    },
 }
 
 /// Read-only instruction fetch boundary for VM execution.
@@ -627,6 +673,68 @@ mod tests {
         assert_eq!(view.validate_address(target), Ok(target));
         assert_eq!(view.get(jump), Ok(&Instruction::Jump(target)));
         assert_eq!(view.get(jump_if_zero), Ok(&Instruction::JumpIfZero(target)));
+    }
+
+    #[test]
+    fn branch_target_patch_updates_only_branch_operands() {
+        let mut code = InstructionSequence::new();
+        let initial = code.append(Instruction::Halt);
+        let jump = code.append(Instruction::Jump(initial));
+        let jump_if_zero = code.append(Instruction::JumpIfZero(initial));
+        let target = code.append(push(7));
+
+        assert_eq!(code.patch_branch_target(jump, target), Ok(()));
+        assert_eq!(code.patch_branch_target(jump_if_zero, target), Ok(()));
+
+        assert_eq!(code.view().get(jump), Ok(&Instruction::Jump(target)));
+        assert_eq!(
+            code.view().get(jump_if_zero),
+            Ok(&Instruction::JumpIfZero(target))
+        );
+    }
+
+    #[test]
+    fn branch_target_patch_rejects_end_and_out_of_range_targets() {
+        let mut code = InstructionSequence::new();
+        let target = code.append(Instruction::Halt);
+        let branch = code.append(Instruction::Jump(target));
+        let end = address(2);
+        let out_of_range = address(3);
+
+        assert_eq!(
+            code.patch_branch_target(branch, end),
+            Err(BranchTargetPatchError::InvalidTarget {
+                source: InstructionAddressError::EndAddress { address: end }
+            })
+        );
+        assert_eq!(
+            code.patch_branch_target(branch, out_of_range),
+            Err(BranchTargetPatchError::InvalidTarget {
+                source: InstructionAddressError::InvalidAddress {
+                    address: out_of_range
+                }
+            })
+        );
+        assert_eq!(code.view().get(branch), Ok(&Instruction::Jump(target)));
+    }
+
+    #[test]
+    fn branch_target_patch_rejects_non_branch_instruction() {
+        let mut code = InstructionSequence::new();
+        let push = code.append(push(1));
+        let target = code.append(Instruction::Halt);
+
+        assert_eq!(
+            code.patch_branch_target(push, target),
+            Err(BranchTargetPatchError::NonBranchInstruction {
+                address: push,
+                instruction: Instruction::Push(Value::integer(1)),
+            })
+        );
+        assert_eq!(
+            code.view().get(push),
+            Ok(&Instruction::Push(Value::integer(1)))
+        );
     }
 
     #[test]

--- a/crates/tbx-next/src/lib.rs
+++ b/crates/tbx-next/src/lib.rs
@@ -87,6 +87,11 @@ mod operator;
 #[allow(dead_code)]
 mod expression;
 
+// ADR #1456/#1449 keep Tiny BASIC local line numbers as owner-local
+// compile-time identifiers resolved by builders, never as runtime values.
+#[allow(dead_code)]
+mod line_number;
+
 pub const STATUS_MESSAGE: &str =
     "TBX Next is under development; language features are not implemented yet.";
 

--- a/crates/tbx-next/src/line_number.rs
+++ b/crates/tbx-next/src/line_number.rs
@@ -1,0 +1,357 @@
+use crate::instruction::{
+    BranchTargetPatchError, InstructionAddress, InstructionAddressError, InstructionSequence,
+};
+use crate::source::SourceSpan;
+use std::collections::HashMap;
+
+/// Owner-local compile-time line number identifier.
+///
+/// ADR #1456 keeps line numbers out of runtime `Value`. This type is used only
+/// by builders that resolve local control-flow targets inside one instruction
+/// owner.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct LocalLineNumber {
+    raw: u64,
+}
+
+#[derive(Debug)]
+pub(crate) struct LocalLineNumberTable {
+    definitions: HashMap<LocalLineNumber, LineNumberDefinition>,
+    patches: Vec<UnresolvedLineNumberPatch>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct LineNumberDefinition {
+    target: InstructionAddress,
+    span: SourceSpan,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct UnresolvedLineNumberPatch {
+    line_number: LocalLineNumber,
+    branch: InstructionAddress,
+    span: SourceSpan,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LineNumberError {
+    Duplicate {
+        line_number: LocalLineNumber,
+        original_span: SourceSpan,
+        duplicate_span: SourceSpan,
+    },
+    Undefined {
+        line_number: LocalLineNumber,
+        span: SourceSpan,
+    },
+    InvalidDefinitionTarget {
+        line_number: LocalLineNumber,
+        span: SourceSpan,
+        source: InstructionAddressError,
+    },
+    Patch {
+        line_number: LocalLineNumber,
+        span: SourceSpan,
+        source: BranchTargetPatchError,
+    },
+}
+
+impl LocalLineNumber {
+    pub(crate) const fn new(raw: u64) -> Self {
+        Self { raw }
+    }
+
+    pub(crate) const fn raw(self) -> u64 {
+        self.raw
+    }
+}
+
+impl LocalLineNumberTable {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn define(
+        &mut self,
+        instructions: &InstructionSequence,
+        line_number: LocalLineNumber,
+        target: InstructionAddress,
+        span: SourceSpan,
+    ) -> Result<(), LineNumberError> {
+        instructions
+            .view()
+            .validate_address(target)
+            .map_err(|source| LineNumberError::InvalidDefinitionTarget {
+                line_number,
+                span,
+                source,
+            })?;
+
+        if let Some(existing) = self.definitions.get(&line_number) {
+            return Err(LineNumberError::Duplicate {
+                line_number,
+                original_span: existing.span,
+                duplicate_span: span,
+            });
+        }
+
+        self.definitions
+            .insert(line_number, LineNumberDefinition { target, span });
+        Ok(())
+    }
+
+    pub(crate) fn add_patch(
+        &mut self,
+        line_number: LocalLineNumber,
+        branch: InstructionAddress,
+        span: SourceSpan,
+    ) {
+        self.patches.push(UnresolvedLineNumberPatch {
+            line_number,
+            branch,
+            span,
+        });
+    }
+
+    pub(crate) fn resolve(
+        &self,
+        instructions: &mut InstructionSequence,
+    ) -> Result<(), LineNumberError> {
+        let mut resolved = Vec::with_capacity(self.patches.len());
+        for patch in &self.patches {
+            let Some(definition) = self.definitions.get(&patch.line_number) else {
+                return Err(LineNumberError::Undefined {
+                    line_number: patch.line_number,
+                    span: patch.span,
+                });
+            };
+            resolved.push((*patch, definition.target));
+        }
+
+        for (patch, target) in resolved {
+            instructions
+                .patch_branch_target(patch.branch, target)
+                .map_err(|source| LineNumberError::Patch {
+                    line_number: patch.line_number,
+                    span: patch.span,
+                    source,
+                })?;
+        }
+
+        Ok(())
+    }
+}
+
+impl Default for LocalLineNumberTable {
+    fn default() -> Self {
+        Self {
+            definitions: HashMap::new(),
+            patches: Vec::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::instruction::{Instruction, InstructionAddress};
+    use crate::source::{SourceId, SourceTexts, SourceView};
+    use crate::value::Value;
+
+    fn source(text: &str) -> (SourceTexts, SourceId) {
+        let mut sources = SourceTexts::new();
+        let id = sources.register(text);
+        (sources, id)
+    }
+
+    fn span(view: SourceView<'_>, source_id: SourceId, start: usize, end: usize) -> SourceSpan {
+        view.span(source_id, start, end)
+            .expect("test span should be valid")
+    }
+
+    fn address(index: usize) -> InstructionAddress {
+        InstructionAddress::from_index(index)
+    }
+
+    fn line(raw: u64) -> LocalLineNumber {
+        LocalLineNumber::new(raw)
+    }
+
+    #[test]
+    fn resolves_same_owner_forward_line_number_patch() {
+        let (sources, source_id) = source("BIF 0, 200\n200 DONE");
+        let branch_span = span(sources.view(), source_id, 7, 10);
+        let target_span = span(sources.view(), source_id, 11, 14);
+        let mut code = InstructionSequence::new();
+        let placeholder = code.append(Instruction::Halt);
+        let branch = code.append(Instruction::JumpIfZero(placeholder));
+        let target = code.append(Instruction::Halt);
+        let mut table = LocalLineNumberTable::new();
+
+        table.add_patch(line(200), branch, branch_span);
+        table
+            .define(&code, line(200), target, target_span)
+            .expect("target should define");
+        table.resolve(&mut code).expect("patch should resolve");
+
+        assert_eq!(
+            code.view().get(branch),
+            Ok(&Instruction::JumpIfZero(target))
+        );
+    }
+
+    #[test]
+    fn resolves_same_owner_backward_line_number_patch() {
+        let (sources, source_id) = source("100 START\nBIF 0, 100");
+        let target_span = span(sources.view(), source_id, 0, 3);
+        let branch_span = span(sources.view(), source_id, 17, 20);
+        let mut code = InstructionSequence::new();
+        let target = code.append(Instruction::Halt);
+        let branch = code.append(Instruction::Jump(address(0)));
+        let mut table = LocalLineNumberTable::new();
+
+        table
+            .define(&code, line(100), target, target_span)
+            .expect("target should define");
+        table.add_patch(line(100), branch, branch_span);
+        table.resolve(&mut code).expect("patch should resolve");
+
+        assert_eq!(code.view().get(branch), Ok(&Instruction::Jump(target)));
+    }
+
+    #[test]
+    fn duplicate_line_number_reports_both_spans() {
+        let (sources, source_id) = source("100 A\n100 B");
+        let first_span = span(sources.view(), source_id, 0, 3);
+        let second_span = span(sources.view(), source_id, 6, 9);
+        let mut code = InstructionSequence::new();
+        let target = code.append(Instruction::Halt);
+        let mut table = LocalLineNumberTable::new();
+
+        table
+            .define(&code, line(100), target, first_span)
+            .expect("first definition should succeed");
+
+        assert_eq!(
+            table.define(&code, line(100), target, second_span),
+            Err(LineNumberError::Duplicate {
+                line_number: line(100),
+                original_span: first_span,
+                duplicate_span: second_span,
+            })
+        );
+    }
+
+    #[test]
+    fn undefined_line_number_reports_operand_span() {
+        let (sources, source_id) = source("BIF 0, 200");
+        let branch_span = span(sources.view(), source_id, 7, 10);
+        let mut code = InstructionSequence::new();
+        let branch = code.append(Instruction::JumpIfZero(address(0)));
+        let mut table = LocalLineNumberTable::new();
+
+        table.add_patch(line(200), branch, branch_span);
+
+        assert_eq!(
+            table.resolve(&mut code),
+            Err(LineNumberError::Undefined {
+                line_number: line(200),
+                span: branch_span,
+            })
+        );
+    }
+
+    #[test]
+    fn line_number_identifier_is_not_limited_to_runtime_integer_range() {
+        let large = line(u64::from(i16::MAX as u16) + 1);
+        let (sources, source_id) = source("40000 TARGET");
+        let target_span = span(sources.view(), source_id, 0, 5);
+        let mut code = InstructionSequence::new();
+        let target = code.append(Instruction::Halt);
+        let mut table = LocalLineNumberTable::new();
+
+        table
+            .define(&code, large, target, target_span)
+            .expect("large line number should be compile-time-only");
+
+        assert_eq!(large.raw(), 32768);
+    }
+
+    #[test]
+    fn definition_rejects_end_and_out_of_range_targets() {
+        let (sources, source_id) = source("100 A");
+        let line_span = span(sources.view(), source_id, 0, 3);
+        let mut code = InstructionSequence::new();
+        code.append(Instruction::Halt);
+        let mut table = LocalLineNumberTable::new();
+
+        assert_eq!(
+            table.define(&code, line(100), address(1), line_span),
+            Err(LineNumberError::InvalidDefinitionTarget {
+                line_number: line(100),
+                span: line_span,
+                source: InstructionAddressError::EndAddress {
+                    address: address(1)
+                },
+            })
+        );
+        assert_eq!(
+            table.define(&code, line(100), address(2), line_span),
+            Err(LineNumberError::InvalidDefinitionTarget {
+                line_number: line(100),
+                span: line_span,
+                source: InstructionAddressError::InvalidAddress {
+                    address: address(2)
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn separate_owners_can_reuse_the_same_line_number() {
+        let (sources, source_id) = source("100 A\n100 B");
+        let first_span = span(sources.view(), source_id, 0, 3);
+        let second_span = span(sources.view(), source_id, 6, 9);
+        let mut first_code = InstructionSequence::new();
+        let mut second_code = InstructionSequence::new();
+        let first_target = first_code.append(Instruction::Halt);
+        let second_target = second_code.append(Instruction::Push(Value::integer(1)));
+        let mut first_table = LocalLineNumberTable::new();
+        let mut second_table = LocalLineNumberTable::new();
+
+        first_table
+            .define(&first_code, line(100), first_target, first_span)
+            .expect("first owner should define line");
+        second_table
+            .define(&second_code, line(100), second_target, second_span)
+            .expect("second owner should define same local line");
+    }
+
+    #[test]
+    fn patch_error_keeps_line_number_operand_span() {
+        let (sources, source_id) = source("BIF 0, 100");
+        let branch_span = span(sources.view(), source_id, 7, 10);
+        let target_span = span(sources.view(), source_id, 7, 10);
+        let mut code = InstructionSequence::new();
+        let non_branch = code.append(Instruction::Push(Value::integer(1)));
+        let target = code.append(Instruction::Halt);
+        let mut table = LocalLineNumberTable::new();
+
+        table
+            .define(&code, line(100), target, target_span)
+            .expect("line should define");
+        table.add_patch(line(100), non_branch, branch_span);
+
+        assert_eq!(
+            table.resolve(&mut code),
+            Err(LineNumberError::Patch {
+                line_number: line(100),
+                span: branch_span,
+                source: BranchTargetPatchError::NonBranchInstruction {
+                    address: non_branch,
+                    instruction: Instruction::Push(Value::integer(1)),
+                },
+            })
+        );
+    }
+}

--- a/crates/tbx-next/src/line_number.rs
+++ b/crates/tbx-next/src/line_number.rs
@@ -14,7 +14,7 @@ pub(crate) struct LocalLineNumber {
     raw: u64,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub(crate) struct LocalLineNumberTable {
     definitions: HashMap<LocalLineNumber, LineNumberDefinition>,
     patches: Vec<UnresolvedLineNumberPatch>,
@@ -139,15 +139,6 @@ impl LocalLineNumberTable {
         }
 
         Ok(())
-    }
-}
-
-impl Default for LocalLineNumberTable {
-    fn default() -> Self {
-        Self {
-            definitions: HashMap::new(),
-            patches: Vec::new(),
-        }
     }
 }
 


### PR DESCRIPTION
## Summary

- `crates/tbx-next` に runtime `Value` と分離した `LocalLineNumber` / `LocalLineNumberTable` を追加
- same-owner の forward/backward line-number reference を builder 側で branch target patch できるようにした
- `InstructionSequence` owner にだけ `Jump` / `JumpIfZero` target patch API を追加し、`InstructionView` は read-only のまま維持
- duplicate / undefined / invalid target / non-branch patch の span 付きエラーと builder-level tests を追加

Closes #1449

## Verification

- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `cargo fmt --check`
