### PR TITLE
TBX Next: END予約名をbinding公開境界で拒否する

### DIFF
--- a/crates/tbx-next/src/binding.rs
+++ b/crates/tbx-next/src/binding.rs
@@ -20,6 +20,7 @@ pub(crate) enum Binding {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum BindingInsertError {
     NameConflict,
+    ReservedName,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -50,11 +51,24 @@ impl Bindings {
         name: NormalizedName,
         binding: Binding,
     ) -> Result<(), BindingInsertError> {
-        if self.entries.contains_key(&name) {
+        self.validate_new_name(&name)?;
+
+        self.entries.insert(name, binding);
+        Ok(())
+    }
+
+    pub(crate) fn validate_new_name(
+        &self,
+        name: &NormalizedName,
+    ) -> Result<(), BindingInsertError> {
+        if is_semantic_reserved_binding_name(name) {
+            return Err(BindingInsertError::ReservedName);
+        }
+
+        if self.entries.contains_key(name) {
             return Err(BindingInsertError::NameConflict);
         }
 
-        self.entries.insert(name, binding);
         Ok(())
     }
 
@@ -103,6 +117,13 @@ impl Bindings {
     pub(crate) fn is_empty(&self) -> bool {
         self.entries.is_empty()
     }
+}
+
+// ADR #1500 3.1.1 makes only normalized END a semantic reserved binding name.
+// Keep this as a publication policy: do not turn END into a lexer keyword, mix
+// it into NormalizedName validation, or revive a general reserved spelling set.
+fn is_semantic_reserved_binding_name(name: &NormalizedName) -> bool {
+    name.as_str() == "END"
 }
 
 #[cfg(test)]
@@ -320,6 +341,46 @@ mod tests {
             Err(BindingInsertError::NameConflict)
         );
         assert_eq!(bindings.get(&name("Foo")), Some(&first));
+    }
+
+    #[test]
+    fn end_case_variants_are_rejected_as_reserved_names() {
+        for input in ["END", "end", "End"] {
+            let mut words = PublishedWords::new();
+            let binding = word_binding(&mut words, 10);
+            let mut bindings = Bindings::new();
+
+            assert_eq!(
+                bindings.validate_new_name(&name(input)),
+                Err(BindingInsertError::ReservedName)
+            );
+            assert_eq!(
+                bindings.insert_new(name(input), binding),
+                Err(BindingInsertError::ReservedName)
+            );
+            assert!(bindings.is_empty());
+        }
+    }
+
+    #[test]
+    fn validate_new_name_distinguishes_reserved_name_from_conflict() {
+        let mut words = PublishedWords::new();
+        let mut bindings = Bindings::new();
+        let existing = word_binding(&mut words, 20);
+
+        bindings
+            .insert_new(name("TAKEN"), existing)
+            .expect("test binding should register");
+
+        assert_eq!(
+            bindings.validate_new_name(&name("TAKEN")),
+            Err(BindingInsertError::NameConflict)
+        );
+        assert_eq!(
+            bindings.validate_new_name(&name("END")),
+            Err(BindingInsertError::ReservedName)
+        );
+        assert_eq!(bindings.validate_new_name(&name("AVAILABLE")), Ok(()));
     }
 
     #[test]

--- a/crates/tbx-next/src/bootstrap.rs
+++ b/crates/tbx-next/src/bootstrap.rs
@@ -14,17 +14,20 @@ const BUILTIN_GLOBAL_VARIABLE_NAMES: [&str; 26] = [
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum PrimitiveBootstrapError {
     NameConflict,
+    ReservedName,
     BindingRegistrationInvariantViolated,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum BuiltinGlobalBootstrapError {
     NameConflict,
+    ReservedName,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SourceWordBootstrapError {
     NameConflict,
+    ReservedName,
     BindingRegistrationInvariantViolated,
 }
 
@@ -42,9 +45,9 @@ pub(crate) fn register_primitive(
     name: NormalizedName,
     primitive: PrimitiveId,
 ) -> Result<WordId, PrimitiveBootstrapError> {
-    if bindings.get(&name).is_some() {
-        return Err(PrimitiveBootstrapError::NameConflict);
-    }
+    bindings
+        .validate_new_name(&name)
+        .map_err(PrimitiveBootstrapError::from_precheck_error)?;
 
     let id = words.add(CompletedWordDefinition::primitive(primitive));
 
@@ -68,9 +71,9 @@ pub(crate) fn register_builtin_global_variables(
     let names = builtin_global_variable_names();
 
     for name in &names {
-        if bindings.get(name).is_some() {
-            return Err(BuiltinGlobalBootstrapError::NameConflict);
-        }
+        bindings
+            .validate_new_name(name)
+            .map_err(BuiltinGlobalBootstrapError::from)?;
     }
 
     let mut ids = Vec::with_capacity(names.len());
@@ -98,9 +101,9 @@ pub(crate) fn register_native_source_word(
     name: NormalizedName,
     handler: NativeSourceWordHandler,
 ) -> Result<SourceWordId, SourceWordBootstrapError> {
-    if bindings.get(&name).is_some() {
-        return Err(SourceWordBootstrapError::NameConflict);
-    }
+    bindings
+        .validate_new_name(&name)
+        .map_err(SourceWordBootstrapError::from_precheck_error)?;
 
     let id = source_words.register(handler);
 
@@ -119,9 +122,12 @@ pub(crate) fn register_builtin_source_words(
     // occupation; bootstrap must fail rather than silently overwrite a binding.
     let var_name = builtin_name("VAR");
     let let_name = builtin_name("LET");
-    if bindings.get(&var_name).is_some() || bindings.get(&let_name).is_some() {
-        return Err(SourceWordBootstrapError::NameConflict);
-    }
+    bindings
+        .validate_new_name(&var_name)
+        .map_err(SourceWordBootstrapError::from_precheck_error)?;
+    bindings
+        .validate_new_name(&let_name)
+        .map_err(SourceWordBootstrapError::from_precheck_error)?;
 
     let var = register_native_source_word(source_words, bindings, var_name, var_source_word)
         .expect("prechecked VAR source word should remain available");
@@ -158,17 +164,42 @@ fn builtin_name(input: &str) -> NormalizedName {
 }
 
 impl PrimitiveBootstrapError {
+    fn from_precheck_error(error: BindingInsertError) -> Self {
+        match error {
+            BindingInsertError::NameConflict => Self::NameConflict,
+            BindingInsertError::ReservedName => Self::ReservedName,
+        }
+    }
+
     fn from_binding_insert_error(error: BindingInsertError) -> Self {
         match error {
             BindingInsertError::NameConflict => Self::BindingRegistrationInvariantViolated,
+            BindingInsertError::ReservedName => Self::BindingRegistrationInvariantViolated,
+        }
+    }
+}
+
+impl From<BindingInsertError> for BuiltinGlobalBootstrapError {
+    fn from(error: BindingInsertError) -> Self {
+        match error {
+            BindingInsertError::NameConflict => Self::NameConflict,
+            BindingInsertError::ReservedName => Self::ReservedName,
         }
     }
 }
 
 impl SourceWordBootstrapError {
+    fn from_precheck_error(error: BindingInsertError) -> Self {
+        match error {
+            BindingInsertError::NameConflict => Self::NameConflict,
+            BindingInsertError::ReservedName => Self::ReservedName,
+        }
+    }
+
     fn from_binding_insert_error(error: BindingInsertError) -> Self {
         match error {
             BindingInsertError::NameConflict => Self::BindingRegistrationInvariantViolated,
+            BindingInsertError::ReservedName => Self::BindingRegistrationInvariantViolated,
         }
     }
 }
@@ -342,6 +373,20 @@ mod tests {
     }
 
     #[test]
+    fn reserved_primitive_name_is_rejected_without_word_id() {
+        for input in ["END", "end", "End"] {
+            let mut words = PublishedWords::new();
+            let mut bindings = Bindings::new();
+
+            let result = register_primitive(&mut words, &mut bindings, name(input), primitive(21));
+
+            assert_eq!(result, Err(PrimitiveBootstrapError::ReservedName));
+            assert_eq!(words.len(), 0);
+            assert!(bindings.is_empty());
+        }
+    }
+
+    #[test]
     fn case_variant_bootstrap_registration_is_rejected_without_mutation() {
         let mut words = PublishedWords::new();
         let mut bindings = Bindings::new();
@@ -452,6 +497,25 @@ mod tests {
         assert_eq!(source_words.len(), 1);
         assert_eq!(bindings.len(), 1);
         assert_source_word_binding(&bindings, "DUP_SOURCE", first);
+    }
+
+    #[test]
+    fn reserved_source_word_name_is_rejected_without_source_word_id() {
+        for input in ["END", "end", "End"] {
+            let mut source_words = SourceWordRegistry::new();
+            let mut bindings = Bindings::new();
+
+            let result = register_native_source_word(
+                &mut source_words,
+                &mut bindings,
+                name(input),
+                source_handler,
+            );
+
+            assert_eq!(result, Err(SourceWordBootstrapError::ReservedName));
+            assert_eq!(source_words.len(), 0);
+            assert!(bindings.is_empty());
+        }
     }
 
     #[test]

--- a/crates/tbx-next/src/lexer.rs
+++ b/crates/tbx-next/src/lexer.rs
@@ -432,6 +432,25 @@ mod tests {
     }
 
     #[test]
+    fn end_lexes_as_an_ordinary_name() {
+        let (sources, id, tokens) = lex_all("END end End");
+
+        assert_eq!(
+            kinds(&tokens),
+            [
+                TokenKind::Name,
+                TokenKind::Name,
+                TokenKind::Name,
+                TokenKind::Eof
+            ]
+        );
+        assert_token(tokens[0], TokenKind::Name, id, 0, 3);
+        assert_token(tokens[1], TokenKind::Name, id, 4, 7);
+        assert_token(tokens[2], TokenKind::Name, id, 8, 11);
+        assert_eq!(slices(sources.view(), &tokens), ["END", "end", "End", ""]);
+    }
+
+    #[test]
     fn minus_is_separate_from_integer_literals() {
         let (sources, _id, tokens) = lex_all("-1 2-3");
 

--- a/crates/tbx-next/src/name.rs
+++ b/crates/tbx-next/src/name.rs
@@ -83,6 +83,13 @@ mod tests {
     }
 
     #[test]
+    fn accepts_end_as_an_ordinary_normalized_name() {
+        assert_eq!(name("END").as_str(), "END");
+        assert_eq!(name("end").as_str(), "END");
+        assert_eq!(name("End").as_str(), "END");
+    }
+
+    #[test]
     fn normalizes_ascii_letters_to_uppercase() {
         assert_eq!(name("foo").as_str(), "FOO");
         assert_eq!(name("FOO").as_str(), "FOO");

--- a/crates/tbx-next/src/published_code.rs
+++ b/crates/tbx-next/src/published_code.rs
@@ -1,4 +1,4 @@
-use crate::binding::{Binding, BindingReplaceError, Bindings};
+use crate::binding::{Binding, BindingInsertError, BindingReplaceError, Bindings};
 use crate::instruction::{
     BranchTargetPatchError, CodeLocation, Instruction, InstructionAddress, InstructionAddressError,
     InstructionView,
@@ -69,6 +69,7 @@ pub(crate) enum WordBodyBuildError {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum NewWordPublicationError {
     NameConflict,
+    ReservedName,
     Build { source: WordBodyBuildError },
     Definition { source: WordDefinitionError },
     BindingCommitInvariantViolated,
@@ -95,9 +96,9 @@ impl PublishedCode {
         name: NormalizedName,
         build: impl FnOnce(&mut PublishedWordBuilder<'_>) -> Result<(), WordBodyBuildError>,
     ) -> Result<PublishedWord, NewWordPublicationError> {
-        if bindings.get(&name).is_some() {
-            return Err(NewWordPublicationError::NameConflict);
-        }
+        bindings
+            .validate_new_name(&name)
+            .map_err(NewWordPublicationError::from_precheck_error)?;
 
         let entry = self
             .build_word_body(build)
@@ -169,6 +170,15 @@ impl PublishedCode {
         Ok(PublishedWordEntry {
             location: self.code.instruction_view().location(entry_address),
         })
+    }
+}
+
+impl NewWordPublicationError {
+    fn from_precheck_error(error: BindingInsertError) -> Self {
+        match error {
+            BindingInsertError::NameConflict => Self::NameConflict,
+            BindingInsertError::ReservedName => Self::ReservedName,
+        }
     }
 }
 
@@ -542,6 +552,28 @@ mod tests {
             assert_eq!(code.len(), 0);
             assert_eq!(words.len(), 0);
             assert_eq!(bindings.get(&name("TAKEN")), Some(&existing));
+        }
+    }
+
+    #[test]
+    fn reserved_name_is_rejected_before_building_code() {
+        for input in ["END", "end", "End"] {
+            let mut code = PublishedCode::new();
+            let mut words = PublishedWords::new();
+            let mut bindings = Bindings::new();
+            let mut build_called = false;
+
+            let result = code.publish_new_word(&mut words, &mut bindings, name(input), |builder| {
+                build_called = true;
+                builder.append_unmapped(push(1))?;
+                Ok(())
+            });
+
+            assert_eq!(result, Err(NewWordPublicationError::ReservedName));
+            assert!(!build_called);
+            assert_eq!(code.len(), 0);
+            assert_eq!(words.len(), 0);
+            assert!(bindings.is_empty());
         }
     }
 

--- a/crates/tbx-next/src/source_word.rs
+++ b/crates/tbx-next/src/source_word.rs
@@ -60,6 +60,9 @@ pub(crate) enum SourceWordError {
     VarNameConflict {
         span: SourceSpan,
     },
+    VarReservedName {
+        span: SourceSpan,
+    },
     VarBindingCommitInvariantViolated {
         span: SourceSpan,
     },
@@ -311,9 +314,12 @@ impl<'source, 'state> NativeSourceWordContext<'source, 'state> {
             NativeSourceWordBindingAccess::Write(bindings) => &mut **bindings,
         };
 
-        if bindings.get(&name).is_some() {
-            return Err(SourceWordError::VarNameConflict { span });
-        }
+        bindings
+            .validate_new_name(&name)
+            .map_err(|source| match source {
+                BindingInsertError::NameConflict => SourceWordError::VarNameConflict { span },
+                BindingInsertError::ReservedName => SourceWordError::VarReservedName { span },
+            })?;
 
         let id = globals.allocate();
         // #1370/#1478/#1487 make binding insertion the VAR commit point:
@@ -322,6 +328,9 @@ impl<'source, 'state> NativeSourceWordContext<'source, 'state> {
             .insert_new(name, Binding::Variable(id))
             .map_err(|source| match source {
                 BindingInsertError::NameConflict => {
+                    SourceWordError::VarBindingCommitInvariantViolated { span }
+                }
+                BindingInsertError::ReservedName => {
                     SourceWordError::VarBindingCommitInvariantViolated { span }
                 }
             })
@@ -821,5 +830,40 @@ mod tests {
                 .get(crate::instruction::InstructionAddress::from_index(0)),
             Ok(&Instruction::Push(Value::integer(1)))
         );
+    }
+
+    #[test]
+    fn var_reserved_name_is_rejected_without_allocating_global_slot() {
+        for input in ["VAR END", "VAR end", "VAR End"] {
+            let (sources, source_id, tokens) = statement_tokens(input);
+            let mut code = SourceMappedCode::new();
+            let mut bindings = Bindings::new();
+            let mut globals = GlobalVariables::new();
+            let expected_span = span(sources.view(), source_id, 4, 7);
+
+            let result = {
+                let mut context = NativeSourceWordContext::new(NativeSourceWordContextParts {
+                    view: sources.view(),
+                    source_id,
+                    tokens: &tokens,
+                    bindings: NativeSourceWordBindingAccess::Write(&mut bindings),
+                    operators: None,
+                    code: &mut code,
+                    local_line_number_prefix: None,
+                    globals: Some(&mut globals),
+                });
+
+                var_source_word(&mut context)
+            };
+
+            assert_eq!(
+                result,
+                Err(SourceWordError::VarReservedName {
+                    span: expected_span
+                })
+            );
+            assert!(globals.is_empty());
+            assert!(bindings.is_empty());
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Add a shared `Bindings::validate_new_name` precheck and reject normalized `END` as a structured reserved binding name.
- Wire the precheck before primitive/source-word/global-variable/compiled-word publication consumes IDs, storage, or code body construction.
- Add focused regression tests that keep `END` ordinary for `NormalizedName` and lexer, while rejecting publication with no partial mutation.

Closes #1502

## Verification

- `cargo test -p tbx-next --no-fail-fast`
- `cargo clippy -p tbx-next --all-targets --all-features -- -D warnings`
- `cargo ci-fmt`
- `cargo ci-clippy`
- `cargo ci-test`
