### PR TITLE
TBX Next: expression Name primaryをLoadVarへlowerする

### DIFF
--- a/crates/tbx-next/src/expression.rs
+++ b/crates/tbx-next/src/expression.rs
@@ -1,3 +1,4 @@
+use crate::global_variable::GlobalVarId;
 use crate::instruction::{Instruction, InstructionSequence};
 use crate::lexer::{Token, TokenKind};
 use crate::operator::{OperatorLookup, OperatorSemantic};
@@ -20,6 +21,7 @@ pub(crate) struct StagedInstruction {
 pub(crate) enum ExpressionError {
     Source(SourceError),
     Syntax(ExpressionSyntaxError),
+    Variable(ExpressionVariableError),
     SourceMappingAppend(SourceMappingAppendError),
 }
 
@@ -40,6 +42,26 @@ pub(crate) enum ExpressionSyntaxErrorKind {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ExpressionVariableError {
+    span: SourceSpan,
+    kind: ExpressionVariableErrorKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ExpressionVariableErrorKind {
+    InvalidName,
+    UndefinedName,
+    TargetIsNotVariable,
+}
+
+pub(crate) trait ExpressionVariableResolver {
+    fn resolve_variable(
+        &self,
+        source_name: &str,
+    ) -> Result<GlobalVarId, ExpressionVariableErrorKind>;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct ParsedExpression {
     contains_comparison: bool,
 }
@@ -51,11 +73,12 @@ struct BinaryOperator {
     comparison: bool,
 }
 
-#[derive(Debug, Clone, Copy)]
-struct ExpressionParser<'a> {
+#[derive(Clone, Copy)]
+struct ExpressionParser<'a, 'r> {
     view: SourceView<'a>,
     tokens: &'a [Token],
     operators: OperatorLookup,
+    variables: &'r dyn ExpressionVariableResolver,
     position: usize,
 }
 
@@ -68,9 +91,22 @@ pub(crate) fn parse_expression(
     view: SourceView<'_>,
     tokens: &[Token],
     operators: OperatorLookup,
+    variables: &dyn ExpressionVariableResolver,
 ) -> Result<ExpressionStaging, ExpressionError> {
-    let mut parser = ExpressionParser::new(view, tokens, operators);
+    let mut parser = ExpressionParser::new(view, tokens, operators, variables);
     parser.parse_complete()
+}
+
+impl<F> ExpressionVariableResolver for F
+where
+    F: Fn(&str) -> Result<GlobalVarId, ExpressionVariableErrorKind>,
+{
+    fn resolve_variable(
+        &self,
+        source_name: &str,
+    ) -> Result<GlobalVarId, ExpressionVariableErrorKind> {
+        self(source_name)
+    }
 }
 
 impl ExpressionStaging {
@@ -128,18 +164,34 @@ impl ExpressionSyntaxError {
     }
 }
 
+impl ExpressionVariableError {
+    pub(crate) const fn span(self) -> SourceSpan {
+        self.span
+    }
+
+    pub(crate) const fn kind(self) -> ExpressionVariableErrorKind {
+        self.kind
+    }
+}
+
 impl From<SourceError> for ExpressionError {
     fn from(error: SourceError) -> Self {
         Self::Source(error)
     }
 }
 
-impl<'a> ExpressionParser<'a> {
-    fn new(view: SourceView<'a>, tokens: &'a [Token], operators: OperatorLookup) -> Self {
+impl<'a, 'r> ExpressionParser<'a, 'r> {
+    fn new(
+        view: SourceView<'a>,
+        tokens: &'a [Token],
+        operators: OperatorLookup,
+        variables: &'r dyn ExpressionVariableResolver,
+    ) -> Self {
         Self {
             view,
             tokens,
             operators,
+            variables,
             position: 0,
         }
     }
@@ -232,6 +284,23 @@ impl<'a> ExpressionParser<'a> {
                 let token = self.advance();
                 let value = self.parse_unsigned_i16(token)?;
                 staging.push(Instruction::Push(Value::integer(value)), token.span());
+                Ok(ParsedExpression {
+                    contains_comparison: false,
+                })
+            }
+            TokenKind::Name => {
+                let token = self.advance();
+                let source_name = self.view.slice(token.span())?;
+                let id = self
+                    .variables
+                    .resolve_variable(source_name)
+                    .map_err(|kind| {
+                        ExpressionError::Variable(ExpressionVariableError {
+                            span: token.span(),
+                            kind,
+                        })
+                    })?;
+                staging.push(Instruction::LoadVar(id), token.span());
                 Ok(ParsedExpression {
                     contains_comparison: false,
                 })
@@ -427,6 +496,7 @@ mod tests {
     use crate::primitive::PrimitiveRegistry;
     use crate::source::{SourceId, SourceTexts};
     use crate::word::PublishedWords;
+    use std::collections::HashMap;
 
     fn source(text: &str) -> (SourceTexts, SourceId) {
         let mut sources = SourceTexts::new();
@@ -456,19 +526,51 @@ mod tests {
     }
 
     fn parse(text: &str) -> (SourceTexts, SourceId, ExpressionStaging) {
+        parse_with_variables(text, empty_variables())
+    }
+
+    fn parse_with_variables(
+        text: &str,
+        variables: impl ExpressionVariableResolver,
+    ) -> (SourceTexts, SourceId, ExpressionStaging) {
         let (sources, id) = source(text);
         let tokens = lex(sources.view(), id);
-        let staging = parse_expression(sources.view(), &tokens, operators())
+        let staging = parse_expression(sources.view(), &tokens, operators(), &variables)
             .expect("expression should parse");
         (sources, id, staging)
     }
 
     fn parse_error(text: &str) -> (SourceTexts, SourceId, ExpressionError) {
+        parse_error_with_variables(text, empty_variables())
+    }
+
+    fn parse_error_with_variables(
+        text: &str,
+        variables: impl ExpressionVariableResolver,
+    ) -> (SourceTexts, SourceId, ExpressionError) {
         let (sources, id) = source(text);
         let tokens = lex(sources.view(), id);
-        let error = parse_expression(sources.view(), &tokens, operators())
+        let error = parse_expression(sources.view(), &tokens, operators(), &variables)
             .expect_err("expression should fail");
         (sources, id, error)
+    }
+
+    fn empty_variables() -> impl ExpressionVariableResolver {
+        |_source_name: &str| Err(ExpressionVariableErrorKind::UndefinedName)
+    }
+
+    fn variables(cases: &[(&str, GlobalVarId)]) -> impl ExpressionVariableResolver {
+        let variables = cases
+            .iter()
+            .map(|(name, id)| (name.to_ascii_uppercase(), *id))
+            .collect::<HashMap<_, _>>();
+
+        move |source_name: &str| {
+            variables
+                .get(&source_name.to_ascii_uppercase())
+                .copied()
+                .ok_or(ExpressionVariableErrorKind::UndefinedName)
+        }
     }
 
     fn span(view: SourceView<'_>, source_id: SourceId, start: usize, end: usize) -> SourceSpan {
@@ -503,6 +605,19 @@ mod tests {
     ) {
         let ExpressionError::Syntax(error) = error else {
             panic!("expected syntax error");
+        };
+
+        assert_eq!(error.span(), expected_span);
+        assert_eq!(error.kind(), expected_kind);
+    }
+
+    fn assert_variable_error(
+        error: ExpressionError,
+        expected_span: SourceSpan,
+        expected_kind: ExpressionVariableErrorKind,
+    ) {
+        let ExpressionError::Variable(error) = error else {
+            panic!("expected variable resolution error");
         };
 
         assert_eq!(error.span(), expected_span);
@@ -688,17 +803,103 @@ mod tests {
     }
 
     #[test]
-    fn name_and_call_like_sequence_remain_unsupported_primary_syntax() {
-        for source in ["FOO", "FOO(1)"] {
-            let (sources, id, error) = parse_error(source);
-            assert_syntax_error(
-                error,
-                span(sources.view(), id, 0, 3),
-                ExpressionSyntaxErrorKind::UnexpectedToken {
-                    kind: TokenKind::Name,
-                },
+    fn name_primary_lowers_to_load_var_with_original_name_span() {
+        let variable = GlobalVarId::test_invalid(12);
+        let (sources, id, staging) = parse_with_variables("foo", variables(&[("FOO", variable)]));
+
+        assert_eq!(instructions(&staging), [Instruction::LoadVar(variable)]);
+        assert_eq!(spans(&staging), [span(sources.view(), id, 0, 3)]);
+    }
+
+    #[test]
+    fn name_primary_resolution_is_case_insensitive_at_resolver_boundary() {
+        let variable = GlobalVarId::test_invalid(3);
+
+        for source in ["A", "a", "Mixed_Case", "mixed_case"] {
+            let (_sources, _id, staging) = parse_with_variables(
+                source,
+                variables(&[("MIXED_CASE", variable), ("A", variable)]),
             );
+
+            assert_eq!(instructions(&staging), [Instruction::LoadVar(variable)]);
         }
+    }
+
+    #[test]
+    fn name_primary_preserves_postfix_order_with_operators_and_grouping() {
+        let lookup = operators();
+        let a = GlobalVarId::test_invalid(0);
+        let b = GlobalVarId::test_invalid(1);
+        let c = GlobalVarId::test_invalid(2);
+        let (sources, id, staging) =
+            parse_with_variables("(A + B) * C", variables(&[("A", a), ("B", b), ("C", c)]));
+        let view = sources.view();
+
+        assert_eq!(
+            instructions(&staging),
+            [
+                Instruction::LoadVar(a),
+                Instruction::LoadVar(b),
+                call(lookup, OperatorSemantic::Add),
+                Instruction::LoadVar(c),
+                call(lookup, OperatorSemantic::Multiply),
+            ]
+        );
+        assert_eq!(
+            spans(&staging),
+            [
+                span(view, id, 1, 2),
+                span(view, id, 5, 6),
+                span(view, id, 3, 4),
+                span(view, id, 10, 11),
+                span(view, id, 8, 9),
+            ]
+        );
+    }
+
+    #[test]
+    fn name_primary_combines_with_unary_and_comparison() {
+        let lookup = operators();
+        let a = GlobalVarId::test_invalid(0);
+        let b = GlobalVarId::test_invalid(1);
+        let (_sources, _id, staging) =
+            parse_with_variables("-(A) < B", variables(&[("A", a), ("B", b)]));
+
+        assert_eq!(
+            instructions(&staging),
+            [
+                Instruction::LoadVar(a),
+                call(lookup, OperatorSemantic::Negate),
+                Instruction::LoadVar(b),
+                call(lookup, OperatorSemantic::Less),
+            ]
+        );
+    }
+
+    #[test]
+    fn unresolved_name_primary_is_structured_variable_error_at_name_span() {
+        let (sources, id, error) = parse_error("FOO");
+
+        assert_variable_error(
+            error,
+            span(sources.view(), id, 0, 3),
+            ExpressionVariableErrorKind::UndefinedName,
+        );
+    }
+
+    #[test]
+    fn call_like_name_sequence_still_does_not_fallback_to_call_syntax() {
+        let variable = GlobalVarId::test_invalid(4);
+        let (sources, id, error) =
+            parse_error_with_variables("FOO(1)", variables(&[("FOO", variable)]));
+
+        assert_syntax_error(
+            error,
+            span(sources.view(), id, 3, 4),
+            ExpressionSyntaxErrorKind::UnexpectedToken {
+                kind: TokenKind::LParen,
+            },
+        );
     }
 
     #[test]

--- a/crates/tbx-next/src/source_processor.rs
+++ b/crates/tbx-next/src/source_processor.rs
@@ -1,6 +1,8 @@
 use crate::binding::Bindings;
-use crate::expression::{parse_expression, ExpressionError, ExpressionSyntaxErrorKind};
-use crate::global_variable::GlobalVariables;
+use crate::expression::{
+    parse_expression, ExpressionError, ExpressionSyntaxErrorKind, ExpressionVariableErrorKind,
+};
+use crate::global_variable::{GlobalVariableView, GlobalVariables};
 use crate::instruction::{
     CodeLocation, CodeSpaceLookup, CodeSpaceLookupError, Instruction, InstructionAddress,
     InstructionSequence, InstructionView,
@@ -52,6 +54,7 @@ pub(crate) struct SourceExecutionContext<'a> {
     source_words: Option<SourceWordLookup<'a>>,
     code_spaces: &'a [InstructionView<'a>],
     source_mappings: &'a [InstructionSourceMappingView<'a>],
+    globals: Option<GlobalVariableView<'a>>,
     words: PublishedWordLookup<'a>,
     primitives: PrimitiveLookup<'a>,
 }
@@ -101,6 +104,7 @@ pub(crate) enum CompileErrorKind {
     LineNumber { source: LineNumberError },
     WordResolution { source: WordResolutionError },
     Expression { source: ExpressionSyntaxErrorKind },
+    ExpressionVariable { source: ExpressionVariableErrorKind },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -484,6 +488,7 @@ fn compile_bif(
         view,
         source_id,
         &tokens[1..comma_index],
+        context.bindings(),
         operators,
         instructions,
         mapping,
@@ -525,6 +530,7 @@ fn compile_expression_tokens(
     view: SourceView<'_>,
     source_id: SourceId,
     tokens: &[Token],
+    bindings: &Bindings,
     operators: OperatorLookup,
     instructions: &mut InstructionSequence,
     mapping: &mut InstructionSourceMapping,
@@ -539,7 +545,8 @@ fn compile_expression_tokens(
         .map_or(0, |token| token.span().end());
     expression_tokens.push(Token::new(TokenKind::Eof, view.span(source_id, end, end)?));
 
-    parse_expression(view, &expression_tokens, operators)
+    let resolver = |source_name: &str| resolve_variable_name(bindings, source_name);
+    parse_expression(view, &expression_tokens, operators, &resolver)
         .map_err(SourceProcessorError::from_expression_error)?
         .commit_to(instructions, mapping)
         .map_err(SourceProcessorError::from_expression_error)
@@ -566,6 +573,9 @@ fn run_unit(
         context.words(),
         context.primitives(),
     );
+    if let Some(globals) = context.globals() {
+        execution = execution.with_global_reader(globals);
+    }
     let mut vm = Vm::new_at_location_in(&mut execution, unit.entry)
         .map_err(|error| map_runtime_error(error, unit, context))?;
     let outcome = vm
@@ -595,6 +605,23 @@ fn map_runtime_error(
         vm: error,
         source_span,
     })
+}
+
+fn resolve_variable_name(
+    bindings: &Bindings,
+    source_name: &str,
+) -> Result<crate::global_variable::GlobalVarId, ExpressionVariableErrorKind> {
+    match resolve_binding_name(bindings, source_name) {
+        Ok(ResolvedBinding::Variable(id)) => Ok(id),
+        Ok(ResolvedBinding::RuntimeWord(_) | ResolvedBinding::SourceWord(_)) => {
+            Err(ExpressionVariableErrorKind::TargetIsNotVariable)
+        }
+        Err(WordResolutionError::InvalidWordName) => Err(ExpressionVariableErrorKind::InvalidName),
+        Err(WordResolutionError::UndefinedName) => Err(ExpressionVariableErrorKind::UndefinedName),
+        Err(WordResolutionError::TargetIsNotWord) => {
+            unreachable!("binding lookup does not require a runtime word target")
+        }
+    }
 }
 
 fn compile_word_reference(
@@ -1092,6 +1119,7 @@ impl<'a> SourceExecutionContext<'a> {
             source_words: None,
             code_spaces: &[],
             source_mappings: &[],
+            globals: None,
             words,
             primitives,
         }
@@ -1109,6 +1137,7 @@ impl<'a> SourceExecutionContext<'a> {
             source_words: None,
             code_spaces: &[],
             source_mappings: &[],
+            globals: None,
             words,
             primitives,
         }
@@ -1126,6 +1155,7 @@ impl<'a> SourceExecutionContext<'a> {
             source_words: Some(source_words),
             code_spaces: &[],
             source_mappings: &[],
+            globals: None,
             words,
             primitives,
         }
@@ -1144,6 +1174,7 @@ impl<'a> SourceExecutionContext<'a> {
             source_words: Some(source_words),
             code_spaces: &[],
             source_mappings: &[],
+            globals: None,
             words,
             primitives,
         }
@@ -1161,6 +1192,7 @@ impl<'a> SourceExecutionContext<'a> {
             source_words: None,
             code_spaces,
             source_mappings: &[],
+            globals: None,
             words,
             primitives,
         }
@@ -1179,6 +1211,7 @@ impl<'a> SourceExecutionContext<'a> {
             source_words: None,
             code_spaces,
             source_mappings: &[],
+            globals: None,
             words,
             primitives,
         }
@@ -1197,9 +1230,15 @@ impl<'a> SourceExecutionContext<'a> {
             source_words: None,
             code_spaces,
             source_mappings,
+            globals: None,
             words,
             primitives,
         }
+    }
+
+    pub(crate) const fn with_globals(mut self, globals: GlobalVariableView<'a>) -> Self {
+        self.globals = Some(globals);
+        self
     }
 
     fn compile_context(&self) -> SourceCompileContext<'_> {
@@ -1219,6 +1258,10 @@ impl<'a> SourceExecutionContext<'a> {
         self.source_mappings
     }
 
+    pub(crate) const fn globals(self) -> Option<GlobalVariableView<'a>> {
+        self.globals
+    }
+
     pub(crate) const fn words(self) -> PublishedWordLookup<'a> {
         self.words
     }
@@ -1235,6 +1278,12 @@ impl SourceProcessorError {
             ExpressionError::Syntax(error) => Self::Compile(CompileError {
                 span: error.span(),
                 kind: CompileErrorKind::Expression {
+                    source: error.kind(),
+                },
+            }),
+            ExpressionError::Variable(error) => Self::Compile(CompileError {
+                span: error.span(),
+                kind: CompileErrorKind::ExpressionVariable {
                     source: error.kind(),
                 },
             }),
@@ -1408,6 +1457,30 @@ mod tests {
             ),
         )
         .expect("source should run with operators");
+        (sources, id, result)
+    }
+
+    fn run_with_bindings_operators_and_globals(
+        text: &str,
+        bindings: &Bindings,
+        globals: &GlobalVariables,
+        words: &PublishedWords,
+        primitives: &PrimitiveRegistry,
+        operators: OperatorLookup,
+    ) -> (SourceTexts, SourceId, SourceRunResult) {
+        let (sources, id) = source(text);
+        let result = run_source(
+            sources.view(),
+            id,
+            SourceExecutionContext::with_operators(
+                bindings,
+                operators,
+                PublishedWordLookup::new(words),
+                primitives.lookup(),
+            )
+            .with_globals(globals.view()),
+        )
+        .expect("source should run with operators and globals");
         (sources, id, result)
     }
 
@@ -2035,6 +2108,268 @@ mod tests {
             unit.source_span(location(&unit, 4)),
             Ok(Some(span(view, id, 6, 7)))
         );
+    }
+
+    #[test]
+    fn bif_condition_lowers_builtin_variable_names_to_load_var() {
+        let (_operator_words, _operator_primitives, operators) = operator_fixture();
+        let mut words = PublishedWords::new();
+        let mut bindings = Bindings::new();
+        let mut globals = GlobalVariables::new();
+        let variables = register_builtin_global_variables(&mut globals, &mut bindings)
+            .expect("A-Z variables should bootstrap");
+        let push7_id = words.add(completed_primitive(0));
+        bindings
+            .insert_new(name("PUSH7"), Binding::Word(push7_id))
+            .expect("primitive word should register");
+
+        let (sources, id, unit) = compile_with_bindings_and_operators(
+            "BIF a + B, 100\n100 PUSH7",
+            &bindings,
+            operators.lookup(),
+        );
+        let view = sources.view();
+
+        assert_eq!(
+            unit.instructions().get(address(0)),
+            Ok(&Instruction::LoadVar(variables[0]))
+        );
+        assert_eq!(
+            unit.instructions().get(address(1)),
+            Ok(&Instruction::LoadVar(variables[1]))
+        );
+        assert_eq!(
+            unit.source_span(location(&unit, 0)),
+            Ok(Some(span(view, id, 4, 5)))
+        );
+        assert_eq!(
+            unit.source_span(location(&unit, 1)),
+            Ok(Some(span(view, id, 8, 9)))
+        );
+    }
+
+    #[test]
+    fn bif_condition_lowers_user_published_variable_name_to_load_var() {
+        let (_operator_words, _operator_primitives, operators) = operator_fixture();
+        let mut source_words = SourceWordRegistry::new();
+        let mut words = PublishedWords::new();
+        let mut bindings = Bindings::new();
+        let mut globals = GlobalVariables::new();
+        register_builtin_source_words(&mut source_words, &mut bindings)
+            .expect("VAR source word should bootstrap");
+        compile_with_var("VAR Score", &mut bindings, &mut globals, &source_words);
+        let Some(Binding::Variable(score)) = bindings.get(&name("score")).copied() else {
+            panic!("SCORE should be a published variable");
+        };
+        let push7_id = words.add(completed_primitive(0));
+        bindings
+            .insert_new(name("PUSH7"), Binding::Word(push7_id))
+            .expect("primitive word should register");
+
+        let (sources, id, unit) = compile_with_bindings_and_operators(
+            "BIF score = 0, 100\n100 PUSH7",
+            &bindings,
+            operators.lookup(),
+        );
+
+        assert_eq!(
+            unit.instructions().get(address(0)),
+            Ok(&Instruction::LoadVar(score))
+        );
+        assert_eq!(
+            unit.source_span(location(&unit, 0)),
+            Ok(Some(span(sources.view(), id, 4, 9)))
+        );
+    }
+
+    #[test]
+    fn bif_condition_variable_reads_from_global_storage_at_runtime() {
+        let mut words = PublishedWords::new();
+        let mut bindings = Bindings::new();
+        let mut primitives = PrimitiveRegistry::new();
+        let mut globals = GlobalVariables::new();
+        let variables = register_builtin_global_variables(&mut globals, &mut bindings)
+            .expect("A-Z variables should bootstrap");
+        let operators = register_operator_primitives(&mut primitives, &mut words);
+        let push7_id = primitives.register(push_7);
+        register_primitive(&mut words, &mut bindings, name("PUSH7"), push7_id)
+            .expect("primitive should register");
+
+        globals
+            .view_mut()
+            .write(variables[0], value(0))
+            .expect("A should be writable");
+        let (_sources, _id, zero_result) = run_with_bindings_operators_and_globals(
+            "BIF A, 100\n5\n100 PUSH7",
+            &bindings,
+            &globals,
+            &words,
+            &primitives,
+            operators.lookup(),
+        );
+        assert_eq!(zero_result.data_stack(), [value(7)]);
+
+        globals
+            .view_mut()
+            .write(variables[0], value(1))
+            .expect("A should be writable");
+        let (_sources, _id, nonzero_result) = run_with_bindings_operators_and_globals(
+            "BIF a, 100\n5\n100 PUSH7",
+            &bindings,
+            &globals,
+            &words,
+            &primitives,
+            operators.lookup(),
+        );
+        assert_eq!(nonzero_result.data_stack(), [value(5), value(7)]);
+    }
+
+    #[test]
+    fn bif_load_var_runtime_failure_maps_to_name_span() {
+        let mut words = PublishedWords::new();
+        let mut bindings = Bindings::new();
+        let mut primitives = PrimitiveRegistry::new();
+        let mut globals = GlobalVariables::new();
+        let variables = register_builtin_global_variables(&mut globals, &mut bindings)
+            .expect("A-Z variables should bootstrap");
+        let operators = register_operator_primitives(&mut primitives, &mut words);
+        let push7_id = primitives.register(push_7);
+        register_primitive(&mut words, &mut bindings, name("PUSH7"), push7_id)
+            .expect("primitive should register");
+        let (sources, id) = source("BIF A, 100\n100 PUSH7");
+
+        let error = run_source(
+            sources.view(),
+            id,
+            SourceExecutionContext::with_operators(
+                &bindings,
+                operators.lookup(),
+                PublishedWordLookup::new(&words),
+                primitives.lookup(),
+            ),
+        )
+        .expect_err("LoadVar without execution globals should fail at runtime");
+
+        let SourceProcessorError::Runtime(runtime) = error else {
+            panic!("expected runtime error");
+        };
+        assert_eq!(
+            runtime.source_span(),
+            Ok(Some(span(sources.view(), id, 4, 5)))
+        );
+        assert_eq!(runtime.vm().address(), address(0));
+        assert!(matches!(
+            runtime.vm().kind(),
+            crate::vm::VmErrorKind::InvalidGlobalVarId {
+                source: crate::global_variable::GlobalVariableError::InvalidGlobalVarId { id }
+            } if id == variables[0]
+        ));
+    }
+
+    #[test]
+    fn bif_name_primary_resolution_failures_are_compile_errors_at_name_span() {
+        let mut source_words = SourceWordRegistry::new();
+        let mut words = PublishedWords::new();
+        let mut bindings = Bindings::new();
+        let mut primitives = PrimitiveRegistry::new();
+        let operators = register_operator_primitives(&mut primitives, &mut words);
+        let push7_id = primitives.register(push_7);
+        register_primitive(&mut words, &mut bindings, name("PUSH7"), push7_id)
+            .expect("primitive should register");
+        register_builtin_source_words(&mut source_words, &mut bindings)
+            .expect("source words should register");
+
+        let cases = [
+            (
+                "BIF MISSING, 100\n100 PUSH7",
+                4,
+                11,
+                ExpressionVariableErrorKind::UndefinedName,
+            ),
+            (
+                "BIF PUSH7, 100\n100 PUSH7",
+                4,
+                9,
+                ExpressionVariableErrorKind::TargetIsNotVariable,
+            ),
+            (
+                "BIF VAR, 100\n100 PUSH7",
+                4,
+                7,
+                ExpressionVariableErrorKind::TargetIsNotVariable,
+            ),
+        ];
+
+        for (source_text, start, end, source_kind) in cases {
+            let (sources, id) = source(source_text);
+            let error = compile_source(
+                sources.view(),
+                id,
+                SourceCompileContext::with_source_words_and_operators(
+                    &bindings,
+                    source_words.lookup(),
+                    operators.lookup(),
+                ),
+            )
+            .expect_err("non-variable expression name should fail");
+
+            assert_eq!(
+                error,
+                SourceProcessorError::Compile(CompileError {
+                    span: span(sources.view(), id, start, end),
+                    kind: CompileErrorKind::ExpressionVariable {
+                        source: source_kind
+                    },
+                }),
+                "{source_text:?} should reject expression name without fallback"
+            );
+        }
+    }
+
+    #[test]
+    fn bif_expression_name_resolution_failure_does_not_partially_commit() {
+        let (_operator_words, _operator_primitives, operators) = operator_fixture();
+        let mut bindings = Bindings::new();
+        let mut globals = GlobalVariables::new();
+        let a = globals.allocate();
+        bindings
+            .insert_new(name("A"), Binding::Variable(a))
+            .expect("variable should register");
+        let (sources, id) = source("A + MISSING");
+        let mut lexer = Lexer::new(sources.view(), id).expect("lexer should build");
+        let mut tokens = Vec::new();
+        loop {
+            let token = lexer.next_token().expect("source should lex");
+            if token.kind() == TokenKind::Eof {
+                break;
+            }
+            tokens.push(token);
+        }
+        let mut instructions = InstructionSequence::new();
+        let mut mapping = InstructionSourceMapping::new(instructions.code_space());
+
+        let error = compile_expression_tokens(
+            sources.view(),
+            id,
+            &tokens,
+            &bindings,
+            operators.lookup(),
+            &mut instructions,
+            &mut mapping,
+        )
+        .expect_err("later unresolved name should fail the expression");
+
+        assert_eq!(
+            error,
+            SourceProcessorError::Compile(CompileError {
+                span: span(sources.view(), id, 4, 11),
+                kind: CompileErrorKind::ExpressionVariable {
+                    source: ExpressionVariableErrorKind::UndefinedName
+                },
+            })
+        );
+        assert_eq!(instructions.len(), 0);
+        assert_eq!(mapping.view().len(), 0);
     }
 
     #[test]

--- a/crates/tbx-next/src/vm.rs
+++ b/crates/tbx-next/src/vm.rs
@@ -1,4 +1,6 @@
-use crate::global_variable::{GlobalVarId, GlobalVariableError, GlobalVariableViewMut};
+use crate::global_variable::{
+    GlobalVarId, GlobalVariableError, GlobalVariableView, GlobalVariableViewMut,
+};
 use crate::instruction::{
     CodeLocation, CodeSpaceLookup, Instruction, InstructionAddress, InstructionLookup,
     InstructionLookupError, InstructionView,
@@ -83,7 +85,13 @@ pub(crate) struct ExecutionView<'a> {
     instructions: InstructionLookup<'a>,
     words: PublishedWordLookup<'a>,
     primitives: PrimitiveLookup<'a>,
-    globals: Option<GlobalVariableViewMut<'a>>,
+    globals: Option<GlobalExecutionAccess<'a>>,
+}
+
+#[derive(Debug)]
+enum GlobalExecutionAccess<'a> {
+    Read(GlobalVariableView<'a>),
+    Write(GlobalVariableViewMut<'a>),
 }
 
 impl<'a> ExecutionView<'a> {
@@ -117,7 +125,12 @@ impl<'a> ExecutionView<'a> {
     }
 
     pub(crate) fn with_globals(mut self, globals: GlobalVariableViewMut<'a>) -> Self {
-        self.globals = Some(globals);
+        self.globals = Some(GlobalExecutionAccess::Write(globals));
+        self
+    }
+
+    pub(crate) fn with_global_reader(mut self, globals: GlobalVariableView<'a>) -> Self {
+        self.globals = Some(GlobalExecutionAccess::Read(globals));
         self
     }
 
@@ -166,17 +179,20 @@ impl<'a> VmExecutionView<'a> for ExecutionView<'a> {
     }
 
     fn read_global(&self, id: GlobalVarId) -> Result<Value, GlobalVariableError> {
-        self.globals
-            .as_ref()
-            .ok_or(GlobalVariableError::InvalidGlobalVarId { id })?
-            .read(id)
+        match &self.globals {
+            Some(GlobalExecutionAccess::Read(globals)) => globals.read(id),
+            Some(GlobalExecutionAccess::Write(globals)) => globals.read(id),
+            None => Err(GlobalVariableError::InvalidGlobalVarId { id }),
+        }
     }
 
     fn write_global(&mut self, id: GlobalVarId, value: Value) -> Result<(), GlobalVariableError> {
-        self.globals
-            .as_mut()
-            .ok_or(GlobalVariableError::InvalidGlobalVarId { id })?
-            .write(id, value)
+        match &mut self.globals {
+            Some(GlobalExecutionAccess::Write(globals)) => globals.write(id, value),
+            Some(GlobalExecutionAccess::Read(_)) | None => {
+                Err(GlobalVariableError::InvalidGlobalVarId { id })
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- expression primaryの`Name`をvariable resolver経由で`Instruction::LoadVar(GlobalVarId)`へlower
- BIF条件のexpression compileで現在の`Bindings`からvariable-onlyに名前解決し、runtime/source wordや未定義名をstructured compile error化
- `SourceExecutionContext`から読み取り専用globalsをVMへ渡し、BIF条件の`LoadVar`実行とsource mappingを検証

Closes #1466

## Verification

- `cargo test -p tbx-next --no-fail-fast`
- `cargo ci-clippy`
- `cargo ci-test`
- `cargo ci-fmt`
