### PR TITLE
TBX Next: reserved publication name validationを共通化する

### DIFF
--- a/crates/tbx-next/src/bootstrap.rs
+++ b/crates/tbx-next/src/bootstrap.rs
@@ -1,6 +1,7 @@
 use crate::binding::{Binding, BindingInsertError, Bindings};
 use crate::global_variable::{GlobalVarId, GlobalVariables};
 use crate::name::NormalizedName;
+use crate::publication_name::{validate_publication_name, PublicationNameError};
 use crate::word::{CompletedWordDefinition, PrimitiveId, PublishedWords, WordId};
 
 const BUILTIN_GLOBAL_VARIABLE_NAMES: [&str; 26] = [
@@ -10,6 +11,7 @@ const BUILTIN_GLOBAL_VARIABLE_NAMES: [&str; 26] = [
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum PrimitiveBootstrapError {
+    ReservedName,
     NameConflict,
     BindingRegistrationInvariantViolated,
 }
@@ -33,6 +35,9 @@ pub(crate) fn register_primitive(
     name: NormalizedName,
     primitive: PrimitiveId,
 ) -> Result<WordId, PrimitiveBootstrapError> {
+    validate_publication_name(&name)
+        .map_err(PrimitiveBootstrapError::from_publication_name_error)?;
+
     if bindings.get(&name).is_some() {
         return Err(PrimitiveBootstrapError::NameConflict);
     }
@@ -84,6 +89,12 @@ fn builtin_global_variable_names() -> [NormalizedName; 26] {
 }
 
 impl PrimitiveBootstrapError {
+    fn from_publication_name_error(error: PublicationNameError) -> Self {
+        match error {
+            PublicationNameError::ReservedName => Self::ReservedName,
+        }
+    }
+
     fn from_binding_insert_error(error: BindingInsertError) -> Self {
         match error {
             BindingInsertError::NameConflict => Self::BindingRegistrationInvariantViolated,
@@ -131,6 +142,35 @@ mod tests {
         let distinct: HashSet<_> = ids.iter().copied().collect();
 
         assert_eq!(distinct.len(), ids.len());
+    }
+
+    #[test]
+    fn reserved_primitive_names_are_rejected_without_mutation() {
+        for input in ["VAR", "var", "Var", "LET", "let", "Let"] {
+            let mut words = PublishedWords::new();
+            let mut bindings = Bindings::new();
+
+            let result = register_primitive(&mut words, &mut bindings, name(input), primitive(80));
+
+            assert_eq!(result, Err(PrimitiveBootstrapError::ReservedName));
+            assert_eq!(words.len(), 0, "{input:?} should not issue a word id");
+            assert_eq!(bindings.len(), 0, "{input:?} should not bind a name");
+        }
+    }
+
+    #[test]
+    fn ordinary_names_near_reserved_spellings_can_register_as_primitives() {
+        for input in ["VAR1", "LETTER", "_LET"] {
+            let mut words = PublishedWords::new();
+            let mut bindings = Bindings::new();
+
+            let id = register_primitive(&mut words, &mut bindings, name(input), primitive(81))
+                .expect("ordinary name should register");
+
+            assert_eq!(words.len(), 1);
+            assert_eq!(bindings.len(), 1);
+            assert_word_binding(&bindings, input, id);
+        }
     }
 
     #[test]

--- a/crates/tbx-next/src/lib.rs
+++ b/crates/tbx-next/src/lib.rs
@@ -42,6 +42,11 @@ mod bootstrap;
 #[allow(dead_code)]
 mod redefinition;
 
+// ADR #1370 reserves selected source-form spellings before any ordinary binding
+// publication can commit IDs, storage, or namespace entries.
+#[allow(dead_code)]
+mod publication_name;
+
 // Phase F for ADR #1367/#1368 gives the future VM a read-only lookup boundary
 // over published executable words without exposing registration or binding APIs.
 #[allow(dead_code)]

--- a/crates/tbx-next/src/publication_name.rs
+++ b/crates/tbx-next/src/publication_name.rs
@@ -1,0 +1,45 @@
+use crate::name::NormalizedName;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PublicationNameError {
+    ReservedName,
+}
+
+/// Validates a normal name before it is published into the shared namespace.
+///
+/// ADR #1370 reserves VAR/LET for source forms, so ordinary words, variables,
+/// and future binding kinds must reject those spellings before committing any
+/// word ID, storage slot, or binding entry.
+pub(crate) fn validate_publication_name(name: &NormalizedName) -> Result<(), PublicationNameError> {
+    match name.as_str() {
+        "VAR" | "LET" => Err(PublicationNameError::ReservedName),
+        _ => Ok(()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn name(input: &str) -> NormalizedName {
+        NormalizedName::new(input).expect("test input should be a valid word name")
+    }
+
+    #[test]
+    fn rejects_reserved_case_variants() {
+        for input in ["VAR", "var", "Var", "LET", "let", "Let"] {
+            assert_eq!(
+                validate_publication_name(&name(input)),
+                Err(PublicationNameError::ReservedName),
+                "{input:?} should be reserved"
+            );
+        }
+    }
+
+    #[test]
+    fn accepts_ordinary_names_that_contain_reserved_spellings() {
+        for input in ["VAR1", "LETTER", "_LET"] {
+            assert_eq!(validate_publication_name(&name(input)), Ok(()));
+        }
+    }
+}

--- a/crates/tbx-next/src/redefinition.rs
+++ b/crates/tbx-next/src/redefinition.rs
@@ -1,5 +1,6 @@
 use crate::binding::{BindingReplaceError, Bindings};
 use crate::name::NormalizedName;
+use crate::publication_name::{validate_publication_name, PublicationNameError};
 use crate::word::{CompletedWordDefinition, PublishedWords, WordId};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -20,6 +21,7 @@ impl WordRedefinition {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum WordRedefinitionError {
+    ReservedName,
     UndefinedName,
     TargetIsNotWord,
     BindingCommitInvariantViolated,
@@ -37,6 +39,8 @@ pub(crate) fn redefine_word(
     name: &NormalizedName,
     definition: CompletedWordDefinition,
 ) -> Result<WordRedefinition, WordRedefinitionError> {
+    validate_publication_name(name).map_err(WordRedefinitionError::from_publication_name_error)?;
+
     let previous = bindings
         .current_word(name)
         .map_err(WordRedefinitionError::from_precheck_error)?;
@@ -51,6 +55,12 @@ pub(crate) fn redefine_word(
 }
 
 impl WordRedefinitionError {
+    fn from_publication_name_error(error: PublicationNameError) -> Self {
+        match error {
+            PublicationNameError::ReservedName => Self::ReservedName,
+        }
+    }
+
     fn from_precheck_error(error: BindingReplaceError) -> Self {
         match error {
             BindingReplaceError::MissingName => Self::UndefinedName,
@@ -133,6 +143,47 @@ mod tests {
             words.get(result.current()),
             Ok(&new_definition.definition())
         );
+    }
+
+    #[test]
+    fn reserved_redefinition_names_are_rejected_before_issuing_word_id() {
+        for input in ["VAR", "var", "Var", "LET", "let", "Let"] {
+            let mut words = PublishedWords::new();
+            let mut bindings = Bindings::new();
+            let old_definition = primitive(10);
+            let old = publish_initial(&mut words, &mut bindings, input, old_definition);
+
+            let result = redefine_word(&mut words, &mut bindings, &name(input), primitive(11));
+
+            assert_eq!(result, Err(WordRedefinitionError::ReservedName));
+            assert_eq!(words.len(), 1, "{input:?} should not issue a word id");
+            assert_eq!(bindings.len(), 1, "{input:?} should not change bindings");
+            assert_word_binding(&bindings, input, old);
+            assert_eq!(words.get(old), Ok(&old_definition.definition()));
+        }
+    }
+
+    #[test]
+    fn ordinary_names_near_reserved_spellings_can_be_redefined() {
+        for input in ["VAR1", "LETTER", "_LET"] {
+            let mut words = PublishedWords::new();
+            let mut bindings = Bindings::new();
+            let old_definition = primitive(12);
+            let new_definition = primitive(13);
+            publish_initial(&mut words, &mut bindings, input, old_definition);
+
+            let result = redefine_word(&mut words, &mut bindings, &name(input), new_definition)
+                .expect("ordinary name should redefine");
+
+            assert_redefinition(
+                &words,
+                &bindings,
+                input,
+                result,
+                old_definition,
+                new_definition,
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `NormalizedName`後の通常publication名を検証するcrate-internal境界を追加
- `VAR` / `LET` のcase-insensitive予約名をprimitive bootstrapとword redefinitionのcommit前に拒否
- 予約名拒否時に`PublishedWords` / `Bindings`が変更されないこと、近い通常名が通ることをテストで確認

Closes #1474

## Verification

- `cargo test -p tbx-next`
- `cargo ci-clippy`
- `cargo ci-test`
- `cargo ci-fmt`
