### PR TITLE
TBX Next: source word のbinding dispatch基盤を追加する

### DIFF
--- a/crates/tbx-next/src/binding.rs
+++ b/crates/tbx-next/src/binding.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use crate::global_variable::GlobalVarId;
 use crate::name::NormalizedName;
+use crate::source_word::SourceWordId;
 use crate::word::WordId;
 
 /// Current published binding for one normalized TBX Next name.
@@ -12,6 +13,7 @@ use crate::word::WordId;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Binding {
     Word(WordId),
+    SourceWord(SourceWordId),
     Variable(GlobalVarId),
 }
 
@@ -66,7 +68,9 @@ impl Bindings {
     ) -> Result<WordId, BindingReplaceError> {
         match self.entries.get(name) {
             Some(Binding::Word(id)) => Ok(*id),
-            Some(Binding::Variable(_)) => Err(BindingReplaceError::TargetIsNotWord),
+            Some(Binding::SourceWord(_) | Binding::Variable(_)) => {
+                Err(BindingReplaceError::TargetIsNotWord)
+            }
             None => Err(BindingReplaceError::MissingName),
         }
     }
@@ -85,7 +89,9 @@ impl Bindings {
             Some(Binding::Word(actual)) => {
                 Err(BindingReplaceError::CurrentWordMismatch { actual: *actual })
             }
-            Some(Binding::Variable(_)) => Err(BindingReplaceError::TargetIsNotWord),
+            Some(Binding::SourceWord(_) | Binding::Variable(_)) => {
+                Err(BindingReplaceError::TargetIsNotWord)
+            }
             None => Err(BindingReplaceError::MissingName),
         }
     }
@@ -103,6 +109,7 @@ impl Bindings {
 mod tests {
     use super::*;
     use crate::global_variable::GlobalVariables;
+    use crate::source_word::SourceWordRegistry;
     use crate::word::{CompletedWordDefinition, PrimitiveId, PublishedWords};
 
     fn name(input: &str) -> NormalizedName {
@@ -121,6 +128,16 @@ mod tests {
 
     fn variable_binding(globals: &mut GlobalVariables) -> Binding {
         Binding::Variable(globals.allocate())
+    }
+
+    fn source_word_binding(source_words: &mut SourceWordRegistry) -> Binding {
+        fn handler(
+            _context: &mut crate::source_word::NativeSourceWordContext<'_>,
+        ) -> Result<(), crate::source_word::SourceWordError> {
+            Ok(())
+        }
+
+        Binding::SourceWord(source_words.register(handler))
     }
 
     #[test]
@@ -181,8 +198,22 @@ mod tests {
             .expect("binding should exist")
         {
             Binding::Word(actual_id) => assert_eq!(*actual_id, id),
-            Binding::Variable(_) => panic!("word binding should preserve kind"),
+            Binding::SourceWord(_) | Binding::Variable(_) => {
+                panic!("word binding should preserve kind")
+            }
         }
+    }
+
+    #[test]
+    fn source_word_binding_registers_and_looks_up_in_the_same_namespace() {
+        let mut source_words = SourceWordRegistry::new();
+        let binding = source_word_binding(&mut source_words);
+        let mut bindings = Bindings::new();
+
+        assert_eq!(bindings.insert_new(name("SOURCE_ONLY"), binding), Ok(()));
+
+        assert_eq!(bindings.get(&name("source_only")), Some(&binding));
+        assert_eq!(bindings.len(), 1);
     }
 
     #[test]

--- a/crates/tbx-next/src/bootstrap.rs
+++ b/crates/tbx-next/src/bootstrap.rs
@@ -2,6 +2,7 @@ use crate::binding::{Binding, BindingInsertError, Bindings};
 use crate::global_variable::{GlobalVarId, GlobalVariables};
 use crate::name::NormalizedName;
 use crate::publication_name::{validate_publication_name, PublicationNameError};
+use crate::source_word::{NativeSourceWordHandler, SourceWordId, SourceWordRegistry};
 use crate::word::{CompletedWordDefinition, PrimitiveId, PublishedWords, WordId};
 
 const BUILTIN_GLOBAL_VARIABLE_NAMES: [&str; 26] = [
@@ -19,6 +20,13 @@ pub(crate) enum PrimitiveBootstrapError {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum BuiltinGlobalBootstrapError {
     NameConflict,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SourceWordBootstrapError {
+    ReservedName,
+    NameConflict,
+    BindingRegistrationInvariantViolated,
 }
 
 /// Registers one primitive word through the bootstrap-only publication boundary.
@@ -82,6 +90,34 @@ pub(crate) fn register_builtin_global_variables(
     Ok(ids)
 }
 
+/// Registers one native source word in the shared published name table.
+///
+/// Source word handlers are stored separately from executable word definitions
+/// so a published source word cannot be reached through `WordId` or
+/// `Instruction::Call`. As with primitive bootstrap, name conflicts are
+/// prechecked before issuing the monotonic source-word ID.
+pub(crate) fn register_native_source_word(
+    source_words: &mut SourceWordRegistry,
+    bindings: &mut Bindings,
+    name: NormalizedName,
+    handler: NativeSourceWordHandler,
+) -> Result<SourceWordId, SourceWordBootstrapError> {
+    validate_publication_name(&name)
+        .map_err(SourceWordBootstrapError::from_publication_name_error)?;
+
+    if bindings.get(&name).is_some() {
+        return Err(SourceWordBootstrapError::NameConflict);
+    }
+
+    let id = source_words.register(handler);
+
+    bindings
+        .insert_new(name, Binding::SourceWord(id))
+        .map_err(SourceWordBootstrapError::from_binding_insert_error)?;
+
+    Ok(id)
+}
+
 fn builtin_global_variable_names() -> [NormalizedName; 26] {
     BUILTIN_GLOBAL_VARIABLE_NAMES.map(|name| {
         NormalizedName::new(name).expect("built-in global variable name should be valid")
@@ -102,10 +138,25 @@ impl PrimitiveBootstrapError {
     }
 }
 
+impl SourceWordBootstrapError {
+    fn from_publication_name_error(error: PublicationNameError) -> Self {
+        match error {
+            PublicationNameError::ReservedName => Self::ReservedName,
+        }
+    }
+
+    fn from_binding_insert_error(error: BindingInsertError) -> Self {
+        match error {
+            BindingInsertError::NameConflict => Self::BindingRegistrationInvariantViolated,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::global_variable::GlobalVariables;
+    use crate::source_word::{NativeSourceWordContext, SourceWordError};
     use crate::value::Value;
     use crate::word::WordDefinition;
     use std::collections::HashSet;
@@ -116,6 +167,10 @@ mod tests {
 
     fn primitive(slot: usize) -> PrimitiveId {
         PrimitiveId::from_slot(slot)
+    }
+
+    fn source_handler(_context: &mut NativeSourceWordContext<'_>) -> Result<(), SourceWordError> {
+        Ok(())
     }
 
     fn assert_primitive(words: &PublishedWords, id: WordId, expected: PrimitiveId) {
@@ -135,6 +190,13 @@ mod tests {
         assert_eq!(
             bindings.get(&name(input)),
             Some(&Binding::Variable(expected))
+        );
+    }
+
+    fn assert_source_word_binding(bindings: &Bindings, input: &str, expected: SourceWordId) {
+        assert_eq!(
+            bindings.get(&name(input)),
+            Some(&Binding::SourceWord(expected))
         );
     }
 
@@ -353,6 +415,112 @@ mod tests {
 
         assert_word_binding(&bindings, "VM_FREE_BOUNDARY", id);
         assert_primitive(&words, id, primitive(60));
+    }
+
+    #[test]
+    fn empty_collections_accept_first_source_word() {
+        let mut source_words = SourceWordRegistry::new();
+        let mut bindings = Bindings::new();
+
+        let id = register_native_source_word(
+            &mut source_words,
+            &mut bindings,
+            name("SOURCE_TEST"),
+            source_handler,
+        )
+        .expect("new source word name should register");
+
+        assert_eq!(source_words.len(), 1);
+        assert_eq!(bindings.len(), 1);
+        assert_source_word_binding(&bindings, "source_test", id);
+    }
+
+    #[test]
+    fn duplicate_source_word_registration_is_rejected_without_mutation() {
+        let mut source_words = SourceWordRegistry::new();
+        let mut bindings = Bindings::new();
+        let first = register_native_source_word(
+            &mut source_words,
+            &mut bindings,
+            name("DUP_SOURCE"),
+            source_handler,
+        )
+        .expect("first source word should register");
+
+        let result = register_native_source_word(
+            &mut source_words,
+            &mut bindings,
+            name("dup_source"),
+            source_handler,
+        );
+
+        assert_eq!(result, Err(SourceWordBootstrapError::NameConflict));
+        assert_eq!(source_words.len(), 1);
+        assert_eq!(bindings.len(), 1);
+        assert_source_word_binding(&bindings, "DUP_SOURCE", first);
+    }
+
+    #[test]
+    fn primitive_registration_conflicts_with_existing_source_word_binding() {
+        let mut words = PublishedWords::new();
+        let mut source_words = SourceWordRegistry::new();
+        let mut bindings = Bindings::new();
+        let source_word = register_native_source_word(
+            &mut source_words,
+            &mut bindings,
+            name("SHARED"),
+            source_handler,
+        )
+        .expect("source word should register");
+
+        let result = register_primitive(&mut words, &mut bindings, name("shared"), primitive(82));
+
+        assert_eq!(result, Err(PrimitiveBootstrapError::NameConflict));
+        assert_eq!(words.len(), 0);
+        assert_eq!(source_words.len(), 1);
+        assert_source_word_binding(&bindings, "SHARED", source_word);
+    }
+
+    #[test]
+    fn source_word_registration_conflicts_with_existing_runtime_word_binding() {
+        let mut words = PublishedWords::new();
+        let mut source_words = SourceWordRegistry::new();
+        let mut bindings = Bindings::new();
+        let word = register_primitive(&mut words, &mut bindings, name("SHARED"), primitive(83))
+            .expect("primitive should register");
+
+        let result = register_native_source_word(
+            &mut source_words,
+            &mut bindings,
+            name("shared"),
+            source_handler,
+        );
+
+        assert_eq!(result, Err(SourceWordBootstrapError::NameConflict));
+        assert_eq!(source_words.len(), 0);
+        assert_word_binding(&bindings, "SHARED", word);
+    }
+
+    #[test]
+    fn source_word_registration_conflicts_with_existing_variable_binding() {
+        let mut globals = GlobalVariables::new();
+        let mut source_words = SourceWordRegistry::new();
+        let mut bindings = Bindings::new();
+        let variable = globals.allocate();
+        bindings
+            .insert_new(name("A"), Binding::Variable(variable))
+            .expect("test variable should register");
+
+        let result = register_native_source_word(
+            &mut source_words,
+            &mut bindings,
+            name("a"),
+            source_handler,
+        );
+
+        assert_eq!(result, Err(SourceWordBootstrapError::NameConflict));
+        assert_eq!(source_words.len(), 0);
+        assert_variable_binding(&bindings, "A", variable);
     }
 
     #[test]

--- a/crates/tbx-next/src/lib.rs
+++ b/crates/tbx-next/src/lib.rs
@@ -82,6 +82,11 @@ mod lexer;
 #[allow(dead_code)]
 mod source_processor;
 
+// ADR #1484 keeps source-processing words distinct from runtime executable
+// words while still allowing published source words to share ordinary binding.
+#[allow(dead_code)]
+mod source_word;
+
 // ADR #1442 keeps expression operators as published primitive words resolved
 // through a crate-internal lookup instead of surface name bindings.
 #[allow(dead_code)]

--- a/crates/tbx-next/src/source_processor.rs
+++ b/crates/tbx-next/src/source_processor.rs
@@ -13,10 +13,15 @@ use crate::source_mapping::{
     InstructionSourceMapping, InstructionSourceMappingView, SourceMappingAppendError,
     SourceMappingLookup, SourceMappingLookupError,
 };
+use crate::source_word::{
+    NativeSourceWordContext, SourceWordError, SourceWordLookup, SourceWordLookupError,
+};
 use crate::value::Value;
 use crate::vm::{ExecutionView, RunOutcome, Vm, VmError};
 use crate::word_lookup::PublishedWordLookup;
-use crate::word_resolution::{resolve_word_name, WordResolutionError};
+use crate::word_resolution::{
+    resolve_binding_name, resolve_word_name, ResolvedBinding, WordResolutionError,
+};
 use std::collections::HashSet;
 
 #[derive(Debug)]
@@ -30,6 +35,7 @@ pub(crate) struct TemporaryExecutionUnit {
 pub(crate) struct SourceCompileContext<'a> {
     bindings: &'a Bindings,
     operators: Option<OperatorLookup>,
+    source_words: Option<SourceWordLookup<'a>>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -62,6 +68,8 @@ pub(crate) enum SourceProcessorError {
     CodeSpaceLookup(CodeSpaceLookupError),
     SourceMappingAppend(SourceMappingAppendError),
     SourceMappingLookup(SourceMappingLookupError),
+    SourceWordLookup(SourceWordLookupError),
+    SourceWord(SourceWordError),
     Runtime(RuntimeError),
 }
 
@@ -134,6 +142,18 @@ impl From<SourceMappingAppendError> for SourceProcessorError {
 impl From<SourceMappingLookupError> for SourceProcessorError {
     fn from(error: SourceMappingLookupError) -> Self {
         Self::SourceMappingLookup(error)
+    }
+}
+
+impl From<SourceWordLookupError> for SourceProcessorError {
+    fn from(error: SourceWordLookupError) -> Self {
+        Self::SourceWordLookup(error)
+    }
+}
+
+impl From<SourceWordError> for SourceProcessorError {
+    fn from(error: SourceWordError) -> Self {
+        Self::SourceWord(error)
     }
 }
 
@@ -290,6 +310,17 @@ fn compile_statement_body(
         );
     }
 
+    if compile_statement_leading_source_word(
+        view,
+        source_id,
+        tokens,
+        context,
+        instructions,
+        mapping,
+    )? {
+        return Ok(());
+    }
+
     if source_requires_expression(tokens) {
         let Some(operators) = context.operators() else {
             let token = first_expression_syntax_token(tokens)
@@ -305,6 +336,51 @@ fn compile_statement_body(
     } else {
         compile_simple_tokens(view, tokens, context, instructions, mapping)
     }
+}
+
+fn compile_statement_leading_source_word(
+    view: SourceView<'_>,
+    source_id: SourceId,
+    tokens: &[Token],
+    context: SourceCompileContext<'_>,
+    instructions: &mut InstructionSequence,
+    mapping: &mut InstructionSourceMapping,
+) -> Result<bool, SourceProcessorError> {
+    let Some(first) = tokens.first().copied() else {
+        return Ok(false);
+    };
+    if first.kind() != TokenKind::Name {
+        return Ok(false);
+    }
+
+    let source_name = view.slice(first.span())?;
+    let binding = match resolve_binding_name(context.bindings(), source_name) {
+        Ok(binding) => binding,
+        Err(WordResolutionError::InvalidWordName | WordResolutionError::UndefinedName) => {
+            return Ok(false);
+        }
+        Err(WordResolutionError::TargetIsNotWord) => {
+            unreachable!("binding-kind resolution does not classify published bindings as non-word")
+        }
+    };
+
+    let ResolvedBinding::SourceWord(id) = binding else {
+        return Ok(false);
+    };
+    let Some(source_words) = context.source_words() else {
+        return Err(CompileError {
+            span: first.span(),
+            kind: CompileErrorKind::WordResolution {
+                source: WordResolutionError::TargetIsNotWord,
+            },
+        }
+        .into());
+    };
+    let handler = source_words.lookup_handler(id)?;
+    let mut source_word_context =
+        NativeSourceWordContext::new(view, source_id, tokens, instructions, mapping);
+    handler(&mut source_word_context)?;
+    Ok(true)
 }
 
 fn compile_simple_tokens(
@@ -904,6 +980,7 @@ impl<'a> SourceCompileContext<'a> {
         Self {
             bindings,
             operators: None,
+            source_words: None,
         }
     }
 
@@ -911,6 +988,30 @@ impl<'a> SourceCompileContext<'a> {
         Self {
             bindings,
             operators: Some(operators),
+            source_words: None,
+        }
+    }
+
+    pub(crate) const fn with_source_words(
+        bindings: &'a Bindings,
+        source_words: SourceWordLookup<'a>,
+    ) -> Self {
+        Self {
+            bindings,
+            operators: None,
+            source_words: Some(source_words),
+        }
+    }
+
+    pub(crate) const fn with_source_words_and_operators(
+        bindings: &'a Bindings,
+        source_words: SourceWordLookup<'a>,
+        operators: OperatorLookup,
+    ) -> Self {
+        Self {
+            bindings,
+            operators: Some(operators),
+            source_words: Some(source_words),
         }
     }
 
@@ -920,6 +1021,10 @@ impl<'a> SourceCompileContext<'a> {
 
     pub(crate) const fn operators(self) -> Option<OperatorLookup> {
         self.operators
+    }
+
+    pub(crate) const fn source_words(self) -> Option<SourceWordLookup<'a>> {
+        self.source_words
     }
 }
 
@@ -946,6 +1051,41 @@ impl<'a> SourceExecutionContext<'a> {
     ) -> Self {
         Self {
             compile: SourceCompileContext::with_operators(bindings, operators),
+            code_spaces: &[],
+            source_mappings: &[],
+            words,
+            primitives,
+        }
+    }
+
+    pub(crate) const fn with_source_words(
+        bindings: &'a Bindings,
+        source_words: SourceWordLookup<'a>,
+        words: PublishedWordLookup<'a>,
+        primitives: PrimitiveLookup<'a>,
+    ) -> Self {
+        Self {
+            compile: SourceCompileContext::with_source_words(bindings, source_words),
+            code_spaces: &[],
+            source_mappings: &[],
+            words,
+            primitives,
+        }
+    }
+
+    pub(crate) const fn with_source_words_and_operators(
+        bindings: &'a Bindings,
+        source_words: SourceWordLookup<'a>,
+        operators: OperatorLookup,
+        words: PublishedWordLookup<'a>,
+        primitives: PrimitiveLookup<'a>,
+    ) -> Self {
+        Self {
+            compile: SourceCompileContext::with_source_words_and_operators(
+                bindings,
+                source_words,
+                operators,
+            ),
             code_spaces: &[],
             source_mappings: &[],
             words,
@@ -1074,7 +1214,7 @@ impl CompileError {
 mod tests {
     use super::*;
     use crate::binding::{Binding, Bindings};
-    use crate::bootstrap::register_primitive;
+    use crate::bootstrap::{register_native_source_word, register_primitive};
     use crate::lexer::InvalidCharacterReason;
     use crate::name::NormalizedName;
     use crate::operator::{register_operator_primitives, OperatorSemantic, OperatorWords};
@@ -1082,6 +1222,7 @@ mod tests {
     use crate::redefinition::redefine_word;
     use crate::source::SourceTexts;
     use crate::source_mapping::{SourceMappingLookup, SourceMappingLookupError};
+    use crate::source_word::{NativeSourceWordContext, SourceWordRegistry};
     use crate::word::{CompletedWordDefinition, PrimitiveId, PublishedWords, WordId};
     use crate::word_lookup::PublishedWordLookup;
 
@@ -1247,6 +1388,17 @@ mod tests {
         )
         .expect("source should run with operators");
         (sources, id, result)
+    }
+
+    fn emit_source_word_marker(
+        context: &mut NativeSourceWordContext<'_>,
+    ) -> Result<(), SourceWordError> {
+        let first = context
+            .tokens()
+            .first()
+            .copied()
+            .expect("source word handler should receive statement tokens");
+        context.append_mapped(Instruction::Push(value(99)), first.span())
     }
 
     fn value(value: i16) -> Value {
@@ -2162,6 +2314,160 @@ mod tests {
         assert_eq!(
             unit.source_span(location(&unit, 2)),
             Ok(Some(span(view, id, 9, 14)))
+        );
+    }
+
+    #[test]
+    fn statement_leading_source_word_dispatches_through_binding_resolution() {
+        let mut source_words = SourceWordRegistry::new();
+        let words = PublishedWords::new();
+        let primitives = PrimitiveRegistry::new();
+        let mut bindings = Bindings::new();
+        let source_word = register_native_source_word(
+            &mut source_words,
+            &mut bindings,
+            name("SOURCE_MARKER"),
+            emit_source_word_marker,
+        )
+        .expect("source word should register");
+        let (sources, source_id) = source("source_marker");
+
+        let unit = compile_source(
+            sources.view(),
+            source_id,
+            SourceCompileContext::with_source_words(&bindings, source_words.lookup()),
+        )
+        .expect("source word should compile");
+
+        assert_eq!(words.len(), 0);
+        assert_eq!(source_word.as_slot(), 0);
+        assert_eq!(
+            unit.instructions().get(address(0)),
+            Ok(&Instruction::Push(value(99)))
+        );
+        assert_eq!(unit.instructions().get(address(1)), Ok(&Instruction::Halt));
+
+        let result = run_unit(
+            &unit,
+            SourceExecutionContext::with_source_words(
+                &bindings,
+                source_words.lookup(),
+                PublishedWordLookup::new(&words),
+                primitives.lookup(),
+            ),
+        )
+        .expect("source word unit should run");
+        assert_eq!(result.data_stack(), [value(99)]);
+    }
+
+    #[test]
+    fn source_word_case_variants_dispatch_to_same_handler() {
+        let mut source_words = SourceWordRegistry::new();
+        let mut bindings = Bindings::new();
+        register_native_source_word(
+            &mut source_words,
+            &mut bindings,
+            name("SOURCE_MARKER"),
+            emit_source_word_marker,
+        )
+        .expect("source word should register");
+
+        let (_sources, _source_id, unit) = {
+            let (sources, source_id) = source("source_marker\nSource_Marker\nSOURCE_MARKER");
+            let unit = compile_source(
+                sources.view(),
+                source_id,
+                SourceCompileContext::with_source_words(&bindings, source_words.lookup()),
+            )
+            .expect("source word case variants should compile");
+            (sources, source_id, unit)
+        };
+
+        assert_eq!(unit.len(), 4);
+        assert_eq!(
+            unit.instructions().get(address(0)),
+            Ok(&Instruction::Push(value(99)))
+        );
+        assert_eq!(
+            unit.instructions().get(address(1)),
+            Ok(&Instruction::Push(value(99)))
+        );
+        assert_eq!(
+            unit.instructions().get(address(2)),
+            Ok(&Instruction::Push(value(99)))
+        );
+    }
+
+    #[test]
+    fn source_word_binding_does_not_lower_to_runtime_call() {
+        let mut source_words = SourceWordRegistry::new();
+        let mut bindings = Bindings::new();
+        register_native_source_word(
+            &mut source_words,
+            &mut bindings,
+            name("SOURCE_MARKER"),
+            emit_source_word_marker,
+        )
+        .expect("source word should register");
+
+        let (_sources, _source_id, unit) = {
+            let (sources, source_id) = source("source_marker");
+            let unit = compile_source(
+                sources.view(),
+                source_id,
+                SourceCompileContext::with_source_words(&bindings, source_words.lookup()),
+            )
+            .expect("source word should compile");
+            (sources, source_id, unit)
+        };
+
+        assert!(!matches!(
+            unit.instructions().get(address(0)),
+            Ok(Instruction::Call(_))
+        ));
+    }
+
+    #[test]
+    fn variable_and_unresolved_leading_names_are_not_source_word_dispatch() {
+        let mut globals = crate::global_variable::GlobalVariables::new();
+        let variable = globals.allocate();
+        let mut bindings = Bindings::new();
+        bindings
+            .insert_new(name("A"), Binding::Variable(variable))
+            .expect("variable should register");
+
+        let (sources, source_id) = source("A");
+        let variable_error = compile_source(
+            sources.view(),
+            source_id,
+            SourceCompileContext::new(&bindings),
+        )
+        .expect_err("variable should not dispatch as source word");
+        assert_eq!(
+            variable_error,
+            SourceProcessorError::Compile(CompileError {
+                span: span(sources.view(), source_id, 0, 1),
+                kind: CompileErrorKind::WordResolution {
+                    source: WordResolutionError::TargetIsNotWord
+                },
+            })
+        );
+
+        let (sources, source_id) = source("MISSING");
+        let unresolved_error = compile_source(
+            sources.view(),
+            source_id,
+            SourceCompileContext::new(&bindings),
+        )
+        .expect_err("unresolved name should not dispatch as source word");
+        assert_eq!(
+            unresolved_error,
+            SourceProcessorError::Compile(CompileError {
+                span: span(sources.view(), source_id, 0, 7),
+                kind: CompileErrorKind::WordResolution {
+                    source: WordResolutionError::UndefinedName
+                },
+            })
         );
     }
 

--- a/crates/tbx-next/src/source_processor.rs
+++ b/crates/tbx-next/src/source_processor.rs
@@ -14,7 +14,7 @@ use crate::source_mapping::{
     SourceMappingLookup, SourceMappingLookupError,
 };
 use crate::source_word::{
-    NativeSourceWordContext, SourceWordError, SourceWordLookup, SourceWordLookupError,
+    NativeSourceWordContext, SourceWordError, SourceWordId, SourceWordLookup, SourceWordLookupError,
 };
 use crate::value::Value;
 use crate::vm::{ExecutionView, RunOutcome, Vm, VmError};
@@ -68,6 +68,7 @@ pub(crate) enum SourceProcessorError {
     CodeSpaceLookup(CodeSpaceLookupError),
     SourceMappingAppend(SourceMappingAppendError),
     SourceMappingLookup(SourceMappingLookupError),
+    SourceWordContextUnavailable { id: SourceWordId },
     SourceWordLookup(SourceWordLookupError),
     SourceWord(SourceWordError),
     Runtime(RuntimeError),
@@ -368,13 +369,7 @@ fn compile_statement_leading_source_word(
         return Ok(false);
     };
     let Some(source_words) = context.source_words() else {
-        return Err(CompileError {
-            span: first.span(),
-            kind: CompileErrorKind::WordResolution {
-                source: WordResolutionError::TargetIsNotWord,
-            },
-        }
-        .into());
+        return Err(SourceProcessorError::SourceWordContextUnavailable { id });
     };
     let handler = source_words.lookup_handler(id)?;
     let mut source_word_context =
@@ -2425,6 +2420,32 @@ mod tests {
             unit.instructions().get(address(0)),
             Ok(Instruction::Call(_))
         ));
+    }
+
+    #[test]
+    fn source_word_binding_without_lookup_is_internal_context_error() {
+        let mut source_words = SourceWordRegistry::new();
+        let mut bindings = Bindings::new();
+        let source_word = register_native_source_word(
+            &mut source_words,
+            &mut bindings,
+            name("SOURCE_MARKER"),
+            emit_source_word_marker,
+        )
+        .expect("source word should register");
+        let (sources, source_id) = source("source_marker");
+
+        let error = compile_source(
+            sources.view(),
+            source_id,
+            SourceCompileContext::new(&bindings),
+        )
+        .expect_err("source word binding without lookup should fail as context error");
+
+        assert_eq!(
+            error,
+            SourceProcessorError::SourceWordContextUnavailable { id: source_word }
+        );
     }
 
     #[test]

--- a/crates/tbx-next/src/source_word.rs
+++ b/crates/tbx-next/src/source_word.rs
@@ -1,0 +1,222 @@
+use crate::instruction::{Instruction, InstructionSequence};
+use crate::lexer::Token;
+use crate::source::{SourceId, SourceSpan, SourceView};
+use crate::source_mapping::{InstructionSourceMapping, SourceMappingAppendError};
+
+/// Internal identifier for a published source-processing word.
+///
+/// Source words share ordinary name binding with runtime words and variables,
+/// but they are intentionally not executable runtime words and never receive a
+/// `WordId`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct SourceWordId {
+    slot: usize,
+}
+
+impl SourceWordId {
+    pub(crate) const fn from_slot(slot: usize) -> Self {
+        Self { slot }
+    }
+
+    pub(crate) const fn as_slot(self) -> usize {
+        self.slot
+    }
+}
+
+pub(crate) type NativeSourceWordHandler =
+    fn(&mut NativeSourceWordContext<'_>) -> Result<(), SourceWordError>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SourceWordError {
+    SourceMappingAppend { source: SourceMappingAppendError },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SourceWordLookupError {
+    InvalidSourceWordId { id: SourceWordId },
+}
+
+/// Narrow source-processing capability passed to native source words.
+///
+/// This is deliberately smaller than a compiler or VM handle. Native source
+/// words can inspect the current logical statement and emit mapped temporary
+/// instructions, but they cannot mutate bindings, words, globals, runtime VM
+/// state, or published code spaces through this context.
+pub(crate) struct NativeSourceWordContext<'a> {
+    view: SourceView<'a>,
+    source_id: SourceId,
+    tokens: &'a [Token],
+    instructions: &'a mut InstructionSequence,
+    mapping: &'a mut InstructionSourceMapping,
+}
+
+impl<'a> NativeSourceWordContext<'a> {
+    pub(crate) fn new(
+        view: SourceView<'a>,
+        source_id: SourceId,
+        tokens: &'a [Token],
+        instructions: &'a mut InstructionSequence,
+        mapping: &'a mut InstructionSourceMapping,
+    ) -> Self {
+        Self {
+            view,
+            source_id,
+            tokens,
+            instructions,
+            mapping,
+        }
+    }
+
+    pub(crate) const fn view(&self) -> SourceView<'a> {
+        self.view
+    }
+
+    pub(crate) const fn source_id(&self) -> SourceId {
+        self.source_id
+    }
+
+    pub(crate) const fn tokens(&self) -> &'a [Token] {
+        self.tokens
+    }
+
+    pub(crate) fn append_mapped(
+        &mut self,
+        instruction: Instruction,
+        span: SourceSpan,
+    ) -> Result<(), SourceWordError> {
+        let address = self.instructions.append(instruction);
+        self.mapping
+            .append_mapped(address, span)
+            .map_err(|source| SourceWordError::SourceMappingAppend { source })
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct SourceWordRegistry {
+    handlers: Vec<NativeSourceWordHandler>,
+}
+
+impl SourceWordRegistry {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn register(&mut self, handler: NativeSourceWordHandler) -> SourceWordId {
+        let id = SourceWordId::from_slot(self.handlers.len());
+        self.handlers.push(handler);
+        id
+    }
+
+    pub(crate) fn lookup(&self) -> SourceWordLookup<'_> {
+        SourceWordLookup { registry: self }
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.handlers.len()
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.handlers.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SourceWordLookup<'a> {
+    registry: &'a SourceWordRegistry,
+}
+
+impl SourceWordLookup<'_> {
+    pub(crate) fn lookup_handler(
+        self,
+        id: SourceWordId,
+    ) -> Result<NativeSourceWordHandler, SourceWordLookupError> {
+        self.registry
+            .handlers
+            .get(id.as_slot())
+            .copied()
+            .ok_or(SourceWordLookupError::InvalidSourceWordId { id })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::source::SourceTexts;
+    use crate::value::Value;
+
+    fn push_one(context: &mut NativeSourceWordContext<'_>) -> Result<(), SourceWordError> {
+        let first = context
+            .tokens()
+            .first()
+            .copied()
+            .expect("test source word should receive its leading token");
+        context.append_mapped(Instruction::Push(Value::integer(1)), first.span())
+    }
+
+    #[test]
+    fn registry_allocates_monotonic_source_word_ids_without_word_ids() {
+        let mut registry = SourceWordRegistry::new();
+
+        let first = registry.register(push_one);
+        let second = registry.register(push_one);
+
+        assert_eq!(first.as_slot(), 0);
+        assert_eq!(second.as_slot(), 1);
+        assert_ne!(first, second);
+        assert_eq!(registry.len(), 2);
+        assert!(!registry.is_empty());
+    }
+
+    #[test]
+    fn read_only_lookup_resolves_registered_handler() {
+        let mut registry = SourceWordRegistry::new();
+        let id = registry.register(push_one);
+
+        assert!(registry.lookup().lookup_handler(id).is_ok());
+    }
+
+    #[test]
+    fn read_only_lookup_rejects_unregistered_source_word_id() {
+        let registry = SourceWordRegistry::new();
+        let id = SourceWordId::from_slot(0);
+
+        assert_eq!(
+            registry.lookup().lookup_handler(id),
+            Err(SourceWordLookupError::InvalidSourceWordId { id })
+        );
+    }
+
+    #[test]
+    fn native_context_emits_mapped_temporary_instruction() {
+        let mut sources = SourceTexts::new();
+        let source_id = sources.register("TEST");
+        let mut lexer = crate::lexer::Lexer::new(sources.view(), source_id)
+            .expect("test source should create lexer");
+        let mut tokens = Vec::new();
+        loop {
+            let token = lexer.next_token().expect("test source should lex");
+            tokens.push(token);
+            if token.kind() == crate::lexer::TokenKind::Eof {
+                break;
+            }
+        }
+        let mut instructions = InstructionSequence::new();
+        let mut mapping = InstructionSourceMapping::new(instructions.code_space());
+        let mut context = NativeSourceWordContext::new(
+            sources.view(),
+            source_id,
+            &tokens[..1],
+            &mut instructions,
+            &mut mapping,
+        );
+
+        push_one(&mut context).expect("test source word should emit");
+
+        assert_eq!(
+            instructions
+                .view()
+                .get(crate::instruction::InstructionAddress::from_index(0)),
+            Ok(&Instruction::Push(Value::integer(1)))
+        );
+    }
+}

--- a/crates/tbx-next/src/word_resolution.rs
+++ b/crates/tbx-next/src/word_resolution.rs
@@ -1,5 +1,7 @@
 use crate::binding::{Binding, Bindings};
+use crate::global_variable::GlobalVarId;
 use crate::name::{NameError, NormalizedName};
+use crate::source_word::SourceWordId;
 use crate::word::WordId;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -7,6 +9,13 @@ pub(crate) enum WordResolutionError {
     InvalidWordName,
     UndefinedName,
     TargetIsNotWord,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ResolvedBinding {
+    RuntimeWord(WordId),
+    SourceWord(SourceWordId),
+    Variable(GlobalVarId),
 }
 
 /// Resolves a source word name through the current published binding only.
@@ -29,7 +38,23 @@ pub(crate) fn resolve_normalized_word(
 ) -> Result<WordId, WordResolutionError> {
     match bindings.get(name) {
         Some(Binding::Word(id)) => Ok(*id),
-        Some(Binding::Variable(_)) => Err(WordResolutionError::TargetIsNotWord),
+        Some(Binding::SourceWord(_) | Binding::Variable(_)) => {
+            Err(WordResolutionError::TargetIsNotWord)
+        }
+        None => Err(WordResolutionError::UndefinedName),
+    }
+}
+
+pub(crate) fn resolve_binding_name(
+    bindings: &Bindings,
+    source_name: &str,
+) -> Result<ResolvedBinding, WordResolutionError> {
+    let name = NormalizedName::new(source_name).map_err(WordResolutionError::from)?;
+
+    match bindings.get(&name) {
+        Some(Binding::Word(id)) => Ok(ResolvedBinding::RuntimeWord(*id)),
+        Some(Binding::SourceWord(id)) => Ok(ResolvedBinding::SourceWord(*id)),
+        Some(Binding::Variable(id)) => Ok(ResolvedBinding::Variable(*id)),
         None => Err(WordResolutionError::UndefinedName),
     }
 }
@@ -51,6 +76,7 @@ mod tests {
     use crate::instruction::{Instruction, InstructionSequence};
     use crate::name::NormalizedName;
     use crate::redefinition::redefine_word;
+    use crate::source_word::SourceWordRegistry;
     use crate::value::Value;
     use crate::word::{
         CompletedWordDefinition, PrimitiveId, PublishedWords, WordDefinition, WordId,
@@ -88,6 +114,12 @@ mod tests {
             .insert_new(name(input), Binding::Word(id))
             .expect("initial test binding should register");
         id
+    }
+
+    fn source_handler(
+        _context: &mut crate::source_word::NativeSourceWordContext<'_>,
+    ) -> Result<(), crate::source_word::SourceWordError> {
+        Ok(())
     }
 
     #[test]
@@ -257,6 +289,55 @@ mod tests {
         assert_eq!(
             resolve_word_name(&bindings, "A"),
             Err(WordResolutionError::TargetIsNotWord)
+        );
+    }
+
+    #[test]
+    fn published_source_word_resolves_as_source_binding_not_runtime_word() {
+        let mut source_words = SourceWordRegistry::new();
+        let id = source_words.register(source_handler);
+        let mut bindings = Bindings::new();
+        bindings
+            .insert_new(name("SOURCE_ONLY"), Binding::SourceWord(id))
+            .expect("source word should register");
+
+        assert_eq!(
+            resolve_binding_name(&bindings, "source_only"),
+            Ok(ResolvedBinding::SourceWord(id))
+        );
+        assert_eq!(
+            resolve_word_name(&bindings, "SOURCE_ONLY"),
+            Err(WordResolutionError::TargetIsNotWord)
+        );
+    }
+
+    #[test]
+    fn binding_resolution_preserves_runtime_source_and_variable_kinds() {
+        let mut words = PublishedWords::new();
+        let mut source_words = SourceWordRegistry::new();
+        let mut globals = GlobalVariables::new();
+        let mut bindings = Bindings::new();
+        let runtime = publish_initial(&mut words, &mut bindings, "RUNME", completed_primitive(8));
+        let source = source_words.register(source_handler);
+        let variable = globals.allocate();
+        bindings
+            .insert_new(name("SOURCE_ONLY"), Binding::SourceWord(source))
+            .expect("source word should register");
+        bindings
+            .insert_new(name("A"), Binding::Variable(variable))
+            .expect("variable should register");
+
+        assert_eq!(
+            resolve_binding_name(&bindings, "runme"),
+            Ok(ResolvedBinding::RuntimeWord(runtime))
+        );
+        assert_eq!(
+            resolve_binding_name(&bindings, "source_only"),
+            Ok(ResolvedBinding::SourceWord(source))
+        );
+        assert_eq!(
+            resolve_binding_name(&bindings, "a"),
+            Ok(ResolvedBinding::Variable(variable))
         );
     }
 }


### PR DESCRIPTION
## Summary

- runtime word / source word / variable を `Binding` と名前解決結果で区別
- runtime `WordId` とは別に `SourceWordId` と native source word registry / lookup / handler context を追加
- statement-leading `Name` から通常のbinding resolutionを通じてsource word handlerへdispatch
- テスト用source wordで登録、case-insensitive lookup、名前衝突、dispatch、`Call(WordId)` 非混入を検証

## Scope notes

- `BIF` の既存 spelling 特例と production lowering は維持
- bare expression rejection、`VAR`、`LET`、safe reader、quotation、public API / runtime `Value` / VM instruction set は未変更

## Verification

- `cargo test -p tbx-next`
- `cargo ci-clippy`
- `cargo ci-test`
- `cargo ci-fmt`

Closes #1483
