### PR TITLE
TBX Next: A-Z組み込みglobal variableをbootstrapする

### DIFF
--- a/crates/tbx-next/src/bootstrap.rs
+++ b/crates/tbx-next/src/bootstrap.rs
@@ -97,6 +97,7 @@ mod tests {
     use crate::global_variable::GlobalVariables;
     use crate::value::Value;
     use crate::word::WordDefinition;
+    use std::collections::HashSet;
 
     fn name(input: &str) -> NormalizedName {
         NormalizedName::new(input).expect("test input should be a valid word name")
@@ -124,6 +125,12 @@ mod tests {
             bindings.get(&name(input)),
             Some(&Binding::Variable(expected))
         );
+    }
+
+    fn assert_distinct_variable_ids(ids: &[GlobalVarId]) {
+        let distinct: HashSet<_> = ids.iter().copied().collect();
+
+        assert_eq!(distinct.len(), ids.len());
     }
 
     #[test]
@@ -317,6 +324,7 @@ mod tests {
             .expect("empty namespace should accept built-in globals");
 
         assert_eq!(ids.len(), 26);
+        assert_distinct_variable_ids(&ids);
         assert_eq!(globals.len(), 26);
         assert_eq!(bindings.len(), 26);
 
@@ -339,6 +347,26 @@ mod tests {
         assert_variable_binding(&bindings, "A", ids[0]);
         assert_variable_binding(&bindings, "z", ids[25]);
         assert_variable_binding(&bindings, "Z", ids[25]);
+    }
+
+    #[test]
+    fn builtin_global_bootstrap_duplicate_run_preserves_existing_variables() {
+        let mut globals = GlobalVariables::new();
+        let mut bindings = Bindings::new();
+        let ids = register_builtin_global_variables(&mut globals, &mut bindings)
+            .expect("first A-Z bootstrap should register");
+
+        let result = register_builtin_global_variables(&mut globals, &mut bindings);
+
+        assert_eq!(result, Err(BuiltinGlobalBootstrapError::NameConflict));
+        assert_eq!(globals.len(), 26);
+        assert_eq!(bindings.len(), 26);
+        assert_distinct_variable_ids(&ids);
+
+        for (index, letter) in BUILTIN_GLOBAL_VARIABLE_NAMES.iter().enumerate() {
+            assert_variable_binding(&bindings, letter, ids[index]);
+            assert_eq!(globals.view().read(ids[index]), Ok(Value::integer(0)));
+        }
     }
 
     #[test]

--- a/crates/tbx-next/src/bootstrap.rs
+++ b/crates/tbx-next/src/bootstrap.rs
@@ -1,11 +1,22 @@
 use crate::binding::{Binding, BindingInsertError, Bindings};
+use crate::global_variable::{GlobalVarId, GlobalVariables};
 use crate::name::NormalizedName;
 use crate::word::{CompletedWordDefinition, PrimitiveId, PublishedWords, WordId};
+
+const BUILTIN_GLOBAL_VARIABLE_NAMES: [&str; 26] = [
+    "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S",
+    "T", "U", "V", "W", "X", "Y", "Z",
+];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum PrimitiveBootstrapError {
     NameConflict,
     BindingRegistrationInvariantViolated,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BuiltinGlobalBootstrapError {
+    NameConflict,
 }
 
 /// Registers one primitive word through the bootstrap-only publication boundary.
@@ -35,6 +46,43 @@ pub(crate) fn register_primitive(
     Ok(id)
 }
 
+/// Registers the Tiny BASIC A-Z built-in scalar variables.
+///
+/// The A-Z variables are ordinary bindings in the shared namespace, backed by
+/// session-owned global variable slots initialized by `GlobalVariables`.
+/// Bootstrap checks every name before allocating storage so a conflict cannot
+/// publish a partial prefix or leave unused variable slots behind.
+pub(crate) fn register_builtin_global_variables(
+    globals: &mut GlobalVariables,
+    bindings: &mut Bindings,
+) -> Result<Vec<GlobalVarId>, BuiltinGlobalBootstrapError> {
+    let names = builtin_global_variable_names();
+
+    for name in &names {
+        if bindings.get(name).is_some() {
+            return Err(BuiltinGlobalBootstrapError::NameConflict);
+        }
+    }
+
+    let mut ids = Vec::with_capacity(names.len());
+
+    for name in names {
+        let id = globals.allocate();
+        bindings
+            .insert_new(name, Binding::Variable(id))
+            .expect("prechecked A-Z bootstrap names should remain available");
+        ids.push(id);
+    }
+
+    Ok(ids)
+}
+
+fn builtin_global_variable_names() -> [NormalizedName; 26] {
+    BUILTIN_GLOBAL_VARIABLE_NAMES.map(|name| {
+        NormalizedName::new(name).expect("built-in global variable name should be valid")
+    })
+}
+
 impl PrimitiveBootstrapError {
     fn from_binding_insert_error(error: BindingInsertError) -> Self {
         match error {
@@ -46,6 +94,8 @@ impl PrimitiveBootstrapError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::global_variable::GlobalVariables;
+    use crate::value::Value;
     use crate::word::WordDefinition;
 
     fn name(input: &str) -> NormalizedName {
@@ -67,6 +117,13 @@ mod tests {
 
     fn assert_word_binding(bindings: &Bindings, input: &str, expected: WordId) {
         assert_eq!(bindings.get(&name(input)), Some(&Binding::Word(expected)));
+    }
+
+    fn assert_variable_binding(bindings: &Bindings, input: &str, expected: GlobalVarId) {
+        assert_eq!(
+            bindings.get(&name(input)),
+            Some(&Binding::Variable(expected))
+        );
     }
 
     #[test]
@@ -249,5 +306,93 @@ mod tests {
 
         assert_word_binding(&bindings, "VM_FREE_BOUNDARY", id);
         assert_primitive(&words, id, primitive(60));
+    }
+
+    #[test]
+    fn builtin_global_bootstrap_registers_a_to_z_variables() {
+        let mut globals = GlobalVariables::new();
+        let mut bindings = Bindings::new();
+
+        let ids = register_builtin_global_variables(&mut globals, &mut bindings)
+            .expect("empty namespace should accept built-in globals");
+
+        assert_eq!(ids.len(), 26);
+        assert_eq!(globals.len(), 26);
+        assert_eq!(bindings.len(), 26);
+
+        for (index, letter) in BUILTIN_GLOBAL_VARIABLE_NAMES.iter().enumerate() {
+            let id = ids[index];
+            assert_variable_binding(&bindings, letter, id);
+            assert_eq!(globals.view().read(id), Ok(Value::integer(0)));
+        }
+    }
+
+    #[test]
+    fn builtin_global_bootstrap_uses_case_insensitive_lookup() {
+        let mut globals = GlobalVariables::new();
+        let mut bindings = Bindings::new();
+
+        let ids = register_builtin_global_variables(&mut globals, &mut bindings)
+            .expect("empty namespace should accept built-in globals");
+
+        assert_variable_binding(&bindings, "a", ids[0]);
+        assert_variable_binding(&bindings, "A", ids[0]);
+        assert_variable_binding(&bindings, "z", ids[25]);
+        assert_variable_binding(&bindings, "Z", ids[25]);
+    }
+
+    #[test]
+    fn builtin_global_bootstrap_conflicts_with_existing_word_binding() {
+        let mut words = PublishedWords::new();
+        let mut globals = GlobalVariables::new();
+        let mut bindings = Bindings::new();
+        let existing = words.add(CompletedWordDefinition::primitive(primitive(70)));
+        bindings
+            .insert_new(name("A"), Binding::Word(existing))
+            .expect("test word should register");
+
+        let result = register_builtin_global_variables(&mut globals, &mut bindings);
+
+        assert_eq!(result, Err(BuiltinGlobalBootstrapError::NameConflict));
+        assert_eq!(globals.len(), 0);
+        assert_eq!(bindings.len(), 1);
+        assert_word_binding(&bindings, "a", existing);
+    }
+
+    #[test]
+    fn builtin_global_bootstrap_conflicts_with_existing_case_variant() {
+        let mut globals = GlobalVariables::new();
+        let existing = globals.allocate();
+        let mut bindings = Bindings::new();
+        bindings
+            .insert_new(name("m"), Binding::Variable(existing))
+            .expect("test variable should register");
+
+        let result = register_builtin_global_variables(&mut globals, &mut bindings);
+
+        assert_eq!(result, Err(BuiltinGlobalBootstrapError::NameConflict));
+        assert_eq!(globals.len(), 1);
+        assert_eq!(globals.view().read(existing), Ok(Value::integer(0)));
+        assert_eq!(bindings.len(), 1);
+        assert_variable_binding(&bindings, "M", existing);
+    }
+
+    #[test]
+    fn builtin_global_bootstrap_conflict_after_prefix_does_not_publish_partial_names() {
+        let mut globals = GlobalVariables::new();
+        let existing = globals.allocate();
+        let mut bindings = Bindings::new();
+        bindings
+            .insert_new(name("Z"), Binding::Variable(existing))
+            .expect("test variable should register");
+
+        let result = register_builtin_global_variables(&mut globals, &mut bindings);
+
+        assert_eq!(result, Err(BuiltinGlobalBootstrapError::NameConflict));
+        assert_eq!(globals.len(), 1);
+        assert_eq!(bindings.len(), 1);
+        assert_eq!(bindings.get(&name("A")), None);
+        assert_eq!(bindings.get(&name("Y")), None);
+        assert_variable_binding(&bindings, "z", existing);
     }
 }


### PR DESCRIPTION
## Summary

- Add an A-Z built-in global variable bootstrap helper.
- Register each letter as an ordinary `Binding::Variable(GlobalVarId)` in the shared binding namespace.
- Precheck all names before allocation so bootstrap conflicts do not leave partial bindings or extra storage slots.

Closes #1464

## Verification

- `cargo ci-clippy`
- `cargo ci-test`
- `cargo ci-fmt`
