### PR TITLE
TBX Next: statement lowering の命令生成先を分離する

### DIFF
--- a/crates/tbx-next/src/expression.rs
+++ b/crates/tbx-next/src/expression.rs
@@ -1,9 +1,9 @@
 use crate::global_variable::GlobalVarId;
 use crate::instruction::Instruction;
+use crate::instruction_builder::{InstructionBuildError, InstructionBuildTarget};
 use crate::lexer::{Token, TokenKind};
 use crate::operator::{OperatorLookup, OperatorSemantic};
 use crate::source::{SourceError, SourceSpan, SourceView};
-use crate::source_mapping::{SourceMappedCode, SourceMappingAppendError};
 use crate::value::Value;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -22,7 +22,7 @@ pub(crate) enum ExpressionError {
     Source(SourceError),
     Syntax(ExpressionSyntaxError),
     Variable(ExpressionVariableError),
-    SourceMappingAppend(SourceMappingAppendError),
+    InstructionBuild(InstructionBuildError),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -120,10 +120,14 @@ impl ExpressionStaging {
         self.entries.push(StagedInstruction { instruction, span });
     }
 
-    pub(crate) fn commit_to(&self, code: &mut SourceMappedCode) -> Result<(), ExpressionError> {
+    pub(crate) fn commit_to(
+        &self,
+        target: &mut dyn InstructionBuildTarget,
+    ) -> Result<(), ExpressionError> {
         for entry in &self.entries {
-            code.append_mapped(entry.instruction, entry.span)
-                .map_err(ExpressionError::SourceMappingAppend)?;
+            target
+                .append_mapped(entry.instruction, entry.span)
+                .map_err(ExpressionError::InstructionBuild)?;
         }
 
         Ok(())
@@ -493,6 +497,7 @@ mod tests {
     use crate::operator::register_operator_primitives;
     use crate::primitive::PrimitiveRegistry;
     use crate::source::{SourceId, SourceTexts};
+    use crate::source_mapping::SourceMappedCode;
     use crate::word::PublishedWords;
     use std::collections::HashMap;
 

--- a/crates/tbx-next/src/instruction_builder.rs
+++ b/crates/tbx-next/src/instruction_builder.rs
@@ -1,0 +1,336 @@
+use crate::instruction::{
+    BranchTargetPatchError, Instruction, InstructionAddress, InstructionAddressError,
+};
+use crate::published_code::{PublishedWordBuilder, WordBodyBuildError};
+use crate::source::SourceSpan;
+use crate::source_mapping::{SourceMappedCode, SourceMappingAppendError};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum InstructionBuildError {
+    SourceMappingAppend { source: SourceMappingAppendError },
+    BranchTargetPatch { source: BranchTargetPatchError },
+    WordBodyBuild { source: WordBodyBuildError },
+    InvalidAddress { source: InstructionAddressError },
+}
+
+pub(crate) trait InstructionBuildTarget {
+    fn current_address(&self) -> InstructionAddress {
+        InstructionAddress::from_index(self.current_len())
+    }
+
+    fn current_len(&self) -> usize;
+
+    fn append_mapped(
+        &mut self,
+        instruction: Instruction,
+        span: SourceSpan,
+    ) -> Result<InstructionAddress, InstructionBuildError>;
+
+    fn append_unmapped(
+        &mut self,
+        instruction: Instruction,
+    ) -> Result<InstructionAddress, InstructionBuildError>;
+
+    fn append_mapped_jump_placeholder(
+        &mut self,
+        span: SourceSpan,
+    ) -> Result<InstructionAddress, InstructionBuildError>;
+
+    fn append_mapped_jump_if_zero_placeholder(
+        &mut self,
+        span: SourceSpan,
+    ) -> Result<InstructionAddress, InstructionBuildError>;
+
+    fn patch_branch_target(
+        &mut self,
+        branch: InstructionAddress,
+        target: InstructionAddress,
+    ) -> Result<(), InstructionBuildError>;
+
+    fn validate_local_target(
+        &self,
+        address: InstructionAddress,
+    ) -> Result<(), InstructionBuildError>;
+}
+
+impl InstructionBuildTarget for SourceMappedCode {
+    fn current_len(&self) -> usize {
+        self.len()
+    }
+
+    fn append_mapped(
+        &mut self,
+        instruction: Instruction,
+        span: SourceSpan,
+    ) -> Result<InstructionAddress, InstructionBuildError> {
+        SourceMappedCode::append_mapped(self, instruction, span)
+            .map_err(|source| InstructionBuildError::SourceMappingAppend { source })
+    }
+
+    fn append_unmapped(
+        &mut self,
+        instruction: Instruction,
+    ) -> Result<InstructionAddress, InstructionBuildError> {
+        SourceMappedCode::append_unmapped(self, instruction)
+            .map_err(|source| InstructionBuildError::SourceMappingAppend { source })
+    }
+
+    fn append_mapped_jump_placeholder(
+        &mut self,
+        span: SourceSpan,
+    ) -> Result<InstructionAddress, InstructionBuildError> {
+        SourceMappedCode::append_mapped(
+            self,
+            Instruction::Jump(InstructionAddress::from_index(0)),
+            span,
+        )
+        .map_err(|source| InstructionBuildError::SourceMappingAppend { source })
+    }
+
+    fn append_mapped_jump_if_zero_placeholder(
+        &mut self,
+        span: SourceSpan,
+    ) -> Result<InstructionAddress, InstructionBuildError> {
+        SourceMappedCode::append_mapped(
+            self,
+            Instruction::JumpIfZero(InstructionAddress::from_index(0)),
+            span,
+        )
+        .map_err(|source| InstructionBuildError::SourceMappingAppend { source })
+    }
+
+    fn patch_branch_target(
+        &mut self,
+        branch: InstructionAddress,
+        target: InstructionAddress,
+    ) -> Result<(), InstructionBuildError> {
+        SourceMappedCode::patch_branch_target(self, branch, target)
+            .map_err(|source| InstructionBuildError::BranchTargetPatch { source })
+    }
+
+    fn validate_local_target(
+        &self,
+        address: InstructionAddress,
+    ) -> Result<(), InstructionBuildError> {
+        self.validate_address(address)
+            .map(|_| ())
+            .map_err(|source| InstructionBuildError::InvalidAddress { source })
+    }
+}
+
+impl InstructionBuildTarget for PublishedWordBuilder<'_> {
+    fn current_len(&self) -> usize {
+        self.current_len()
+    }
+
+    fn append_mapped(
+        &mut self,
+        instruction: Instruction,
+        span: SourceSpan,
+    ) -> Result<InstructionAddress, InstructionBuildError> {
+        PublishedWordBuilder::append_mapped(self, instruction, span)
+            .map_err(|source| InstructionBuildError::WordBodyBuild { source })
+    }
+
+    fn append_unmapped(
+        &mut self,
+        instruction: Instruction,
+    ) -> Result<InstructionAddress, InstructionBuildError> {
+        PublishedWordBuilder::append_unmapped(self, instruction)
+            .map_err(|source| InstructionBuildError::WordBodyBuild { source })
+    }
+
+    fn append_mapped_jump_placeholder(
+        &mut self,
+        span: SourceSpan,
+    ) -> Result<InstructionAddress, InstructionBuildError> {
+        PublishedWordBuilder::append_mapped_jump_placeholder(self, span)
+            .map_err(|source| InstructionBuildError::WordBodyBuild { source })
+    }
+
+    fn append_mapped_jump_if_zero_placeholder(
+        &mut self,
+        span: SourceSpan,
+    ) -> Result<InstructionAddress, InstructionBuildError> {
+        PublishedWordBuilder::append_mapped_jump_if_zero_placeholder(self, span)
+            .map_err(|source| InstructionBuildError::WordBodyBuild { source })
+    }
+
+    fn patch_branch_target(
+        &mut self,
+        branch: InstructionAddress,
+        target: InstructionAddress,
+    ) -> Result<(), InstructionBuildError> {
+        PublishedWordBuilder::patch_branch_target(self, branch, target)
+            .map_err(|source| InstructionBuildError::WordBodyBuild { source })
+    }
+
+    fn validate_local_target(
+        &self,
+        address: InstructionAddress,
+    ) -> Result<(), InstructionBuildError> {
+        self.validate_local_target(address)
+            .map_err(|source| InstructionBuildError::WordBodyBuild { source })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::binding::Bindings;
+    use crate::instruction::Instruction;
+    use crate::name::NormalizedName;
+    use crate::published_code::{NewWordPublicationError, PublishedCode};
+    use crate::source::{SourceId, SourceTexts, SourceView};
+    use crate::value::Value;
+    use crate::word::PublishedWords;
+
+    fn name(input: &str) -> NormalizedName {
+        NormalizedName::new(input).expect("test input should be a valid word name")
+    }
+
+    fn source(text: &str) -> (SourceTexts, SourceId) {
+        let mut sources = SourceTexts::new();
+        let id = sources.register(text);
+        (sources, id)
+    }
+
+    fn span(view: SourceView<'_>, source_id: SourceId, start: usize, end: usize) -> SourceSpan {
+        view.span(source_id, start, end)
+            .expect("test span should be valid")
+    }
+
+    fn push(value: i16) -> Instruction {
+        Instruction::Push(Value::integer(value))
+    }
+
+    fn unwrap_published_build_error(error: InstructionBuildError) -> WordBodyBuildError {
+        match error {
+            InstructionBuildError::WordBodyBuild { source } => source,
+            source => panic!("unexpected target error: {source:?}"),
+        }
+    }
+
+    #[test]
+    fn temporary_target_maps_placeholder_and_patches_without_mapping_change() {
+        let (sources, source_id) = source("BIF X, 20\n20");
+        let branch_span = span(sources.view(), source_id, 0, 3);
+        let target_span = span(sources.view(), source_id, 10, 12);
+        let mut code = SourceMappedCode::new();
+
+        let branch = code
+            .append_mapped_jump_if_zero_placeholder(branch_span)
+            .expect("branch placeholder should append");
+        let target = code
+            .append_mapped(Instruction::Halt, target_span)
+            .expect("target should append");
+        code.patch_branch_target(branch, target)
+            .expect("branch should patch");
+
+        assert_eq!(
+            code.instruction_view().get(branch),
+            Ok(&Instruction::JumpIfZero(target))
+        );
+        assert_eq!(
+            code.source_mapping()
+                .source_span(code.instruction_view().location(branch)),
+            Ok(Some(branch_span))
+        );
+    }
+
+    #[test]
+    fn published_target_uses_builder_branch_placeholder_contract() {
+        let (sources, source_id) = source("BIF X, 20\n20");
+        let branch_span = span(sources.view(), source_id, 0, 3);
+        let target_span = span(sources.view(), source_id, 10, 12);
+        let mut code = PublishedCode::new();
+        let mut words = PublishedWords::new();
+        let mut bindings = Bindings::new();
+
+        let word = code
+            .publish_new_word(&mut words, &mut bindings, name("BRANCH"), |builder| {
+                let target: &mut dyn InstructionBuildTarget = builder;
+                let branch = target
+                    .append_mapped_jump_if_zero_placeholder(branch_span)
+                    .map_err(unwrap_published_build_error)?;
+                let destination = target
+                    .append_mapped(Instruction::Return, target_span)
+                    .map_err(unwrap_published_build_error)?;
+                target
+                    .patch_branch_target(branch, destination)
+                    .map_err(unwrap_published_build_error)
+            })
+            .expect("word should publish");
+
+        assert_eq!(
+            code.instruction_view().get_location(word.entry()),
+            Ok(&Instruction::JumpIfZero(InstructionAddress::from_index(1)))
+        );
+        assert_eq!(
+            code.source_mapping().source_span(word.entry()),
+            Ok(Some(branch_span))
+        );
+    }
+
+    #[test]
+    fn published_target_rejects_direct_branch_append_through_common_interface() {
+        let (sources, source_id) = source("GOTO");
+        let branch_span = span(sources.view(), source_id, 0, 4);
+        let mut code = PublishedCode::new();
+        let mut words = PublishedWords::new();
+        let mut bindings = Bindings::new();
+        let branch = Instruction::Jump(InstructionAddress::from_index(0));
+
+        let result = code.publish_new_word(&mut words, &mut bindings, name("BAD"), |builder| {
+            let target: &mut dyn InstructionBuildTarget = builder;
+            target
+                .append_mapped(branch, branch_span)
+                .map(|_| ())
+                .map_err(unwrap_published_build_error)
+        });
+
+        assert_eq!(
+            result,
+            Err(NewWordPublicationError::Build {
+                source: WordBodyBuildError::BranchInstructionRequiresPatch {
+                    instruction: branch
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn published_target_rejects_patch_to_previous_body_address() {
+        let (sources, source_id) = source("GOTO OLD");
+        let branch_span = span(sources.view(), source_id, 0, 4);
+        let mut code = PublishedCode::new();
+        let mut words = PublishedWords::new();
+        let mut bindings = Bindings::new();
+        let old = code
+            .publish_new_word(&mut words, &mut bindings, name("OLD"), |builder| {
+                builder.append_unmapped(push(1))?;
+                builder.append_unmapped(Instruction::Return)?;
+                Ok(())
+            })
+            .expect("old word should publish");
+
+        let result = code.publish_new_word(&mut words, &mut bindings, name("NEW"), |builder| {
+            let target: &mut dyn InstructionBuildTarget = builder;
+            let branch = target
+                .append_mapped_jump_placeholder(branch_span)
+                .map_err(unwrap_published_build_error)?;
+            target
+                .patch_branch_target(branch, old.entry().address())
+                .map_err(unwrap_published_build_error)
+        });
+
+        assert_eq!(
+            result,
+            Err(NewWordPublicationError::Build {
+                source: WordBodyBuildError::AddressOutsideCurrentBody {
+                    address: old.entry().address()
+                }
+            })
+        );
+    }
+}

--- a/crates/tbx-next/src/lib.rs
+++ b/crates/tbx-next/src/lib.rs
@@ -67,6 +67,11 @@ mod source;
 #[allow(dead_code)]
 mod source_mapping;
 
+// #1504 keeps statement lowering independent from concrete instruction owners
+// while preserving published-word branch patch contracts.
+#[allow(dead_code)]
+mod instruction_builder;
+
 // ADR #1369/#1461 coordinates internal runtime word body construction and
 // publication into one shared source-mapped published code owner.
 #[allow(dead_code)]

--- a/crates/tbx-next/src/line_number.rs
+++ b/crates/tbx-next/src/line_number.rs
@@ -1,6 +1,6 @@
-use crate::instruction::{BranchTargetPatchError, InstructionAddress, InstructionAddressError};
+use crate::instruction::InstructionAddress;
+use crate::instruction_builder::{InstructionBuildError, InstructionBuildTarget};
 use crate::source::SourceSpan;
-use crate::source_mapping::SourceMappedCode;
 use std::collections::HashMap;
 
 /// Owner-local compile-time line number identifier.
@@ -46,12 +46,12 @@ pub(crate) enum LineNumberError {
     InvalidDefinitionTarget {
         line_number: LocalLineNumber,
         span: SourceSpan,
-        source: InstructionAddressError,
+        source: InstructionBuildError,
     },
     Patch {
         line_number: LocalLineNumber,
         span: SourceSpan,
-        source: BranchTargetPatchError,
+        source: InstructionBuildError,
     },
 }
 
@@ -72,18 +72,18 @@ impl LocalLineNumberTable {
 
     pub(crate) fn define(
         &mut self,
-        code: &SourceMappedCode,
+        target_owner: &dyn InstructionBuildTarget,
         line_number: LocalLineNumber,
         target: InstructionAddress,
         span: SourceSpan,
     ) -> Result<(), LineNumberError> {
-        code.validate_address(target).map_err(|source| {
-            LineNumberError::InvalidDefinitionTarget {
+        target_owner
+            .validate_local_target(target)
+            .map_err(|source| LineNumberError::InvalidDefinitionTarget {
                 line_number,
                 span,
                 source,
-            }
-        })?;
+            })?;
 
         if let Some(existing) = self.definitions.get(&line_number) {
             return Err(LineNumberError::Duplicate {
@@ -111,7 +111,10 @@ impl LocalLineNumberTable {
         });
     }
 
-    pub(crate) fn resolve(&self, code: &mut SourceMappedCode) -> Result<(), LineNumberError> {
+    pub(crate) fn resolve(
+        &self,
+        target: &mut dyn InstructionBuildTarget,
+    ) -> Result<(), LineNumberError> {
         let mut resolved = Vec::with_capacity(self.patches.len());
         for patch in &self.patches {
             let Some(definition) = self.definitions.get(&patch.line_number) else {
@@ -123,8 +126,9 @@ impl LocalLineNumberTable {
             resolved.push((*patch, definition.target));
         }
 
-        for (patch, target) in resolved {
-            code.patch_branch_target(patch.branch, target)
+        for (patch, target_address) in resolved {
+            target
+                .patch_branch_target(patch.branch, target_address)
                 .map_err(|source| LineNumberError::Patch {
                     line_number: patch.line_number,
                     span: patch.span,
@@ -150,8 +154,11 @@ impl LineNumberError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::instruction::{Instruction, InstructionAddress};
+    use crate::instruction::{
+        BranchTargetPatchError, Instruction, InstructionAddress, InstructionAddressError,
+    };
     use crate::source::{SourceId, SourceTexts, SourceView};
+    use crate::source_mapping::SourceMappedCode;
     use crate::value::Value;
 
     fn source(text: &str) -> (SourceTexts, SourceId) {
@@ -294,8 +301,10 @@ mod tests {
             Err(LineNumberError::InvalidDefinitionTarget {
                 line_number: line(100),
                 span: line_span,
-                source: InstructionAddressError::EndAddress {
-                    address: address(1)
+                source: InstructionBuildError::InvalidAddress {
+                    source: InstructionAddressError::EndAddress {
+                        address: address(1)
+                    }
                 },
             })
         );
@@ -304,8 +313,10 @@ mod tests {
             Err(LineNumberError::InvalidDefinitionTarget {
                 line_number: line(100),
                 span: line_span,
-                source: InstructionAddressError::InvalidAddress {
-                    address: address(2)
+                source: InstructionBuildError::InvalidAddress {
+                    source: InstructionAddressError::InvalidAddress {
+                        address: address(2)
+                    }
                 },
             })
         );
@@ -351,9 +362,11 @@ mod tests {
             Err(LineNumberError::Patch {
                 line_number: line(100),
                 span: branch_span,
-                source: BranchTargetPatchError::NonBranchInstruction {
-                    address: non_branch,
-                    instruction: Instruction::Push(Value::integer(1)),
+                source: InstructionBuildError::BranchTargetPatch {
+                    source: BranchTargetPatchError::NonBranchInstruction {
+                        address: non_branch,
+                        instruction: Instruction::Push(Value::integer(1)),
+                    }
                 },
             })
         );

--- a/crates/tbx-next/src/published_code.rs
+++ b/crates/tbx-next/src/published_code.rs
@@ -193,6 +193,14 @@ impl PublishedWord {
 }
 
 impl PublishedWordBuilder<'_> {
+    pub(crate) fn current_address(&self) -> InstructionAddress {
+        InstructionAddress::from_index(self.code.len())
+    }
+
+    pub(crate) fn current_len(&self) -> usize {
+        self.code.len()
+    }
+
     pub(crate) fn append_mapped(
         &mut self,
         instruction: Instruction,
@@ -286,6 +294,13 @@ impl PublishedWordBuilder<'_> {
 
         self.unresolved_patches.push(branch);
         Ok(branch)
+    }
+
+    pub(crate) fn validate_local_target(
+        &self,
+        address: InstructionAddress,
+    ) -> Result<(), WordBodyBuildError> {
+        self.validate_current_body_address(address)
     }
 
     fn validate_current_body_address(

--- a/crates/tbx-next/src/source_processor.rs
+++ b/crates/tbx-next/src/source_processor.rs
@@ -7,14 +7,14 @@ use crate::instruction::{
     CodeLocation, CodeSpaceLookup, CodeSpaceLookupError, Instruction, InstructionAddress,
     InstructionView,
 };
+use crate::instruction_builder::{InstructionBuildError, InstructionBuildTarget};
 use crate::lexer::{LexError, Lexer, Token, TokenKind};
 use crate::line_number::{LineNumberError, LocalLineNumber, LocalLineNumberTable};
 use crate::operator::OperatorLookup;
 use crate::primitive::PrimitiveLookup;
 use crate::source::{SourceError, SourceId, SourceSpan, SourceView};
 use crate::source_mapping::{
-    InstructionSourceMappingView, SourceMappedCode, SourceMappingAppendError, SourceMappingLookup,
-    SourceMappingLookupError,
+    InstructionSourceMappingView, SourceMappedCode, SourceMappingLookup, SourceMappingLookupError,
 };
 use crate::source_word::{
     NativeSourceWordBindingAccess, NativeSourceWordContext, NativeSourceWordContextParts,
@@ -78,13 +78,13 @@ pub(crate) struct RuntimeError {
     source_span: Result<Option<SourceSpan>, SourceMappingLookupError>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum SourceProcessorError {
     Source(SourceError),
     Lex(LexError),
     Compile(CompileError),
     CodeSpaceLookup(CodeSpaceLookupError),
-    SourceMappingAppend(SourceMappingAppendError),
+    InstructionBuild(InstructionBuildError),
     SourceMappingLookup(SourceMappingLookupError),
     SourceWordContextUnavailable { id: SourceWordId },
     SourceWordLookup(SourceWordLookupError),
@@ -92,13 +92,13 @@ pub(crate) enum SourceProcessorError {
     Runtime(RuntimeError),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct CompileError {
     span: SourceSpan,
     kind: CompileErrorKind,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum CompileErrorKind {
     UnsupportedToken { kind: TokenKind },
     BareExpression,
@@ -107,7 +107,7 @@ pub(crate) enum CompileErrorKind {
     IntegerLiteralConversion,
     LineNumberLiteralOutOfRange,
     LineNumberLiteralConversion,
-    LineNumber { source: LineNumberError },
+    LineNumber { source: Box<LineNumberError> },
     WordResolution { source: WordResolutionError },
     Expression { source: ExpressionSyntaxErrorKind },
     ExpressionVariable { source: ExpressionVariableErrorKind },
@@ -124,7 +124,7 @@ pub(crate) enum BifSyntaxErrorKind {
 type OptionalLineNumberPrefix = Option<(LocalLineNumber, SourceSpan)>;
 
 struct StatementCompileState<'a> {
-    code: &'a mut SourceMappedCode,
+    code: &'a mut dyn InstructionBuildTarget,
     line_numbers: &'a mut LocalLineNumberTable,
     referenced_line_numbers: &'a HashSet<LocalLineNumber>,
 }
@@ -153,9 +153,9 @@ impl From<CodeSpaceLookupError> for SourceProcessorError {
     }
 }
 
-impl From<SourceMappingAppendError> for SourceProcessorError {
-    fn from(error: SourceMappingAppendError) -> Self {
-        Self::SourceMappingAppend(error)
+impl From<InstructionBuildError> for SourceProcessorError {
+    fn from(error: InstructionBuildError) -> Self {
+        Self::InstructionBuild(error)
     }
 }
 
@@ -199,7 +199,7 @@ pub(crate) fn compile_source(
         Terminal::Eof(eof) => eof,
         Terminal::LexError(error) => return Err(error.into()),
     };
-    code.append_mapped(Instruction::Halt, eof.span())?;
+    InstructionBuildTarget::append_mapped(&mut code, Instruction::Halt, eof.span())?;
 
     let entry = code
         .instruction_view()
@@ -260,7 +260,7 @@ fn compile_statement<'source>(
         state.referenced_line_numbers,
         context.bindings(),
     )?;
-    let start = state.code.len();
+    let start = state.code.current_address();
     let local_line_number_prefix = line_number.map(|(_, span)| span);
     compile_statement_body(
         view,
@@ -273,10 +273,9 @@ fn compile_statement<'source>(
     )?;
 
     if let Some((line_number, span)) = line_number {
-        let target = InstructionAddress::from_index(start);
         state
             .line_numbers
-            .define(state.code, line_number, target, span)
+            .define(state.code, line_number, start, span)
             .map_err(|source| line_number_compile_error(source).into())
     } else {
         Ok(())
@@ -362,7 +361,7 @@ fn compile_statement_leading_source_word<'source>(
     tokens: &'source [Token],
     context: &mut SourceCompileContext<'_>,
     local_line_number_prefix: Option<SourceSpan>,
-    code: &mut SourceMappedCode,
+    code: &mut dyn InstructionBuildTarget,
     cursor: &mut LogicalStatementCursor<'source, 'source>,
 ) -> Result<bool, SourceProcessorError> {
     let Some(first) = tokens.first().copied() else {
@@ -415,7 +414,7 @@ fn compile_simple_tokens(
     view: SourceView<'_>,
     tokens: &[Token],
     context: &SourceCompileContext<'_>,
-    code: &mut SourceMappedCode,
+    code: &mut dyn InstructionBuildTarget,
 ) -> Result<(), SourceProcessorError> {
     for token in tokens {
         match token.kind() {
@@ -459,7 +458,7 @@ fn compile_bif(
     source_id: SourceId,
     tokens: &[Token],
     context: &SourceCompileContext<'_>,
-    code: &mut SourceMappedCode,
+    code: &mut dyn InstructionBuildTarget,
     line_numbers: &mut LocalLineNumberTable,
 ) -> Result<(), SourceProcessorError> {
     let bif = tokens
@@ -511,10 +510,7 @@ fn compile_bif(
     }
 
     let line_number = compile_line_number_literal(view, target)?;
-    let branch = code.append_mapped(
-        Instruction::JumpIfZero(InstructionAddress::from_index(0)),
-        bif.span(),
-    )?;
+    let branch = code.append_mapped_jump_if_zero_placeholder(bif.span())?;
     line_numbers.add_patch(line_number, branch, target.span());
     Ok(())
 }
@@ -525,7 +521,7 @@ fn compile_expression_tokens(
     tokens: &[Token],
     bindings: &Bindings,
     operators: OperatorLookup,
-    code: &mut SourceMappedCode,
+    code: &mut dyn InstructionBuildTarget,
 ) -> Result<(), SourceProcessorError> {
     let mut expression_tokens = tokens
         .iter()
@@ -849,7 +845,9 @@ fn bif_syntax(span: SourceSpan, source: BifSyntaxErrorKind) -> CompileError {
 fn line_number_compile_error(source: LineNumberError) -> CompileError {
     CompileError {
         span: source.primary_span(),
-        kind: CompileErrorKind::LineNumber { source },
+        kind: CompileErrorKind::LineNumber {
+            source: Box::new(source),
+        },
     }
 }
 
@@ -1354,7 +1352,7 @@ impl SourceProcessorError {
                     source: error.kind(),
                 },
             }),
-            ExpressionError::SourceMappingAppend(error) => Self::SourceMappingAppend(error),
+            ExpressionError::InstructionBuild(error) => Self::InstructionBuild(error),
         }
     }
 }
@@ -1384,12 +1382,12 @@ impl RuntimeError {
 }
 
 impl CompileError {
-    pub(crate) const fn span(self) -> SourceSpan {
+    pub(crate) const fn span(&self) -> SourceSpan {
         self.span
     }
 
-    pub(crate) const fn kind(self) -> CompileErrorKind {
-        self.kind
+    pub(crate) fn kind(&self) -> CompileErrorKind {
+        self.kind.clone()
     }
 }
 
@@ -3252,10 +3250,10 @@ mod tests {
         assert_eq!(
             error.kind(),
             CompileErrorKind::LineNumber {
-                source: LineNumberError::Undefined {
+                source: Box::new(LineNumberError::Undefined {
                     line_number: LocalLineNumber::new(200),
                     span: span(sources.view(), id, 7, 10),
-                }
+                })
             }
         );
     }
@@ -3272,11 +3270,11 @@ mod tests {
         assert_eq!(
             error.kind(),
             CompileErrorKind::LineNumber {
-                source: LineNumberError::Duplicate {
+                source: Box::new(LineNumberError::Duplicate {
                     line_number: LocalLineNumber::new(100),
                     original_span: span(sources.view(), id, 0, 3),
                     duplicate_span: span(sources.view(), id, 15, 18),
-                }
+                })
             }
         );
     }

--- a/crates/tbx-next/src/source_word.rs
+++ b/crates/tbx-next/src/source_word.rs
@@ -4,11 +4,11 @@ use crate::expression::{
 };
 use crate::global_variable::GlobalVariables;
 use crate::instruction::Instruction;
+use crate::instruction_builder::{InstructionBuildError, InstructionBuildTarget};
 use crate::lexer::{LexError, Token, TokenKind};
 use crate::name::{NameError, NormalizedName};
 use crate::operator::OperatorLookup;
 use crate::source::{SourceError, SourceId, SourceSpan, SourceView};
-use crate::source_mapping::{SourceMappedCode, SourceMappingAppendError};
 use crate::word_resolution::{resolve_binding_name, ResolvedBinding, WordResolutionError};
 
 /// Internal identifier for a published source-processing word.
@@ -39,8 +39,8 @@ pub(crate) enum SourceWordError {
     Source {
         source: SourceError,
     },
-    SourceMappingAppend {
-        source: SourceMappingAppendError,
+    InstructionBuild {
+        source: InstructionBuildError,
     },
     UnsupportedSourceWord {
         span: SourceSpan,
@@ -304,7 +304,7 @@ pub(crate) struct NativeSourceWordContext<'source, 'state> {
     block_reader: Option<SourceBlockReader<'source, 'state>>,
     bindings: NativeSourceWordBindingAccess<'state>,
     operators: Option<OperatorLookup>,
-    code: &'state mut SourceMappedCode,
+    code: &'state mut dyn InstructionBuildTarget,
     local_line_number_prefix: Option<SourceSpan>,
     globals: Option<&'state mut GlobalVariables>,
 }
@@ -316,7 +316,7 @@ pub(crate) struct NativeSourceWordContextParts<'source, 'state> {
     pub(crate) block_reader: Option<SourceBlockReader<'source, 'state>>,
     pub(crate) bindings: NativeSourceWordBindingAccess<'state>,
     pub(crate) operators: Option<OperatorLookup>,
-    pub(crate) code: &'state mut SourceMappedCode,
+    pub(crate) code: &'state mut dyn InstructionBuildTarget,
     pub(crate) local_line_number_prefix: Option<SourceSpan>,
     pub(crate) globals: Option<&'state mut GlobalVariables>,
 }
@@ -375,7 +375,7 @@ impl<'source, 'state> NativeSourceWordContext<'source, 'state> {
         self.code
             .append_mapped(instruction, span)
             .map(|_| ())
-            .map_err(|source| SourceWordError::SourceMappingAppend { source })
+            .map_err(|source| SourceWordError::InstructionBuild { source })
     }
 
     pub(crate) fn publish_global_variable(
@@ -459,8 +459,8 @@ impl<'source, 'state> NativeSourceWordContext<'source, 'state> {
         staging: &ExpressionStaging,
     ) -> Result<(), SourceWordError> {
         staging.commit_to(self.code).map_err(|source| match source {
-            ExpressionError::SourceMappingAppend(source) => {
-                SourceWordError::SourceMappingAppend { source }
+            ExpressionError::InstructionBuild(source) => {
+                SourceWordError::InstructionBuild { source }
             }
             source => SourceWordError::Expression { source },
         })
@@ -658,6 +658,7 @@ impl SourceWordLookup<'_> {
 mod tests {
     use super::*;
     use crate::source::SourceTexts;
+    use crate::source_mapping::SourceMappedCode;
     use crate::value::Value;
 
     fn statement_tokens(text: &str) -> (SourceTexts, SourceId, Vec<Token>) {


### PR DESCRIPTION
## Summary

- Added a crate-internal `InstructionBuildTarget` boundary with adapters for temporary `SourceMappedCode` and `PublishedWordBuilder`.
- Moved expression staging, source word emission, BIF lowering, and local line number define/resolve onto the common build target.
- Preserved published word branch safety by requiring placeholder APIs for branch emission and validating patch targets inside the current body.

## Verification

- `cargo test -p tbx-next --no-fail-fast`
- `cargo clippy -p tbx-next --all-targets --all-features -- -D warnings`
- `cargo ci-fmt`
- `cargo ci-clippy`
- `cargo ci-test`

Closes #1504
