### PR TITLE
ローカルCI用clippy aliasを追加

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+[alias]
+ci-clippy = "clippy --workspace --all-targets -- -D warnings"
+ci-fmt = "fmt --all --check"
+ci-test = "test --workspace"

--- a/.github/agents/implement-issue.agent.md
+++ b/.github/agents/implement-issue.agent.md
@@ -63,7 +63,7 @@ Rustのベストプラクティスに従いコードを実装する。
 ```bash
 cargo build
 cargo test
-cargo clippy --all-targets -- -D warnings
+cargo ci-clippy
 ```
 
 ビルドエラー・テスト失敗・clippy警告がある場合は修正してから次のステップに進む。
@@ -133,7 +133,7 @@ INSERT OR REPLACE INTO session_state (key, value) VALUES ('review_before_review_
          ```bash
          cargo build
          cargo test
-         cargo clippy --all-targets -- -D warnings
+         cargo ci-clippy
          ```
        - 以下の形式でコミットしてpushする（事前に SQL で `loop_count` の値を取得しておくこと）：
          ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,8 +175,8 @@ cargo test
 # Run a single test by name
 cargo test test_name
 
-# Lint (must pass with zero warnings — use --all-targets to catch #[cfg(test)] code)
-cargo clippy --all-targets -- -D warnings
+# Lint (must pass with zero warnings across the workspace)
+cargo ci-clippy
 
 # Format check
 cargo fmt --check
@@ -210,12 +210,12 @@ cargo run
 コミット前に以下のコマンドを実行してCIと同じ条件でチェックすること。
 
 ```bash
-cargo clippy --all-targets -- -D warnings
-cargo test
-cargo fmt --check
+cargo ci-clippy
+cargo ci-test
+cargo ci-fmt
 ```
 
-**重要**: `--all-targets` を省略すると `#[cfg(test)]` ブロック内のコードが lint 対象から外れ、CIでのみ検出される警告が発生する。
+**重要**: CI の `Workspace / Clippy` は workspace 全体を対象にするため、`--workspace` を省略すると `crates/tbx-next` などが lint 対象から外れ、CIでのみ検出される警告が発生する。`--all-targets` を省略すると `#[cfg(test)]` ブロック内のコードが lint 対象から外れる。
 
 ## ユーザーへの確認ルール
 


### PR DESCRIPTION
## Summary

- `cargo ci-clippy` alias を追加し、workspace 全体を `--all-targets` かつ warnings as errors で確認できるようにした
- `cargo ci-test` / `cargo ci-fmt` alias も追加し、ローカルのCI相当チェックを短いコマンドにした
- `AGENTS.md` と implement-issue agent 手順を `cargo ci-clippy` 使用へ更新し、`--workspace` 抜けで `crates/tbx-next` が lint 対象外になる問題を明記

## Verification

- `cargo ci-clippy`
- `cargo ci-test`
- `cargo ci-fmt`
