### PR TITLE
TBX Next: GlobalVarIdとglobal variable storage基盤を追加

### DIFF
--- a/crates/tbx-next/src/binding.rs
+++ b/crates/tbx-next/src/binding.rs
@@ -1,17 +1,18 @@
 use std::collections::HashMap;
 
+use crate::global_variable::GlobalVarId;
 use crate::name::NormalizedName;
 use crate::word::WordId;
 
 /// Current published binding for one normalized TBX Next name.
 ///
-/// ADR #1368 keeps words, scalars, and arrays in one logical namespace. This
-/// enum starts with word bindings only because scalar and array IDs do not exist
-/// yet; later variants must use the same registry so ordinary registration can
-/// reject cross-kind name conflicts.
+/// ADR #1368 keeps words, scalars, and arrays in one logical namespace, so
+/// ordinary registration rejects cross-kind name conflicts through this same
+/// registry instead of splitting words and variables into separate maps.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Binding {
     Word(WordId),
+    Variable(GlobalVarId),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -65,6 +66,7 @@ impl Bindings {
     ) -> Result<WordId, BindingReplaceError> {
         match self.entries.get(name) {
             Some(Binding::Word(id)) => Ok(*id),
+            Some(Binding::Variable(_)) => Err(BindingReplaceError::TargetIsNotWord),
             None => Err(BindingReplaceError::MissingName),
         }
     }
@@ -83,6 +85,7 @@ impl Bindings {
             Some(Binding::Word(actual)) => {
                 Err(BindingReplaceError::CurrentWordMismatch { actual: *actual })
             }
+            Some(Binding::Variable(_)) => Err(BindingReplaceError::TargetIsNotWord),
             None => Err(BindingReplaceError::MissingName),
         }
     }
@@ -99,6 +102,7 @@ impl Bindings {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::global_variable::GlobalVariables;
     use crate::word::{CompletedWordDefinition, PrimitiveId, PublishedWords};
 
     fn name(input: &str) -> NormalizedName {
@@ -113,6 +117,10 @@ mod tests {
 
     fn word_binding(words: &mut PublishedWords, primitive_slot: usize) -> Binding {
         Binding::Word(add_word(words, primitive_slot))
+    }
+
+    fn variable_binding(globals: &mut GlobalVariables) -> Binding {
+        Binding::Variable(globals.allocate())
     }
 
     #[test]
@@ -173,7 +181,20 @@ mod tests {
             .expect("binding should exist")
         {
             Binding::Word(actual_id) => assert_eq!(*actual_id, id),
+            Binding::Variable(_) => panic!("word binding should preserve kind"),
         }
+    }
+
+    #[test]
+    fn variable_binding_registers_and_looks_up_in_the_same_namespace() {
+        let mut globals = GlobalVariables::new();
+        let binding = variable_binding(&mut globals);
+        let mut bindings = Bindings::new();
+
+        assert_eq!(bindings.insert_new(name("A"), binding), Ok(()));
+
+        assert_eq!(bindings.get(&name("A")), Some(&binding));
+        assert_eq!(bindings.len(), 1);
     }
 
     #[test]
@@ -268,6 +289,63 @@ mod tests {
             Err(BindingInsertError::NameConflict)
         );
         assert_eq!(bindings.get(&name("Foo")), Some(&first));
+    }
+
+    #[test]
+    fn word_then_variable_same_name_is_rejected() {
+        let mut words = PublishedWords::new();
+        let word = word_binding(&mut words, 12);
+        let mut globals = GlobalVariables::new();
+        let variable = variable_binding(&mut globals);
+        let mut bindings = Bindings::new();
+
+        bindings
+            .insert_new(name("X"), word)
+            .expect("word should register first");
+
+        assert_eq!(
+            bindings.insert_new(name("X"), variable),
+            Err(BindingInsertError::NameConflict)
+        );
+        assert_eq!(bindings.get(&name("X")), Some(&word));
+    }
+
+    #[test]
+    fn variable_then_word_same_name_is_rejected() {
+        let mut globals = GlobalVariables::new();
+        let variable = variable_binding(&mut globals);
+        let mut words = PublishedWords::new();
+        let word = word_binding(&mut words, 13);
+        let mut bindings = Bindings::new();
+
+        bindings
+            .insert_new(name("Y"), variable)
+            .expect("variable should register first");
+
+        assert_eq!(
+            bindings.insert_new(name("Y"), word),
+            Err(BindingInsertError::NameConflict)
+        );
+        assert_eq!(bindings.get(&name("Y")), Some(&variable));
+    }
+
+    #[test]
+    fn word_and_variable_case_variant_registration_is_a_name_conflict() {
+        let mut globals = GlobalVariables::new();
+        let variable = variable_binding(&mut globals);
+        let mut words = PublishedWords::new();
+        let word = word_binding(&mut words, 14);
+        let mut bindings = Bindings::new();
+
+        bindings
+            .insert_new(name("score"), variable)
+            .expect("variable should register first");
+
+        assert_eq!(
+            bindings.insert_new(name("SCORE"), word),
+            Err(BindingInsertError::NameConflict)
+        );
+        assert_eq!(bindings.get(&name("Score")), Some(&variable));
     }
 
     #[test]
@@ -374,6 +452,44 @@ mod tests {
             Err(BindingReplaceError::CurrentWordMismatch { actual })
         );
         assert_eq!(bindings.current_word(&name("TARGET")), Ok(actual));
+        assert_eq!(bindings.len(), 1);
+    }
+
+    #[test]
+    fn current_word_rejects_variable_binding() {
+        let mut globals = GlobalVariables::new();
+        let variable = variable_binding(&mut globals);
+        let mut bindings = Bindings::new();
+
+        bindings
+            .insert_new(name("TOTAL"), variable)
+            .expect("variable should register");
+
+        assert_eq!(
+            bindings.current_word(&name("TOTAL")),
+            Err(BindingReplaceError::TargetIsNotWord)
+        );
+        assert_eq!(bindings.get(&name("TOTAL")), Some(&variable));
+    }
+
+    #[test]
+    fn replace_word_rejects_variable_binding_without_mutation() {
+        let mut globals = GlobalVariables::new();
+        let variable = variable_binding(&mut globals);
+        let mut words = PublishedWords::new();
+        let expected = add_word(&mut words, 70);
+        let replacement = add_word(&mut words, 71);
+        let mut bindings = Bindings::new();
+
+        bindings
+            .insert_new(name("TOTAL"), variable)
+            .expect("variable should register");
+
+        assert_eq!(
+            bindings.replace_word(&name("TOTAL"), expected, replacement),
+            Err(BindingReplaceError::TargetIsNotWord)
+        );
+        assert_eq!(bindings.get(&name("TOTAL")), Some(&variable));
         assert_eq!(bindings.len(), 1);
     }
 }

--- a/crates/tbx-next/src/global_variable.rs
+++ b/crates/tbx-next/src/global_variable.rs
@@ -1,0 +1,201 @@
+use crate::value::Value;
+
+/// Crate-internal identifier for one global scalar variable slot.
+///
+/// ADR #1370 keeps global storage outside fresh `Vm` control state. IDs are
+/// issued monotonically in this milestone and are not runtime `Value`s,
+/// serialized handles, or reusable public ABI.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct GlobalVarId {
+    slot: usize,
+}
+
+impl GlobalVarId {
+    #[cfg(test)]
+    pub(crate) const fn test_invalid(slot: usize) -> Self {
+        Self { slot }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GlobalVariableError {
+    InvalidGlobalVarId { id: GlobalVarId },
+}
+
+/// Session-owned storage for TBX Next global scalar variables.
+///
+/// The VM receives only narrow access views later; this owner is deliberately
+/// independent from executable code, bindings, and transient VM execution state.
+#[derive(Debug, Default)]
+pub(crate) struct GlobalVariables {
+    slots: Vec<Value>,
+}
+
+impl GlobalVariables {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn allocate(&mut self) -> GlobalVarId {
+        let id = GlobalVarId {
+            slot: self.slots.len(),
+        };
+        self.slots.push(Value::integer(0));
+        id
+    }
+
+    pub(crate) fn view(&self) -> GlobalVariableView<'_> {
+        GlobalVariableView { slots: &self.slots }
+    }
+
+    pub(crate) fn view_mut(&mut self) -> GlobalVariableViewMut<'_> {
+        GlobalVariableViewMut {
+            slots: &mut self.slots,
+        }
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.slots.len()
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.slots.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct GlobalVariableView<'a> {
+    slots: &'a [Value],
+}
+
+impl GlobalVariableView<'_> {
+    pub(crate) fn read(self, id: GlobalVarId) -> Result<Value, GlobalVariableError> {
+        self.slots
+            .get(id.slot)
+            .copied()
+            .ok_or(GlobalVariableError::InvalidGlobalVarId { id })
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct GlobalVariableViewMut<'a> {
+    slots: &'a mut [Value],
+}
+
+impl GlobalVariableViewMut<'_> {
+    pub(crate) fn read(&self, id: GlobalVarId) -> Result<Value, GlobalVariableError> {
+        self.slots
+            .get(id.slot)
+            .copied()
+            .ok_or(GlobalVariableError::InvalidGlobalVarId { id })
+    }
+
+    pub(crate) fn write(
+        &mut self,
+        id: GlobalVarId,
+        value: Value,
+    ) -> Result<(), GlobalVariableError> {
+        let slot = self
+            .slots
+            .get_mut(id.slot)
+            .ok_or(GlobalVariableError::InvalidGlobalVarId { id })?;
+        *slot = value;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allocation_initializes_slot_to_integer_zero() {
+        let mut globals = GlobalVariables::new();
+
+        let id = globals.allocate();
+
+        assert_eq!(globals.len(), 1);
+        assert!(!globals.is_empty());
+        assert_eq!(globals.view().read(id), Ok(Value::integer(0)));
+    }
+
+    #[test]
+    fn multiple_slots_keep_independent_identity() {
+        let mut globals = GlobalVariables::new();
+        let first = globals.allocate();
+        let second = globals.allocate();
+        let third = globals.allocate();
+
+        assert_ne!(first, second);
+        assert_ne!(first, third);
+        assert_ne!(second, third);
+
+        let mut view = globals.view_mut();
+        view.write(first, Value::integer(10))
+            .expect("first slot should be valid");
+        view.write(second, Value::integer(20))
+            .expect("second slot should be valid");
+        view.write(third, Value::integer(30))
+            .expect("third slot should be valid");
+
+        assert_eq!(view.read(first), Ok(Value::integer(10)));
+        assert_eq!(view.read(second), Ok(Value::integer(20)));
+        assert_eq!(view.read(third), Ok(Value::integer(30)));
+    }
+
+    #[test]
+    fn read_and_write_valid_id() {
+        let mut globals = GlobalVariables::new();
+        let id = globals.allocate();
+
+        {
+            let mut view = globals.view_mut();
+            assert_eq!(view.write(id, Value::integer(-7)), Ok(()));
+            assert_eq!(view.read(id), Ok(Value::integer(-7)));
+        }
+
+        assert_eq!(globals.view().read(id), Ok(Value::integer(-7)));
+    }
+
+    #[test]
+    fn invalid_id_is_structured_error_without_mutation() {
+        let mut globals = GlobalVariables::new();
+        let valid = globals.allocate();
+        let invalid = GlobalVarId::test_invalid(99);
+
+        {
+            let mut view = globals.view_mut();
+            assert_eq!(
+                view.write(invalid, Value::integer(42)),
+                Err(GlobalVariableError::InvalidGlobalVarId { id: invalid })
+            );
+            assert_eq!(
+                view.read(invalid),
+                Err(GlobalVariableError::InvalidGlobalVarId { id: invalid })
+            );
+        }
+
+        assert_eq!(globals.view().read(valid), Ok(Value::integer(0)));
+    }
+
+    #[test]
+    fn later_allocations_do_not_change_previous_ids() {
+        let mut globals = GlobalVariables::new();
+        let first = globals.allocate();
+        let second = globals.allocate();
+
+        {
+            let mut view = globals.view_mut();
+            view.write(first, Value::integer(1))
+                .expect("first slot should be valid");
+            view.write(second, Value::integer(2))
+                .expect("second slot should be valid");
+        }
+
+        let third = globals.allocate();
+
+        assert_eq!(globals.view().read(first), Ok(Value::integer(1)));
+        assert_eq!(globals.view().read(second), Ok(Value::integer(2)));
+        assert_eq!(globals.view().read(third), Ok(Value::integer(0)));
+    }
+}

--- a/crates/tbx-next/src/lib.rs
+++ b/crates/tbx-next/src/lib.rs
@@ -92,6 +92,11 @@ mod expression;
 #[allow(dead_code)]
 mod line_number;
 
+// ADR #1370 keeps global variable identity and storage as session-owned mutable
+// state, separate from VM control state and runtime values.
+#[allow(dead_code)]
+mod global_variable;
+
 pub const STATUS_MESSAGE: &str =
     "TBX Next is under development; language features are not implemented yet.";
 

--- a/crates/tbx-next/src/word_resolution.rs
+++ b/crates/tbx-next/src/word_resolution.rs
@@ -29,6 +29,7 @@ pub(crate) fn resolve_normalized_word(
 ) -> Result<WordId, WordResolutionError> {
     match bindings.get(name) {
         Some(Binding::Word(id)) => Ok(*id),
+        Some(Binding::Variable(_)) => Err(WordResolutionError::TargetIsNotWord),
         None => Err(WordResolutionError::UndefinedName),
     }
 }
@@ -46,6 +47,7 @@ mod tests {
     use super::*;
     use crate::binding::{Binding, Bindings};
     use crate::bootstrap::register_primitive;
+    use crate::global_variable::GlobalVariables;
     use crate::instruction::{Instruction, InstructionSequence};
     use crate::name::NormalizedName;
     use crate::redefinition::redefine_word;
@@ -241,5 +243,20 @@ mod tests {
         .expect("primitive should bootstrap");
 
         assert_eq!(resolve_word_name(&bindings, "bootstrapped"), Ok(id));
+    }
+
+    #[test]
+    fn variable_binding_is_not_resolved_as_word() {
+        let mut globals = GlobalVariables::new();
+        let variable = globals.allocate();
+        let mut bindings = Bindings::new();
+        bindings
+            .insert_new(name("A"), Binding::Variable(variable))
+            .expect("variable should register");
+
+        assert_eq!(
+            resolve_word_name(&bindings, "A"),
+            Err(WordResolutionError::TargetIsNotWord)
+        );
     }
 }


### PR DESCRIPTION
## Summary

- `crates/tbx-next` に crate-internal な `GlobalVarId` と `GlobalVariables` storage を追加
- global variable slot を `Value::integer(0)` で初期化し、view 経由の read/write と invalid ID error を追加
- `Binding::Variable(GlobalVarId)` を同一 `Bindings` namespace に追加し、word/variable の同名衝突と word 再定義拒否を固定
- word name resolution が variable binding を `TargetIsNotWord` として扱うよう更新

Closes #1462

## Verification

- `cargo test -p tbx-next`
- `cargo ci-clippy`
- `cargo ci-test`
- `cargo ci-fmt`
