### PR TITLE
TBX Next: 命令列とsource mappingの構築境界を統合

### DIFF
--- a/crates/tbx-next/src/expression.rs
+++ b/crates/tbx-next/src/expression.rs
@@ -1,9 +1,9 @@
 use crate::global_variable::GlobalVarId;
-use crate::instruction::{Instruction, InstructionSequence};
+use crate::instruction::Instruction;
 use crate::lexer::{Token, TokenKind};
 use crate::operator::{OperatorLookup, OperatorSemantic};
 use crate::source::{SourceError, SourceSpan, SourceView};
-use crate::source_mapping::{InstructionSourceMapping, SourceMappingAppendError};
+use crate::source_mapping::{SourceMappedCode, SourceMappingAppendError};
 use crate::value::Value;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -120,15 +120,9 @@ impl ExpressionStaging {
         self.entries.push(StagedInstruction { instruction, span });
     }
 
-    pub(crate) fn commit_to(
-        &self,
-        instructions: &mut InstructionSequence,
-        mapping: &mut InstructionSourceMapping,
-    ) -> Result<(), ExpressionError> {
+    pub(crate) fn commit_to(&self, code: &mut SourceMappedCode) -> Result<(), ExpressionError> {
         for entry in &self.entries {
-            let address = instructions.append(entry.instruction);
-            mapping
-                .append_mapped(address, entry.span)
+            code.append_mapped(entry.instruction, entry.span)
                 .map_err(ExpressionError::SourceMappingAppend)?;
         }
 
@@ -910,26 +904,24 @@ mod tests {
     fn commit_appends_staged_instructions_only_after_parse_success() {
         let (sources, id, staging) = parse("1+2");
         let view = sources.view();
-        let mut instructions = InstructionSequence::new();
-        let mut mapping = InstructionSourceMapping::new(instructions.code_space());
+        let mut code = SourceMappedCode::new();
 
-        staging
-            .commit_to(&mut instructions, &mut mapping)
-            .expect("staging should commit");
+        staging.commit_to(&mut code).expect("staging should commit");
 
-        assert_eq!(instructions.len(), 3);
+        assert_eq!(code.len(), 3);
         assert_eq!(
-            instructions.view().get(InstructionAddress::from_index(0)),
+            code.instruction_view()
+                .get(InstructionAddress::from_index(0)),
             Ok(&Instruction::Push(value(1)))
         );
         assert_eq!(
-            instructions.view().get(InstructionAddress::from_index(1)),
+            code.instruction_view()
+                .get(InstructionAddress::from_index(1)),
             Ok(&Instruction::Push(value(2)))
         );
         assert_eq!(
-            mapping.view().source_span(
-                instructions
-                    .view()
+            code.source_mapping().source_span(
+                code.instruction_view()
                     .location(InstructionAddress::from_index(2))
             ),
             Ok(Some(span(view, id, 1, 2)))
@@ -937,6 +929,6 @@ mod tests {
 
         let (_sources, _id, error) = parse_error("1+");
         assert!(matches!(error, ExpressionError::Syntax(_)));
-        assert_eq!(instructions.len(), 3);
+        assert_eq!(code.len(), 3);
     }
 }

--- a/crates/tbx-next/src/line_number.rs
+++ b/crates/tbx-next/src/line_number.rs
@@ -1,7 +1,6 @@
-use crate::instruction::{
-    BranchTargetPatchError, InstructionAddress, InstructionAddressError, InstructionSequence,
-};
+use crate::instruction::{BranchTargetPatchError, InstructionAddress, InstructionAddressError};
 use crate::source::SourceSpan;
+use crate::source_mapping::SourceMappedCode;
 use std::collections::HashMap;
 
 /// Owner-local compile-time line number identifier.
@@ -73,19 +72,18 @@ impl LocalLineNumberTable {
 
     pub(crate) fn define(
         &mut self,
-        instructions: &InstructionSequence,
+        code: &SourceMappedCode,
         line_number: LocalLineNumber,
         target: InstructionAddress,
         span: SourceSpan,
     ) -> Result<(), LineNumberError> {
-        instructions
-            .view()
-            .validate_address(target)
-            .map_err(|source| LineNumberError::InvalidDefinitionTarget {
+        code.validate_address(target).map_err(|source| {
+            LineNumberError::InvalidDefinitionTarget {
                 line_number,
                 span,
                 source,
-            })?;
+            }
+        })?;
 
         if let Some(existing) = self.definitions.get(&line_number) {
             return Err(LineNumberError::Duplicate {
@@ -113,10 +111,7 @@ impl LocalLineNumberTable {
         });
     }
 
-    pub(crate) fn resolve(
-        &self,
-        instructions: &mut InstructionSequence,
-    ) -> Result<(), LineNumberError> {
+    pub(crate) fn resolve(&self, code: &mut SourceMappedCode) -> Result<(), LineNumberError> {
         let mut resolved = Vec::with_capacity(self.patches.len());
         for patch in &self.patches {
             let Some(definition) = self.definitions.get(&patch.line_number) else {
@@ -129,8 +124,7 @@ impl LocalLineNumberTable {
         }
 
         for (patch, target) in resolved {
-            instructions
-                .patch_branch_target(patch.branch, target)
+            code.patch_branch_target(patch.branch, target)
                 .map_err(|source| LineNumberError::Patch {
                     line_number: patch.line_number,
                     span: patch.span,
@@ -179,15 +173,20 @@ mod tests {
         LocalLineNumber::new(raw)
     }
 
+    fn append(code: &mut SourceMappedCode, instruction: Instruction) -> InstructionAddress {
+        code.append_unmapped(instruction)
+            .expect("test instruction should append")
+    }
+
     #[test]
     fn resolves_same_owner_forward_line_number_patch() {
         let (sources, source_id) = source("BIF 0, 200\n200 DONE");
         let branch_span = span(sources.view(), source_id, 7, 10);
         let target_span = span(sources.view(), source_id, 11, 14);
-        let mut code = InstructionSequence::new();
-        let placeholder = code.append(Instruction::Halt);
-        let branch = code.append(Instruction::JumpIfZero(placeholder));
-        let target = code.append(Instruction::Halt);
+        let mut code = SourceMappedCode::new();
+        let placeholder = append(&mut code, Instruction::Halt);
+        let branch = append(&mut code, Instruction::JumpIfZero(placeholder));
+        let target = append(&mut code, Instruction::Halt);
         let mut table = LocalLineNumberTable::new();
 
         table.add_patch(line(200), branch, branch_span);
@@ -197,7 +196,7 @@ mod tests {
         table.resolve(&mut code).expect("patch should resolve");
 
         assert_eq!(
-            code.view().get(branch),
+            code.instruction_view().get(branch),
             Ok(&Instruction::JumpIfZero(target))
         );
     }
@@ -207,9 +206,9 @@ mod tests {
         let (sources, source_id) = source("100 START\nBIF 0, 100");
         let target_span = span(sources.view(), source_id, 0, 3);
         let branch_span = span(sources.view(), source_id, 17, 20);
-        let mut code = InstructionSequence::new();
-        let target = code.append(Instruction::Halt);
-        let branch = code.append(Instruction::Jump(address(0)));
+        let mut code = SourceMappedCode::new();
+        let target = append(&mut code, Instruction::Halt);
+        let branch = append(&mut code, Instruction::Jump(address(0)));
         let mut table = LocalLineNumberTable::new();
 
         table
@@ -218,7 +217,10 @@ mod tests {
         table.add_patch(line(100), branch, branch_span);
         table.resolve(&mut code).expect("patch should resolve");
 
-        assert_eq!(code.view().get(branch), Ok(&Instruction::Jump(target)));
+        assert_eq!(
+            code.instruction_view().get(branch),
+            Ok(&Instruction::Jump(target))
+        );
     }
 
     #[test]
@@ -226,8 +228,8 @@ mod tests {
         let (sources, source_id) = source("100 A\n100 B");
         let first_span = span(sources.view(), source_id, 0, 3);
         let second_span = span(sources.view(), source_id, 6, 9);
-        let mut code = InstructionSequence::new();
-        let target = code.append(Instruction::Halt);
+        let mut code = SourceMappedCode::new();
+        let target = append(&mut code, Instruction::Halt);
         let mut table = LocalLineNumberTable::new();
 
         table
@@ -248,8 +250,8 @@ mod tests {
     fn undefined_line_number_reports_operand_span() {
         let (sources, source_id) = source("BIF 0, 200");
         let branch_span = span(sources.view(), source_id, 7, 10);
-        let mut code = InstructionSequence::new();
-        let branch = code.append(Instruction::JumpIfZero(address(0)));
+        let mut code = SourceMappedCode::new();
+        let branch = append(&mut code, Instruction::JumpIfZero(address(0)));
         let mut table = LocalLineNumberTable::new();
 
         table.add_patch(line(200), branch, branch_span);
@@ -268,8 +270,8 @@ mod tests {
         let large = line(u64::from(i16::MAX as u16) + 1);
         let (sources, source_id) = source("40000 TARGET");
         let target_span = span(sources.view(), source_id, 0, 5);
-        let mut code = InstructionSequence::new();
-        let target = code.append(Instruction::Halt);
+        let mut code = SourceMappedCode::new();
+        let target = append(&mut code, Instruction::Halt);
         let mut table = LocalLineNumberTable::new();
 
         table
@@ -283,8 +285,8 @@ mod tests {
     fn definition_rejects_end_and_out_of_range_targets() {
         let (sources, source_id) = source("100 A");
         let line_span = span(sources.view(), source_id, 0, 3);
-        let mut code = InstructionSequence::new();
-        code.append(Instruction::Halt);
+        let mut code = SourceMappedCode::new();
+        append(&mut code, Instruction::Halt);
         let mut table = LocalLineNumberTable::new();
 
         assert_eq!(
@@ -314,10 +316,10 @@ mod tests {
         let (sources, source_id) = source("100 A\n100 B");
         let first_span = span(sources.view(), source_id, 0, 3);
         let second_span = span(sources.view(), source_id, 6, 9);
-        let mut first_code = InstructionSequence::new();
-        let mut second_code = InstructionSequence::new();
-        let first_target = first_code.append(Instruction::Halt);
-        let second_target = second_code.append(Instruction::Push(Value::integer(1)));
+        let mut first_code = SourceMappedCode::new();
+        let mut second_code = SourceMappedCode::new();
+        let first_target = append(&mut first_code, Instruction::Halt);
+        let second_target = append(&mut second_code, Instruction::Push(Value::integer(1)));
         let mut first_table = LocalLineNumberTable::new();
         let mut second_table = LocalLineNumberTable::new();
 
@@ -334,9 +336,9 @@ mod tests {
         let (sources, source_id) = source("BIF 0, 100");
         let branch_span = span(sources.view(), source_id, 7, 10);
         let target_span = span(sources.view(), source_id, 7, 10);
-        let mut code = InstructionSequence::new();
-        let non_branch = code.append(Instruction::Push(Value::integer(1)));
-        let target = code.append(Instruction::Halt);
+        let mut code = SourceMappedCode::new();
+        let non_branch = append(&mut code, Instruction::Push(Value::integer(1)));
+        let target = append(&mut code, Instruction::Halt);
         let mut table = LocalLineNumberTable::new();
 
         table

--- a/crates/tbx-next/src/source_mapping.rs
+++ b/crates/tbx-next/src/source_mapping.rs
@@ -1,5 +1,19 @@
-use crate::instruction::{CodeLocation, CodeSpaceId, InstructionAddress, InstructionAddressError};
+use crate::instruction::{
+    BranchTargetPatchError, CodeLocation, CodeSpaceId, Instruction, InstructionAddress,
+    InstructionAddressError, InstructionSequence, InstructionView,
+};
 use crate::source::SourceSpan;
+
+/// Crate-internal owner for executable instructions and their source mapping.
+///
+/// #1461 requires ordinary codegen to decide `Instruction + Option<SourceSpan>`
+/// together and commit both in the same local address order. Backpatching is
+/// intentionally limited to instruction operands and never rewrites origins.
+#[derive(Debug)]
+pub(crate) struct SourceMappedCode {
+    instructions: InstructionSequence,
+    mapping: InstructionSourceMapping,
+}
 
 /// Owner for source spans keyed by one instruction sequence's code space.
 ///
@@ -79,6 +93,79 @@ impl InstructionSourceMapping {
 
         self.spans.push(span);
         Ok(())
+    }
+}
+
+impl SourceMappedCode {
+    pub(crate) fn new() -> Self {
+        let instructions = InstructionSequence::new();
+        let mapping = InstructionSourceMapping::new(instructions.code_space());
+        Self {
+            instructions,
+            mapping,
+        }
+    }
+
+    pub(crate) fn append_mapped(
+        &mut self,
+        instruction: Instruction,
+        span: SourceSpan,
+    ) -> Result<InstructionAddress, SourceMappingAppendError> {
+        self.append(instruction, Some(span))
+    }
+
+    pub(crate) fn append_unmapped(
+        &mut self,
+        instruction: Instruction,
+    ) -> Result<InstructionAddress, SourceMappingAppendError> {
+        self.append(instruction, None)
+    }
+
+    pub(crate) fn patch_branch_target(
+        &mut self,
+        branch: InstructionAddress,
+        target: InstructionAddress,
+    ) -> Result<(), BranchTargetPatchError> {
+        self.instructions.patch_branch_target(branch, target)
+    }
+
+    pub(crate) fn validate_address(
+        &self,
+        address: InstructionAddress,
+    ) -> Result<InstructionAddress, InstructionAddressError> {
+        self.instructions.view().validate_address(address)
+    }
+
+    pub(crate) fn instruction_view(&self) -> InstructionView<'_> {
+        self.instructions.view()
+    }
+
+    pub(crate) fn source_mapping(&self) -> InstructionSourceMappingView<'_> {
+        self.mapping.view()
+    }
+
+    pub(crate) const fn code_space(&self) -> CodeSpaceId {
+        self.instructions.code_space()
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.instructions.len()
+    }
+
+    fn append(
+        &mut self,
+        instruction: Instruction,
+        span: Option<SourceSpan>,
+    ) -> Result<InstructionAddress, SourceMappingAppendError> {
+        let address = self.instructions.append(instruction);
+        self.mapping.append(address, span)?;
+        Ok(address)
+    }
+}
+
+impl Default for SourceMappedCode {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -196,6 +283,60 @@ mod tests {
 
     fn address(index: usize) -> InstructionAddress {
         InstructionAddress::from_index(index)
+    }
+
+    #[test]
+    fn source_mapped_code_appends_instruction_and_origin_at_same_address() {
+        let (sources, source_id) = source("10 20");
+        let mut code = SourceMappedCode::new();
+        let first_span = span(sources.view(), source_id, 0, 2);
+        let first = code
+            .append_mapped(Instruction::Halt, first_span)
+            .expect("mapped instruction should append");
+        let second = code
+            .append_unmapped(Instruction::Return)
+            .expect("unmapped instruction should append");
+
+        assert_eq!(first, address(0));
+        assert_eq!(second, address(1));
+        assert_eq!(code.len(), code.source_mapping().len());
+        assert_eq!(code.instruction_view().get(first), Ok(&Instruction::Halt));
+        assert_eq!(
+            code.source_mapping()
+                .source_span(code.instruction_view().location(first)),
+            Ok(Some(first_span))
+        );
+        assert_eq!(
+            code.source_mapping()
+                .source_span(code.instruction_view().location(second)),
+            Ok(None)
+        );
+    }
+
+    #[test]
+    fn source_mapped_code_backpatch_keeps_existing_origin() {
+        let (sources, source_id) = source("BIF 0, 20\n20");
+        let branch_span = span(sources.view(), source_id, 0, 3);
+        let mut code = SourceMappedCode::new();
+        let branch = code
+            .append_mapped(Instruction::JumpIfZero(address(0)), branch_span)
+            .expect("branch should append");
+        let target = code
+            .append_unmapped(Instruction::Halt)
+            .expect("target should append");
+        let branch_location = code.instruction_view().location(branch);
+
+        code.patch_branch_target(branch, target)
+            .expect("branch target should patch");
+
+        assert_eq!(
+            code.instruction_view().get(branch),
+            Ok(&Instruction::JumpIfZero(target))
+        );
+        assert_eq!(
+            code.source_mapping().source_span(branch_location),
+            Ok(Some(branch_span))
+        );
     }
 
     #[test]

--- a/crates/tbx-next/src/source_processor.rs
+++ b/crates/tbx-next/src/source_processor.rs
@@ -5,7 +5,7 @@ use crate::expression::{
 use crate::global_variable::{GlobalVariableView, GlobalVariables};
 use crate::instruction::{
     CodeLocation, CodeSpaceLookup, CodeSpaceLookupError, Instruction, InstructionAddress,
-    InstructionSequence, InstructionView,
+    InstructionView,
 };
 use crate::lexer::{LexError, Lexer, Token, TokenKind};
 use crate::line_number::{LineNumberError, LocalLineNumber, LocalLineNumberTable};
@@ -13,8 +13,8 @@ use crate::operator::OperatorLookup;
 use crate::primitive::PrimitiveLookup;
 use crate::source::{SourceError, SourceId, SourceSpan, SourceView};
 use crate::source_mapping::{
-    InstructionSourceMapping, InstructionSourceMappingView, SourceMappingAppendError,
-    SourceMappingLookup, SourceMappingLookupError,
+    InstructionSourceMappingView, SourceMappedCode, SourceMappingAppendError, SourceMappingLookup,
+    SourceMappingLookupError,
 };
 use crate::source_word::{
     NativeSourceWordBindingAccess, NativeSourceWordContext, NativeSourceWordContextParts,
@@ -30,8 +30,7 @@ use std::collections::HashSet;
 
 #[derive(Debug)]
 pub(crate) struct TemporaryExecutionUnit {
-    instructions: InstructionSequence,
-    mapping: InstructionSourceMapping,
+    code: SourceMappedCode,
     entry: CodeLocation,
 }
 
@@ -124,8 +123,7 @@ pub(crate) enum BifSyntaxErrorKind {
 type OptionalLineNumberPrefix = Option<(LocalLineNumber, SourceSpan)>;
 
 struct StatementCompileState<'a> {
-    instructions: &'a mut InstructionSequence,
-    mapping: &'a mut InstructionSourceMapping,
+    code: &'a mut SourceMappedCode,
     line_numbers: &'a mut LocalLineNumberTable,
     referenced_line_numbers: &'a HashSet<LocalLineNumber>,
 }
@@ -185,37 +183,26 @@ pub(crate) fn compile_source(
 ) -> Result<TemporaryExecutionUnit, SourceProcessorError> {
     let segmented = SegmentedSource::collect(view, source_id)?;
 
-    let mut instructions = InstructionSequence::new();
-    let mut mapping = InstructionSourceMapping::new(instructions.code_space());
+    let mut code = SourceMappedCode::new();
 
     compile_statements(
         view,
         source_id,
         segmented.completed_statements(),
         context,
-        &mut instructions,
-        &mut mapping,
+        &mut code,
     )?;
 
     let eof = match segmented.terminal() {
         Terminal::Eof(eof) => eof,
         Terminal::LexError(error) => return Err(error.into()),
     };
-    append_mapped(
-        &mut instructions,
-        &mut mapping,
-        Instruction::Halt,
-        eof.span(),
-    )?;
+    code.append_mapped(Instruction::Halt, eof.span())?;
 
-    let entry = instructions
-        .view()
+    let entry = code
+        .instruction_view()
         .location(InstructionAddress::from_index(0));
-    Ok(TemporaryExecutionUnit {
-        instructions,
-        mapping,
-        entry,
-    })
+    Ok(TemporaryExecutionUnit { code, entry })
 }
 
 fn compile_statements(
@@ -223,8 +210,7 @@ fn compile_statements(
     source_id: SourceId,
     statements: &[LogicalStatement],
     mut context: SourceCompileContext<'_>,
-    instructions: &mut InstructionSequence,
-    mapping: &mut InstructionSourceMapping,
+    code: &mut SourceMappedCode,
 ) -> Result<(), SourceProcessorError> {
     let mut line_numbers = LocalLineNumberTable::new();
     // A leading integer remains an expression/literal unless this unit uses it
@@ -239,8 +225,7 @@ fn compile_statements(
             statement.tokens(),
             &mut context,
             &mut StatementCompileState {
-                instructions,
-                mapping,
+                code,
                 line_numbers: &mut line_numbers,
                 referenced_line_numbers: &referenced_line_numbers,
             },
@@ -248,7 +233,7 @@ fn compile_statements(
     }
 
     line_numbers
-        .resolve(instructions)
+        .resolve(code)
         .map_err(|source| line_number_compile_error(source).into())
 }
 
@@ -269,7 +254,7 @@ fn compile_statement(
         state.referenced_line_numbers,
         context.bindings(),
     )?;
-    let start = state.instructions.len();
+    let start = state.code.len();
     let local_line_number_prefix = line_number.map(|(_, span)| span);
     compile_statement_body(
         view,
@@ -284,7 +269,7 @@ fn compile_statement(
         let target = InstructionAddress::from_index(start);
         state
             .line_numbers
-            .define(state.instructions, line_number, target, span)
+            .define(state.code, line_number, target, span)
             .map_err(|source| line_number_compile_error(source).into())
     } else {
         Ok(())
@@ -335,8 +320,7 @@ fn compile_statement_body(
             source_id,
             tokens,
             context,
-            state.instructions,
-            state.mapping,
+            state.code,
             state.line_numbers,
         );
     }
@@ -347,8 +331,7 @@ fn compile_statement_body(
         tokens,
         context,
         local_line_number_prefix,
-        state.instructions,
-        state.mapping,
+        state.code,
     )? {
         return Ok(());
     }
@@ -361,7 +344,7 @@ fn compile_statement_body(
         .into());
     }
 
-    compile_simple_tokens(view, tokens, context, state.instructions, state.mapping)
+    compile_simple_tokens(view, tokens, context, state.code)
 }
 
 fn compile_statement_leading_source_word(
@@ -370,8 +353,7 @@ fn compile_statement_leading_source_word(
     tokens: &[Token],
     context: &mut SourceCompileContext<'_>,
     local_line_number_prefix: Option<SourceSpan>,
-    instructions: &mut InstructionSequence,
-    mapping: &mut InstructionSourceMapping,
+    code: &mut SourceMappedCode,
 ) -> Result<bool, SourceProcessorError> {
     let Some(first) = tokens.first().copied() else {
         return Ok(false);
@@ -410,8 +392,7 @@ fn compile_statement_leading_source_word(
         tokens,
         bindings: binding_access,
         operators,
-        instructions,
-        mapping,
+        code,
         local_line_number_prefix,
         globals,
     });
@@ -423,23 +404,17 @@ fn compile_simple_tokens(
     view: SourceView<'_>,
     tokens: &[Token],
     context: &SourceCompileContext<'_>,
-    instructions: &mut InstructionSequence,
-    mapping: &mut InstructionSourceMapping,
+    code: &mut SourceMappedCode,
 ) -> Result<(), SourceProcessorError> {
     for token in tokens {
         match token.kind() {
             TokenKind::IntegerLiteral => {
                 let value = compile_integer_literal(view, *token)?;
-                append_mapped(
-                    instructions,
-                    mapping,
-                    Instruction::Push(Value::integer(value)),
-                    token.span(),
-                )?;
+                code.append_mapped(Instruction::Push(Value::integer(value)), token.span())?;
             }
             TokenKind::Name => {
                 let id = compile_word_reference(view, *token, context)?;
-                append_mapped(instructions, mapping, Instruction::Call(id), token.span())?;
+                code.append_mapped(Instruction::Call(id), token.span())?;
             }
             TokenKind::LineBoundary | TokenKind::Eof => {}
             TokenKind::Plus
@@ -473,8 +448,7 @@ fn compile_bif(
     source_id: SourceId,
     tokens: &[Token],
     context: &SourceCompileContext<'_>,
-    instructions: &mut InstructionSequence,
-    mapping: &mut InstructionSourceMapping,
+    code: &mut SourceMappedCode,
     line_numbers: &mut LocalLineNumberTable,
 ) -> Result<(), SourceProcessorError> {
     let bif = tokens
@@ -501,8 +475,7 @@ fn compile_bif(
         &tokens[1..comma_index],
         context.bindings(),
         operators,
-        instructions,
-        mapping,
+        code,
     )?;
 
     let target_tokens = &tokens[comma_index + 1..];
@@ -527,9 +500,7 @@ fn compile_bif(
     }
 
     let line_number = compile_line_number_literal(view, target)?;
-    let branch = append_mapped(
-        instructions,
-        mapping,
+    let branch = code.append_mapped(
         Instruction::JumpIfZero(InstructionAddress::from_index(0)),
         bif.span(),
     )?;
@@ -543,8 +514,7 @@ fn compile_expression_tokens(
     tokens: &[Token],
     bindings: &Bindings,
     operators: OperatorLookup,
-    instructions: &mut InstructionSequence,
-    mapping: &mut InstructionSourceMapping,
+    code: &mut SourceMappedCode,
 ) -> Result<(), SourceProcessorError> {
     let mut expression_tokens = tokens
         .iter()
@@ -559,7 +529,7 @@ fn compile_expression_tokens(
     let resolver = |source_name: &str| resolve_variable_name(bindings, source_name);
     parse_expression(view, &expression_tokens, operators, &resolver)
         .map_err(SourceProcessorError::from_expression_error)?
-        .commit_to(instructions, mapping)
+        .commit_to(code)
         .map_err(SourceProcessorError::from_expression_error)
 }
 
@@ -577,7 +547,7 @@ fn run_unit(
     context: SourceExecutionContext<'_>,
 ) -> Result<SourceRunResult, SourceProcessorError> {
     let mut code_spaces = Vec::with_capacity(context.code_spaces.len() + 1);
-    code_spaces.push(unit.instructions.view());
+    code_spaces.push(unit.code.instruction_view());
     code_spaces.extend_from_slice(context.code_spaces);
     let mut execution = ExecutionView::with_code_spaces(
         CodeSpaceLookup::new(&code_spaces)?,
@@ -600,7 +570,7 @@ fn run_unit(
     Ok(SourceRunResult {
         outcome,
         data_stack,
-        instruction_count: unit.instructions.len(),
+        instruction_count: unit.code.len(),
     })
 }
 
@@ -872,17 +842,6 @@ fn line_number_compile_error(source: LineNumberError) -> CompileError {
     }
 }
 
-fn append_mapped(
-    instructions: &mut InstructionSequence,
-    mapping: &mut InstructionSourceMapping,
-    instruction: Instruction,
-    span: SourceSpan,
-) -> Result<InstructionAddress, SourceMappingAppendError> {
-    let address = instructions.append(instruction);
-    mapping.append_mapped(address, span)?;
-    Ok(address)
-}
-
 // Segmentation is the source of truth for top-level statement boundaries.
 // Lexical failure keeps already completed statements visible while leaving the
 // unbounded tail unavailable to semantic compilation and source-wide analysis.
@@ -1019,22 +978,22 @@ impl TemporaryExecutionUnit {
     }
 
     pub(crate) fn instructions(&self) -> crate::instruction::InstructionView<'_> {
-        self.instructions.view()
+        self.code.instruction_view()
     }
 
     pub(crate) fn source_mapping(&self) -> InstructionSourceMappingView<'_> {
-        self.mapping.view()
+        self.code.source_mapping()
     }
 
     pub(crate) fn len(&self) -> usize {
-        self.instructions.len()
+        self.code.len()
     }
 
     pub(crate) fn source_span(
         &self,
         location: CodeLocation,
     ) -> Result<Option<SourceSpan>, SourceMappingLookupError> {
-        self.mapping.view().source_span(location)
+        self.code.source_mapping().source_span(location)
     }
 }
 
@@ -1367,13 +1326,16 @@ mod tests {
         register_native_source_word, register_primitive,
     };
     use crate::global_variable::{GlobalVarId, GlobalVariables};
+    use crate::instruction::InstructionSequence;
     use crate::lexer::InvalidCharacterReason;
     use crate::name::NormalizedName;
     use crate::operator::{register_operator_primitives, OperatorSemantic, OperatorWords};
     use crate::primitive::{PrimitiveContext, PrimitiveError, PrimitiveRegistry};
     use crate::redefinition::redefine_word;
     use crate::source::SourceTexts;
-    use crate::source_mapping::{SourceMappingLookup, SourceMappingLookupError};
+    use crate::source_mapping::{
+        InstructionSourceMapping, SourceMappingLookup, SourceMappingLookupError,
+    };
     use crate::source_word::{
         LetSyntaxErrorKind, NativeSourceWordContext, SourceWordRegistry, VarSyntaxErrorKind,
     };
@@ -2966,8 +2928,7 @@ mod tests {
             }
             tokens.push(token);
         }
-        let mut instructions = InstructionSequence::new();
-        let mut mapping = InstructionSourceMapping::new(instructions.code_space());
+        let mut code = SourceMappedCode::new();
 
         let error = compile_expression_tokens(
             sources.view(),
@@ -2975,8 +2936,7 @@ mod tests {
             &tokens,
             &bindings,
             operators.lookup(),
-            &mut instructions,
-            &mut mapping,
+            &mut code,
         )
         .expect_err("later unresolved name should fail the expression");
 
@@ -2989,8 +2949,8 @@ mod tests {
                 },
             })
         );
-        assert_eq!(instructions.len(), 0);
-        assert_eq!(mapping.view().len(), 0);
+        assert_eq!(code.len(), 0);
+        assert_eq!(code.source_mapping().len(), 0);
     }
 
     #[test]

--- a/crates/tbx-next/src/source_word.rs
+++ b/crates/tbx-next/src/source_word.rs
@@ -3,12 +3,12 @@ use crate::expression::{
     parse_expression, ExpressionError, ExpressionStaging, ExpressionVariableErrorKind,
 };
 use crate::global_variable::GlobalVariables;
-use crate::instruction::{Instruction, InstructionSequence};
+use crate::instruction::Instruction;
 use crate::lexer::{Token, TokenKind};
 use crate::name::{NameError, NormalizedName};
 use crate::operator::OperatorLookup;
 use crate::source::{SourceError, SourceId, SourceSpan, SourceView};
-use crate::source_mapping::{InstructionSourceMapping, SourceMappingAppendError};
+use crate::source_mapping::{SourceMappedCode, SourceMappingAppendError};
 use crate::word_resolution::{resolve_binding_name, ResolvedBinding, WordResolutionError};
 
 /// Internal identifier for a published source-processing word.
@@ -227,8 +227,7 @@ pub(crate) struct NativeSourceWordContext<'source, 'state> {
     reader: SourceStatementReader<'source>,
     bindings: NativeSourceWordBindingAccess<'state>,
     operators: Option<OperatorLookup>,
-    instructions: &'state mut InstructionSequence,
-    mapping: &'state mut InstructionSourceMapping,
+    code: &'state mut SourceMappedCode,
     local_line_number_prefix: Option<SourceSpan>,
     globals: Option<&'state mut GlobalVariables>,
 }
@@ -239,8 +238,7 @@ pub(crate) struct NativeSourceWordContextParts<'source, 'state> {
     pub(crate) tokens: &'source [Token],
     pub(crate) bindings: NativeSourceWordBindingAccess<'state>,
     pub(crate) operators: Option<OperatorLookup>,
-    pub(crate) instructions: &'state mut InstructionSequence,
-    pub(crate) mapping: &'state mut InstructionSourceMapping,
+    pub(crate) code: &'state mut SourceMappedCode,
     pub(crate) local_line_number_prefix: Option<SourceSpan>,
     pub(crate) globals: Option<&'state mut GlobalVariables>,
 }
@@ -260,8 +258,7 @@ impl<'source, 'state> NativeSourceWordContext<'source, 'state> {
             reader,
             bindings: parts.bindings,
             operators: parts.operators,
-            instructions: parts.instructions,
-            mapping: parts.mapping,
+            code: parts.code,
             local_line_number_prefix: parts.local_line_number_prefix,
             globals: parts.globals,
         }
@@ -292,9 +289,9 @@ impl<'source, 'state> NativeSourceWordContext<'source, 'state> {
         instruction: Instruction,
         span: SourceSpan,
     ) -> Result<(), SourceWordError> {
-        let address = self.instructions.append(instruction);
-        self.mapping
-            .append_mapped(address, span)
+        self.code
+            .append_mapped(instruction, span)
+            .map(|_| ())
             .map_err(|source| SourceWordError::SourceMappingAppend { source })
     }
 
@@ -372,14 +369,12 @@ impl<'source, 'state> NativeSourceWordContext<'source, 'state> {
         &mut self,
         staging: &ExpressionStaging,
     ) -> Result<(), SourceWordError> {
-        staging
-            .commit_to(self.instructions, self.mapping)
-            .map_err(|source| match source {
-                ExpressionError::SourceMappingAppend(source) => {
-                    SourceWordError::SourceMappingAppend { source }
-                }
-                source => SourceWordError::Expression { source },
-            })
+        staging.commit_to(self.code).map_err(|source| match source {
+            ExpressionError::SourceMappingAppend(source) => {
+                SourceWordError::SourceMappingAppend { source }
+            }
+            source => SourceWordError::Expression { source },
+        })
     }
 
     fn bindings(&self) -> &Bindings {
@@ -605,8 +600,7 @@ mod tests {
     #[test]
     fn native_context_lends_one_reader_without_resetting_position() {
         let (sources, source_id, tokens) = statement_tokens("TEST A B");
-        let mut instructions = InstructionSequence::new();
-        let mut mapping = InstructionSourceMapping::new(instructions.code_space());
+        let mut code = SourceMappedCode::new();
         let bindings = Bindings::new();
         let mut context = NativeSourceWordContext::new(NativeSourceWordContextParts {
             view: sources.view(),
@@ -614,8 +608,7 @@ mod tests {
             tokens: &tokens,
             bindings: NativeSourceWordBindingAccess::Read(&bindings),
             operators: None,
-            instructions: &mut instructions,
-            mapping: &mut mapping,
+            code: &mut code,
             local_line_number_prefix: None,
             globals: None,
         });
@@ -808,8 +801,7 @@ mod tests {
                 break;
             }
         }
-        let mut instructions = InstructionSequence::new();
-        let mut mapping = InstructionSourceMapping::new(instructions.code_space());
+        let mut code = SourceMappedCode::new();
         let bindings = Bindings::new();
         let mut context = NativeSourceWordContext::new(NativeSourceWordContextParts {
             view: sources.view(),
@@ -817,8 +809,7 @@ mod tests {
             tokens: &tokens[..1],
             bindings: NativeSourceWordBindingAccess::Read(&bindings),
             operators: None,
-            instructions: &mut instructions,
-            mapping: &mut mapping,
+            code: &mut code,
             local_line_number_prefix: None,
             globals: None,
         });
@@ -826,8 +817,7 @@ mod tests {
         push_one(&mut context).expect("test source word should emit");
 
         assert_eq!(
-            instructions
-                .view()
+            code.instruction_view()
                 .get(crate::instruction::InstructionAddress::from_index(0)),
             Ok(&Instruction::Push(Value::integer(1)))
         );


### PR DESCRIPTION
## Summary

- Add `SourceMappedCode` as the crate-internal owner for an `InstructionSequence` and its same-code-space `InstructionSourceMapping`.
- Move temporary execution codegen, expression staging commits, native source words, and local line-number patching to the unified owner.
- Add tests for same-address instruction/origin append, valid `None` mapping entries, and source origin stability after backpatching.

Closes #1496

## Verification

- `cargo test -p tbx-next`
- `cargo clippy -p tbx-next --all-targets --all-features -- -D warnings`
- `cargo ci-fmt`
- `cargo ci-clippy`
- `cargo ci-test`
