### PR TITLE
TBX Next: 宣言駆動のstructured block readerを追加

### DIFF
--- a/crates/tbx-next/src/source_processor.rs
+++ b/crates/tbx-next/src/source_processor.rs
@@ -509,6 +509,7 @@ where
         return Err(SourceProcessorError::SourceWordContextUnavailable { id });
     };
     let handler = source_words.lookup_handler(id)?;
+    let syntax_markers = source_words.syntax_markers(id)?;
     let operators = context.operators();
     let globals = context.globals.as_deref_mut();
     let mut runtime_publisher =
@@ -534,7 +535,7 @@ where
         view,
         source_id,
         tokens,
-        block_reader: Some(SourceBlockReader::new(cursor)),
+        block_reader: Some(SourceBlockReader::new(view, cursor, syntax_markers)),
         bindings: binding_access,
         operators,
         code,
@@ -1751,7 +1752,7 @@ mod tests {
     use crate::binding::{Binding, Bindings};
     use crate::bootstrap::{
         register_builtin_global_variables, register_builtin_source_words,
-        register_native_source_word, register_primitive,
+        register_native_source_word, register_native_source_word_with_markers, register_primitive,
     };
     use crate::global_variable::{GlobalVarId, GlobalVariables};
     use crate::instruction::InstructionSequence;
@@ -1766,8 +1767,8 @@ mod tests {
         InstructionSourceMapping, SourceMappingLookup, SourceMappingLookupError,
     };
     use crate::source_word::{
-        DefSyntaxErrorKind, LetSyntaxErrorKind, NativeSourceWordContext, SourceWordRegistry,
-        VarSyntaxErrorKind,
+        DefSyntaxErrorKind, LetSyntaxErrorKind, NativeSourceWordContext, SourceBlockItem,
+        SourceWordRegistry, SourceWordSyntaxMarker, SourceWordSyntaxMarkerRole, VarSyntaxErrorKind,
     };
     use crate::word::{CompletedWordDefinition, PrimitiveId, PublishedWords, WordId};
     use crate::word_lookup::PublishedWordLookup;
@@ -2002,6 +2003,73 @@ mod tests {
             Instruction::Push(value(statement.tokens().len() as i16)),
             statement.span(),
         )
+    }
+
+    fn classify_one_declared_block_item(
+        context: &mut NativeSourceWordContext<'_, '_>,
+    ) -> Result<(), SourceWordError> {
+        let item = context
+            .block_reader_mut()
+            .expect("block reader should be available to source words")
+            .next_item()?;
+
+        let (emitted, span) = match item {
+            SourceBlockItem::Statement(statement) => {
+                (statement.tokens().len() as i16, statement.span())
+            }
+            SourceBlockItem::Marker(marker) => {
+                let value = match marker.role() {
+                    SourceWordSyntaxMarkerRole::BlockContinuation => 10,
+                    SourceWordSyntaxMarkerRole::BlockTerminator => 20,
+                };
+                assert_eq!(marker.statement().span(), marker.span());
+                assert_eq!(marker.token().span(), marker.span());
+                assert!(!marker.name().as_str().is_empty());
+                (value, marker.span())
+            }
+            SourceBlockItem::Terminal(terminal) => {
+                let span = terminal
+                    .eof_span()
+                    .unwrap_or_else(|| context.source_word_token().span());
+                (30, span)
+            }
+        };
+
+        context.append_mapped(Instruction::Push(value(emitted)), span)
+    }
+
+    fn consume_until_declared_terminator(
+        context: &mut NativeSourceWordContext<'_, '_>,
+    ) -> Result<(), SourceWordError> {
+        loop {
+            let item = context
+                .block_reader_mut()
+                .expect("block reader should be available to source words")
+                .next_item()?;
+            match item {
+                SourceBlockItem::Statement(statement) => {
+                    context.append_mapped(
+                        Instruction::Push(value(statement.tokens().len() as i16)),
+                        statement.span(),
+                    )?;
+                }
+                SourceBlockItem::Marker(marker)
+                    if marker.role() == SourceWordSyntaxMarkerRole::BlockTerminator =>
+                {
+                    context.append_mapped(Instruction::Push(value(20)), marker.span())?;
+                    return Ok(());
+                }
+                SourceBlockItem::Marker(marker) => {
+                    context.append_mapped(Instruction::Push(value(10)), marker.span())?;
+                }
+                SourceBlockItem::Terminal(terminal) => {
+                    let span = terminal
+                        .eof_span()
+                        .unwrap_or_else(|| context.source_word_token().span());
+                    return Err(SourceWordError::UnsupportedSourceWord { span });
+                }
+            }
+        }
     }
 
     fn read_eof_terminal_as_missing_terminator(
@@ -2271,6 +2339,10 @@ mod tests {
 
     fn name(input: &str) -> NormalizedName {
         NormalizedName::new(input).expect("test input should be a valid word name")
+    }
+
+    fn marker(input: &str, role: SourceWordSyntaxMarkerRole) -> SourceWordSyntaxMarker {
+        SourceWordSyntaxMarker::new(name(input), role)
     }
 
     fn completed_primitive(slot: usize) -> CompletedWordDefinition {
@@ -5000,6 +5072,123 @@ mod tests {
         );
         assert_eq!(
             unit.instructions().get(address(1)),
+            Ok(&Instruction::Push(value(99)))
+        );
+    }
+
+    #[test]
+    fn block_reader_recognizes_owner_declared_marker_roles() {
+        let mut source_words = SourceWordRegistry::new();
+        let mut bindings = Bindings::new();
+        register_native_source_word_with_markers(
+            &mut source_words,
+            &mut bindings,
+            name("BLOCK"),
+            classify_one_declared_block_item,
+            vec![marker(
+                "ELSE",
+                SourceWordSyntaxMarkerRole::BlockContinuation,
+            )],
+        )
+        .expect("block source word should register with marker");
+        let (sources, source_id) = source("BLOCK\nelse");
+
+        let unit = compile_source(
+            sources.view(),
+            source_id,
+            SourceCompileContext::with_source_words(&bindings, source_words.lookup()),
+        )
+        .expect("declared marker should be classified");
+
+        assert_eq!(
+            unit.instructions().get(address(0)),
+            Ok(&Instruction::Push(value(10)))
+        );
+        assert_eq!(
+            unit.source_span(location(&unit, 0)),
+            Ok(Some(span(sources.view(), source_id, 6, 10)))
+        );
+    }
+
+    #[test]
+    fn block_reader_does_not_treat_undeclared_name_as_marker() {
+        let mut source_words = SourceWordRegistry::new();
+        let mut bindings = Bindings::new();
+        register_native_source_word_with_markers(
+            &mut source_words,
+            &mut bindings,
+            name("BLOCK"),
+            classify_one_declared_block_item,
+            vec![marker("ENDIF", SourceWordSyntaxMarkerRole::BlockTerminator)],
+        )
+        .expect("block source word should register with marker");
+        let (sources, source_id) = source("BLOCK\nELSE");
+
+        let unit = compile_source(
+            sources.view(),
+            source_id,
+            SourceCompileContext::with_source_words(&bindings, source_words.lookup()),
+        )
+        .expect("undeclared marker spelling should remain a statement");
+
+        assert_eq!(
+            unit.instructions().get(address(0)),
+            Ok(&Instruction::Push(value(1)))
+        );
+    }
+
+    #[test]
+    fn block_reader_keeps_other_owner_marker_as_statement() {
+        let mut source_words = SourceWordRegistry::new();
+        let mut bindings = Bindings::new();
+        register_native_source_word_with_markers(
+            &mut source_words,
+            &mut bindings,
+            name("OUTER"),
+            consume_until_declared_terminator,
+            vec![marker(
+                "OUT_END",
+                SourceWordSyntaxMarkerRole::BlockTerminator,
+            )],
+        )
+        .expect("outer source word should register with marker");
+        register_native_source_word_with_markers(
+            &mut source_words,
+            &mut bindings,
+            name("INNER"),
+            classify_one_declared_block_item,
+            vec![marker(
+                "INNER_END",
+                SourceWordSyntaxMarkerRole::BlockTerminator,
+            )],
+        )
+        .expect("inner source word should register with a distinct marker");
+        register_native_source_word(
+            &mut source_words,
+            &mut bindings,
+            name("SOURCE_MARKER"),
+            emit_source_word_marker,
+        )
+        .expect("source word should register");
+        let (sources, source_id) = source("OUTER\nINNER_END\nOUT_END\nSOURCE_MARKER");
+
+        let unit = compile_source(
+            sources.view(),
+            source_id,
+            SourceCompileContext::with_source_words(&bindings, source_words.lookup()),
+        )
+        .expect("outer reader should classify only its own markers");
+
+        assert_eq!(
+            unit.instructions().get(address(0)),
+            Ok(&Instruction::Push(value(1)))
+        );
+        assert_eq!(
+            unit.instructions().get(address(1)),
+            Ok(&Instruction::Push(value(20)))
+        );
+        assert_eq!(
+            unit.instructions().get(address(2)),
             Ok(&Instruction::Push(value(99)))
         );
     }

--- a/crates/tbx-next/src/source_word.rs
+++ b/crates/tbx-next/src/source_word.rs
@@ -231,6 +231,14 @@ pub(crate) struct SourceBlockStatement<'source> {
     span: SourceSpan,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SourceBlockMarker<'source> {
+    statement: SourceBlockStatement<'source>,
+    token: Token,
+    name: NormalizedName,
+    role: SourceWordSyntaxMarkerRole,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SourceBlockTerminal {
     Eof { span: SourceSpan },
@@ -243,12 +251,21 @@ pub(crate) enum SourceBlockRead<'source> {
     Terminal(SourceBlockTerminal),
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SourceBlockItem<'source> {
+    Statement(SourceBlockStatement<'source>),
+    Marker(SourceBlockMarker<'source>),
+    Terminal(SourceBlockTerminal),
+}
+
 pub(crate) trait SourceBlockCursor<'source> {
     fn read_next_block_statement(&mut self) -> Result<SourceBlockRead<'source>, SourceWordError>;
 }
 
 pub(crate) struct SourceBlockReader<'source, 'cursor> {
+    view: SourceView<'source>,
     cursor: &'cursor mut dyn SourceBlockCursor<'source>,
+    syntax_markers: &'cursor [SourceWordSyntaxMarker],
 }
 
 pub(crate) trait RuntimeDefinitionPublisher<'source> {
@@ -283,6 +300,28 @@ impl<'source> SourceBlockStatement<'source> {
     }
 }
 
+impl<'source> SourceBlockMarker<'source> {
+    pub(crate) const fn statement(&self) -> SourceBlockStatement<'source> {
+        self.statement
+    }
+
+    pub(crate) const fn token(&self) -> Token {
+        self.token
+    }
+
+    pub(crate) fn name(&self) -> &NormalizedName {
+        &self.name
+    }
+
+    pub(crate) const fn role(&self) -> SourceWordSyntaxMarkerRole {
+        self.role
+    }
+
+    pub(crate) const fn span(&self) -> SourceSpan {
+        self.statement.span()
+    }
+}
+
 impl SourceBlockTerminal {
     pub(crate) const fn eof_span(self) -> Option<SourceSpan> {
         match self {
@@ -300,12 +339,63 @@ impl SourceBlockTerminal {
 }
 
 impl<'source, 'cursor> SourceBlockReader<'source, 'cursor> {
-    pub(crate) fn new(cursor: &'cursor mut dyn SourceBlockCursor<'source>) -> Self {
-        Self { cursor }
+    pub(crate) fn new(
+        view: SourceView<'source>,
+        cursor: &'cursor mut dyn SourceBlockCursor<'source>,
+        syntax_markers: &'cursor [SourceWordSyntaxMarker],
+    ) -> Self {
+        Self {
+            view,
+            cursor,
+            syntax_markers,
+        }
     }
 
     pub(crate) fn next_statement(&mut self) -> Result<SourceBlockRead<'source>, SourceWordError> {
         self.cursor.read_next_block_statement()
+    }
+
+    pub(crate) fn next_item(&mut self) -> Result<SourceBlockItem<'source>, SourceWordError> {
+        match self.next_statement()? {
+            SourceBlockRead::Statement(statement) => {
+                if let Some(marker) = self.classify_marker(statement)? {
+                    Ok(SourceBlockItem::Marker(marker))
+                } else {
+                    Ok(SourceBlockItem::Statement(statement))
+                }
+            }
+            SourceBlockRead::Terminal(terminal) => Ok(SourceBlockItem::Terminal(terminal)),
+        }
+    }
+
+    fn classify_marker(
+        &self,
+        statement: SourceBlockStatement<'source>,
+    ) -> Result<Option<SourceBlockMarker<'source>>, SourceWordError> {
+        // #1513/#1516: structured matching is owner-declaration driven and
+        // complete-statement based. The outer reader must not raw-scan nested
+        // marker spellings or treat another source word's markers as its own.
+        let Some(token) = statement.standalone_name() else {
+            return Ok(None);
+        };
+        let source_name = self
+            .view
+            .slice(token.span())
+            .map_err(|source| SourceWordError::Source { source })?;
+        let Ok(name) = NormalizedName::new(source_name) else {
+            return Ok(None);
+        };
+
+        Ok(self
+            .syntax_markers
+            .iter()
+            .find(|marker| marker.name() == &name)
+            .map(|marker| SourceBlockMarker {
+                statement,
+                token,
+                name,
+                role: marker.role(),
+            }))
     }
 }
 


### PR DESCRIPTION
## Summary

- `SourceBlockReader` に owner source word の構文標識宣言を渡し、`next_item()` で `Statement` / `Marker` / `Terminal` を分類できる境界を追加
- marker view として statement span、marker token、normalized name、role を owner handler へ返せるようにした
- 既存の raw `next_statement()` と `DEF ... END` の reader behavior は維持
- 宣言済み marker、未宣言名、別 owner marker、outer cursor 継続の回帰をテストで追加

## Scope

#1524 の見直しにより、この PR は宣言駆動の structured block reader 境界までを対象とする。

nested structured source word の通常 statement dispatch、inner handler 終了後の outer cursor 継続、nested same-owner / different-owner の実処理は対象外とし、設計を #1533、実装を #1534 で扱う。

Closes #1524
Related: #1533, #1534

## Verification

- `cargo test -p tbx-next --no-fail-fast`
- `cargo clippy -p tbx-next --all-targets --all-features -- -D warnings`
- `cargo ci-fmt`
- `cargo ci-clippy`
- `cargo ci-test`
