### PR TITLE
TBX Next: DEF source wordをruntime word publicationへ接続

### DIFF
--- a/crates/tbx-next/src/bootstrap.rs
+++ b/crates/tbx-next/src/bootstrap.rs
@@ -2,7 +2,8 @@ use crate::binding::{Binding, BindingInsertError, Bindings};
 use crate::global_variable::{GlobalVarId, GlobalVariables};
 use crate::name::NormalizedName;
 use crate::source_word::{
-    let_source_word, var_source_word, NativeSourceWordHandler, SourceWordId, SourceWordRegistry,
+    def_source_word, let_source_word, var_source_word, NativeSourceWordHandler, SourceWordId,
+    SourceWordRegistry,
 };
 use crate::word::{CompletedWordDefinition, PrimitiveId, PublishedWords, WordId};
 
@@ -122,25 +123,32 @@ pub(crate) fn register_builtin_source_words(
     // occupation; bootstrap must fail rather than silently overwrite a binding.
     let var_name = builtin_name("VAR");
     let let_name = builtin_name("LET");
+    let def_name = builtin_name("DEF");
     bindings
         .validate_new_name(&var_name)
         .map_err(SourceWordBootstrapError::from_precheck_error)?;
     bindings
         .validate_new_name(&let_name)
         .map_err(SourceWordBootstrapError::from_precheck_error)?;
+    bindings
+        .validate_new_name(&def_name)
+        .map_err(SourceWordBootstrapError::from_precheck_error)?;
 
     let var = register_native_source_word(source_words, bindings, var_name, var_source_word)
         .expect("prechecked VAR source word should remain available");
     let let_ = register_native_source_word(source_words, bindings, let_name, let_source_word)
         .expect("prechecked LET source word should remain available");
+    let def = register_native_source_word(source_words, bindings, def_name, def_source_word)
+        .expect("prechecked DEF source word should remain available");
 
-    Ok(BuiltinSourceWordIds { var, let_ })
+    Ok(BuiltinSourceWordIds { var, let_, def })
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct BuiltinSourceWordIds {
     var: SourceWordId,
     let_: SourceWordId,
+    def: SourceWordId,
 }
 
 impl BuiltinSourceWordIds {
@@ -150,6 +158,10 @@ impl BuiltinSourceWordIds {
 
     pub(crate) const fn let_(self) -> SourceWordId {
         self.let_
+    }
+
+    pub(crate) const fn def(self) -> SourceWordId {
+        self.def
     }
 }
 
@@ -589,11 +601,13 @@ mod tests {
         let ids = register_builtin_source_words(&mut source_words, &mut bindings)
             .expect("empty namespace should accept built-in source words");
 
-        assert_eq!(source_words.len(), 2);
+        assert_eq!(source_words.len(), 3);
         assert_source_word_binding(&bindings, "VAR", ids.var());
         assert_source_word_binding(&bindings, "var", ids.var());
         assert_source_word_binding(&bindings, "LET", ids.let_());
         assert_source_word_binding(&bindings, "let", ids.let_());
+        assert_source_word_binding(&bindings, "DEF", ids.def());
+        assert_source_word_binding(&bindings, "def", ids.def());
     }
 
     #[test]
@@ -633,6 +647,27 @@ mod tests {
         assert_eq!(source_words.len(), 1);
         assert_eq!(bindings.get(&name("VAR")), None);
         assert_source_word_binding(&bindings, "LET", existing);
+    }
+
+    #[test]
+    fn builtin_source_word_bootstrap_def_conflict_does_not_publish_prefix() {
+        let mut source_words = SourceWordRegistry::new();
+        let mut bindings = Bindings::new();
+        let existing = register_native_source_word(
+            &mut source_words,
+            &mut bindings,
+            name("def"),
+            source_handler,
+        )
+        .expect("test DEF source word should register");
+
+        let result = register_builtin_source_words(&mut source_words, &mut bindings);
+
+        assert_eq!(result, Err(SourceWordBootstrapError::NameConflict));
+        assert_eq!(source_words.len(), 1);
+        assert_eq!(bindings.get(&name("VAR")), None);
+        assert_eq!(bindings.get(&name("LET")), None);
+        assert_source_word_binding(&bindings, "DEF", existing);
     }
 
     #[test]

--- a/crates/tbx-next/src/instruction_builder.rs
+++ b/crates/tbx-next/src/instruction_builder.rs
@@ -248,7 +248,7 @@ mod tests {
         let mut bindings = Bindings::new();
 
         let word = code
-            .publish_new_word(&mut words, &mut bindings, name("BRANCH"), |builder| {
+            .publish_new_word(&mut words, &mut bindings, name("BRANCH"), |_, builder| {
                 let target: &mut dyn InstructionBuildTarget = builder;
                 let branch = target
                     .append_mapped_jump_if_zero_placeholder(branch_span)
@@ -281,7 +281,7 @@ mod tests {
         let mut bindings = Bindings::new();
         let branch = Instruction::Jump(InstructionAddress::from_index(0));
 
-        let result = code.publish_new_word(&mut words, &mut bindings, name("BAD"), |builder| {
+        let result = code.publish_new_word(&mut words, &mut bindings, name("BAD"), |_, builder| {
             let target: &mut dyn InstructionBuildTarget = builder;
             target
                 .append_mapped(branch, branch_span)
@@ -307,14 +307,14 @@ mod tests {
         let mut words = PublishedWords::new();
         let mut bindings = Bindings::new();
         let old = code
-            .publish_new_word(&mut words, &mut bindings, name("OLD"), |builder| {
+            .publish_new_word(&mut words, &mut bindings, name("OLD"), |_, builder| {
                 builder.append_unmapped(push(1))?;
                 builder.append_unmapped(Instruction::Return)?;
                 Ok(())
             })
             .expect("old word should publish");
 
-        let result = code.publish_new_word(&mut words, &mut bindings, name("NEW"), |builder| {
+        let result = code.publish_new_word(&mut words, &mut bindings, name("NEW"), |_, builder| {
             let target: &mut dyn InstructionBuildTarget = builder;
             let branch = target
                 .append_mapped_jump_placeholder(branch_span)

--- a/crates/tbx-next/src/published_code.rs
+++ b/crates/tbx-next/src/published_code.rs
@@ -95,34 +95,6 @@ impl PublishedCode {
         words: &mut PublishedWords,
         bindings: &mut Bindings,
         name: NormalizedName,
-        build: impl FnOnce(&mut PublishedWordBuilder<'_>) -> Result<(), WordBodyBuildError>,
-    ) -> Result<PublishedWord, NewWordPublicationError> {
-        bindings
-            .validate_new_name(&name)
-            .map_err(NewWordPublicationError::from_precheck_error)?;
-
-        let entry = self
-            .build_word_body(build)
-            .map_err(|source| NewWordPublicationError::Build { source })?;
-        let definition = CompletedWordDefinition::compiled(entry.location, self.instruction_view())
-            .map_err(|source| NewWordPublicationError::Definition { source })?;
-        let id = words.add(definition);
-
-        bindings
-            .insert_new(name, Binding::Word(id))
-            .map_err(|_| NewWordPublicationError::BindingCommitInvariantViolated)?;
-
-        Ok(PublishedWord {
-            id,
-            entry: entry.location,
-        })
-    }
-
-    pub(crate) fn publish_new_word_with_bindings(
-        &mut self,
-        words: &mut PublishedWords,
-        bindings: &mut Bindings,
-        name: NormalizedName,
         build: impl FnOnce(&Bindings, &mut PublishedWordBuilder<'_>) -> Result<(), WordBodyBuildError>,
     ) -> Result<PublishedWord, NewWordPublicationError> {
         bindings
@@ -443,7 +415,7 @@ mod tests {
         input: &str,
         value: i16,
     ) -> PublishedWord {
-        code.publish_new_word(words, bindings, name(input), |builder| {
+        code.publish_new_word(words, bindings, name(input), |_, builder| {
             builder.append_unmapped(push(value))?;
             builder.append_unmapped(Instruction::Return)?;
             Ok(())
@@ -505,7 +477,7 @@ mod tests {
         let mut bindings = Bindings::new();
 
         let word = code
-            .publish_new_word(&mut words, &mut bindings, name("MAPPED"), |builder| {
+            .publish_new_word(&mut words, &mut bindings, name("MAPPED"), |_, builder| {
                 builder.append_mapped(push(1), first_span)?;
                 builder.append_unmapped(Instruction::Return)?;
                 Ok(())
@@ -528,10 +500,11 @@ mod tests {
         let mut words = PublishedWords::new();
         let mut bindings = Bindings::new();
 
-        let result = code.publish_new_word(&mut words, &mut bindings, name("BROKEN"), |builder| {
-            builder.append_unmapped(push(1))?;
-            Err(WordBodyBuildError::BodyRejected)
-        });
+        let result =
+            code.publish_new_word(&mut words, &mut bindings, name("BROKEN"), |_, builder| {
+                builder.append_unmapped(push(1))?;
+                Err(WordBodyBuildError::BodyRejected)
+            });
 
         assert_eq!(
             result,
@@ -557,7 +530,7 @@ mod tests {
         let mut words = PublishedWords::new();
         let mut bindings = Bindings::new();
 
-        let result = code.publish_new_word(&mut words, &mut bindings, name("EMPTY"), |_| Ok(()));
+        let result = code.publish_new_word(&mut words, &mut bindings, name("EMPTY"), |_, _| Ok(()));
 
         assert_eq!(
             result,
@@ -605,7 +578,7 @@ mod tests {
                 .expect("test binding should register");
 
             let result =
-                code.publish_new_word(&mut words, &mut bindings, name("TAKEN"), |builder| {
+                code.publish_new_word(&mut words, &mut bindings, name("TAKEN"), |_, builder| {
                     builder.append_unmapped(push(1))?;
                     Ok(())
                 });
@@ -625,11 +598,12 @@ mod tests {
             let mut bindings = Bindings::new();
             let mut build_called = false;
 
-            let result = code.publish_new_word(&mut words, &mut bindings, name(input), |builder| {
-                build_called = true;
-                builder.append_unmapped(push(1))?;
-                Ok(())
-            });
+            let result =
+                code.publish_new_word(&mut words, &mut bindings, name(input), |_, builder| {
+                    build_called = true;
+                    builder.append_unmapped(push(1))?;
+                    Ok(())
+                });
 
             assert_eq!(result, Err(NewWordPublicationError::ReservedName));
             assert!(!build_called);
@@ -722,7 +696,7 @@ mod tests {
         let mut words = PublishedWords::new();
         let mut bindings = Bindings::new();
         let old = code
-            .publish_new_word(&mut words, &mut bindings, name("TARGET"), |builder| {
+            .publish_new_word(&mut words, &mut bindings, name("TARGET"), |_, builder| {
                 builder.append_mapped(push(1), old_span)?;
                 builder.append_unmapped(Instruction::Return)?;
                 Ok(())
@@ -763,7 +737,7 @@ mod tests {
         let mut bindings = Bindings::new();
         let old = publish_push(&mut code, &mut words, &mut bindings, "TARGET", 1);
         let caller = code
-            .publish_new_word(&mut words, &mut bindings, name("CALLER"), |builder| {
+            .publish_new_word(&mut words, &mut bindings, name("CALLER"), |_, builder| {
                 builder.append_unmapped(Instruction::Call(old.id()))?;
                 builder.append_unmapped(Instruction::Return)?;
                 Ok(())
@@ -792,7 +766,7 @@ mod tests {
         let mut bindings = Bindings::new();
 
         let word = code
-            .publish_new_word(&mut words, &mut bindings, name("BRANCH"), |builder| {
+            .publish_new_word(&mut words, &mut bindings, name("BRANCH"), |_, builder| {
                 let branch = builder.append_unmapped_jump_placeholder()?;
                 let target = builder.append_unmapped(Instruction::Return)?;
                 builder.patch_branch_target(branch, target)?;
@@ -813,10 +787,11 @@ mod tests {
         let mut bindings = Bindings::new();
         let branch = Instruction::Jump(InstructionAddress::from_index(0));
 
-        let result = code.publish_new_word(&mut words, &mut bindings, name("BRANCH"), |builder| {
-            builder.append_unmapped(branch)?;
-            Ok(())
-        });
+        let result =
+            code.publish_new_word(&mut words, &mut bindings, name("BRANCH"), |_, builder| {
+                builder.append_unmapped(branch)?;
+                Ok(())
+            });
 
         assert_eq!(
             result,
@@ -837,11 +812,12 @@ mod tests {
         let mut words = PublishedWords::new();
         let mut bindings = Bindings::new();
 
-        let result = code.publish_new_word(&mut words, &mut bindings, name("BROKEN"), |builder| {
-            let _branch = builder.append_unmapped_jump_placeholder()?;
-            builder.append_unmapped(Instruction::Return)?;
-            Ok(())
-        });
+        let result =
+            code.publish_new_word(&mut words, &mut bindings, name("BROKEN"), |_, builder| {
+                let _branch = builder.append_unmapped_jump_placeholder()?;
+                builder.append_unmapped(Instruction::Return)?;
+                Ok(())
+            });
 
         assert_eq!(
             result,
@@ -862,7 +838,7 @@ mod tests {
         let mut words = PublishedWords::new();
         let mut bindings = Bindings::new();
         let old = code
-            .publish_new_word(&mut words, &mut bindings, name("OLD"), |builder| {
+            .publish_new_word(&mut words, &mut bindings, name("OLD"), |_, builder| {
                 let branch = builder.append_unmapped_jump_placeholder()?;
                 let target = builder.append_unmapped(Instruction::Return)?;
                 builder.patch_branch_target(branch, target)?;
@@ -870,7 +846,7 @@ mod tests {
             })
             .expect("old word should publish");
 
-        let result = code.publish_new_word(&mut words, &mut bindings, name("NEW"), |builder| {
+        let result = code.publish_new_word(&mut words, &mut bindings, name("NEW"), |_, builder| {
             let target = builder.append_unmapped(Instruction::Return)?;
             builder.patch_branch_target(old.entry().address(), target)?;
             Ok(())
@@ -900,7 +876,7 @@ mod tests {
         let mut bindings = Bindings::new();
         let old = publish_push(&mut code, &mut words, &mut bindings, "OLD", 1);
 
-        let result = code.publish_new_word(&mut words, &mut bindings, name("NEW"), |builder| {
+        let result = code.publish_new_word(&mut words, &mut bindings, name("NEW"), |_, builder| {
             let branch = builder.append_unmapped_jump_placeholder()?;
             builder.patch_branch_target(branch, old.entry().address())?;
             Ok(())
@@ -928,7 +904,7 @@ mod tests {
         let mut words = PublishedWords::new();
         let mut bindings = Bindings::new();
         let old = code
-            .publish_new_word(&mut words, &mut bindings, name("TARGET"), |builder| {
+            .publish_new_word(&mut words, &mut bindings, name("TARGET"), |_, builder| {
                 builder.append_mapped(push(1), old_span)?;
                 builder.append_unmapped(Instruction::Return)?;
                 Ok(())

--- a/crates/tbx-next/src/published_code.rs
+++ b/crates/tbx-next/src/published_code.rs
@@ -59,6 +59,7 @@ pub(crate) enum WordBodyBuildError {
     UnresolvedBranchPatch {
         branch: InstructionAddress,
     },
+    DefinitionBodyCompileRejected,
     InvalidEntry {
         source: InstructionAddressError,
     },
@@ -102,6 +103,34 @@ impl PublishedCode {
 
         let entry = self
             .build_word_body(build)
+            .map_err(|source| NewWordPublicationError::Build { source })?;
+        let definition = CompletedWordDefinition::compiled(entry.location, self.instruction_view())
+            .map_err(|source| NewWordPublicationError::Definition { source })?;
+        let id = words.add(definition);
+
+        bindings
+            .insert_new(name, Binding::Word(id))
+            .map_err(|_| NewWordPublicationError::BindingCommitInvariantViolated)?;
+
+        Ok(PublishedWord {
+            id,
+            entry: entry.location,
+        })
+    }
+
+    pub(crate) fn publish_new_word_with_bindings(
+        &mut self,
+        words: &mut PublishedWords,
+        bindings: &mut Bindings,
+        name: NormalizedName,
+        build: impl FnOnce(&Bindings, &mut PublishedWordBuilder<'_>) -> Result<(), WordBodyBuildError>,
+    ) -> Result<PublishedWord, NewWordPublicationError> {
+        bindings
+            .validate_new_name(&name)
+            .map_err(NewWordPublicationError::from_precheck_error)?;
+
+        let entry = self
+            .build_word_body(|builder| build(bindings, builder))
             .map_err(|source| NewWordPublicationError::Build { source })?;
         let definition = CompletedWordDefinition::compiled(entry.location, self.instruction_view())
             .map_err(|source| NewWordPublicationError::Definition { source })?;

--- a/crates/tbx-next/src/source_processor.rs
+++ b/crates/tbx-next/src/source_processor.rs
@@ -12,18 +12,22 @@ use crate::lexer::{LexError, Lexer, Token, TokenKind};
 use crate::line_number::{LineNumberError, LocalLineNumber, LocalLineNumberTable};
 use crate::operator::OperatorLookup;
 use crate::primitive::PrimitiveLookup;
-use crate::published_code::{PublishedWordBuilder, WordBodyBuildError};
+use crate::published_code::{
+    NewWordPublicationError, PublishedCode, PublishedWordBuilder, WordBodyBuildError,
+};
 use crate::source::{SourceError, SourceId, SourceSpan, SourceView};
 use crate::source_mapping::{
     InstructionSourceMappingView, SourceMappedCode, SourceMappingLookup, SourceMappingLookupError,
 };
 use crate::source_word::{
     NativeSourceWordBindingAccess, NativeSourceWordContext, NativeSourceWordContextParts,
-    SourceBlockCursor, SourceBlockRead, SourceBlockReader, SourceBlockStatement,
-    SourceBlockTerminal, SourceWordError, SourceWordId, SourceWordLookup, SourceWordLookupError,
+    RuntimeDefinitionPublisher, SourceBlockCursor, SourceBlockRead, SourceBlockReader,
+    SourceBlockStatement, SourceBlockTerminal, SourceWordError, SourceWordId, SourceWordLookup,
+    SourceWordLookupError,
 };
 use crate::value::Value;
 use crate::vm::{ExecutionView, RunOutcome, Vm, VmError};
+use crate::word::{PublishedWords, WordId};
 use crate::word_lookup::PublishedWordLookup;
 use crate::word_resolution::{
     resolve_binding_name, resolve_word_name, ResolvedBinding, WordResolutionError,
@@ -41,6 +45,7 @@ pub(crate) struct SourceCompileContext<'a> {
     operators: Option<OperatorLookup>,
     source_words: Option<SourceWordLookup<'a>>,
     globals: Option<&'a mut GlobalVariables>,
+    runtime_definitions: Option<RuntimeDefinitionPublicationAccess<'a>>,
 }
 
 pub(crate) struct DefinitionBodyCompileContext<'a> {
@@ -50,13 +55,18 @@ pub(crate) struct DefinitionBodyCompileContext<'a> {
 }
 
 pub(crate) struct DefinitionBodyStatements<'a> {
-    statements: &'a [LogicalStatement],
+    statements: &'a [SourceBlockStatement<'a>],
     terminal: Terminal,
 }
 
 enum BindingAccess<'a> {
     Read(&'a Bindings),
     Write(&'a mut Bindings),
+}
+
+struct RuntimeDefinitionPublicationAccess<'a> {
+    code: &'a mut PublishedCode,
+    words: &'a mut PublishedWords,
 }
 
 #[derive(Debug)]
@@ -213,11 +223,11 @@ pub(crate) fn compile_source(
         &mut code,
     )?;
 
-    let eof = match segmented.terminal() {
-        Terminal::Eof(eof) => eof,
+    let eof_span = match segmented.terminal() {
+        Terminal::Eof { span } => span,
         Terminal::LexError(error) => return Err(error.into()),
     };
-    InstructionBuildTarget::append_mapped(&mut code, Instruction::Halt, eof.span())?;
+    InstructionBuildTarget::append_mapped(&mut code, Instruction::Halt, eof_span)?;
 
     let entry = code
         .instruction_view()
@@ -237,6 +247,7 @@ pub(crate) fn compile_definition_body<'source>(
         operators: context.operators,
         source_words: context.source_words,
         globals: None,
+        runtime_definitions: None,
     };
 
     compile_statements(
@@ -249,14 +260,17 @@ pub(crate) fn compile_definition_body<'source>(
     )
 }
 
-fn compile_statements<'source>(
+fn compile_statements<'source, S>(
     view: SourceView<'source>,
     source_id: SourceId,
-    statements: &'source [LogicalStatement],
+    statements: &'source [S],
     terminal: Terminal,
     mut context: SourceCompileContext<'_>,
     code: &mut dyn InstructionBuildTarget,
-) -> Result<(), SourceProcessorError> {
+) -> Result<(), SourceProcessorError>
+where
+    S: LogicalStatementView,
+{
     let mut line_numbers = LocalLineNumberTable::new();
     // A leading integer remains an expression/literal unless this unit uses it
     // as local control-flow syntax. This preserves existing source paths while
@@ -284,14 +298,17 @@ fn compile_statements<'source>(
         .map_err(|source| line_number_compile_error(source).into())
 }
 
-fn compile_statement<'source>(
+fn compile_statement<'source, S>(
     view: SourceView<'source>,
     source_id: SourceId,
     statement: &'source [Token],
     context: &mut SourceCompileContext<'_>,
     state: &mut StatementCompileState<'_>,
-    cursor: &mut LogicalStatementCursor<'source, 'source>,
-) -> Result<(), SourceProcessorError> {
+    cursor: &mut LogicalStatementCursor<'source, 'source, S>,
+) -> Result<(), SourceProcessorError>
+where
+    S: LogicalStatementView,
+{
     if statement.is_empty() {
         return Ok(());
     }
@@ -350,15 +367,18 @@ fn split_statement_line_number<'a>(
     Ok((Some((line_number, first.span())), rest))
 }
 
-fn compile_statement_body<'source>(
+fn compile_statement_body<'source, S>(
     view: SourceView<'source>,
     source_id: SourceId,
     tokens: &'source [Token],
     context: &mut SourceCompileContext<'_>,
     local_line_number_prefix: Option<SourceSpan>,
     state: &mut StatementCompileState<'_>,
-    cursor: &mut LogicalStatementCursor<'source, 'source>,
-) -> Result<(), SourceProcessorError> {
+    cursor: &mut LogicalStatementCursor<'source, 'source, S>,
+) -> Result<(), SourceProcessorError>
+where
+    S: LogicalStatementView,
+{
     let Some((&first, _)) = tokens.split_first() else {
         return Ok(());
     };
@@ -397,15 +417,18 @@ fn compile_statement_body<'source>(
     compile_simple_tokens(view, tokens, context, state.code)
 }
 
-fn compile_statement_leading_source_word<'source>(
+fn compile_statement_leading_source_word<'source, S>(
     view: SourceView<'source>,
     source_id: SourceId,
     tokens: &'source [Token],
     context: &mut SourceCompileContext<'_>,
     local_line_number_prefix: Option<SourceSpan>,
     code: &mut dyn InstructionBuildTarget,
-    cursor: &mut LogicalStatementCursor<'source, 'source>,
-) -> Result<bool, SourceProcessorError> {
+    cursor: &mut LogicalStatementCursor<'source, 'source, S>,
+) -> Result<bool, SourceProcessorError>
+where
+    S: LogicalStatementView,
+{
     let Some(first) = tokens.first().copied() else {
         return Ok(false);
     };
@@ -433,6 +456,21 @@ fn compile_statement_leading_source_word<'source>(
     let handler = source_words.lookup_handler(id)?;
     let operators = context.operators();
     let globals = context.globals.as_deref_mut();
+    let mut runtime_publisher =
+        context
+            .runtime_definitions
+            .as_mut()
+            .map(|publication| RuntimeDefinitionPublisherAdapter {
+                view,
+                source_id,
+                operators,
+                source_words,
+                code: &mut *publication.code,
+                words: &mut *publication.words,
+            });
+    let runtime_definitions = runtime_publisher
+        .as_mut()
+        .map(|publisher| publisher as &mut dyn RuntimeDefinitionPublisher<'source>);
     let binding_access = match &mut context.bindings {
         BindingAccess::Read(bindings) => NativeSourceWordBindingAccess::Read(bindings),
         BindingAccess::Write(bindings) => NativeSourceWordBindingAccess::Write(bindings),
@@ -447,6 +485,7 @@ fn compile_statement_leading_source_word<'source>(
         code,
         local_line_number_prefix,
         globals,
+        runtime_definitions,
     });
     handler(&mut source_word_context)?;
     Ok(true)
@@ -820,10 +859,13 @@ fn is_statement_line_number_candidate(
         .unwrap_or(false))
 }
 
-fn collect_referenced_line_numbers(
+fn collect_referenced_line_numbers<S>(
     view: SourceView<'_>,
-    statements: &[LogicalStatement],
-) -> HashSet<LocalLineNumber> {
+    statements: &[S],
+) -> HashSet<LocalLineNumber>
+where
+    S: LogicalStatementView,
+{
     let mut references = HashSet::new();
 
     for statement in statements {
@@ -908,18 +950,23 @@ struct LogicalStatement {
     tokens: Vec<Token>,
 }
 
+trait LogicalStatementView {
+    fn tokens(&self) -> &[Token];
+    fn span(&self, view: SourceView<'_>, source_id: SourceId) -> Result<SourceSpan, SourceError>;
+}
+
 #[derive(Debug)]
-struct LogicalStatementCursor<'source, 'statements> {
+struct LogicalStatementCursor<'source, 'statements, S> {
     view: SourceView<'source>,
     source_id: SourceId,
-    statements: &'statements [LogicalStatement],
+    statements: &'statements [S],
     terminal: Terminal,
     position: usize,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Terminal {
-    Eof(Token),
+    Eof { span: SourceSpan },
     LexError(LexError),
 }
 
@@ -931,7 +978,7 @@ impl SegmentedSource {
         loop {
             match lexer.next_token() {
                 Ok(token) if token.kind() == TokenKind::Eof => {
-                    return Ok(collector.finish(Terminal::Eof(token)));
+                    return Ok(collector.finish(Terminal::Eof { span: token.span() }));
                 }
                 Ok(token) => collector.push_token(token),
                 Err(error) => return Ok(collector.finish(Terminal::LexError(error))),
@@ -961,6 +1008,12 @@ impl LogicalStatement {
     fn tokens(&self) -> &[Token] {
         &self.tokens
     }
+}
+
+impl LogicalStatementView for LogicalStatement {
+    fn tokens(&self) -> &[Token] {
+        self.tokens()
+    }
 
     fn span(&self, view: SourceView<'_>, source_id: SourceId) -> Result<SourceSpan, SourceError> {
         let first = self
@@ -975,11 +1028,21 @@ impl LogicalStatement {
     }
 }
 
-impl<'source, 'statements> LogicalStatementCursor<'source, 'statements> {
+impl LogicalStatementView for SourceBlockStatement<'_> {
+    fn tokens(&self) -> &[Token] {
+        SourceBlockStatement::tokens(*self)
+    }
+
+    fn span(&self, _view: SourceView<'_>, _source_id: SourceId) -> Result<SourceSpan, SourceError> {
+        Ok(SourceBlockStatement::span(*self))
+    }
+}
+
+impl<'source, 'statements, S> LogicalStatementCursor<'source, 'statements, S> {
     fn new(
         view: SourceView<'source>,
         source_id: SourceId,
-        statements: &'statements [LogicalStatement],
+        statements: &'statements [S],
         terminal: Terminal,
     ) -> Self {
         Self {
@@ -991,20 +1054,23 @@ impl<'source, 'statements> LogicalStatementCursor<'source, 'statements> {
         }
     }
 
-    fn next_completed_statement(&mut self) -> Option<&'statements LogicalStatement> {
+    fn next_completed_statement(&mut self) -> Option<&'statements S> {
         let statement = self.statements.get(self.position)?;
         self.position += 1;
         Some(statement)
     }
 }
 
-impl<'statements> SourceBlockCursor<'statements> for LogicalStatementCursor<'_, 'statements> {
+impl<'statements, S> SourceBlockCursor<'statements> for LogicalStatementCursor<'_, 'statements, S>
+where
+    S: LogicalStatementView + 'statements,
+{
     fn read_next_block_statement(
         &mut self,
     ) -> Result<SourceBlockRead<'statements>, SourceWordError> {
         let Some(statement) = self.next_completed_statement() else {
             return Ok(SourceBlockRead::Terminal(match self.terminal {
-                Terminal::Eof(token) => SourceBlockTerminal::Eof { span: token.span() },
+                Terminal::Eof { span } => SourceBlockTerminal::Eof { span },
                 Terminal::LexError(error) => SourceBlockTerminal::LexError { error },
             }));
         };
@@ -1051,7 +1117,7 @@ impl LogicalStatementCollector {
     }
 
     fn finish(mut self, terminal: Terminal) -> SegmentedSource {
-        if matches!(terminal, Terminal::Eof(_)) {
+        if matches!(terminal, Terminal::Eof { .. }) {
             self.finish_current_statement();
         }
 
@@ -1120,6 +1186,7 @@ impl<'a> SourceCompileContext<'a> {
             operators: None,
             source_words: None,
             globals: None,
+            runtime_definitions: None,
         }
     }
 
@@ -1129,6 +1196,7 @@ impl<'a> SourceCompileContext<'a> {
             operators: Some(operators),
             source_words: None,
             globals: None,
+            runtime_definitions: None,
         }
     }
 
@@ -1141,6 +1209,7 @@ impl<'a> SourceCompileContext<'a> {
             operators: None,
             source_words: Some(source_words),
             globals: None,
+            runtime_definitions: None,
         }
     }
 
@@ -1154,6 +1223,7 @@ impl<'a> SourceCompileContext<'a> {
             operators: Some(operators),
             source_words: Some(source_words),
             globals: None,
+            runtime_definitions: None,
         }
     }
 
@@ -1167,6 +1237,7 @@ impl<'a> SourceCompileContext<'a> {
             operators: None,
             source_words: Some(source_words),
             globals: Some(globals),
+            runtime_definitions: None,
         }
     }
 
@@ -1181,6 +1252,24 @@ impl<'a> SourceCompileContext<'a> {
             operators: Some(operators),
             source_words: Some(source_words),
             globals: Some(globals),
+            runtime_definitions: None,
+        }
+    }
+
+    pub(crate) fn with_runtime_definition_publication_and_operators(
+        bindings: &'a mut Bindings,
+        source_words: SourceWordLookup<'a>,
+        operators: OperatorLookup,
+        globals: &'a mut GlobalVariables,
+        code: &'a mut PublishedCode,
+        words: &'a mut PublishedWords,
+    ) -> Self {
+        Self {
+            bindings: BindingAccess::Write(bindings),
+            operators: Some(operators),
+            source_words: Some(source_words),
+            globals: Some(globals),
+            runtime_definitions: Some(RuntimeDefinitionPublicationAccess { code, words }),
         }
     }
 
@@ -1241,11 +1330,85 @@ impl<'a> DefinitionBodyCompileContext<'a> {
 }
 
 impl<'a> DefinitionBodyStatements<'a> {
-    const fn new(statements: &'a [LogicalStatement], terminal: Terminal) -> Self {
+    const fn new(statements: &'a [SourceBlockStatement<'a>], terminal: Terminal) -> Self {
         Self {
             statements,
             terminal,
         }
+    }
+}
+
+struct RuntimeDefinitionPublisherAdapter<'a, 'source> {
+    view: SourceView<'source>,
+    source_id: SourceId,
+    operators: Option<OperatorLookup>,
+    source_words: SourceWordLookup<'a>,
+    code: &'a mut PublishedCode,
+    words: &'a mut PublishedWords,
+}
+
+impl<'source> RuntimeDefinitionPublisher<'source>
+    for RuntimeDefinitionPublisherAdapter<'_, 'source>
+{
+    fn publish_runtime_definition(
+        &mut self,
+        bindings: &mut Bindings,
+        name: crate::name::NormalizedName,
+        name_span: SourceSpan,
+        body: &[SourceBlockStatement<'source>],
+        end_span: SourceSpan,
+    ) -> Result<WordId, SourceWordError> {
+        let mut body_error = None;
+        let published = self
+            .code
+            .publish_new_word_with_bindings(self.words, bindings, name, |body_bindings, builder| {
+                let result = compile_definition_body(
+                    self.view,
+                    self.source_id,
+                    DefinitionBodyStatements::new(body, Terminal::Eof { span: end_span }),
+                    DefinitionBodyCompileContext::with_source_words_and_operators(
+                        body_bindings,
+                        self.source_words,
+                        self.operators
+                            .expect("runtime definition publication requires operators"),
+                    ),
+                    builder,
+                );
+                if let Err(error) = result {
+                    body_error = Some(error);
+                    return Err(WordBodyBuildError::DefinitionBodyCompileRejected);
+                }
+                builder
+                    .append_mapped(Instruction::Return, end_span)
+                    .map(|_| ())
+            })
+            .map_err(|error| match error {
+                NewWordPublicationError::NameConflict => {
+                    SourceWordError::DefNameConflict { span: name_span }
+                }
+                NewWordPublicationError::ReservedName => {
+                    SourceWordError::DefReservedName { span: name_span }
+                }
+                NewWordPublicationError::Build {
+                    source: WordBodyBuildError::DefinitionBodyCompileRejected,
+                } => SourceWordError::DefBodyCompile {
+                    span: body_error
+                        .as_ref()
+                        .and_then(SourceProcessorError::primary_span)
+                        .unwrap_or(name_span),
+                },
+                NewWordPublicationError::Build { .. } => {
+                    SourceWordError::DefBodyBuild { span: end_span }
+                }
+                NewWordPublicationError::Definition { .. } => {
+                    SourceWordError::DefDefinition { span: end_span }
+                }
+                NewWordPublicationError::BindingCommitInvariantViolated => {
+                    SourceWordError::DefBindingCommitInvariantViolated { span: name_span }
+                }
+            })?;
+
+        Ok(published.id())
     }
 }
 
@@ -1397,6 +1560,7 @@ impl<'a> SourceExecutionContext<'a> {
             operators: self.operators,
             source_words: self.source_words,
             globals: None,
+            runtime_definitions: None,
         }
     }
 
@@ -1418,6 +1582,21 @@ impl<'a> SourceExecutionContext<'a> {
 }
 
 impl SourceProcessorError {
+    fn primary_span(&self) -> Option<SourceSpan> {
+        match self {
+            Self::Source(_) | Self::CodeSpaceLookup(_) | Self::SourceMappingLookup(_) => None,
+            Self::Lex(error) => match error {
+                LexError::Source(_) => None,
+                LexError::InvalidCharacter { span, .. } => Some(*span),
+            },
+            Self::Compile(error) => Some(error.span()),
+            Self::InstructionBuild(_) => None,
+            Self::SourceWordContextUnavailable { .. } | Self::SourceWordLookup(_) => None,
+            Self::SourceWord(error) => error.primary_span(),
+            Self::Runtime(error) => error.source_span().ok().flatten(),
+        }
+    }
+
     fn from_expression_error(error: ExpressionError) -> Self {
         match error {
             ExpressionError::Source(error) => Self::Source(error),
@@ -1493,7 +1672,8 @@ mod tests {
         InstructionSourceMapping, SourceMappingLookup, SourceMappingLookupError,
     };
     use crate::source_word::{
-        LetSyntaxErrorKind, NativeSourceWordContext, SourceWordRegistry, VarSyntaxErrorKind,
+        DefSyntaxErrorKind, LetSyntaxErrorKind, NativeSourceWordContext, SourceWordRegistry,
+        VarSyntaxErrorKind,
     };
     use crate::word::{CompletedWordDefinition, PrimitiveId, PublishedWords, WordId};
     use crate::word_lookup::PublishedWordLookup;
@@ -1829,6 +2009,58 @@ mod tests {
         (sources, id, error)
     }
 
+    fn compile_with_def(
+        text: &str,
+        bindings: &mut Bindings,
+        globals: &mut GlobalVariables,
+        source_words: &SourceWordRegistry,
+        operators: OperatorLookup,
+        code: &mut PublishedCode,
+        words: &mut PublishedWords,
+    ) -> (SourceTexts, SourceId, TemporaryExecutionUnit) {
+        let (sources, id) = source(text);
+        let unit = compile_source(
+            sources.view(),
+            id,
+            SourceCompileContext::with_runtime_definition_publication_and_operators(
+                bindings,
+                source_words.lookup(),
+                operators,
+                globals,
+                code,
+                words,
+            ),
+        )
+        .expect("DEF source should compile");
+        (sources, id, unit)
+    }
+
+    fn compile_with_def_error(
+        text: &str,
+        bindings: &mut Bindings,
+        globals: &mut GlobalVariables,
+        source_words: &SourceWordRegistry,
+        operators: OperatorLookup,
+        code: &mut PublishedCode,
+        words: &mut PublishedWords,
+    ) -> (SourceTexts, SourceId, SourceProcessorError) {
+        let (sources, id) = source(text);
+        let error = compile_source(
+            sources.view(),
+            id,
+            SourceCompileContext::with_runtime_definition_publication_and_operators(
+                bindings,
+                source_words.lookup(),
+                operators,
+                globals,
+                code,
+                words,
+            ),
+        )
+        .expect_err("DEF source should fail");
+        (sources, id, error)
+    }
+
     fn compile_body(
         text: &str,
         context: DefinitionBodyCompileContext<'_>,
@@ -1858,14 +2090,21 @@ mod tests {
         segmented: &SegmentedSource,
         context: DefinitionBodyCompileContext<'_>,
     ) -> Result<(), SourceProcessorError> {
+        let statements = segmented
+            .completed_statements()
+            .iter()
+            .map(|statement| {
+                Ok(SourceBlockStatement::new(
+                    statement.tokens(),
+                    statement.span(view, source_id)?,
+                ))
+            })
+            .collect::<Result<Vec<_>, SourceError>>()?;
         code.test_build_word_body(|builder| {
             compile_definition_body(
                 view,
                 source_id,
-                DefinitionBodyStatements::new(
-                    segmented.completed_statements(),
-                    segmented.terminal(),
-                ),
+                DefinitionBodyStatements::new(&statements, segmented.terminal()),
                 context,
                 builder,
             )
@@ -2073,7 +2312,7 @@ mod tests {
             [TokenKind::IntegerLiteral, TokenKind::IntegerLiteral]
         );
         assert_eq!(segmented.incomplete_tail(), []);
-        assert!(matches!(segmented.terminal(), Terminal::Eof(_)));
+        assert!(matches!(segmented.terminal(), Terminal::Eof { .. }));
     }
 
     #[test]
@@ -4627,6 +4866,374 @@ mod tests {
         assert!(matches!(error, SourceProcessorError::Lex(_)));
         assert_eq!(bindings.get(&name("SCORE")), None);
         assert_eq!(globals.len(), 0);
+    }
+
+    #[test]
+    fn def_publishes_empty_runtime_word_with_return_mapped_to_end() {
+        let (mut words, _primitives, operators) = operator_fixture();
+        let mut source_words = SourceWordRegistry::new();
+        let mut bindings = Bindings::new();
+        let mut globals = GlobalVariables::new();
+        let builtin = register_builtin_source_words(&mut source_words, &mut bindings)
+            .expect("built-in source words should bootstrap");
+        let mut code = PublishedCode::new();
+        let initial_words_len = words.len();
+
+        let (sources, id, unit) = compile_with_def(
+            "def Foo\nEND",
+            &mut bindings,
+            &mut globals,
+            &source_words,
+            operators.lookup(),
+            &mut code,
+            &mut words,
+        );
+
+        let Some(Binding::Word(foo)) = bindings.get(&name("FOO")).copied() else {
+            panic!("FOO should be published as a runtime word");
+        };
+        assert_eq!(
+            bindings.get(&name("DEF")),
+            Some(&Binding::SourceWord(builtin.def()))
+        );
+        assert_eq!(words.len(), initial_words_len + 1);
+        assert_eq!(
+            words.get(foo).expect("published word should be defined"),
+            &crate::word::WordDefinition::Compiled {
+                entry: code.instruction_view().location(address(0))
+            }
+        );
+        assert_eq!(code.len(), 1);
+        assert_eq!(
+            code.instruction_view().get(address(0)),
+            Ok(&Instruction::Return)
+        );
+        assert_eq!(
+            code.source_mapping()
+                .source_span(code.instruction_view().location(address(0))),
+            Ok(Some(span(sources.view(), id, 8, 11)))
+        );
+        assert_eq!(unit.len(), 1);
+        assert_eq!(unit.instructions().get(address(0)), Ok(&Instruction::Halt));
+    }
+
+    #[test]
+    fn def_body_compiles_calls_before_appending_single_return() {
+        let (mut words, mut primitives, operators) = operator_fixture();
+        let primitive = primitives.register(push_7);
+        let mut source_words = SourceWordRegistry::new();
+        let mut bindings = Bindings::new();
+        register_builtin_source_words(&mut source_words, &mut bindings)
+            .expect("built-in source words should bootstrap");
+        register_primitive(&mut words, &mut bindings, name("PUSH7"), primitive)
+            .expect("runtime word should register");
+        let mut globals = GlobalVariables::new();
+        let mut code = PublishedCode::new();
+
+        let (sources, id, _unit) = compile_with_def(
+            "DEF FOO\npush7\nEND",
+            &mut bindings,
+            &mut globals,
+            &source_words,
+            operators.lookup(),
+            &mut code,
+            &mut words,
+        );
+
+        assert_eq!(code.len(), 2);
+        assert_eq!(
+            code.instruction_view().get(address(0)),
+            Ok(&Instruction::Call(
+                resolve_word_name(&bindings, "PUSH7").expect("PUSH7 should resolve")
+            ))
+        );
+        assert_eq!(
+            code.instruction_view().get(address(1)),
+            Ok(&Instruction::Return)
+        );
+        assert_eq!(
+            code.source_mapping()
+                .source_span(code.instruction_view().location(address(1))),
+            Ok(Some(span(sources.view(), id, 14, 17)))
+        );
+    }
+
+    #[test]
+    fn def_rejects_header_errors_without_consuming_body_or_publishing() {
+        for source_text in ["DEF", "DEF 123\nEND", "DEF FOO EXTRA\nEND"] {
+            let (mut words, _primitives, operators) = operator_fixture();
+            let mut source_words = SourceWordRegistry::new();
+            let mut bindings = Bindings::new();
+            let mut globals = GlobalVariables::new();
+            register_builtin_source_words(&mut source_words, &mut bindings)
+                .expect("built-in source words should bootstrap");
+            let mut code = PublishedCode::new();
+            let initial_words_len = words.len();
+
+            let (sources, id, error) = compile_with_def_error(
+                source_text,
+                &mut bindings,
+                &mut globals,
+                &source_words,
+                operators.lookup(),
+                &mut code,
+                &mut words,
+            );
+
+            let expected = match source_text {
+                "DEF" => SourceWordError::DefSyntax {
+                    span: span(sources.view(), id, 0, 3),
+                    kind: DefSyntaxErrorKind::MissingName,
+                },
+                "DEF 123\nEND" => SourceWordError::DefSyntax {
+                    span: span(sources.view(), id, 4, 7),
+                    kind: DefSyntaxErrorKind::MissingName,
+                },
+                "DEF FOO EXTRA\nEND" => SourceWordError::DefSyntax {
+                    span: span(sources.view(), id, 8, 13),
+                    kind: DefSyntaxErrorKind::TrailingToken {
+                        kind: TokenKind::Name,
+                    },
+                },
+                _ => unreachable!(),
+            };
+            assert_eq!(error, SourceProcessorError::SourceWord(expected));
+            assert_eq!(bindings.get(&name("FOO")), None);
+            assert_eq!(words.len(), initial_words_len);
+            assert_eq!(code.len(), 0);
+        }
+    }
+
+    #[test]
+    fn def_rejects_name_conflicts_and_reserved_end_before_building_body() {
+        let (mut words, _primitives, operators) = operator_fixture();
+        let mut source_words = SourceWordRegistry::new();
+        let mut bindings = Bindings::new();
+        let mut globals = GlobalVariables::new();
+        register_builtin_source_words(&mut source_words, &mut bindings)
+            .expect("built-in source words should bootstrap");
+        compile_with_var("VAR SCORE", &mut bindings, &mut globals, &source_words);
+        let mut code = PublishedCode::new();
+        let initial_words_len = words.len();
+
+        let (sources, id, error) = compile_with_def_error(
+            "DEF score\nMISSING\nEND",
+            &mut bindings,
+            &mut globals,
+            &source_words,
+            operators.lookup(),
+            &mut code,
+            &mut words,
+        );
+        assert_eq!(
+            error,
+            SourceProcessorError::SourceWord(SourceWordError::DefNameConflict {
+                span: span(sources.view(), id, 4, 9)
+            })
+        );
+        assert_eq!(code.len(), 0);
+        assert_eq!(words.len(), initial_words_len);
+
+        let (sources, id, error) = compile_with_def_error(
+            "DEF END\nMISSING\nEND",
+            &mut bindings,
+            &mut globals,
+            &source_words,
+            operators.lookup(),
+            &mut code,
+            &mut words,
+        );
+        assert_eq!(
+            error,
+            SourceProcessorError::SourceWord(SourceWordError::DefReservedName {
+                span: span(sources.view(), id, 4, 7)
+            })
+        );
+        assert_eq!(code.len(), 0);
+        assert_eq!(words.len(), initial_words_len);
+    }
+
+    #[test]
+    fn def_consumes_only_through_standalone_end_and_returns_outer_processing() {
+        let (mut words, _primitives, operators) = operator_fixture();
+        let mut source_words = SourceWordRegistry::new();
+        let mut bindings = Bindings::new();
+        let mut globals = GlobalVariables::new();
+        register_builtin_source_words(&mut source_words, &mut bindings)
+            .expect("built-in source words should bootstrap");
+        let mut code = PublishedCode::new();
+
+        let (_sources, _id, unit) = compile_with_def(
+            "DEF FOO\nEND\n1",
+            &mut bindings,
+            &mut globals,
+            &source_words,
+            operators.lookup(),
+            &mut code,
+            &mut words,
+        );
+
+        assert!(matches!(bindings.get(&name("FOO")), Some(Binding::Word(_))));
+        assert_eq!(
+            code.instruction_view().get(address(0)),
+            Ok(&Instruction::Return)
+        );
+        assert_eq!(
+            unit.instructions().get(address(0)),
+            Ok(&Instruction::Push(value(1)))
+        );
+        assert_eq!(unit.instructions().get(address(1)), Ok(&Instruction::Halt));
+    }
+
+    #[test]
+    fn def_reports_missing_end_and_lexical_terminal_without_publication() {
+        for source_text in ["DEF FOO", "DEF FOO\n@"] {
+            let (mut words, _primitives, operators) = operator_fixture();
+            let mut source_words = SourceWordRegistry::new();
+            let mut bindings = Bindings::new();
+            let mut globals = GlobalVariables::new();
+            register_builtin_source_words(&mut source_words, &mut bindings)
+                .expect("built-in source words should bootstrap");
+            let mut code = PublishedCode::new();
+            let initial_words_len = words.len();
+
+            let (sources, id, error) = compile_with_def_error(
+                source_text,
+                &mut bindings,
+                &mut globals,
+                &source_words,
+                operators.lookup(),
+                &mut code,
+                &mut words,
+            );
+
+            match source_text {
+                "DEF FOO" => assert_eq!(
+                    error,
+                    SourceProcessorError::SourceWord(SourceWordError::DefMissingEnd {
+                        span: span(sources.view(), id, 7, 7)
+                    })
+                ),
+                "DEF FOO\n@" => assert!(matches!(
+                    error,
+                    SourceProcessorError::SourceWord(SourceWordError::DefLex { .. })
+                )),
+                _ => unreachable!(),
+            }
+            assert_eq!(bindings.get(&name("FOO")), None);
+            assert_eq!(words.len(), initial_words_len);
+            assert_eq!(code.len(), 0);
+        }
+    }
+
+    #[test]
+    fn def_body_failure_does_not_publish_and_later_definition_can_build() {
+        let (mut words, _primitives, operators) = operator_fixture();
+        let mut source_words = SourceWordRegistry::new();
+        let mut bindings = Bindings::new();
+        let mut globals = GlobalVariables::new();
+        register_builtin_source_words(&mut source_words, &mut bindings)
+            .expect("built-in source words should bootstrap");
+        let mut code = PublishedCode::new();
+        let initial_words_len = words.len();
+
+        let (sources, id, error) = compile_with_def_error(
+            "DEF BAD\n1 MISSING\nEND",
+            &mut bindings,
+            &mut globals,
+            &source_words,
+            operators.lookup(),
+            &mut code,
+            &mut words,
+        );
+
+        assert_eq!(
+            error,
+            SourceProcessorError::SourceWord(SourceWordError::DefBodyCompile {
+                span: span(sources.view(), id, 10, 17)
+            })
+        );
+        assert_eq!(bindings.get(&name("BAD")), None);
+        assert_eq!(words.len(), initial_words_len);
+        assert_eq!(
+            code.instruction_view().get(address(0)),
+            Ok(&Instruction::Push(value(1)))
+        );
+
+        compile_with_def(
+            "DEF GOOD\nEND",
+            &mut bindings,
+            &mut globals,
+            &source_words,
+            operators.lookup(),
+            &mut code,
+            &mut words,
+        );
+        assert!(matches!(
+            bindings.get(&name("GOOD")),
+            Some(Binding::Word(_))
+        ));
+        assert_eq!(words.len(), initial_words_len + 1);
+        assert_eq!(
+            code.instruction_view().get(address(1)),
+            Ok(&Instruction::Return)
+        );
+    }
+
+    #[test]
+    fn nested_def_body_fails_without_inner_publication_capability() {
+        let (mut words, _primitives, operators) = operator_fixture();
+        let mut source_words = SourceWordRegistry::new();
+        let mut bindings = Bindings::new();
+        let mut globals = GlobalVariables::new();
+        register_builtin_source_words(&mut source_words, &mut bindings)
+            .expect("built-in source words should bootstrap");
+        let mut code = PublishedCode::new();
+        let initial_words_len = words.len();
+
+        let (sources, id, error) = compile_with_def_error(
+            "DEF OUTER\nDEF INNER\nEND\nEND",
+            &mut bindings,
+            &mut globals,
+            &source_words,
+            operators.lookup(),
+            &mut code,
+            &mut words,
+        );
+
+        assert_eq!(
+            error,
+            SourceProcessorError::SourceWord(SourceWordError::DefBodyCompile {
+                span: span(sources.view(), id, 10, 13)
+            })
+        );
+        assert_eq!(bindings.get(&name("OUTER")), None);
+        assert_eq!(bindings.get(&name("INNER")), None);
+        assert_eq!(words.len(), initial_words_len);
+    }
+
+    #[test]
+    fn def_without_runtime_publication_context_is_structured_error() {
+        let mut source_words = SourceWordRegistry::new();
+        let mut bindings = Bindings::new();
+        register_builtin_source_words(&mut source_words, &mut bindings)
+            .expect("built-in source words should bootstrap");
+        let (sources, id) = source("DEF FOO\nEND");
+
+        let error = compile_source(
+            sources.view(),
+            id,
+            SourceCompileContext::with_source_words(&bindings, source_words.lookup()),
+        )
+        .expect_err("DEF should need runtime publication capability");
+
+        assert_eq!(
+            error,
+            SourceProcessorError::SourceWord(SourceWordError::DefPublicationContextUnavailable {
+                span: span(sources.view(), id, 0, 3)
+            })
+        );
+        assert_eq!(bindings.get(&name("FOO")), None);
     }
 
     #[test]

--- a/crates/tbx-next/src/source_processor.rs
+++ b/crates/tbx-next/src/source_processor.rs
@@ -1361,7 +1361,7 @@ impl<'source> RuntimeDefinitionPublisher<'source>
         let mut body_error = None;
         let published = self
             .code
-            .publish_new_word_with_bindings(self.words, bindings, name, |body_bindings, builder| {
+            .publish_new_word(self.words, bindings, name, |body_bindings, builder| {
                 let result = compile_definition_body(
                     self.view,
                     self.source_id,

--- a/crates/tbx-next/src/source_word.rs
+++ b/crates/tbx-next/src/source_word.rs
@@ -9,6 +9,7 @@ use crate::lexer::{LexError, Token, TokenKind};
 use crate::name::{NameError, NormalizedName};
 use crate::operator::OperatorLookup;
 use crate::source::{SourceError, SourceId, SourceSpan, SourceView};
+use crate::word::WordId;
 use crate::word_resolution::{resolve_binding_name, ResolvedBinding, WordResolutionError};
 
 /// Internal identifier for a published source-processing word.
@@ -80,6 +81,41 @@ pub(crate) enum SourceWordError {
     Expression {
         source: ExpressionError,
     },
+    DefSyntax {
+        span: SourceSpan,
+        kind: DefSyntaxErrorKind,
+    },
+    DefName {
+        span: SourceSpan,
+        source: NameError,
+    },
+    DefNameConflict {
+        span: SourceSpan,
+    },
+    DefReservedName {
+        span: SourceSpan,
+    },
+    DefPublicationContextUnavailable {
+        span: SourceSpan,
+    },
+    DefMissingEnd {
+        span: SourceSpan,
+    },
+    DefLex {
+        source: LexError,
+    },
+    DefBodyCompile {
+        span: SourceSpan,
+    },
+    DefBodyBuild {
+        span: SourceSpan,
+    },
+    DefDefinition {
+        span: SourceSpan,
+    },
+    DefBindingCommitInvariantViolated {
+        span: SourceSpan,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -98,6 +134,47 @@ pub(crate) enum LetSyntaxErrorKind {
     Target,
     Equal,
     Rhs,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DefSyntaxErrorKind {
+    MissingName,
+    TrailingToken { kind: TokenKind },
+}
+
+impl SourceWordError {
+    pub(crate) fn primary_span(self) -> Option<SourceSpan> {
+        match self {
+            Self::Source { .. }
+            | Self::InstructionBuild { .. }
+            | Self::VarPublicationContextUnavailable
+            | Self::Expression { .. } => None,
+            Self::UnsupportedSourceWord { span }
+            | Self::VarSyntax { span, .. }
+            | Self::VarLocalLineNumberPrefix { span }
+            | Self::VarName { span, .. }
+            | Self::VarNameConflict { span }
+            | Self::VarReservedName { span }
+            | Self::VarBindingCommitInvariantViolated { span }
+            | Self::LetSyntax { span, .. }
+            | Self::LetTarget { span, .. }
+            | Self::LetExpressionContextUnavailable { span }
+            | Self::DefSyntax { span, .. }
+            | Self::DefName { span, .. }
+            | Self::DefNameConflict { span }
+            | Self::DefReservedName { span }
+            | Self::DefPublicationContextUnavailable { span }
+            | Self::DefMissingEnd { span }
+            | Self::DefBodyCompile { span }
+            | Self::DefBodyBuild { span }
+            | Self::DefDefinition { span }
+            | Self::DefBindingCommitInvariantViolated { span } => Some(span),
+            Self::DefLex { source } => match source {
+                LexError::Source(_) => None,
+                LexError::InvalidCharacter { span, .. } => Some(span),
+            },
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -146,6 +223,17 @@ pub(crate) trait SourceBlockCursor<'source> {
 
 pub(crate) struct SourceBlockReader<'source, 'cursor> {
     cursor: &'cursor mut dyn SourceBlockCursor<'source>,
+}
+
+pub(crate) trait RuntimeDefinitionPublisher<'source> {
+    fn publish_runtime_definition(
+        &mut self,
+        bindings: &mut Bindings,
+        name: NormalizedName,
+        name_span: SourceSpan,
+        body: &[SourceBlockStatement<'source>],
+        end_span: SourceSpan,
+    ) -> Result<WordId, SourceWordError>;
 }
 
 impl<'source> SourceBlockStatement<'source> {
@@ -307,6 +395,7 @@ pub(crate) struct NativeSourceWordContext<'source, 'state> {
     code: &'state mut dyn InstructionBuildTarget,
     local_line_number_prefix: Option<SourceSpan>,
     globals: Option<&'state mut GlobalVariables>,
+    runtime_definitions: Option<&'state mut dyn RuntimeDefinitionPublisher<'source>>,
 }
 
 pub(crate) struct NativeSourceWordContextParts<'source, 'state> {
@@ -319,6 +408,7 @@ pub(crate) struct NativeSourceWordContextParts<'source, 'state> {
     pub(crate) code: &'state mut dyn InstructionBuildTarget,
     pub(crate) local_line_number_prefix: Option<SourceSpan>,
     pub(crate) globals: Option<&'state mut GlobalVariables>,
+    pub(crate) runtime_definitions: Option<&'state mut dyn RuntimeDefinitionPublisher<'source>>,
 }
 
 impl<'source, 'state> NativeSourceWordContext<'source, 'state> {
@@ -340,6 +430,7 @@ impl<'source, 'state> NativeSourceWordContext<'source, 'state> {
             code: parts.code,
             local_line_number_prefix: parts.local_line_number_prefix,
             globals: parts.globals,
+            runtime_definitions: parts.runtime_definitions,
         }
     }
 
@@ -414,6 +505,45 @@ impl<'source, 'state> NativeSourceWordContext<'source, 'state> {
                     SourceWordError::VarBindingCommitInvariantViolated { span }
                 }
             })
+    }
+
+    pub(crate) fn validate_runtime_definition_name(
+        &self,
+        name: &NormalizedName,
+        span: SourceSpan,
+    ) -> Result<(), SourceWordError> {
+        self.bindings()
+            .validate_new_name(name)
+            .map_err(|source| match source {
+                BindingInsertError::NameConflict => SourceWordError::DefNameConflict { span },
+                BindingInsertError::ReservedName => SourceWordError::DefReservedName { span },
+            })
+    }
+
+    pub(crate) fn has_runtime_definition_publication(&self) -> bool {
+        self.runtime_definitions.is_some()
+            && matches!(&self.bindings, NativeSourceWordBindingAccess::Write(_))
+    }
+
+    pub(crate) fn publish_runtime_definition(
+        &mut self,
+        name: NormalizedName,
+        name_span: SourceSpan,
+        body: &[SourceBlockStatement<'source>],
+        end_span: SourceSpan,
+    ) -> Result<WordId, SourceWordError> {
+        let Some(publisher) = &mut self.runtime_definitions else {
+            return Err(SourceWordError::DefPublicationContextUnavailable {
+                span: self.source_word_token.span(),
+            });
+        };
+        let NativeSourceWordBindingAccess::Write(bindings) = &mut self.bindings else {
+            return Err(SourceWordError::DefPublicationContextUnavailable {
+                span: self.source_word_token.span(),
+            });
+        };
+
+        publisher.publish_runtime_definition(bindings, name, name_span, body, end_span)
     }
 
     pub(crate) fn resolve_variable_target(
@@ -529,11 +659,82 @@ pub(crate) fn let_source_word(
     context.commit_staging(&staging)
 }
 
+pub(crate) fn def_source_word(
+    context: &mut NativeSourceWordContext<'_, '_>,
+) -> Result<(), SourceWordError> {
+    let name_token = {
+        let reader = context.statement_reader_mut();
+        let name_token = reader.read_name().map_err(def_reader_error)?;
+        reader.finish().map_err(def_reader_error)?;
+        name_token
+    };
+
+    let source_name = context
+        .view()
+        .slice(name_token.span())
+        .map_err(|source| SourceWordError::Source { source })?;
+    let name = NormalizedName::new(source_name).map_err(|source| SourceWordError::DefName {
+        span: name_token.span(),
+        source,
+    })?;
+    context.validate_runtime_definition_name(&name, name_token.span())?;
+    if !context.has_runtime_definition_publication() {
+        return Err(SourceWordError::DefPublicationContextUnavailable {
+            span: context.source_word_token().span(),
+        });
+    }
+
+    let view = context.view();
+    let mut body = Vec::new();
+    let end_span = loop {
+        let read = {
+            let Some(reader) = context.block_reader_mut() else {
+                return Err(SourceWordError::DefPublicationContextUnavailable {
+                    span: context.source_word_token().span(),
+                });
+            };
+            reader.next_statement()?
+        };
+
+        match read {
+            SourceBlockRead::Statement(statement) if is_standalone_end(view, statement)? => {
+                break statement.span();
+            }
+            SourceBlockRead::Statement(statement) => body.push(statement),
+            SourceBlockRead::Terminal(SourceBlockTerminal::Eof { span }) => {
+                return Err(SourceWordError::DefMissingEnd { span });
+            }
+            SourceBlockRead::Terminal(SourceBlockTerminal::LexError { error }) => {
+                return Err(SourceWordError::DefLex { source: error });
+            }
+        }
+    };
+
+    context.publish_runtime_definition(name, name_token.span(), &body, end_span)?;
+    Ok(())
+}
+
 pub(crate) fn unsupported_source_word(
     context: &mut NativeSourceWordContext<'_, '_>,
 ) -> Result<(), SourceWordError> {
     let first = context.source_word_token();
     Err(SourceWordError::UnsupportedSourceWord { span: first.span() })
+}
+
+fn is_standalone_end(
+    view: SourceView<'_>,
+    statement: SourceBlockStatement<'_>,
+) -> Result<bool, SourceWordError> {
+    let Some(token) = statement.standalone_name() else {
+        return Ok(false);
+    };
+    let source_name = view
+        .slice(token.span())
+        .map_err(|source| SourceWordError::Source { source })?;
+    let Ok(name) = NormalizedName::new(source_name) else {
+        return Ok(false);
+    };
+    Ok(name.as_str() == "END")
 }
 
 fn var_reader_error(error: SourceStatementReaderError) -> SourceWordError {
@@ -549,6 +750,25 @@ fn var_reader_error(error: SourceStatementReaderError) -> SourceWordError {
         SourceStatementReaderError::TrailingToken { actual } => SourceWordError::VarSyntax {
             span: actual.span(),
             kind: VarSyntaxErrorKind::TrailingToken {
+                kind: actual.kind(),
+            },
+        },
+    }
+}
+
+fn def_reader_error(error: SourceStatementReaderError) -> SourceWordError {
+    match error {
+        SourceStatementReaderError::Missing { span, .. } => SourceWordError::DefSyntax {
+            span,
+            kind: DefSyntaxErrorKind::MissingName,
+        },
+        SourceStatementReaderError::Unexpected { actual, .. } => SourceWordError::DefSyntax {
+            span: actual.span(),
+            kind: DefSyntaxErrorKind::MissingName,
+        },
+        SourceStatementReaderError::TrailingToken { actual } => SourceWordError::DefSyntax {
+            span: actual.span(),
+            kind: DefSyntaxErrorKind::TrailingToken {
                 kind: actual.kind(),
             },
         },
@@ -702,6 +922,7 @@ mod tests {
             code: &mut code,
             local_line_number_prefix: None,
             globals: None,
+            runtime_definitions: None,
         });
 
         let first_body_token = context
@@ -904,6 +1125,7 @@ mod tests {
             code: &mut code,
             local_line_number_prefix: None,
             globals: None,
+            runtime_definitions: None,
         });
 
         push_one(&mut context).expect("test source word should emit");
@@ -935,6 +1157,7 @@ mod tests {
                     code: &mut code,
                     local_line_number_prefix: None,
                     globals: Some(&mut globals),
+                    runtime_definitions: None,
                 });
 
                 var_source_word(&mut context)


### PR DESCRIPTION
## Summary

- `DEF` を built-in source word として登録し、通常の `Binding::SourceWord` 解決で dispatch するようにしました。
- top-level source compile から runtime definition publication 専用 capability を渡し、`PublishedCode` / `PublishedWords` の raw mutable access を handler へ公開しない形で接続しました。
- `DEF` header/block/body compile/publication の契約をテストし、body 成功後に `END` span へ mapped `Return` を1命令だけ追加します。

Closes #1506

## Verification

- `cargo test -p tbx-next --no-fail-fast`
- `cargo clippy -p tbx-next --all-targets --all-features -- -D warnings`
- `cargo ci-fmt`
- `cargo ci-clippy`
- `cargo ci-test`
