### PR TITLE
TBX Next: static quotation artifactと親attachmentを実装

### DIFF
--- a/crates/tbx-next/src/block_code.rs
+++ b/crates/tbx-next/src/block_code.rs
@@ -16,6 +16,7 @@ pub(crate) struct BlockCodeBuilder<'a> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct CompletedBlockCode {
     entry: InstructionAddress,
+    end: InstructionAddress,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -62,6 +63,30 @@ impl<'a> BlockCodeBuilder<'a> {
         instruction: Instruction,
     ) -> Result<InstructionAddress, BlockCodeBuildError> {
         reject_direct_branch_instruction(instruction)?;
+        self.code
+            .append_unmapped(instruction)
+            .map_err(|source| BlockCodeBuildError::SourceMappingAppend { source })
+    }
+
+    pub(crate) fn append_resolved_mapped(
+        &mut self,
+        instruction: Instruction,
+        span: SourceSpan,
+    ) -> Result<InstructionAddress, BlockCodeBuildError> {
+        // #1516/#1518: completed child artifacts may attach already-resolved
+        // branches after rebasing. Ordinary builders must still use placeholders
+        // so unresolved patches cannot masquerade as completed block code.
+        self.code
+            .append_mapped(instruction, span)
+            .map_err(|source| BlockCodeBuildError::SourceMappingAppend { source })
+    }
+
+    pub(crate) fn append_resolved_unmapped(
+        &mut self,
+        instruction: Instruction,
+    ) -> Result<InstructionAddress, BlockCodeBuildError> {
+        // See `append_resolved_mapped`; this is only for validated attachment of
+        // completed local code, not for ordinary branch construction.
         self.code
             .append_unmapped(instruction)
             .map_err(|source| BlockCodeBuildError::SourceMappingAppend { source })
@@ -144,6 +169,7 @@ impl<'a> BlockCodeBuilder<'a> {
 
         Ok(CompletedBlockCode {
             entry: self.block_start,
+            end: self.current_address(),
         })
     }
 
@@ -167,6 +193,23 @@ impl<'a> BlockCodeBuilder<'a> {
 impl CompletedBlockCode {
     pub(crate) const fn entry(self) -> InstructionAddress {
         self.entry
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn test_new(entry: InstructionAddress, end: InstructionAddress) -> Self {
+        Self { entry, end }
+    }
+
+    pub(crate) const fn end(self) -> InstructionAddress {
+        self.end
+    }
+
+    pub(crate) fn len(self) -> usize {
+        self.end.as_index() - self.entry.as_index()
+    }
+
+    pub(crate) fn contains(self, address: InstructionAddress) -> bool {
+        address.as_index() >= self.entry.as_index() && address.as_index() < self.end.as_index()
     }
 }
 

--- a/crates/tbx-next/src/lib.rs
+++ b/crates/tbx-next/src/lib.rs
@@ -72,6 +72,11 @@ mod source_mapping;
 #[allow(dead_code)]
 mod block_code;
 
+// #1516/#1518 keeps static quotations as immutable unpublished artifacts and
+// makes parent attachment an explicit local-address rebasing boundary.
+#[allow(dead_code)]
+mod static_quotation;
+
 // #1504 keeps statement lowering independent from concrete instruction owners
 // while preserving published-word branch patch contracts.
 #[allow(dead_code)]

--- a/crates/tbx-next/src/source_mapping.rs
+++ b/crates/tbx-next/src/source_mapping.rs
@@ -144,6 +144,20 @@ impl SourceMappedCode {
         self.mapping.view()
     }
 
+    pub(crate) fn mapped_instruction(
+        &self,
+        address: InstructionAddress,
+    ) -> Result<(&Instruction, Option<SourceSpan>), SourceMappingLookupError> {
+        let location = self.instruction_view().location(address);
+        let instruction = self
+            .instruction_view()
+            .get(address)
+            .map_err(|source| SourceMappingLookupError::Address { source })?;
+        let span = self.source_mapping().source_span(location)?;
+
+        Ok((instruction, span))
+    }
+
     pub(crate) const fn code_space(&self) -> CodeSpaceId {
         self.instructions.code_space()
     }

--- a/crates/tbx-next/src/static_quotation.rs
+++ b/crates/tbx-next/src/static_quotation.rs
@@ -1,0 +1,339 @@
+use crate::block_code::{BlockCodeBuildError, BlockCodeBuilder, CompletedBlockCode};
+use crate::instruction::{Instruction, InstructionAddress};
+use crate::source::SourceSpan;
+use crate::source_mapping::{SourceMappedCode, SourceMappingLookupError};
+
+/// Immutable unpublished code artifact for a static quotation.
+///
+/// Per #1516/#1518, a quotation is completed as local source-mapped block code,
+/// but it is not a published runtime code space and carries no `WordId` or
+/// executable entry binding. Parent attachment explicitly re-expresses local
+/// branch targets in the parent's instruction owner.
+#[derive(Debug)]
+pub(crate) struct StaticQuotation {
+    code: SourceMappedCode,
+    completed: CompletedBlockCode,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StaticQuotationBuildError {
+    Build { source: BlockCodeBuildError },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StaticQuotationAttachError {
+    LocalSourceMapping { source: SourceMappingLookupError },
+    InvalidLocalTarget { target: InstructionAddress },
+    TargetRebaseOverflow { target: InstructionAddress },
+    ParentAppend { source: BlockCodeBuildError },
+}
+
+impl StaticQuotation {
+    pub(crate) fn build(
+        build: impl FnOnce(&mut BlockCodeBuilder<'_>) -> Result<(), BlockCodeBuildError>,
+    ) -> Result<Self, StaticQuotationBuildError> {
+        let mut code = SourceMappedCode::new();
+        let completed = {
+            let mut builder = BlockCodeBuilder::new(&mut code);
+            build(&mut builder).map_err(|source| StaticQuotationBuildError::Build { source })?;
+            builder
+                .finish()
+                .map_err(|source| StaticQuotationBuildError::Build { source })?
+        };
+
+        Ok(Self { code, completed })
+    }
+
+    pub(crate) fn attach_to(
+        &self,
+        parent: &mut BlockCodeBuilder<'_>,
+    ) -> Result<(), StaticQuotationAttachError> {
+        let parent_start = parent.current_address();
+        let instructions = self.rebased_instructions(parent_start)?;
+
+        for MappedInstruction { instruction, span } in instructions {
+            if let Some(span) = span {
+                parent
+                    .append_resolved_mapped(instruction, span)
+                    .map_err(|source| StaticQuotationAttachError::ParentAppend { source })?;
+            } else {
+                parent
+                    .append_resolved_unmapped(instruction)
+                    .map_err(|source| StaticQuotationAttachError::ParentAppend { source })?;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.completed.len()
+    }
+
+    fn rebased_instructions(
+        &self,
+        parent_start: InstructionAddress,
+    ) -> Result<Vec<MappedInstruction>, StaticQuotationAttachError> {
+        let mut rebased = Vec::with_capacity(self.completed.len());
+
+        for offset in 0..self.completed.len() {
+            let local = InstructionAddress::from_index(self.completed.entry().as_index() + offset);
+            let (instruction, span) = self
+                .code
+                .mapped_instruction(local)
+                .map_err(|source| StaticQuotationAttachError::LocalSourceMapping { source })?;
+            let instruction = self.rebase_instruction(*instruction, parent_start)?;
+            rebased.push(MappedInstruction { instruction, span });
+        }
+
+        Ok(rebased)
+    }
+
+    fn rebase_instruction(
+        &self,
+        instruction: Instruction,
+        parent_start: InstructionAddress,
+    ) -> Result<Instruction, StaticQuotationAttachError> {
+        match instruction {
+            Instruction::Jump(target) => self
+                .rebase_target(target, parent_start)
+                .map(Instruction::Jump),
+            Instruction::JumpIfZero(target) => self
+                .rebase_target(target, parent_start)
+                .map(Instruction::JumpIfZero),
+            Instruction::Push(_)
+            | Instruction::LoadVar(_)
+            | Instruction::StoreVar(_)
+            | Instruction::Call(_)
+            | Instruction::Return
+            | Instruction::Halt => Ok(instruction),
+        }
+    }
+
+    fn rebase_target(
+        &self,
+        target: InstructionAddress,
+        parent_start: InstructionAddress,
+    ) -> Result<InstructionAddress, StaticQuotationAttachError> {
+        if !self.completed.contains(target) {
+            return Err(StaticQuotationAttachError::InvalidLocalTarget { target });
+        }
+
+        let local_offset = target.as_index() - self.completed.entry().as_index();
+        let parent_index = parent_start
+            .as_index()
+            .checked_add(local_offset)
+            .ok_or(StaticQuotationAttachError::TargetRebaseOverflow { target })?;
+
+        Ok(InstructionAddress::from_index(parent_index))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct MappedInstruction {
+    instruction: Instruction,
+    span: Option<SourceSpan>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::block_code::BlockCodeBuildError;
+    use crate::source::{SourceId, SourceTexts, SourceView};
+    use crate::value::Value;
+
+    fn source(text: &str) -> (SourceTexts, SourceId) {
+        let mut sources = SourceTexts::new();
+        let id = sources.register(text);
+        (sources, id)
+    }
+
+    fn span(view: SourceView<'_>, source_id: SourceId, start: usize, end: usize) -> SourceSpan {
+        view.span(source_id, start, end)
+            .expect("test span should be valid")
+    }
+
+    fn address(index: usize) -> InstructionAddress {
+        InstructionAddress::from_index(index)
+    }
+
+    fn push(value: i16) -> Instruction {
+        Instruction::Push(Value::integer(value))
+    }
+
+    fn build_parent(
+        build: impl FnOnce(&mut BlockCodeBuilder<'_>) -> Result<(), BlockCodeBuildError>,
+    ) -> SourceMappedCode {
+        let mut code = SourceMappedCode::new();
+        {
+            let mut builder = BlockCodeBuilder::new(&mut code);
+            build(&mut builder).expect("parent build should succeed");
+            builder.finish().expect("parent block should complete");
+        }
+        code
+    }
+
+    #[test]
+    fn empty_quotation_completes_and_attaches_without_parent_instructions() {
+        let quotation = StaticQuotation::build(|_| Ok(())).expect("empty quotation completes");
+        let parent =
+            build_parent(|builder| quotation.attach_to(builder).map_err(|_| unreachable!()));
+
+        assert_eq!(quotation.len(), 0);
+        assert_eq!(parent.len(), 0);
+    }
+
+    #[test]
+    fn mapped_and_unmapped_instructions_attach_in_order() {
+        let (sources, source_id) = source("A B");
+        let first_span = span(sources.view(), source_id, 0, 1);
+        let quotation = StaticQuotation::build(|builder| {
+            builder.append_mapped(push(1), first_span)?;
+            builder.append_unmapped(Instruction::Return)?;
+            Ok(())
+        })
+        .expect("quotation completes");
+
+        let parent =
+            build_parent(|builder| quotation.attach_to(builder).map_err(|_| unreachable!()));
+
+        assert_eq!(parent.instruction_view().get(address(0)), Ok(&push(1)));
+        assert_eq!(
+            parent.instruction_view().get(address(1)),
+            Ok(&Instruction::Return)
+        );
+        assert_eq!(
+            parent
+                .source_mapping()
+                .source_span(parent.instruction_view().location(address(0))),
+            Ok(Some(first_span))
+        );
+        assert_eq!(
+            parent
+                .source_mapping()
+                .source_span(parent.instruction_view().location(address(1))),
+            Ok(None)
+        );
+    }
+
+    #[test]
+    fn resolved_forward_and_backward_branches_rebase_to_parent_start() {
+        let quotation = StaticQuotation::build(|builder| {
+            let forward = builder.append_unmapped_jump_placeholder()?;
+            let backward_target = builder.append_unmapped(push(1))?;
+            let backward = builder.append_unmapped_jump_if_zero_placeholder()?;
+            let forward_target = builder.append_unmapped(Instruction::Return)?;
+            builder.patch_branch_target(forward, forward_target)?;
+            builder.patch_branch_target(backward, backward_target)?;
+            Ok(())
+        })
+        .expect("quotation completes");
+
+        let parent = build_parent(|builder| {
+            builder.append_unmapped(push(99))?;
+            quotation.attach_to(builder).map_err(|_| unreachable!())?;
+            Ok(())
+        });
+
+        assert_eq!(
+            parent.instruction_view().get(address(1)),
+            Ok(&Instruction::Jump(address(4)))
+        );
+        assert_eq!(
+            parent.instruction_view().get(address(3)),
+            Ok(&Instruction::JumpIfZero(address(2)))
+        );
+    }
+
+    #[test]
+    fn unresolved_branch_rejects_quotation_completion() {
+        let error = StaticQuotation::build(|builder| {
+            builder.append_unmapped_jump_placeholder()?;
+            Ok(())
+        })
+        .expect_err("unresolved quotation must not complete");
+
+        assert_eq!(
+            error,
+            StaticQuotationBuildError::Build {
+                source: BlockCodeBuildError::UnresolvedBranchPatch { branch: address(0) }
+            }
+        );
+    }
+
+    #[test]
+    fn invalid_local_branch_target_rejects_attachment_without_parent_mutation() {
+        let mut code = SourceMappedCode::new();
+        code.append_unmapped(Instruction::Jump(address(99)))
+            .expect("test quotation instruction should append");
+        let quotation = StaticQuotation {
+            code,
+            completed: CompletedBlockCode::test_new(address(0), address(1)),
+        };
+        let mut parent_code = SourceMappedCode::new();
+        let mut parent = BlockCodeBuilder::new(&mut parent_code);
+        parent
+            .append_unmapped(push(10))
+            .expect("prefix should append");
+
+        assert_eq!(
+            quotation.attach_to(&mut parent),
+            Err(StaticQuotationAttachError::InvalidLocalTarget {
+                target: address(99)
+            })
+        );
+        assert_eq!(parent.current_len(), 1);
+        parent.finish().expect("parent should still complete");
+        assert_eq!(parent_code.len(), 1);
+    }
+
+    #[test]
+    fn invalid_completed_range_rejects_attachment_without_parent_mutation() {
+        let mut code = SourceMappedCode::new();
+        code.append_unmapped(push(1))
+            .expect("test quotation instruction should append");
+        let quotation = StaticQuotation {
+            code,
+            completed: CompletedBlockCode::test_new(address(0), address(2)),
+        };
+        let mut parent_code = SourceMappedCode::new();
+        let mut parent = BlockCodeBuilder::new(&mut parent_code);
+
+        assert!(matches!(
+            quotation.attach_to(&mut parent),
+            Err(StaticQuotationAttachError::LocalSourceMapping { .. })
+        ));
+        assert_eq!(parent.current_len(), 0);
+        parent.finish().expect("parent should still complete");
+        assert_eq!(parent_code.len(), 0);
+    }
+
+    #[test]
+    fn nested_quotations_attach_sequentially() {
+        let child = StaticQuotation::build(|builder| {
+            builder.append_unmapped(push(7))?;
+            Ok(())
+        })
+        .expect("child quotation completes");
+        let parent_quotation = StaticQuotation::build(|builder| {
+            builder.append_unmapped(push(1))?;
+            child.attach_to(builder).map_err(|_| unreachable!())?;
+            builder.append_unmapped(Instruction::Return)?;
+            Ok(())
+        })
+        .expect("parent quotation completes");
+
+        let parent = build_parent(|builder| {
+            parent_quotation
+                .attach_to(builder)
+                .map_err(|_| unreachable!())
+        });
+
+        assert_eq!(parent.instruction_view().get(address(0)), Ok(&push(1)));
+        assert_eq!(parent.instruction_view().get(address(1)), Ok(&push(7)));
+        assert_eq!(
+            parent.instruction_view().get(address(2)),
+            Ok(&Instruction::Return)
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- add a crate-internal `StaticQuotation` immutable unpublished artifact built from completed block code
- separate quotation completion from parent attachment, preserving instruction/source mapping order
- rebase quotation-local branch targets into the parent block during attachment and reject invalid local targets or mapping inconsistencies before mutating the parent

Closes #1522

## Verification

- `cargo test -p tbx-next --no-fail-fast`
- `cargo clippy -p tbx-next --all-targets --all-features -- -D warnings`
- `cargo ci-fmt`
- `cargo ci-clippy`
- `cargo ci-test`
