### PR TITLE
TBX Next: 未公開block code構築境界を抽出

### DIFF
--- a/crates/tbx-next/src/block_code.rs
+++ b/crates/tbx-next/src/block_code.rs
@@ -1,0 +1,352 @@
+use crate::instruction::{BranchTargetPatchError, Instruction, InstructionAddress};
+use crate::source::SourceSpan;
+use crate::source_mapping::{SourceMappedCode, SourceMappingAppendError};
+
+/// Common unpublished builder for one owner-local instruction block.
+///
+/// Per #1518, completing a block only proves its local instruction/mapping and
+/// branch-patch contract. Runtime word publication remains a separate boundary.
+#[derive(Debug)]
+pub(crate) struct BlockCodeBuilder<'a> {
+    code: &'a mut SourceMappedCode,
+    block_start: InstructionAddress,
+    unresolved_patches: Vec<InstructionAddress>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CompletedBlockCode {
+    entry: InstructionAddress,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BlockCodeBuildError {
+    SourceMappingAppend { source: SourceMappingAppendError },
+    BranchTargetPatch { source: BranchTargetPatchError },
+    BranchInstructionRequiresPatch { instruction: Instruction },
+    AddressOutsideCurrentBlock { address: InstructionAddress },
+    UnknownBranchPatch { branch: InstructionAddress },
+    UnresolvedBranchPatch { branch: InstructionAddress },
+}
+
+impl<'a> BlockCodeBuilder<'a> {
+    pub(crate) fn new(code: &'a mut SourceMappedCode) -> Self {
+        let block_start = InstructionAddress::from_index(code.len());
+        Self {
+            code,
+            block_start,
+            unresolved_patches: Vec::new(),
+        }
+    }
+
+    pub(crate) fn current_address(&self) -> InstructionAddress {
+        InstructionAddress::from_index(self.code.len())
+    }
+
+    pub(crate) fn current_len(&self) -> usize {
+        self.code.len()
+    }
+
+    pub(crate) fn append_mapped(
+        &mut self,
+        instruction: Instruction,
+        span: SourceSpan,
+    ) -> Result<InstructionAddress, BlockCodeBuildError> {
+        reject_direct_branch_instruction(instruction)?;
+        self.code
+            .append_mapped(instruction, span)
+            .map_err(|source| BlockCodeBuildError::SourceMappingAppend { source })
+    }
+
+    pub(crate) fn append_unmapped(
+        &mut self,
+        instruction: Instruction,
+    ) -> Result<InstructionAddress, BlockCodeBuildError> {
+        reject_direct_branch_instruction(instruction)?;
+        self.code
+            .append_unmapped(instruction)
+            .map_err(|source| BlockCodeBuildError::SourceMappingAppend { source })
+    }
+
+    pub(crate) fn append_mapped_jump_placeholder(
+        &mut self,
+        span: SourceSpan,
+    ) -> Result<InstructionAddress, BlockCodeBuildError> {
+        self.append_branch_placeholder(
+            Instruction::Jump(InstructionAddress::from_index(0)),
+            Some(span),
+        )
+    }
+
+    pub(crate) fn append_unmapped_jump_placeholder(
+        &mut self,
+    ) -> Result<InstructionAddress, BlockCodeBuildError> {
+        self.append_branch_placeholder(Instruction::Jump(InstructionAddress::from_index(0)), None)
+    }
+
+    pub(crate) fn append_mapped_jump_if_zero_placeholder(
+        &mut self,
+        span: SourceSpan,
+    ) -> Result<InstructionAddress, BlockCodeBuildError> {
+        self.append_branch_placeholder(
+            Instruction::JumpIfZero(InstructionAddress::from_index(0)),
+            Some(span),
+        )
+    }
+
+    pub(crate) fn append_unmapped_jump_if_zero_placeholder(
+        &mut self,
+    ) -> Result<InstructionAddress, BlockCodeBuildError> {
+        self.append_branch_placeholder(
+            Instruction::JumpIfZero(InstructionAddress::from_index(0)),
+            None,
+        )
+    }
+
+    pub(crate) fn patch_branch_target(
+        &mut self,
+        branch: InstructionAddress,
+        target: InstructionAddress,
+    ) -> Result<(), BlockCodeBuildError> {
+        self.validate_local_target(branch)?;
+        self.validate_local_target(target)?;
+        let Some(position) = self
+            .unresolved_patches
+            .iter()
+            .position(|pending| *pending == branch)
+        else {
+            return Err(BlockCodeBuildError::UnknownBranchPatch { branch });
+        };
+
+        self.code
+            .patch_branch_target(branch, target)
+            .map_err(|source| BlockCodeBuildError::BranchTargetPatch { source })?;
+
+        self.unresolved_patches.swap_remove(position);
+        Ok(())
+    }
+
+    pub(crate) fn validate_local_target(
+        &self,
+        address: InstructionAddress,
+    ) -> Result<(), BlockCodeBuildError> {
+        if address.as_index() < self.block_start.as_index() || address.as_index() >= self.code.len()
+        {
+            return Err(BlockCodeBuildError::AddressOutsideCurrentBlock { address });
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn finish(self) -> Result<CompletedBlockCode, BlockCodeBuildError> {
+        if let Some(branch) = self.unresolved_patches.first().copied() {
+            return Err(BlockCodeBuildError::UnresolvedBranchPatch { branch });
+        }
+
+        Ok(CompletedBlockCode {
+            entry: self.block_start,
+        })
+    }
+
+    fn append_branch_placeholder(
+        &mut self,
+        instruction: Instruction,
+        span: Option<SourceSpan>,
+    ) -> Result<InstructionAddress, BlockCodeBuildError> {
+        let branch = if let Some(span) = span {
+            self.code.append_mapped(instruction, span)
+        } else {
+            self.code.append_unmapped(instruction)
+        }
+        .map_err(|source| BlockCodeBuildError::SourceMappingAppend { source })?;
+
+        self.unresolved_patches.push(branch);
+        Ok(branch)
+    }
+}
+
+impl CompletedBlockCode {
+    pub(crate) const fn entry(self) -> InstructionAddress {
+        self.entry
+    }
+}
+
+fn reject_direct_branch_instruction(instruction: Instruction) -> Result<(), BlockCodeBuildError> {
+    match instruction {
+        Instruction::Jump(_) | Instruction::JumpIfZero(_) => {
+            Err(BlockCodeBuildError::BranchInstructionRequiresPatch { instruction })
+        }
+        Instruction::Push(_)
+        | Instruction::LoadVar(_)
+        | Instruction::StoreVar(_)
+        | Instruction::Call(_)
+        | Instruction::Return
+        | Instruction::Halt => Ok(()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::source::{SourceId, SourceTexts, SourceView};
+    use crate::value::Value;
+
+    fn source(text: &str) -> (SourceTexts, SourceId) {
+        let mut sources = SourceTexts::new();
+        let id = sources.register(text);
+        (sources, id)
+    }
+
+    fn span(view: SourceView<'_>, source_id: SourceId, start: usize, end: usize) -> SourceSpan {
+        view.span(source_id, start, end)
+            .expect("test span should be valid")
+    }
+
+    fn address(index: usize) -> InstructionAddress {
+        InstructionAddress::from_index(index)
+    }
+
+    fn push(value: i16) -> Instruction {
+        Instruction::Push(Value::integer(value))
+    }
+
+    #[test]
+    fn mapped_and_unmapped_instructions_keep_local_address_mapping_order() {
+        let (sources, source_id) = source("A B");
+        let first_span = span(sources.view(), source_id, 0, 1);
+        let mut code = SourceMappedCode::new();
+
+        let completed = {
+            let mut builder = BlockCodeBuilder::new(&mut code);
+            let first = builder
+                .append_mapped(push(1), first_span)
+                .expect("mapped instruction should append");
+            let second = builder
+                .append_unmapped(Instruction::Return)
+                .expect("unmapped instruction should append");
+            assert_eq!(first, address(0));
+            assert_eq!(second, address(1));
+            builder.finish().expect("block should complete")
+        };
+
+        assert_eq!(completed.entry(), address(0));
+        assert_eq!(code.len(), code.source_mapping().len());
+        assert_eq!(code.instruction_view().get(address(0)), Ok(&push(1)));
+        assert_eq!(
+            code.source_mapping()
+                .source_span(code.instruction_view().location(address(0))),
+            Ok(Some(first_span))
+        );
+        assert_eq!(
+            code.source_mapping()
+                .source_span(code.instruction_view().location(address(1))),
+            Ok(None)
+        );
+    }
+
+    #[test]
+    fn branch_placeholder_can_patch_and_complete() {
+        let (sources, source_id) = source("BIF X, 20\n20");
+        let branch_span = span(sources.view(), source_id, 0, 3);
+        let target_span = span(sources.view(), source_id, 10, 12);
+        let mut code = SourceMappedCode::new();
+
+        let branch = {
+            let mut builder = BlockCodeBuilder::new(&mut code);
+            let branch = builder
+                .append_mapped_jump_if_zero_placeholder(branch_span)
+                .expect("placeholder should append");
+            let target = builder
+                .append_mapped(Instruction::Halt, target_span)
+                .expect("target should append");
+            builder
+                .patch_branch_target(branch, target)
+                .expect("branch should patch");
+            builder.finish().expect("block should complete");
+            branch
+        };
+
+        assert_eq!(
+            code.instruction_view().get(branch),
+            Ok(&Instruction::JumpIfZero(address(1)))
+        );
+        assert_eq!(
+            code.source_mapping()
+                .source_span(code.instruction_view().location(branch)),
+            Ok(Some(branch_span))
+        );
+    }
+
+    #[test]
+    fn direct_branch_append_is_rejected() {
+        let mut code = SourceMappedCode::new();
+        let mut builder = BlockCodeBuilder::new(&mut code);
+        let branch = Instruction::Jump(address(0));
+
+        assert_eq!(
+            builder.append_unmapped(branch),
+            Err(BlockCodeBuildError::BranchInstructionRequiresPatch {
+                instruction: branch
+            })
+        );
+    }
+
+    #[test]
+    fn patch_target_must_be_inside_current_block() {
+        let mut code = SourceMappedCode::new();
+        {
+            let mut first = BlockCodeBuilder::new(&mut code);
+            first
+                .append_unmapped(Instruction::Return)
+                .expect("old instruction should append");
+            first.finish().expect("old block should complete");
+        }
+
+        let mut second = BlockCodeBuilder::new(&mut code);
+        let branch = second
+            .append_unmapped_jump_placeholder()
+            .expect("placeholder should append");
+        assert_eq!(
+            second.patch_branch_target(branch, address(0)),
+            Err(BlockCodeBuildError::AddressOutsideCurrentBlock {
+                address: address(0)
+            })
+        );
+    }
+
+    #[test]
+    fn unknown_and_duplicate_patches_are_rejected() {
+        let mut code = SourceMappedCode::new();
+        let mut builder = BlockCodeBuilder::new(&mut code);
+        let branch = builder
+            .append_unmapped_jump_placeholder()
+            .expect("placeholder should append");
+        let target = builder
+            .append_unmapped(Instruction::Return)
+            .expect("target should append");
+
+        builder
+            .patch_branch_target(branch, target)
+            .expect("first patch should succeed");
+        assert_eq!(
+            builder.patch_branch_target(branch, target),
+            Err(BlockCodeBuildError::UnknownBranchPatch { branch })
+        );
+    }
+
+    #[test]
+    fn unresolved_patch_rejects_completion() {
+        let mut code = SourceMappedCode::new();
+        let mut builder = BlockCodeBuilder::new(&mut code);
+        let branch = builder
+            .append_unmapped_jump_placeholder()
+            .expect("placeholder should append");
+        builder
+            .append_unmapped(Instruction::Return)
+            .expect("target should append");
+
+        assert_eq!(
+            builder.finish(),
+            Err(BlockCodeBuildError::UnresolvedBranchPatch { branch })
+        );
+    }
+}

--- a/crates/tbx-next/src/expression.rs
+++ b/crates/tbx-next/src/expression.rs
@@ -492,6 +492,7 @@ const fn unexpected_token(token: Token) -> ExpressionSyntaxErrorKind {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::block_code::BlockCodeBuilder;
     use crate::instruction::InstructionAddress;
     use crate::lexer::Lexer;
     use crate::operator::register_operator_primitives;
@@ -910,8 +911,12 @@ mod tests {
         let (sources, id, staging) = parse("1+2");
         let view = sources.view();
         let mut code = SourceMappedCode::new();
+        let mut builder = BlockCodeBuilder::new(&mut code);
 
-        staging.commit_to(&mut code).expect("staging should commit");
+        staging
+            .commit_to(&mut builder)
+            .expect("staging should commit");
+        builder.finish().expect("block should complete");
 
         assert_eq!(code.len(), 3);
         assert_eq!(

--- a/crates/tbx-next/src/instruction_builder.rs
+++ b/crates/tbx-next/src/instruction_builder.rs
@@ -1,16 +1,18 @@
-use crate::instruction::{
-    BranchTargetPatchError, Instruction, InstructionAddress, InstructionAddressError,
-};
+use crate::block_code::{BlockCodeBuildError, BlockCodeBuilder};
+use crate::instruction::{Instruction, InstructionAddress};
 use crate::published_code::{PublishedWordBuilder, WordBodyBuildError};
 use crate::source::SourceSpan;
-use crate::source_mapping::{SourceMappedCode, SourceMappingAppendError};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum InstructionBuildError {
-    SourceMappingAppend { source: SourceMappingAppendError },
-    BranchTargetPatch { source: BranchTargetPatchError },
+    BlockCodeBuild { source: BlockCodeBuildError },
     WordBodyBuild { source: WordBodyBuildError },
-    InvalidAddress { source: InstructionAddressError },
+}
+
+impl From<BlockCodeBuildError> for InstructionBuildError {
+    fn from(source: BlockCodeBuildError) -> Self {
+        Self::BlockCodeBuild { source }
+    }
 }
 
 pub(crate) trait InstructionBuildTarget {
@@ -53,9 +55,9 @@ pub(crate) trait InstructionBuildTarget {
     ) -> Result<(), InstructionBuildError>;
 }
 
-impl InstructionBuildTarget for SourceMappedCode {
+impl InstructionBuildTarget for BlockCodeBuilder<'_> {
     fn current_len(&self) -> usize {
-        self.len()
+        self.current_len()
     }
 
     fn append_mapped(
@@ -63,40 +65,32 @@ impl InstructionBuildTarget for SourceMappedCode {
         instruction: Instruction,
         span: SourceSpan,
     ) -> Result<InstructionAddress, InstructionBuildError> {
-        SourceMappedCode::append_mapped(self, instruction, span)
-            .map_err(|source| InstructionBuildError::SourceMappingAppend { source })
+        BlockCodeBuilder::append_mapped(self, instruction, span)
+            .map_err(|source| InstructionBuildError::BlockCodeBuild { source })
     }
 
     fn append_unmapped(
         &mut self,
         instruction: Instruction,
     ) -> Result<InstructionAddress, InstructionBuildError> {
-        SourceMappedCode::append_unmapped(self, instruction)
-            .map_err(|source| InstructionBuildError::SourceMappingAppend { source })
+        BlockCodeBuilder::append_unmapped(self, instruction)
+            .map_err(|source| InstructionBuildError::BlockCodeBuild { source })
     }
 
     fn append_mapped_jump_placeholder(
         &mut self,
         span: SourceSpan,
     ) -> Result<InstructionAddress, InstructionBuildError> {
-        SourceMappedCode::append_mapped(
-            self,
-            Instruction::Jump(InstructionAddress::from_index(0)),
-            span,
-        )
-        .map_err(|source| InstructionBuildError::SourceMappingAppend { source })
+        BlockCodeBuilder::append_mapped_jump_placeholder(self, span)
+            .map_err(|source| InstructionBuildError::BlockCodeBuild { source })
     }
 
     fn append_mapped_jump_if_zero_placeholder(
         &mut self,
         span: SourceSpan,
     ) -> Result<InstructionAddress, InstructionBuildError> {
-        SourceMappedCode::append_mapped(
-            self,
-            Instruction::JumpIfZero(InstructionAddress::from_index(0)),
-            span,
-        )
-        .map_err(|source| InstructionBuildError::SourceMappingAppend { source })
+        BlockCodeBuilder::append_mapped_jump_if_zero_placeholder(self, span)
+            .map_err(|source| InstructionBuildError::BlockCodeBuild { source })
     }
 
     fn patch_branch_target(
@@ -104,17 +98,16 @@ impl InstructionBuildTarget for SourceMappedCode {
         branch: InstructionAddress,
         target: InstructionAddress,
     ) -> Result<(), InstructionBuildError> {
-        SourceMappedCode::patch_branch_target(self, branch, target)
-            .map_err(|source| InstructionBuildError::BranchTargetPatch { source })
+        BlockCodeBuilder::patch_branch_target(self, branch, target)
+            .map_err(|source| InstructionBuildError::BlockCodeBuild { source })
     }
 
     fn validate_local_target(
         &self,
         address: InstructionAddress,
     ) -> Result<(), InstructionBuildError> {
-        self.validate_address(address)
-            .map(|_| ())
-            .map_err(|source| InstructionBuildError::InvalidAddress { source })
+        BlockCodeBuilder::validate_local_target(self, address)
+            .map_err(|source| InstructionBuildError::BlockCodeBuild { source })
     }
 }
 
@@ -178,10 +171,12 @@ impl InstructionBuildTarget for PublishedWordBuilder<'_> {
 mod tests {
     use super::*;
     use crate::binding::Bindings;
+    use crate::block_code::BlockCodeBuildError;
     use crate::instruction::Instruction;
     use crate::name::NormalizedName;
     use crate::published_code::{NewWordPublicationError, PublishedCode};
     use crate::source::{SourceId, SourceTexts, SourceView};
+    use crate::source_mapping::SourceMappedCode;
     use crate::value::Value;
     use crate::word::PublishedWords;
 
@@ -211,6 +206,13 @@ mod tests {
         }
     }
 
+    fn unwrap_block_build_error(error: InstructionBuildError) -> BlockCodeBuildError {
+        match error {
+            InstructionBuildError::BlockCodeBuild { source } => source,
+            source => panic!("unexpected target error: {source:?}"),
+        }
+    }
+
     #[test]
     fn temporary_target_maps_placeholder_and_patches_without_mapping_change() {
         let (sources, source_id) = source("BIF X, 20\n20");
@@ -218,14 +220,17 @@ mod tests {
         let target_span = span(sources.view(), source_id, 10, 12);
         let mut code = SourceMappedCode::new();
 
-        let branch = code
+        let mut builder = BlockCodeBuilder::new(&mut code);
+        let branch = builder
             .append_mapped_jump_if_zero_placeholder(branch_span)
             .expect("branch placeholder should append");
-        let target = code
+        let target = builder
             .append_mapped(Instruction::Halt, target_span)
             .expect("target should append");
-        code.patch_branch_target(branch, target)
+        builder
+            .patch_branch_target(branch, target)
             .expect("branch should patch");
+        builder.finish().expect("block should complete");
 
         assert_eq!(
             code.instruction_view().get(branch),
@@ -330,6 +335,26 @@ mod tests {
                 source: WordBodyBuildError::AddressOutsideCurrentBody {
                     address: old.entry().address()
                 }
+            })
+        );
+    }
+
+    #[test]
+    fn block_target_rejects_direct_branch_append_through_common_interface() {
+        let mut code = SourceMappedCode::new();
+        let mut builder = BlockCodeBuilder::new(&mut code);
+        let branch = Instruction::Jump(InstructionAddress::from_index(0));
+        let target: &mut dyn InstructionBuildTarget = &mut builder;
+
+        let result = target
+            .append_unmapped(branch)
+            .map(|_| ())
+            .map_err(unwrap_block_build_error);
+
+        assert_eq!(
+            result,
+            Err(BlockCodeBuildError::BranchInstructionRequiresPatch {
+                instruction: branch
             })
         );
     }

--- a/crates/tbx-next/src/lib.rs
+++ b/crates/tbx-next/src/lib.rs
@@ -67,6 +67,11 @@ mod source;
 #[allow(dead_code)]
 mod source_mapping;
 
+// #1518/#1519 centralizes unpublished block construction, local branch
+// completion, and source mapping order before any runtime publication step.
+#[allow(dead_code)]
+mod block_code;
+
 // #1504 keeps statement lowering independent from concrete instruction owners
 // while preserving published-word branch patch contracts.
 #[allow(dead_code)]

--- a/crates/tbx-next/src/line_number.rs
+++ b/crates/tbx-next/src/line_number.rs
@@ -154,9 +154,8 @@ impl LineNumberError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::instruction::{
-        BranchTargetPatchError, Instruction, InstructionAddress, InstructionAddressError,
-    };
+    use crate::block_code::{BlockCodeBuildError, BlockCodeBuilder};
+    use crate::instruction::{Instruction, InstructionAddress};
     use crate::source::{SourceId, SourceTexts, SourceView};
     use crate::source_mapping::SourceMappedCode;
     use crate::value::Value;
@@ -180,8 +179,9 @@ mod tests {
         LocalLineNumber::new(raw)
     }
 
-    fn append(code: &mut SourceMappedCode, instruction: Instruction) -> InstructionAddress {
-        code.append_unmapped(instruction)
+    fn append(builder: &mut BlockCodeBuilder<'_>, instruction: Instruction) -> InstructionAddress {
+        builder
+            .append_unmapped(instruction)
             .expect("test instruction should append")
     }
 
@@ -191,16 +191,19 @@ mod tests {
         let branch_span = span(sources.view(), source_id, 7, 10);
         let target_span = span(sources.view(), source_id, 11, 14);
         let mut code = SourceMappedCode::new();
-        let placeholder = append(&mut code, Instruction::Halt);
-        let branch = append(&mut code, Instruction::JumpIfZero(placeholder));
-        let target = append(&mut code, Instruction::Halt);
+        let mut builder = BlockCodeBuilder::new(&mut code);
+        let branch = builder
+            .append_unmapped_jump_if_zero_placeholder()
+            .expect("branch should append");
+        let target = append(&mut builder, Instruction::Halt);
         let mut table = LocalLineNumberTable::new();
 
         table.add_patch(line(200), branch, branch_span);
         table
-            .define(&code, line(200), target, target_span)
+            .define(&builder, line(200), target, target_span)
             .expect("target should define");
-        table.resolve(&mut code).expect("patch should resolve");
+        table.resolve(&mut builder).expect("patch should resolve");
+        builder.finish().expect("block should complete");
 
         assert_eq!(
             code.instruction_view().get(branch),
@@ -214,15 +217,19 @@ mod tests {
         let target_span = span(sources.view(), source_id, 0, 3);
         let branch_span = span(sources.view(), source_id, 17, 20);
         let mut code = SourceMappedCode::new();
-        let target = append(&mut code, Instruction::Halt);
-        let branch = append(&mut code, Instruction::Jump(address(0)));
+        let mut builder = BlockCodeBuilder::new(&mut code);
+        let target = append(&mut builder, Instruction::Halt);
+        let branch = builder
+            .append_unmapped_jump_placeholder()
+            .expect("branch should append");
         let mut table = LocalLineNumberTable::new();
 
         table
-            .define(&code, line(100), target, target_span)
+            .define(&builder, line(100), target, target_span)
             .expect("target should define");
         table.add_patch(line(100), branch, branch_span);
-        table.resolve(&mut code).expect("patch should resolve");
+        table.resolve(&mut builder).expect("patch should resolve");
+        builder.finish().expect("block should complete");
 
         assert_eq!(
             code.instruction_view().get(branch),
@@ -236,15 +243,16 @@ mod tests {
         let first_span = span(sources.view(), source_id, 0, 3);
         let second_span = span(sources.view(), source_id, 6, 9);
         let mut code = SourceMappedCode::new();
-        let target = append(&mut code, Instruction::Halt);
+        let mut builder = BlockCodeBuilder::new(&mut code);
+        let target = append(&mut builder, Instruction::Halt);
         let mut table = LocalLineNumberTable::new();
 
         table
-            .define(&code, line(100), target, first_span)
+            .define(&builder, line(100), target, first_span)
             .expect("first definition should succeed");
 
         assert_eq!(
-            table.define(&code, line(100), target, second_span),
+            table.define(&builder, line(100), target, second_span),
             Err(LineNumberError::Duplicate {
                 line_number: line(100),
                 original_span: first_span,
@@ -258,13 +266,16 @@ mod tests {
         let (sources, source_id) = source("BIF 0, 200");
         let branch_span = span(sources.view(), source_id, 7, 10);
         let mut code = SourceMappedCode::new();
-        let branch = append(&mut code, Instruction::JumpIfZero(address(0)));
+        let mut builder = BlockCodeBuilder::new(&mut code);
+        let branch = builder
+            .append_unmapped_jump_if_zero_placeholder()
+            .expect("branch should append");
         let mut table = LocalLineNumberTable::new();
 
         table.add_patch(line(200), branch, branch_span);
 
         assert_eq!(
-            table.resolve(&mut code),
+            table.resolve(&mut builder),
             Err(LineNumberError::Undefined {
                 line_number: line(200),
                 span: branch_span,
@@ -278,11 +289,12 @@ mod tests {
         let (sources, source_id) = source("40000 TARGET");
         let target_span = span(sources.view(), source_id, 0, 5);
         let mut code = SourceMappedCode::new();
-        let target = append(&mut code, Instruction::Halt);
+        let mut builder = BlockCodeBuilder::new(&mut code);
+        let target = append(&mut builder, Instruction::Halt);
         let mut table = LocalLineNumberTable::new();
 
         table
-            .define(&code, large, target, target_span)
+            .define(&builder, large, target, target_span)
             .expect("large line number should be compile-time-only");
 
         assert_eq!(large.raw(), 32768);
@@ -293,30 +305,31 @@ mod tests {
         let (sources, source_id) = source("100 A");
         let line_span = span(sources.view(), source_id, 0, 3);
         let mut code = SourceMappedCode::new();
-        append(&mut code, Instruction::Halt);
+        let mut builder = BlockCodeBuilder::new(&mut code);
+        append(&mut builder, Instruction::Halt);
         let mut table = LocalLineNumberTable::new();
 
         assert_eq!(
-            table.define(&code, line(100), address(1), line_span),
+            table.define(&builder, line(100), address(1), line_span),
             Err(LineNumberError::InvalidDefinitionTarget {
                 line_number: line(100),
                 span: line_span,
-                source: InstructionBuildError::InvalidAddress {
-                    source: InstructionAddressError::EndAddress {
-                        address: address(1)
-                    }
+                source: InstructionBuildError::BlockCodeBuild {
+                    source: BlockCodeBuildError::AddressOutsideCurrentBlock {
+                        address: address(1),
+                    },
                 },
             })
         );
         assert_eq!(
-            table.define(&code, line(100), address(2), line_span),
+            table.define(&builder, line(100), address(2), line_span),
             Err(LineNumberError::InvalidDefinitionTarget {
                 line_number: line(100),
                 span: line_span,
-                source: InstructionBuildError::InvalidAddress {
-                    source: InstructionAddressError::InvalidAddress {
-                        address: address(2)
-                    }
+                source: InstructionBuildError::BlockCodeBuild {
+                    source: BlockCodeBuildError::AddressOutsideCurrentBlock {
+                        address: address(2),
+                    },
                 },
             })
         );
@@ -329,16 +342,18 @@ mod tests {
         let second_span = span(sources.view(), source_id, 6, 9);
         let mut first_code = SourceMappedCode::new();
         let mut second_code = SourceMappedCode::new();
-        let first_target = append(&mut first_code, Instruction::Halt);
-        let second_target = append(&mut second_code, Instruction::Push(Value::integer(1)));
+        let mut first_builder = BlockCodeBuilder::new(&mut first_code);
+        let mut second_builder = BlockCodeBuilder::new(&mut second_code);
+        let first_target = append(&mut first_builder, Instruction::Halt);
+        let second_target = append(&mut second_builder, Instruction::Push(Value::integer(1)));
         let mut first_table = LocalLineNumberTable::new();
         let mut second_table = LocalLineNumberTable::new();
 
         first_table
-            .define(&first_code, line(100), first_target, first_span)
+            .define(&first_builder, line(100), first_target, first_span)
             .expect("first owner should define line");
         second_table
-            .define(&second_code, line(100), second_target, second_span)
+            .define(&second_builder, line(100), second_target, second_span)
             .expect("second owner should define same local line");
     }
 
@@ -348,25 +363,23 @@ mod tests {
         let branch_span = span(sources.view(), source_id, 7, 10);
         let target_span = span(sources.view(), source_id, 7, 10);
         let mut code = SourceMappedCode::new();
-        let non_branch = append(&mut code, Instruction::Push(Value::integer(1)));
-        let target = append(&mut code, Instruction::Halt);
+        let mut builder = BlockCodeBuilder::new(&mut code);
+        let non_branch = append(&mut builder, Instruction::Push(Value::integer(1)));
+        let target = append(&mut builder, Instruction::Halt);
         let mut table = LocalLineNumberTable::new();
 
         table
-            .define(&code, line(100), target, target_span)
+            .define(&builder, line(100), target, target_span)
             .expect("line should define");
         table.add_patch(line(100), non_branch, branch_span);
 
         assert_eq!(
-            table.resolve(&mut code),
+            table.resolve(&mut builder),
             Err(LineNumberError::Patch {
                 line_number: line(100),
                 span: branch_span,
-                source: InstructionBuildError::BranchTargetPatch {
-                    source: BranchTargetPatchError::NonBranchInstruction {
-                        address: non_branch,
-                        instruction: Instruction::Push(Value::integer(1)),
-                    }
+                source: InstructionBuildError::BlockCodeBuild {
+                    source: BlockCodeBuildError::UnknownBranchPatch { branch: non_branch },
                 },
             })
         );

--- a/crates/tbx-next/src/published_code.rs
+++ b/crates/tbx-next/src/published_code.rs
@@ -1,14 +1,12 @@
 use crate::binding::{Binding, BindingInsertError, BindingReplaceError, Bindings};
+use crate::block_code::{BlockCodeBuildError, BlockCodeBuilder};
 use crate::instruction::{
-    BranchTargetPatchError, CodeLocation, Instruction, InstructionAddress, InstructionAddressError,
-    InstructionView,
+    CodeLocation, Instruction, InstructionAddress, InstructionAddressError, InstructionView,
 };
 use crate::name::NormalizedName;
 use crate::redefinition::{redefine_word, WordRedefinition, WordRedefinitionError};
 use crate::source::SourceSpan;
-use crate::source_mapping::{
-    InstructionSourceMappingView, SourceMappedCode, SourceMappingAppendError,
-};
+use crate::source_mapping::{InstructionSourceMappingView, SourceMappedCode};
 use crate::word::{CompletedWordDefinition, PublishedWords, WordDefinitionError, WordId};
 
 /// Session-owned code space for all published compiled runtime words.
@@ -23,9 +21,7 @@ pub(crate) struct PublishedCode {
 
 #[derive(Debug)]
 pub(crate) struct PublishedWordBuilder<'a> {
-    code: &'a mut SourceMappedCode,
-    body_start: InstructionAddress,
-    unresolved_patches: Vec<InstructionAddress>,
+    block: BlockCodeBuilder<'a>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -42,10 +38,10 @@ pub(crate) struct PublishedWord {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum WordBodyBuildError {
     SourceMappingAppend {
-        source: SourceMappingAppendError,
+        source: crate::source_mapping::SourceMappingAppendError,
     },
     BranchTargetPatch {
-        source: BranchTargetPatchError,
+        source: crate::instruction::BranchTargetPatchError,
     },
     BranchInstructionRequiresPatch {
         instruction: Instruction,
@@ -157,9 +153,7 @@ impl PublishedCode {
         let entry_address = InstructionAddress::from_index(self.code.len());
 
         let mut builder = PublishedWordBuilder {
-            code: &mut self.code,
-            body_start: entry_address,
-            unresolved_patches: Vec::new(),
+            block: BlockCodeBuilder::new(&mut self.code),
         };
         build(&mut builder)?;
         builder.finish()?;
@@ -181,11 +175,8 @@ impl PublishedCode {
     where
         E: From<WordBodyBuildError>,
     {
-        let entry_address = InstructionAddress::from_index(self.code.len());
         let mut builder = PublishedWordBuilder {
-            code: &mut self.code,
-            body_start: entry_address,
-            unresolved_patches: Vec::new(),
+            block: BlockCodeBuilder::new(&mut self.code),
         };
         build(&mut builder)?;
         builder.finish().map_err(E::from)
@@ -213,11 +204,11 @@ impl PublishedWord {
 
 impl PublishedWordBuilder<'_> {
     pub(crate) fn current_address(&self) -> InstructionAddress {
-        InstructionAddress::from_index(self.code.len())
+        self.block.current_address()
     }
 
     pub(crate) fn current_len(&self) -> usize {
-        self.code.len()
+        self.block.current_len()
     }
 
     pub(crate) fn append_mapped(
@@ -225,55 +216,52 @@ impl PublishedWordBuilder<'_> {
         instruction: Instruction,
         span: SourceSpan,
     ) -> Result<InstructionAddress, WordBodyBuildError> {
-        reject_direct_branch_instruction(instruction)?;
-        self.code
+        self.block
             .append_mapped(instruction, span)
-            .map_err(|source| WordBodyBuildError::SourceMappingAppend { source })
+            .map_err(WordBodyBuildError::from)
     }
 
     pub(crate) fn append_unmapped(
         &mut self,
         instruction: Instruction,
     ) -> Result<InstructionAddress, WordBodyBuildError> {
-        reject_direct_branch_instruction(instruction)?;
-        self.code
+        self.block
             .append_unmapped(instruction)
-            .map_err(|source| WordBodyBuildError::SourceMappingAppend { source })
+            .map_err(WordBodyBuildError::from)
     }
 
     pub(crate) fn append_mapped_jump_placeholder(
         &mut self,
         span: SourceSpan,
     ) -> Result<InstructionAddress, WordBodyBuildError> {
-        self.append_branch_placeholder(
-            Instruction::Jump(InstructionAddress::from_index(0)),
-            Some(span),
-        )
+        self.block
+            .append_mapped_jump_placeholder(span)
+            .map_err(WordBodyBuildError::from)
     }
 
     pub(crate) fn append_unmapped_jump_placeholder(
         &mut self,
     ) -> Result<InstructionAddress, WordBodyBuildError> {
-        self.append_branch_placeholder(Instruction::Jump(InstructionAddress::from_index(0)), None)
+        self.block
+            .append_unmapped_jump_placeholder()
+            .map_err(WordBodyBuildError::from)
     }
 
     pub(crate) fn append_mapped_jump_if_zero_placeholder(
         &mut self,
         span: SourceSpan,
     ) -> Result<InstructionAddress, WordBodyBuildError> {
-        self.append_branch_placeholder(
-            Instruction::JumpIfZero(InstructionAddress::from_index(0)),
-            Some(span),
-        )
+        self.block
+            .append_mapped_jump_if_zero_placeholder(span)
+            .map_err(WordBodyBuildError::from)
     }
 
     pub(crate) fn append_unmapped_jump_if_zero_placeholder(
         &mut self,
     ) -> Result<InstructionAddress, WordBodyBuildError> {
-        self.append_branch_placeholder(
-            Instruction::JumpIfZero(InstructionAddress::from_index(0)),
-            None,
-        )
+        self.block
+            .append_unmapped_jump_if_zero_placeholder()
+            .map_err(WordBodyBuildError::from)
     }
 
     pub(crate) fn patch_branch_target(
@@ -281,79 +269,48 @@ impl PublishedWordBuilder<'_> {
         branch: InstructionAddress,
         target: InstructionAddress,
     ) -> Result<(), WordBodyBuildError> {
-        self.validate_current_body_address(branch)?;
-        self.validate_current_body_address(target)?;
-        let Some(position) = self
-            .unresolved_patches
-            .iter()
-            .position(|pending| *pending == branch)
-        else {
-            return Err(WordBodyBuildError::UnknownBranchPatch { branch });
-        };
-
-        self.code
+        self.block
             .patch_branch_target(branch, target)
-            .map_err(|source| WordBodyBuildError::BranchTargetPatch { source })?;
-
-        self.unresolved_patches.swap_remove(position);
-        Ok(())
-    }
-
-    fn append_branch_placeholder(
-        &mut self,
-        instruction: Instruction,
-        span: Option<SourceSpan>,
-    ) -> Result<InstructionAddress, WordBodyBuildError> {
-        let branch = if let Some(span) = span {
-            self.code.append_mapped(instruction, span)
-        } else {
-            self.code.append_unmapped(instruction)
-        }
-        .map_err(|source| WordBodyBuildError::SourceMappingAppend { source })?;
-
-        self.unresolved_patches.push(branch);
-        Ok(branch)
+            .map_err(WordBodyBuildError::from)
     }
 
     pub(crate) fn validate_local_target(
         &self,
         address: InstructionAddress,
     ) -> Result<(), WordBodyBuildError> {
-        self.validate_current_body_address(address)
-    }
-
-    fn validate_current_body_address(
-        &self,
-        address: InstructionAddress,
-    ) -> Result<(), WordBodyBuildError> {
-        if address.as_index() < self.body_start.as_index() || address.as_index() >= self.code.len()
-        {
-            return Err(WordBodyBuildError::AddressOutsideCurrentBody { address });
-        }
-
-        Ok(())
+        self.block
+            .validate_local_target(address)
+            .map_err(WordBodyBuildError::from)
     }
 
     fn finish(self) -> Result<(), WordBodyBuildError> {
-        if let Some(branch) = self.unresolved_patches.first().copied() {
-            return Err(WordBodyBuildError::UnresolvedBranchPatch { branch });
-        }
-
-        Ok(())
+        self.block
+            .finish()
+            .map(|_| ())
+            .map_err(WordBodyBuildError::from)
     }
 }
 
-fn reject_direct_branch_instruction(instruction: Instruction) -> Result<(), WordBodyBuildError> {
-    match instruction {
-        Instruction::Jump(_) | Instruction::JumpIfZero(_) => {
-            Err(WordBodyBuildError::BranchInstructionRequiresPatch { instruction })
+impl From<BlockCodeBuildError> for WordBodyBuildError {
+    fn from(error: BlockCodeBuildError) -> Self {
+        match error {
+            BlockCodeBuildError::SourceMappingAppend { source } => {
+                Self::SourceMappingAppend { source }
+            }
+            BlockCodeBuildError::BranchTargetPatch { source } => Self::BranchTargetPatch { source },
+            BlockCodeBuildError::BranchInstructionRequiresPatch { instruction } => {
+                Self::BranchInstructionRequiresPatch { instruction }
+            }
+            BlockCodeBuildError::AddressOutsideCurrentBlock { address } => {
+                Self::AddressOutsideCurrentBody { address }
+            }
+            BlockCodeBuildError::UnknownBranchPatch { branch } => {
+                Self::UnknownBranchPatch { branch }
+            }
+            BlockCodeBuildError::UnresolvedBranchPatch { branch } => {
+                Self::UnresolvedBranchPatch { branch }
+            }
         }
-        Instruction::Push(_)
-        | Instruction::LoadVar(_)
-        | Instruction::StoreVar(_)
-        | Instruction::Call(_)
-        | Instruction::Return
-        | Instruction::Halt => Ok(()),
     }
 }
 

--- a/crates/tbx-next/src/source_processor.rs
+++ b/crates/tbx-next/src/source_processor.rs
@@ -1,4 +1,5 @@
 use crate::binding::Bindings;
+use crate::block_code::BlockCodeBuilder;
 use crate::expression::{
     parse_expression, ExpressionError, ExpressionSyntaxErrorKind, ExpressionVariableErrorKind,
 };
@@ -214,20 +215,24 @@ pub(crate) fn compile_source(
 
     let mut code = SourceMappedCode::new();
 
-    compile_statements(
-        view,
-        source_id,
-        segmented.completed_statements(),
-        segmented.terminal(),
-        context,
-        &mut code,
-    )?;
+    {
+        let mut builder = BlockCodeBuilder::new(&mut code);
+        compile_statements(
+            view,
+            source_id,
+            segmented.completed_statements(),
+            segmented.terminal(),
+            context,
+            &mut builder,
+        )?;
 
-    let eof_span = match segmented.terminal() {
-        Terminal::Eof { span } => span,
-        Terminal::LexError(error) => return Err(error.into()),
-    };
-    InstructionBuildTarget::append_mapped(&mut code, Instruction::Halt, eof_span)?;
+        let eof_span = match segmented.terminal() {
+            Terminal::Eof { span } => span,
+            Terminal::LexError(error) => return Err(error.into()),
+        };
+        InstructionBuildTarget::append_mapped(&mut builder, Instruction::Halt, eof_span)?;
+        builder.finish().map_err(InstructionBuildError::from)?;
+    }
 
     let entry = code
         .instruction_view()
@@ -3856,6 +3861,7 @@ mod tests {
             tokens.push(token);
         }
         let mut code = SourceMappedCode::new();
+        let mut builder = BlockCodeBuilder::new(&mut code);
 
         let error = compile_expression_tokens(
             sources.view(),
@@ -3863,7 +3869,7 @@ mod tests {
             &tokens,
             &bindings,
             operators.lookup(),
-            &mut code,
+            &mut builder,
         )
         .expect_err("later unresolved name should fail the expression");
 

--- a/crates/tbx-next/src/source_word.rs
+++ b/crates/tbx-next/src/source_word.rs
@@ -877,6 +877,7 @@ impl SourceWordLookup<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::block_code::BlockCodeBuilder;
     use crate::source::SourceTexts;
     use crate::source_mapping::SourceMappedCode;
     use crate::value::Value;
@@ -911,6 +912,7 @@ mod tests {
     fn native_context_lends_one_reader_without_resetting_position() {
         let (sources, source_id, tokens) = statement_tokens("TEST A B");
         let mut code = SourceMappedCode::new();
+        let mut builder = BlockCodeBuilder::new(&mut code);
         let bindings = Bindings::new();
         let mut context = NativeSourceWordContext::new(NativeSourceWordContextParts {
             view: sources.view(),
@@ -919,7 +921,7 @@ mod tests {
             block_reader: None,
             bindings: NativeSourceWordBindingAccess::Read(&bindings),
             operators: None,
-            code: &mut code,
+            code: &mut builder,
             local_line_number_prefix: None,
             globals: None,
             runtime_definitions: None,
@@ -1114,21 +1116,25 @@ mod tests {
             }
         }
         let mut code = SourceMappedCode::new();
+        let mut builder = BlockCodeBuilder::new(&mut code);
         let bindings = Bindings::new();
-        let mut context = NativeSourceWordContext::new(NativeSourceWordContextParts {
-            view: sources.view(),
-            source_id,
-            tokens: &tokens[..1],
-            block_reader: None,
-            bindings: NativeSourceWordBindingAccess::Read(&bindings),
-            operators: None,
-            code: &mut code,
-            local_line_number_prefix: None,
-            globals: None,
-            runtime_definitions: None,
-        });
+        {
+            let mut context = NativeSourceWordContext::new(NativeSourceWordContextParts {
+                view: sources.view(),
+                source_id,
+                tokens: &tokens[..1],
+                block_reader: None,
+                bindings: NativeSourceWordBindingAccess::Read(&bindings),
+                operators: None,
+                code: &mut builder,
+                local_line_number_prefix: None,
+                globals: None,
+                runtime_definitions: None,
+            });
 
-        push_one(&mut context).expect("test source word should emit");
+            push_one(&mut context).expect("test source word should emit");
+        }
+        builder.finish().expect("block should complete");
 
         assert_eq!(
             code.instruction_view()
@@ -1142,6 +1148,7 @@ mod tests {
         for input in ["VAR END", "VAR end", "VAR End"] {
             let (sources, source_id, tokens) = statement_tokens(input);
             let mut code = SourceMappedCode::new();
+            let mut builder = BlockCodeBuilder::new(&mut code);
             let mut bindings = Bindings::new();
             let mut globals = GlobalVariables::new();
             let expected_span = span(sources.view(), source_id, 4, 7);
@@ -1154,7 +1161,7 @@ mod tests {
                     block_reader: None,
                     bindings: NativeSourceWordBindingAccess::Write(&mut bindings),
                     operators: None,
-                    code: &mut code,
+                    code: &mut builder,
                     local_line_number_prefix: None,
                     globals: Some(&mut globals),
                     runtime_definitions: None,


### PR DESCRIPTION
## Summary

- Add crate-internal `BlockCodeBuilder` for unpublished block construction, source mapping order, branch placeholders, local target validation, and completion checks.
- Move `PublishedWordBuilder` branch completion responsibility onto the shared builder while keeping runtime word publication separate.
- Route temporary source compilation, expression/source-word tests, and local line-number tests through the shared `InstructionBuildTarget` boundary.

Closes #1519

## Verification

- `cargo test -p tbx-next --no-fail-fast`
- `cargo clippy -p tbx-next --all-targets --all-features -- -D warnings`
- `cargo ci-fmt`
- `cargo ci-clippy`
- `cargo ci-test`
