### PR TITLE
TBX Next: nested structured source word の cursor 継続を実装

### DIFF
--- a/crates/tbx-next/src/source_processor.rs
+++ b/crates/tbx-next/src/source_processor.rs
@@ -21,10 +21,10 @@ use crate::source_mapping::{
     InstructionSourceMappingView, SourceMappedCode, SourceMappingLookup, SourceMappingLookupError,
 };
 use crate::source_word::{
-    NativeSourceWordBindingAccess, NativeSourceWordContext, NativeSourceWordContextParts,
-    RuntimeDefinitionPublisher, SourceBlockCursor, SourceBlockRead, SourceBlockReader,
-    SourceBlockStatement, SourceBlockTerminal, SourceWordError, SourceWordId, SourceWordLookup,
-    SourceWordLookupError,
+    classify_source_block_marker, NativeSourceWordBindingAccess, NativeSourceWordContext,
+    NativeSourceWordContextParts, RuntimeDefinitionPublisher, SourceBlockCursor, SourceBlockRead,
+    SourceBlockReader, SourceBlockStatement, SourceBlockTerminal, SourceWordError, SourceWordId,
+    SourceWordLookup, SourceWordLookupError,
 };
 use crate::static_quotation::{StaticQuotation, StaticQuotationBuildError};
 use crate::value::Value;
@@ -506,6 +506,7 @@ where
     };
     let handler = source_words.lookup_handler(id)?;
     let syntax_markers = source_words.syntax_markers(id)?;
+    let body_start_position = cursor.position();
     let operators = context.operators();
     let globals = context.globals.as_deref_mut();
     let mut runtime_publisher =
@@ -538,208 +539,68 @@ where
         local_line_number_prefix,
         globals,
         runtime_definitions,
-        line_numbers: Some(state.line_numbers),
-        source_words: Some(source_words),
-        statement_processor: Some(process_source_word_block_statement),
     });
     handler(&mut source_word_context)?;
-    Ok(true)
-}
 
-fn process_source_word_block_statement<'source>(
-    context: &mut NativeSourceWordContext<'source, '_>,
-    statement: SourceBlockStatement<'source>,
-) -> Result<(), SourceWordError> {
-    let start = {
-        let access = context.compile_access();
-        access.code.current_address()
-    };
-    let (line_number, body) = split_statement_line_number(context.view(), statement.tokens())
-        .map_err(|source| map_block_statement_compile_error(source, statement.span()))?;
-    let local_line_number_prefix = line_number.map(|(_, span)| span);
-    compile_source_word_block_statement_body(context, body, local_line_number_prefix, statement)?;
-
-    let Some((line_number, span)) = line_number else {
-        return Ok(());
-    };
-    let access = context.compile_access();
-    let Some(line_numbers) = access.line_numbers else {
-        return Err(SourceWordError::BlockStatementCompile {
-            span: statement.span(),
-        });
-    };
-    line_numbers
-        .define(access.code, line_number, start, span)
-        .map_err(|_| SourceWordError::BlockStatementCompile { span })
-}
-
-fn compile_source_word_block_statement_body<'source>(
-    context: &mut NativeSourceWordContext<'source, '_>,
-    tokens: &'source [Token],
-    local_line_number_prefix: Option<SourceSpan>,
-    statement: SourceBlockStatement<'source>,
-) -> Result<(), SourceWordError> {
-    let Some((&first, _)) = tokens.split_first() else {
-        return Ok(());
-    };
-
-    if is_bif_keyword(context.view(), first)
-        .map_err(|source| map_block_statement_compile_error(source, statement.span()))?
-    {
-        let view = context.view();
-        let source_id = context.source_id();
-        let access = context.compile_access();
-        let Some(line_numbers) = access.line_numbers else {
-            return Err(SourceWordError::BlockStatementCompile {
-                span: statement.span(),
-            });
-        };
-        let bindings = match access.bindings {
-            NativeSourceWordBindingAccess::Read(bindings) => bindings,
-            NativeSourceWordBindingAccess::Write(bindings) => bindings,
-        };
-        let compile_context = SourceCompileContext {
-            bindings: BindingAccess::Read(bindings),
-            operators: access.operators,
-            source_words: access.source_words,
-            globals: None,
-            runtime_definitions: None,
-        };
-        return compile_bif(
+    if !syntax_markers.is_empty() && cursor.position() == body_start_position {
+        compile_structured_source_word_body(
             view,
             source_id,
-            tokens,
-            &compile_context,
-            access.code,
-            line_numbers,
-        )
-        .map_err(|source| map_block_statement_compile_error(source, statement.span()));
-    }
-
-    if compile_statement_leading_source_word_in_context(
-        context,
-        tokens,
-        local_line_number_prefix,
-        statement,
-    )? {
-        return Ok(());
-    }
-
-    if contains_expression_syntax(tokens) {
-        return Err(SourceWordError::BlockStatementCompile { span: first.span() });
-    }
-
-    let view = context.view();
-    let access = context.compile_access();
-    let bindings = match access.bindings {
-        NativeSourceWordBindingAccess::Read(bindings) => bindings,
-        NativeSourceWordBindingAccess::Write(bindings) => bindings,
-    };
-    let compile_context = SourceCompileContext {
-        bindings: BindingAccess::Read(bindings),
-        operators: access.operators,
-        source_words: access.source_words,
-        globals: None,
-        runtime_definitions: None,
-    };
-    compile_simple_tokens(view, tokens, &compile_context, access.code)
-        .map_err(|source| map_block_statement_compile_error(source, statement.span()))
-}
-
-fn compile_statement_leading_source_word_in_context<'source>(
-    context: &mut NativeSourceWordContext<'source, '_>,
-    tokens: &'source [Token],
-    local_line_number_prefix: Option<SourceSpan>,
-    statement: SourceBlockStatement<'source>,
-) -> Result<bool, SourceWordError> {
-    let Some(first) = tokens.first().copied() else {
-        return Ok(false);
-    };
-    if first.kind() != TokenKind::Name {
-        return Ok(false);
-    }
-
-    let source_name = context
-        .view()
-        .slice(first.span())
-        .map_err(|source| SourceWordError::Source { source })?;
-    let view = context.view();
-    let source_id = context.source_id();
-    let access = context.compile_access();
-    let bindings = match &access.bindings {
-        NativeSourceWordBindingAccess::Read(bindings) => *bindings,
-        NativeSourceWordBindingAccess::Write(bindings) => bindings,
-    };
-    let binding = match resolve_binding_name(bindings, source_name) {
-        Ok(binding) => binding,
-        Err(WordResolutionError::InvalidWordName | WordResolutionError::UndefinedName) => {
-            return Ok(false);
-        }
-        Err(WordResolutionError::TargetIsNotWord) => {
-            unreachable!("binding-kind resolution does not classify published bindings as non-word")
-        }
-    };
-
-    let ResolvedBinding::SourceWord(id) = binding else {
-        return Ok(false);
-    };
-    let Some(source_words) = access.source_words else {
-        return Err(SourceWordError::BlockStatementCompile {
-            span: statement.span(),
-        });
-    };
-    let handler =
-        source_words
-            .lookup_handler(id)
-            .map_err(|_| SourceWordError::BlockStatementCompile {
-                span: statement.span(),
-            })?;
-    let syntax_markers =
-        source_words
-            .syntax_markers(id)
-            .map_err(|_| SourceWordError::BlockStatementCompile {
-                span: statement.span(),
-            })?;
-
-    // #1516/#1533: nested structured source words are entered through normal
-    // binding dispatch, while the shared logical-statement cursor remains
-    // owned by the source processor.
-    let mut source_word_context = NativeSourceWordContext::new(NativeSourceWordContextParts {
-        view,
-        source_id,
-        tokens,
-        block_reader: Some(SourceBlockReader::new(
-            view,
-            access
-                .cursor
-                .expect("nested block processing requires an outer reader"),
             syntax_markers,
-        )),
-        bindings: access.bindings,
-        operators: access.operators,
-        code: access.code,
-        local_line_number_prefix,
-        globals: access.globals,
-        runtime_definitions: None,
-        line_numbers: access.line_numbers,
-        source_words: access.source_words,
-        statement_processor: access.statement_processor,
-    });
-    handler(&mut source_word_context)?;
+            context,
+            state,
+            cursor,
+            first.span(),
+        )?;
+    }
+
     Ok(true)
 }
 
-fn map_block_statement_compile_error(
-    source: SourceProcessorError,
-    fallback: SourceSpan,
-) -> SourceWordError {
-    match source {
-        SourceProcessorError::Source(source) => SourceWordError::Source { source },
-        SourceProcessorError::Lex(source) => SourceWordError::DefLex { source },
-        SourceProcessorError::SourceWord(source) => source,
-        source => SourceWordError::BlockStatementCompile {
-            span: source.primary_span().unwrap_or(fallback),
-        },
+fn compile_structured_source_word_body<'source, S>(
+    view: SourceView<'source>,
+    source_id: SourceId,
+    syntax_markers: &[crate::source_word::SourceWordSyntaxMarker],
+    context: &mut SourceCompileContext<'_>,
+    state: &mut StatementCompileState<'_>,
+    cursor: &mut LogicalStatementCursor<'source, 'source, S>,
+    missing_anchor: SourceSpan,
+) -> Result<(), SourceProcessorError>
+where
+    S: LogicalStatementView,
+{
+    loop {
+        let read = cursor.read_next_block_statement()?;
+        let statement = match read {
+            SourceBlockRead::Statement(statement) => statement,
+            SourceBlockRead::Terminal(SourceBlockTerminal::LexError { error }) => {
+                return Err(SourceProcessorError::Lex(error));
+            }
+            SourceBlockRead::Terminal(SourceBlockTerminal::Eof { span }) => {
+                return Err(SourceProcessorError::SourceWord(
+                    SourceWordError::UnsupportedSourceWord {
+                        span: if span.start() == span.end() {
+                            missing_anchor
+                        } else {
+                            span
+                        },
+                    },
+                ));
+            }
+        };
+
+        if let Some(marker) = classify_source_block_marker(view, syntax_markers, statement)? {
+            if marker.role() == crate::source_word::SourceWordSyntaxMarkerRole::BlockTerminator {
+                return Ok(());
+            }
+            continue;
+        }
+
+        // #1516/#1533: the source processor keeps the logical-statement cursor
+        // and normal traversal. A nested source word is just another
+        // statement-leading dispatch; when it completes, this loop resumes at
+        // the next statement for the outer owner.
+        compile_statement(view, source_id, statement.tokens(), context, state, cursor)?;
     }
 }
 
@@ -1235,6 +1096,10 @@ impl<'source, 'statements, S> LogicalStatementCursor<'source, 'statements, S> {
         let statement = self.statements.get(self.position)?;
         self.position += 1;
         Some(statement)
+    }
+
+    fn position(&self) -> usize {
+        self.position
     }
 }
 
@@ -2194,28 +2059,9 @@ mod tests {
     }
 
     fn process_until_declared_terminator(
-        context: &mut NativeSourceWordContext<'_, '_>,
+        _context: &mut NativeSourceWordContext<'_, '_>,
     ) -> Result<(), SourceWordError> {
-        loop {
-            match context.process_next_block_item()? {
-                SourceBlockItem::Statement(_) => {}
-                SourceBlockItem::Marker(marker)
-                    if marker.role() == SourceWordSyntaxMarkerRole::BlockTerminator =>
-                {
-                    context.append_mapped(Instruction::Push(value(20)), marker.span())?;
-                    return Ok(());
-                }
-                SourceBlockItem::Marker(marker) => {
-                    context.append_mapped(Instruction::Push(value(10)), marker.span())?;
-                }
-                SourceBlockItem::Terminal(SourceBlockTerminal::LexError { error }) => {
-                    return Err(SourceWordError::DefLex { source: error });
-                }
-                SourceBlockItem::Terminal(SourceBlockTerminal::Eof { span }) => {
-                    return Err(SourceWordError::UnsupportedSourceWord { span });
-                }
-            }
-        }
+        Ok(())
     }
 
     fn read_eof_terminal_as_missing_terminator(
@@ -5550,7 +5396,7 @@ mod tests {
         )
         .expect("structured body unit should run");
 
-        assert_eq!(result.data_stack(), [value(7), value(20), value(7)]);
+        assert_eq!(result.data_stack(), [value(7), value(7)]);
     }
 
     #[test]
@@ -5583,10 +5429,7 @@ mod tests {
             panic!("SCORE should be published by nested VAR");
         };
         assert_eq!(globals.view().read(id), Ok(value(0)));
-        assert_eq!(
-            unit.instructions().get(address(0)),
-            Ok(&Instruction::Push(value(20)))
-        );
+        assert_eq!(unit.instructions().get(address(0)), Ok(&Instruction::Halt));
     }
 
     #[test]
@@ -5634,10 +5477,7 @@ mod tests {
         )
         .expect("nested same-owner source word should run");
 
-        assert_eq!(
-            result.data_stack(),
-            [value(1), value(20), value(2), value(20), value(3)]
-        );
+        assert_eq!(result.data_stack(), [value(1), value(2), value(3)]);
     }
 
     #[test]
@@ -5699,10 +5539,7 @@ mod tests {
         )
         .expect("nested different-owner source word should run");
 
-        assert_eq!(
-            result.data_stack(),
-            [value(1), value(20), value(2), value(20), value(3)]
-        );
+        assert_eq!(result.data_stack(), [value(1), value(2), value(3)]);
     }
 
     #[test]
@@ -5742,9 +5579,7 @@ mod tests {
 
         assert!(matches!(
             error,
-            SourceProcessorError::SourceWord(SourceWordError::DefLex {
-                source: LexError::InvalidCharacter { .. }
-            })
+            SourceProcessorError::Lex(LexError::InvalidCharacter { .. })
         ));
     }
 

--- a/crates/tbx-next/src/source_processor.rs
+++ b/crates/tbx-next/src/source_processor.rs
@@ -22,7 +22,8 @@ use crate::source_mapping::{
 };
 use crate::source_word::{
     classify_source_block_marker, NativeSourceWordBindingAccess, NativeSourceWordContext,
-    NativeSourceWordContextParts, RuntimeDefinitionPublisher, SourceBlockCursor, SourceBlockRead,
+    NativeSourceWordContextParts, RuntimeDefinitionPublisher, SourceBlockCursor,
+    SourceBlockMarkerAction, SourceBlockMarkerContext, SourceBlockMarkerHandler, SourceBlockRead,
     SourceBlockReader, SourceBlockStatement, SourceBlockTerminal, SourceWordError, SourceWordId,
     SourceWordLookup, SourceWordLookupError,
 };
@@ -528,43 +529,54 @@ where
         BindingAccess::Read(bindings) => NativeSourceWordBindingAccess::Read(bindings),
         BindingAccess::Write(bindings) => NativeSourceWordBindingAccess::Write(bindings),
     };
-    let mut source_word_context = NativeSourceWordContext::new(NativeSourceWordContextParts {
-        view,
-        source_id,
-        tokens,
-        block_reader: Some(SourceBlockReader::new(view, cursor, syntax_markers)),
-        bindings: binding_access,
-        operators,
-        code: state.code,
-        local_line_number_prefix,
-        globals,
-        runtime_definitions,
-    });
-    handler(&mut source_word_context)?;
+    let block_marker_handler = {
+        let mut source_word_context = NativeSourceWordContext::new(NativeSourceWordContextParts {
+            view,
+            source_id,
+            tokens,
+            block_reader: Some(SourceBlockReader::new(view, cursor, syntax_markers)),
+            bindings: binding_access,
+            operators,
+            code: state.code,
+            local_line_number_prefix,
+            globals,
+            runtime_definitions,
+        });
+        handler(&mut source_word_context)?;
+        source_word_context.block_marker_handler()
+    };
 
     if !syntax_markers.is_empty() && cursor.position() == body_start_position {
         compile_structured_source_word_body(
-            view,
-            source_id,
-            syntax_markers,
+            StructuredSourceWordOwner {
+                view,
+                source_id,
+                syntax_markers,
+                block_marker_handler,
+                source_word_token: first,
+            },
             context,
             state,
             cursor,
-            first.span(),
         )?;
     }
 
     Ok(true)
 }
 
-fn compile_structured_source_word_body<'source, S>(
+struct StructuredSourceWordOwner<'source, 'markers> {
     view: SourceView<'source>,
     source_id: SourceId,
-    syntax_markers: &[crate::source_word::SourceWordSyntaxMarker],
+    syntax_markers: &'markers [crate::source_word::SourceWordSyntaxMarker],
+    block_marker_handler: Option<SourceBlockMarkerHandler<'source>>,
+    source_word_token: Token,
+}
+
+fn compile_structured_source_word_body<'source, S>(
+    owner: StructuredSourceWordOwner<'source, '_>,
     context: &mut SourceCompileContext<'_>,
     state: &mut StatementCompileState<'_>,
     cursor: &mut LogicalStatementCursor<'source, 'source, S>,
-    missing_anchor: SourceSpan,
 ) -> Result<(), SourceProcessorError>
 where
     S: LogicalStatementView,
@@ -580,7 +592,7 @@ where
                 return Err(SourceProcessorError::SourceWord(
                     SourceWordError::UnsupportedSourceWord {
                         span: if span.start() == span.end() {
-                            missing_anchor
+                            owner.source_word_token.span()
                         } else {
                             span
                         },
@@ -589,18 +601,40 @@ where
             }
         };
 
-        if let Some(marker) = classify_source_block_marker(view, syntax_markers, statement)? {
-            if marker.role() == crate::source_word::SourceWordSyntaxMarkerRole::BlockTerminator {
-                return Ok(());
+        if let Some(marker) =
+            classify_source_block_marker(owner.view, owner.syntax_markers, statement)?
+        {
+            let Some(handle_marker) = owner.block_marker_handler else {
+                return Err(SourceProcessorError::SourceWord(
+                    SourceWordError::UnsupportedSourceWord {
+                        span: marker.span(),
+                    },
+                ));
+            };
+            let mut marker_context = SourceBlockMarkerContext::new(
+                owner.view,
+                owner.source_id,
+                owner.source_word_token,
+                state.code,
+            );
+            match handle_marker(&mut marker_context, marker)? {
+                SourceBlockMarkerAction::Continue => continue,
+                SourceBlockMarkerAction::Complete => return Ok(()),
             }
-            continue;
         }
 
         // #1516/#1533: the source processor keeps the logical-statement cursor
         // and normal traversal. A nested source word is just another
         // statement-leading dispatch; when it completes, this loop resumes at
         // the next statement for the outer owner.
-        compile_statement(view, source_id, statement.tokens(), context, state, cursor)?;
+        compile_statement(
+            owner.view,
+            owner.source_id,
+            statement.tokens(),
+            context,
+            state,
+            cursor,
+        )?;
     }
 }
 
@@ -1754,7 +1788,8 @@ mod tests {
     };
     use crate::source_word::{
         DefSyntaxErrorKind, LetSyntaxErrorKind, NativeSourceWordContext, SourceBlockItem,
-        SourceWordRegistry, SourceWordSyntaxMarker, SourceWordSyntaxMarkerRole, VarSyntaxErrorKind,
+        SourceBlockMarker, SourceBlockMarkerAction, SourceBlockMarkerContext, SourceWordRegistry,
+        SourceWordSyntaxMarker, SourceWordSyntaxMarkerRole, VarSyntaxErrorKind,
     };
     use crate::word::{CompletedWordDefinition, PrimitiveId, PublishedWords, WordId};
     use crate::word_lookup::PublishedWordLookup;
@@ -2058,9 +2093,25 @@ mod tests {
         }
     }
 
+    fn transition_on_declared_marker(
+        context: &mut SourceBlockMarkerContext<'_, '_>,
+        marker: SourceBlockMarker<'_>,
+    ) -> Result<SourceBlockMarkerAction, SourceWordError> {
+        let emitted = match marker.role() {
+            SourceWordSyntaxMarkerRole::BlockContinuation => 10,
+            SourceWordSyntaxMarkerRole::BlockTerminator => 20,
+        };
+        context.append_mapped(Instruction::Push(value(emitted)), marker.span())?;
+        Ok(match marker.role() {
+            SourceWordSyntaxMarkerRole::BlockContinuation => SourceBlockMarkerAction::Continue,
+            SourceWordSyntaxMarkerRole::BlockTerminator => SourceBlockMarkerAction::Complete,
+        })
+    }
+
     fn process_until_declared_terminator(
-        _context: &mut NativeSourceWordContext<'_, '_>,
+        context: &mut NativeSourceWordContext<'_, '_>,
     ) -> Result<(), SourceWordError> {
+        context.set_block_marker_handler(transition_on_declared_marker);
         Ok(())
     }
 
@@ -5396,7 +5447,7 @@ mod tests {
         )
         .expect("structured body unit should run");
 
-        assert_eq!(result.data_stack(), [value(7), value(7)]);
+        assert_eq!(result.data_stack(), [value(7), value(20), value(7)]);
     }
 
     #[test]
@@ -5429,7 +5480,64 @@ mod tests {
             panic!("SCORE should be published by nested VAR");
         };
         assert_eq!(globals.view().read(id), Ok(value(0)));
-        assert_eq!(unit.instructions().get(address(0)), Ok(&Instruction::Halt));
+        assert_eq!(
+            unit.instructions().get(address(0)),
+            Ok(&Instruction::Push(value(20)))
+        );
+    }
+
+    #[test]
+    fn structured_body_owner_marker_transition_continues_to_statement_and_outer_resume() {
+        let mut source_words = SourceWordRegistry::new();
+        let mut words = PublishedWords::new();
+        let mut primitives = PrimitiveRegistry::new();
+        let mut bindings = Bindings::new();
+        for (source_name, primitive) in [
+            (
+                "PUSH1",
+                push_1 as fn(&mut PrimitiveContext<'_>) -> Result<(), PrimitiveError>,
+            ),
+            ("PUSH2", push_2),
+            ("PUSH3", push_3),
+        ] {
+            let primitive = primitives.register(primitive);
+            register_primitive(&mut words, &mut bindings, name(source_name), primitive)
+                .expect("runtime word should register");
+        }
+        register_native_source_word_with_markers(
+            &mut source_words,
+            &mut bindings,
+            name("OUTER"),
+            process_until_declared_terminator,
+            vec![
+                marker("OUT_ELSE", SourceWordSyntaxMarkerRole::BlockContinuation),
+                marker("OUT_DONE", SourceWordSyntaxMarkerRole::BlockTerminator),
+            ],
+        )
+        .expect("outer source word should register");
+        let (sources, source_id) = source("OUTER\nPUSH1\nOUT_ELSE\nPUSH2\nOUT_DONE\nPUSH3");
+
+        let unit = compile_source(
+            sources.view(),
+            source_id,
+            SourceCompileContext::with_source_words(&bindings, source_words.lookup()),
+        )
+        .expect("structured body should compile owner marker transitions");
+        let result = run_unit(
+            &unit,
+            SourceExecutionContext::with_source_words(
+                &bindings,
+                source_words.lookup(),
+                PublishedWordLookup::new(&words),
+                primitives.lookup(),
+            ),
+        )
+        .expect("structured body unit should run");
+
+        assert_eq!(
+            result.data_stack(),
+            [value(1), value(10), value(2), value(20), value(3)]
+        );
     }
 
     #[test]
@@ -5477,7 +5585,10 @@ mod tests {
         )
         .expect("nested same-owner source word should run");
 
-        assert_eq!(result.data_stack(), [value(1), value(2), value(3)]);
+        assert_eq!(
+            result.data_stack(),
+            [value(1), value(20), value(2), value(20), value(3)]
+        );
     }
 
     #[test]
@@ -5539,7 +5650,10 @@ mod tests {
         )
         .expect("nested different-owner source word should run");
 
-        assert_eq!(result.data_stack(), [value(1), value(2), value(3)]);
+        assert_eq!(
+            result.data_stack(),
+            [value(1), value(20), value(2), value(20), value(3)]
+        );
     }
 
     #[test]

--- a/crates/tbx-next/src/source_processor.rs
+++ b/crates/tbx-next/src/source_processor.rs
@@ -451,7 +451,7 @@ where
         tokens,
         context,
         local_line_number_prefix,
-        state.code,
+        state,
         cursor,
     )? {
         return Ok(());
@@ -474,7 +474,7 @@ fn compile_statement_leading_source_word<'source, S>(
     tokens: &'source [Token],
     context: &mut SourceCompileContext<'_>,
     local_line_number_prefix: Option<SourceSpan>,
-    code: &mut dyn InstructionBuildTarget,
+    state: &mut StatementCompileState<'_>,
     cursor: &mut LogicalStatementCursor<'source, 'source, S>,
 ) -> Result<bool, SourceProcessorError>
 where
@@ -534,13 +534,213 @@ where
         block_reader: Some(SourceBlockReader::new(view, cursor, syntax_markers)),
         bindings: binding_access,
         operators,
-        code,
+        code: state.code,
         local_line_number_prefix,
         globals,
         runtime_definitions,
+        line_numbers: Some(state.line_numbers),
+        source_words: Some(source_words),
+        statement_processor: Some(process_source_word_block_statement),
     });
     handler(&mut source_word_context)?;
     Ok(true)
+}
+
+fn process_source_word_block_statement<'source>(
+    context: &mut NativeSourceWordContext<'source, '_>,
+    statement: SourceBlockStatement<'source>,
+) -> Result<(), SourceWordError> {
+    let start = {
+        let access = context.compile_access();
+        access.code.current_address()
+    };
+    let (line_number, body) = split_statement_line_number(context.view(), statement.tokens())
+        .map_err(|source| map_block_statement_compile_error(source, statement.span()))?;
+    let local_line_number_prefix = line_number.map(|(_, span)| span);
+    compile_source_word_block_statement_body(context, body, local_line_number_prefix, statement)?;
+
+    let Some((line_number, span)) = line_number else {
+        return Ok(());
+    };
+    let access = context.compile_access();
+    let Some(line_numbers) = access.line_numbers else {
+        return Err(SourceWordError::BlockStatementCompile {
+            span: statement.span(),
+        });
+    };
+    line_numbers
+        .define(access.code, line_number, start, span)
+        .map_err(|_| SourceWordError::BlockStatementCompile { span })
+}
+
+fn compile_source_word_block_statement_body<'source>(
+    context: &mut NativeSourceWordContext<'source, '_>,
+    tokens: &'source [Token],
+    local_line_number_prefix: Option<SourceSpan>,
+    statement: SourceBlockStatement<'source>,
+) -> Result<(), SourceWordError> {
+    let Some((&first, _)) = tokens.split_first() else {
+        return Ok(());
+    };
+
+    if is_bif_keyword(context.view(), first)
+        .map_err(|source| map_block_statement_compile_error(source, statement.span()))?
+    {
+        let view = context.view();
+        let source_id = context.source_id();
+        let access = context.compile_access();
+        let Some(line_numbers) = access.line_numbers else {
+            return Err(SourceWordError::BlockStatementCompile {
+                span: statement.span(),
+            });
+        };
+        let bindings = match access.bindings {
+            NativeSourceWordBindingAccess::Read(bindings) => bindings,
+            NativeSourceWordBindingAccess::Write(bindings) => bindings,
+        };
+        let compile_context = SourceCompileContext {
+            bindings: BindingAccess::Read(bindings),
+            operators: access.operators,
+            source_words: access.source_words,
+            globals: None,
+            runtime_definitions: None,
+        };
+        return compile_bif(
+            view,
+            source_id,
+            tokens,
+            &compile_context,
+            access.code,
+            line_numbers,
+        )
+        .map_err(|source| map_block_statement_compile_error(source, statement.span()));
+    }
+
+    if compile_statement_leading_source_word_in_context(
+        context,
+        tokens,
+        local_line_number_prefix,
+        statement,
+    )? {
+        return Ok(());
+    }
+
+    if contains_expression_syntax(tokens) {
+        return Err(SourceWordError::BlockStatementCompile { span: first.span() });
+    }
+
+    let view = context.view();
+    let access = context.compile_access();
+    let bindings = match access.bindings {
+        NativeSourceWordBindingAccess::Read(bindings) => bindings,
+        NativeSourceWordBindingAccess::Write(bindings) => bindings,
+    };
+    let compile_context = SourceCompileContext {
+        bindings: BindingAccess::Read(bindings),
+        operators: access.operators,
+        source_words: access.source_words,
+        globals: None,
+        runtime_definitions: None,
+    };
+    compile_simple_tokens(view, tokens, &compile_context, access.code)
+        .map_err(|source| map_block_statement_compile_error(source, statement.span()))
+}
+
+fn compile_statement_leading_source_word_in_context<'source>(
+    context: &mut NativeSourceWordContext<'source, '_>,
+    tokens: &'source [Token],
+    local_line_number_prefix: Option<SourceSpan>,
+    statement: SourceBlockStatement<'source>,
+) -> Result<bool, SourceWordError> {
+    let Some(first) = tokens.first().copied() else {
+        return Ok(false);
+    };
+    if first.kind() != TokenKind::Name {
+        return Ok(false);
+    }
+
+    let source_name = context
+        .view()
+        .slice(first.span())
+        .map_err(|source| SourceWordError::Source { source })?;
+    let view = context.view();
+    let source_id = context.source_id();
+    let access = context.compile_access();
+    let bindings = match &access.bindings {
+        NativeSourceWordBindingAccess::Read(bindings) => *bindings,
+        NativeSourceWordBindingAccess::Write(bindings) => bindings,
+    };
+    let binding = match resolve_binding_name(bindings, source_name) {
+        Ok(binding) => binding,
+        Err(WordResolutionError::InvalidWordName | WordResolutionError::UndefinedName) => {
+            return Ok(false);
+        }
+        Err(WordResolutionError::TargetIsNotWord) => {
+            unreachable!("binding-kind resolution does not classify published bindings as non-word")
+        }
+    };
+
+    let ResolvedBinding::SourceWord(id) = binding else {
+        return Ok(false);
+    };
+    let Some(source_words) = access.source_words else {
+        return Err(SourceWordError::BlockStatementCompile {
+            span: statement.span(),
+        });
+    };
+    let handler =
+        source_words
+            .lookup_handler(id)
+            .map_err(|_| SourceWordError::BlockStatementCompile {
+                span: statement.span(),
+            })?;
+    let syntax_markers =
+        source_words
+            .syntax_markers(id)
+            .map_err(|_| SourceWordError::BlockStatementCompile {
+                span: statement.span(),
+            })?;
+
+    // #1516/#1533: nested structured source words are entered through normal
+    // binding dispatch, while the shared logical-statement cursor remains
+    // owned by the source processor.
+    let mut source_word_context = NativeSourceWordContext::new(NativeSourceWordContextParts {
+        view,
+        source_id,
+        tokens,
+        block_reader: Some(SourceBlockReader::new(
+            view,
+            access
+                .cursor
+                .expect("nested block processing requires an outer reader"),
+            syntax_markers,
+        )),
+        bindings: access.bindings,
+        operators: access.operators,
+        code: access.code,
+        local_line_number_prefix,
+        globals: access.globals,
+        runtime_definitions: None,
+        line_numbers: access.line_numbers,
+        source_words: access.source_words,
+        statement_processor: access.statement_processor,
+    });
+    handler(&mut source_word_context)?;
+    Ok(true)
+}
+
+fn map_block_statement_compile_error(
+    source: SourceProcessorError,
+    fallback: SourceSpan,
+) -> SourceWordError {
+    match source {
+        SourceProcessorError::Source(source) => SourceWordError::Source { source },
+        SourceProcessorError::Lex(source) => SourceWordError::DefLex { source },
+        SourceProcessorError::SourceWord(source) => source,
+        source => SourceWordError::BlockStatementCompile {
+            span: source.primary_span().unwrap_or(fallback),
+        },
+    }
 }
 
 fn compile_simple_tokens(
@@ -1987,6 +2187,31 @@ mod tests {
                     let span = terminal
                         .eof_span()
                         .unwrap_or_else(|| context.source_word_token().span());
+                    return Err(SourceWordError::UnsupportedSourceWord { span });
+                }
+            }
+        }
+    }
+
+    fn process_until_declared_terminator(
+        context: &mut NativeSourceWordContext<'_, '_>,
+    ) -> Result<(), SourceWordError> {
+        loop {
+            match context.process_next_block_item()? {
+                SourceBlockItem::Statement(_) => {}
+                SourceBlockItem::Marker(marker)
+                    if marker.role() == SourceWordSyntaxMarkerRole::BlockTerminator =>
+                {
+                    context.append_mapped(Instruction::Push(value(20)), marker.span())?;
+                    return Ok(());
+                }
+                SourceBlockItem::Marker(marker) => {
+                    context.append_mapped(Instruction::Push(value(10)), marker.span())?;
+                }
+                SourceBlockItem::Terminal(SourceBlockTerminal::LexError { error }) => {
+                    return Err(SourceWordError::DefLex { source: error });
+                }
+                SourceBlockItem::Terminal(SourceBlockTerminal::Eof { span }) => {
                     return Err(SourceWordError::UnsupportedSourceWord { span });
                 }
             }
@@ -5284,6 +5509,243 @@ mod tests {
             unit.instructions().get(address(1)),
             Ok(&Instruction::Push(value(99)))
         );
+    }
+
+    #[test]
+    fn structured_body_processes_runtime_word_statement_and_line_prefix() {
+        let mut source_words = SourceWordRegistry::new();
+        let mut words = PublishedWords::new();
+        let mut primitives = PrimitiveRegistry::new();
+        let mut bindings = Bindings::new();
+        let push7_id = primitives.register(push_7);
+        register_primitive(&mut words, &mut bindings, name("PUSH7"), push7_id)
+            .expect("runtime word should register");
+        register_native_source_word_with_markers(
+            &mut source_words,
+            &mut bindings,
+            name("OUTER"),
+            process_until_declared_terminator,
+            vec![marker(
+                "OUT_DONE",
+                SourceWordSyntaxMarkerRole::BlockTerminator,
+            )],
+        )
+        .expect("outer source word should register");
+        let (sources, source_id) = source("OUTER\n100 PUSH7\nOUT_DONE\nPUSH7");
+
+        let unit = compile_source(
+            sources.view(),
+            source_id,
+            SourceCompileContext::with_source_words(&bindings, source_words.lookup()),
+        )
+        .expect("structured body should compile ordinary runtime statements");
+        let result = run_unit(
+            &unit,
+            SourceExecutionContext::with_source_words(
+                &bindings,
+                source_words.lookup(),
+                PublishedWordLookup::new(&words),
+                primitives.lookup(),
+            ),
+        )
+        .expect("structured body unit should run");
+
+        assert_eq!(result.data_stack(), [value(7), value(20), value(7)]);
+    }
+
+    #[test]
+    fn structured_body_source_word_dispatch_preserves_publication_capability() {
+        let mut source_words = SourceWordRegistry::new();
+        let mut bindings = Bindings::new();
+        let mut globals = GlobalVariables::new();
+        register_builtin_source_words(&mut source_words, &mut bindings)
+            .expect("built-in source words should bootstrap");
+        register_native_source_word_with_markers(
+            &mut source_words,
+            &mut bindings,
+            name("OUTER"),
+            process_until_declared_terminator,
+            vec![marker(
+                "OUT_DONE",
+                SourceWordSyntaxMarkerRole::BlockTerminator,
+            )],
+        )
+        .expect("outer source word should register");
+
+        let (_sources, _id, unit) = compile_with_var(
+            "OUTER\nVAR SCORE\nOUT_DONE",
+            &mut bindings,
+            &mut globals,
+            &source_words,
+        );
+
+        let Some(Binding::Variable(id)) = bindings.get(&name("SCORE")).copied() else {
+            panic!("SCORE should be published by nested VAR");
+        };
+        assert_eq!(globals.view().read(id), Ok(value(0)));
+        assert_eq!(
+            unit.instructions().get(address(0)),
+            Ok(&Instruction::Push(value(20)))
+        );
+    }
+
+    #[test]
+    fn nested_same_owner_source_word_completes_before_outer_continues() {
+        let mut source_words = SourceWordRegistry::new();
+        let mut words = PublishedWords::new();
+        let mut primitives = PrimitiveRegistry::new();
+        let mut bindings = Bindings::new();
+        for (source_name, primitive) in [
+            (
+                "PUSH1",
+                push_1 as fn(&mut PrimitiveContext<'_>) -> Result<(), PrimitiveError>,
+            ),
+            ("PUSH2", push_2),
+            ("PUSH3", push_3),
+        ] {
+            let primitive = primitives.register(primitive);
+            register_primitive(&mut words, &mut bindings, name(source_name), primitive)
+                .expect("runtime word should register");
+        }
+        register_native_source_word_with_markers(
+            &mut source_words,
+            &mut bindings,
+            name("OUTER"),
+            process_until_declared_terminator,
+            vec![marker("DONE", SourceWordSyntaxMarkerRole::BlockTerminator)],
+        )
+        .expect("same-owner source word should register");
+        let (sources, source_id) = source("OUTER\nOUTER\nPUSH1\nDONE\nPUSH2\nDONE\nPUSH3");
+
+        let unit = compile_source(
+            sources.view(),
+            source_id,
+            SourceCompileContext::with_source_words(&bindings, source_words.lookup()),
+        )
+        .expect("nested same-owner source word should compile");
+        let result = run_unit(
+            &unit,
+            SourceExecutionContext::with_source_words(
+                &bindings,
+                source_words.lookup(),
+                PublishedWordLookup::new(&words),
+                primitives.lookup(),
+            ),
+        )
+        .expect("nested same-owner source word should run");
+
+        assert_eq!(
+            result.data_stack(),
+            [value(1), value(20), value(2), value(20), value(3)]
+        );
+    }
+
+    #[test]
+    fn nested_different_owner_marker_set_does_not_leak_to_outer() {
+        let mut source_words = SourceWordRegistry::new();
+        let mut words = PublishedWords::new();
+        let mut primitives = PrimitiveRegistry::new();
+        let mut bindings = Bindings::new();
+        for (source_name, primitive) in [
+            (
+                "PUSH1",
+                push_1 as fn(&mut PrimitiveContext<'_>) -> Result<(), PrimitiveError>,
+            ),
+            ("PUSH2", push_2),
+            ("PUSH3", push_3),
+        ] {
+            let primitive = primitives.register(primitive);
+            register_primitive(&mut words, &mut bindings, name(source_name), primitive)
+                .expect("runtime word should register");
+        }
+        register_native_source_word_with_markers(
+            &mut source_words,
+            &mut bindings,
+            name("OUTER"),
+            process_until_declared_terminator,
+            vec![marker(
+                "OUT_DONE",
+                SourceWordSyntaxMarkerRole::BlockTerminator,
+            )],
+        )
+        .expect("outer source word should register");
+        register_native_source_word_with_markers(
+            &mut source_words,
+            &mut bindings,
+            name("INNER"),
+            process_until_declared_terminator,
+            vec![marker(
+                "IN_DONE",
+                SourceWordSyntaxMarkerRole::BlockTerminator,
+            )],
+        )
+        .expect("inner source word should register");
+        let (sources, source_id) = source("OUTER\nINNER\nPUSH1\nIN_DONE\nPUSH2\nOUT_DONE\nPUSH3");
+
+        let unit = compile_source(
+            sources.view(),
+            source_id,
+            SourceCompileContext::with_source_words(&bindings, source_words.lookup()),
+        )
+        .expect("nested different-owner source word should compile");
+        let result = run_unit(
+            &unit,
+            SourceExecutionContext::with_source_words(
+                &bindings,
+                source_words.lookup(),
+                PublishedWordLookup::new(&words),
+                primitives.lookup(),
+            ),
+        )
+        .expect("nested different-owner source word should run");
+
+        assert_eq!(
+            result.data_stack(),
+            [value(1), value(20), value(2), value(20), value(3)]
+        );
+    }
+
+    #[test]
+    fn nested_body_lexical_failure_preempts_outer_missing_terminator() {
+        let mut source_words = SourceWordRegistry::new();
+        let mut bindings = Bindings::new();
+        register_native_source_word_with_markers(
+            &mut source_words,
+            &mut bindings,
+            name("OUTER"),
+            process_until_declared_terminator,
+            vec![marker(
+                "OUT_DONE",
+                SourceWordSyntaxMarkerRole::BlockTerminator,
+            )],
+        )
+        .expect("outer source word should register");
+        register_native_source_word_with_markers(
+            &mut source_words,
+            &mut bindings,
+            name("INNER"),
+            process_until_declared_terminator,
+            vec![marker(
+                "IN_DONE",
+                SourceWordSyntaxMarkerRole::BlockTerminator,
+            )],
+        )
+        .expect("inner source word should register");
+        let (sources, source_id) = source("OUTER\nINNER\n@");
+
+        let error = compile_source(
+            sources.view(),
+            source_id,
+            SourceCompileContext::with_source_words(&bindings, source_words.lookup()),
+        )
+        .expect_err("inner lexical error should be preserved");
+
+        assert!(matches!(
+            error,
+            SourceProcessorError::SourceWord(SourceWordError::DefLex {
+                source: LexError::InvalidCharacter { .. }
+            })
+        ));
     }
 
     #[test]

--- a/crates/tbx-next/src/source_word.rs
+++ b/crates/tbx-next/src/source_word.rs
@@ -35,10 +35,22 @@ impl SourceWordId {
 pub(crate) type NativeSourceWordHandler =
     fn(&mut NativeSourceWordContext<'_, '_>) -> Result<(), SourceWordError>;
 
+pub(crate) type SourceBlockMarkerHandler<'source> =
+    for<'state> fn(
+        &mut SourceBlockMarkerContext<'source, 'state>,
+        SourceBlockMarker<'source>,
+    ) -> Result<SourceBlockMarkerAction, SourceWordError>;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SourceWordSyntaxMarkerRole {
     BlockContinuation,
     BlockTerminator,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SourceBlockMarkerAction {
+    Continue,
+    Complete,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -279,6 +291,18 @@ pub(crate) trait RuntimeDefinitionPublisher<'source> {
     ) -> Result<WordId, SourceWordError>;
 }
 
+/// Narrow capability passed when a structured source word receives a marker.
+///
+/// The source processor owns traversal and cursor advancement. Marker handlers
+/// can update the owner's grammar state by emitting mapped temporary
+/// instructions, but they cannot pull or dispatch ordinary statements.
+pub(crate) struct SourceBlockMarkerContext<'source, 'state> {
+    view: SourceView<'source>,
+    source_id: SourceId,
+    source_word_token: Token,
+    code: &'state mut dyn InstructionBuildTarget,
+}
+
 impl<'source> SourceBlockStatement<'source> {
     pub(crate) const fn new(tokens: &'source [Token], span: SourceSpan) -> Self {
         Self { tokens, span }
@@ -297,6 +321,45 @@ impl<'source> SourceBlockStatement<'source> {
             [token] if token.kind() == TokenKind::Name => Some(*token),
             _ => None,
         }
+    }
+}
+
+impl<'source, 'state> SourceBlockMarkerContext<'source, 'state> {
+    pub(crate) const fn new(
+        view: SourceView<'source>,
+        source_id: SourceId,
+        source_word_token: Token,
+        code: &'state mut dyn InstructionBuildTarget,
+    ) -> Self {
+        Self {
+            view,
+            source_id,
+            source_word_token,
+            code,
+        }
+    }
+
+    pub(crate) const fn view(&self) -> SourceView<'source> {
+        self.view
+    }
+
+    pub(crate) const fn source_id(&self) -> SourceId {
+        self.source_id
+    }
+
+    pub(crate) fn source_word_token(&self) -> Token {
+        self.source_word_token
+    }
+
+    pub(crate) fn append_mapped(
+        &mut self,
+        instruction: Instruction,
+        span: SourceSpan,
+    ) -> Result<(), SourceWordError> {
+        self.code
+            .append_mapped(instruction, span)
+            .map(|_| ())
+            .map_err(|source| SourceWordError::InstructionBuild { source })
     }
 }
 
@@ -518,6 +581,7 @@ pub(crate) struct NativeSourceWordContext<'source, 'state> {
     local_line_number_prefix: Option<SourceSpan>,
     globals: Option<&'state mut GlobalVariables>,
     runtime_definitions: Option<&'state mut dyn RuntimeDefinitionPublisher<'source>>,
+    block_marker_handler: Option<SourceBlockMarkerHandler<'source>>,
 }
 
 pub(crate) struct NativeSourceWordContextParts<'source, 'state> {
@@ -553,6 +617,7 @@ impl<'source, 'state> NativeSourceWordContext<'source, 'state> {
             local_line_number_prefix: parts.local_line_number_prefix,
             globals: parts.globals,
             runtime_definitions: parts.runtime_definitions,
+            block_marker_handler: None,
         }
     }
 
@@ -574,6 +639,14 @@ impl<'source, 'state> NativeSourceWordContext<'source, 'state> {
 
     pub(crate) fn block_reader_mut(&mut self) -> Option<&mut SourceBlockReader<'source, 'state>> {
         self.block_reader.as_mut()
+    }
+
+    pub(crate) fn set_block_marker_handler(&mut self, handler: SourceBlockMarkerHandler<'source>) {
+        self.block_marker_handler = Some(handler);
+    }
+
+    pub(crate) const fn block_marker_handler(&self) -> Option<SourceBlockMarkerHandler<'source>> {
+        self.block_marker_handler
     }
 
     pub(crate) const fn local_line_number_prefix(&self) -> Option<SourceSpan> {

--- a/crates/tbx-next/src/source_word.rs
+++ b/crates/tbx-next/src/source_word.rs
@@ -6,6 +6,7 @@ use crate::global_variable::GlobalVariables;
 use crate::instruction::Instruction;
 use crate::instruction_builder::{InstructionBuildError, InstructionBuildTarget};
 use crate::lexer::{LexError, Token, TokenKind};
+use crate::line_number::LocalLineNumberTable;
 use crate::name::{NameError, NormalizedName};
 use crate::operator::OperatorLookup;
 use crate::source::{SourceError, SourceId, SourceSpan, SourceView};
@@ -34,6 +35,11 @@ impl SourceWordId {
 
 pub(crate) type NativeSourceWordHandler =
     fn(&mut NativeSourceWordContext<'_, '_>) -> Result<(), SourceWordError>;
+pub(crate) type SourceBlockStatementProcessor<'source> =
+    for<'state> fn(
+        &mut NativeSourceWordContext<'source, 'state>,
+        SourceBlockStatement<'source>,
+    ) -> Result<(), SourceWordError>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SourceWordSyntaxMarkerRole {
@@ -142,6 +148,9 @@ pub(crate) enum SourceWordError {
     DefBindingCommitInvariantViolated {
         span: SourceSpan,
     },
+    BlockStatementCompile {
+        span: SourceSpan,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -194,7 +203,8 @@ impl SourceWordError {
             | Self::DefBodyCompile { span }
             | Self::DefBodyBuild { span }
             | Self::DefDefinition { span }
-            | Self::DefBindingCommitInvariantViolated { span } => Some(span),
+            | Self::DefBindingCommitInvariantViolated { span }
+            | Self::BlockStatementCompile { span } => Some(span),
             Self::DefLex { source } => match source {
                 LexError::Source(_) => None,
                 LexError::InvalidCharacter { span, .. } => Some(span),
@@ -355,6 +365,10 @@ impl<'source, 'cursor> SourceBlockReader<'source, 'cursor> {
         self.cursor.read_next_block_statement()
     }
 
+    pub(crate) fn cursor_mut(&mut self) -> &mut dyn SourceBlockCursor<'source> {
+        self.cursor
+    }
+
     pub(crate) fn next_item(&mut self) -> Result<SourceBlockItem<'source>, SourceWordError> {
         match self.next_statement()? {
             SourceBlockRead::Statement(statement) => {
@@ -512,6 +526,9 @@ pub(crate) struct NativeSourceWordContext<'source, 'state> {
     local_line_number_prefix: Option<SourceSpan>,
     globals: Option<&'state mut GlobalVariables>,
     runtime_definitions: Option<&'state mut dyn RuntimeDefinitionPublisher<'source>>,
+    line_numbers: Option<&'state mut LocalLineNumberTable>,
+    source_words: Option<SourceWordLookup<'state>>,
+    statement_processor: Option<SourceBlockStatementProcessor<'source>>,
 }
 
 pub(crate) struct NativeSourceWordContextParts<'source, 'state> {
@@ -525,6 +542,9 @@ pub(crate) struct NativeSourceWordContextParts<'source, 'state> {
     pub(crate) local_line_number_prefix: Option<SourceSpan>,
     pub(crate) globals: Option<&'state mut GlobalVariables>,
     pub(crate) runtime_definitions: Option<&'state mut dyn RuntimeDefinitionPublisher<'source>>,
+    pub(crate) line_numbers: Option<&'state mut LocalLineNumberTable>,
+    pub(crate) source_words: Option<SourceWordLookup<'state>>,
+    pub(crate) statement_processor: Option<SourceBlockStatementProcessor<'source>>,
 }
 
 impl<'source, 'state> NativeSourceWordContext<'source, 'state> {
@@ -547,6 +567,9 @@ impl<'source, 'state> NativeSourceWordContext<'source, 'state> {
             local_line_number_prefix: parts.local_line_number_prefix,
             globals: parts.globals,
             runtime_definitions: parts.runtime_definitions,
+            line_numbers: parts.line_numbers,
+            source_words: parts.source_words,
+            statement_processor: parts.statement_processor,
         }
     }
 
@@ -568,6 +591,27 @@ impl<'source, 'state> NativeSourceWordContext<'source, 'state> {
 
     pub(crate) fn block_reader_mut(&mut self) -> Option<&mut SourceBlockReader<'source, 'state>> {
         self.block_reader.as_mut()
+    }
+
+    pub(crate) fn process_next_block_item(
+        &mut self,
+    ) -> Result<SourceBlockItem<'source>, SourceWordError> {
+        let Some(reader) = &mut self.block_reader else {
+            return Err(SourceWordError::UnsupportedSourceWord {
+                span: self.source_word_token.span(),
+            });
+        };
+        let item = reader.next_item()?;
+        let SourceBlockItem::Statement(statement) = item else {
+            return Ok(item);
+        };
+        let Some(process_statement) = self.statement_processor else {
+            return Err(SourceWordError::UnsupportedSourceWord {
+                span: statement.span(),
+            });
+        };
+        process_statement(self, statement)?;
+        Ok(SourceBlockItem::Statement(statement))
     }
 
     pub(crate) const fn local_line_number_prefix(&self) -> Option<SourceSpan> {
@@ -718,11 +762,45 @@ impl<'source, 'state> NativeSourceWordContext<'source, 'state> {
             NativeSourceWordBindingAccess::Write(bindings) => bindings,
         }
     }
+
+    pub(crate) fn compile_access(&mut self) -> NativeSourceWordCompileAccess<'_, 'source> {
+        NativeSourceWordCompileAccess {
+            bindings: match &mut self.bindings {
+                NativeSourceWordBindingAccess::Read(bindings) => {
+                    NativeSourceWordBindingAccess::Read(bindings)
+                }
+                NativeSourceWordBindingAccess::Write(bindings) => {
+                    NativeSourceWordBindingAccess::Write(bindings)
+                }
+            },
+            operators: self.operators,
+            code: &mut *self.code,
+            globals: self.globals.as_deref_mut(),
+            line_numbers: self.line_numbers.as_deref_mut(),
+            source_words: self.source_words,
+            statement_processor: self.statement_processor,
+            cursor: self
+                .block_reader
+                .as_mut()
+                .map(SourceBlockReader::cursor_mut),
+        }
+    }
 }
 
 pub(crate) enum NativeSourceWordBindingAccess<'a> {
     Read(&'a Bindings),
     Write(&'a mut Bindings),
+}
+
+pub(crate) struct NativeSourceWordCompileAccess<'state, 'source> {
+    pub(crate) bindings: NativeSourceWordBindingAccess<'state>,
+    pub(crate) operators: Option<OperatorLookup>,
+    pub(crate) code: &'state mut dyn InstructionBuildTarget,
+    pub(crate) globals: Option<&'state mut GlobalVariables>,
+    pub(crate) line_numbers: Option<&'state mut LocalLineNumberTable>,
+    pub(crate) source_words: Option<SourceWordLookup<'state>>,
+    pub(crate) statement_processor: Option<SourceBlockStatementProcessor<'source>>,
+    pub(crate) cursor: Option<&'state mut dyn SourceBlockCursor<'source>>,
 }
 
 pub(crate) fn var_source_word(
@@ -1069,6 +1147,9 @@ mod tests {
             local_line_number_prefix: None,
             globals: None,
             runtime_definitions: None,
+            line_numbers: None,
+            source_words: None,
+            statement_processor: None,
         });
 
         let first_body_token = context
@@ -1274,6 +1355,9 @@ mod tests {
                 local_line_number_prefix: None,
                 globals: None,
                 runtime_definitions: None,
+                line_numbers: None,
+                source_words: None,
+                statement_processor: None,
             });
 
             push_one(&mut context).expect("test source word should emit");
@@ -1309,6 +1393,9 @@ mod tests {
                     local_line_number_prefix: None,
                     globals: Some(&mut globals),
                     runtime_definitions: None,
+                    line_numbers: None,
+                    source_words: None,
+                    statement_processor: None,
                 });
 
                 var_source_word(&mut context)

--- a/crates/tbx-next/src/source_word.rs
+++ b/crates/tbx-next/src/source_word.rs
@@ -6,7 +6,6 @@ use crate::global_variable::GlobalVariables;
 use crate::instruction::Instruction;
 use crate::instruction_builder::{InstructionBuildError, InstructionBuildTarget};
 use crate::lexer::{LexError, Token, TokenKind};
-use crate::line_number::LocalLineNumberTable;
 use crate::name::{NameError, NormalizedName};
 use crate::operator::OperatorLookup;
 use crate::source::{SourceError, SourceId, SourceSpan, SourceView};
@@ -35,11 +34,6 @@ impl SourceWordId {
 
 pub(crate) type NativeSourceWordHandler =
     fn(&mut NativeSourceWordContext<'_, '_>) -> Result<(), SourceWordError>;
-pub(crate) type SourceBlockStatementProcessor<'source> =
-    for<'state> fn(
-        &mut NativeSourceWordContext<'source, 'state>,
-        SourceBlockStatement<'source>,
-    ) -> Result<(), SourceWordError>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SourceWordSyntaxMarkerRole {
@@ -148,9 +142,6 @@ pub(crate) enum SourceWordError {
     DefBindingCommitInvariantViolated {
         span: SourceSpan,
     },
-    BlockStatementCompile {
-        span: SourceSpan,
-    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -203,8 +194,7 @@ impl SourceWordError {
             | Self::DefBodyCompile { span }
             | Self::DefBodyBuild { span }
             | Self::DefDefinition { span }
-            | Self::DefBindingCommitInvariantViolated { span }
-            | Self::BlockStatementCompile { span } => Some(span),
+            | Self::DefBindingCommitInvariantViolated { span } => Some(span),
             Self::DefLex { source } => match source {
                 LexError::Source(_) => None,
                 LexError::InvalidCharacter { span, .. } => Some(span),
@@ -365,10 +355,6 @@ impl<'source, 'cursor> SourceBlockReader<'source, 'cursor> {
         self.cursor.read_next_block_statement()
     }
 
-    pub(crate) fn cursor_mut(&mut self) -> &mut dyn SourceBlockCursor<'source> {
-        self.cursor
-    }
-
     pub(crate) fn next_item(&mut self) -> Result<SourceBlockItem<'source>, SourceWordError> {
         match self.next_statement()? {
             SourceBlockRead::Statement(statement) => {
@@ -386,31 +372,37 @@ impl<'source, 'cursor> SourceBlockReader<'source, 'cursor> {
         &self,
         statement: SourceBlockStatement<'source>,
     ) -> Result<Option<SourceBlockMarker<'source>>, SourceWordError> {
-        // #1513/#1516: structured matching is owner-declaration driven and
-        // complete-statement based. The outer reader must not raw-scan nested
-        // marker spellings or treat another source word's markers as its own.
-        let Some(token) = statement.standalone_name() else {
-            return Ok(None);
-        };
-        let source_name = self
-            .view
-            .slice(token.span())
-            .map_err(|source| SourceWordError::Source { source })?;
-        let Ok(name) = NormalizedName::new(source_name) else {
-            return Ok(None);
-        };
-
-        Ok(self
-            .syntax_markers
-            .iter()
-            .find(|marker| marker.name() == &name)
-            .map(|marker| SourceBlockMarker {
-                statement,
-                token,
-                name,
-                role: marker.role(),
-            }))
+        classify_source_block_marker(self.view, self.syntax_markers, statement)
     }
+}
+
+pub(crate) fn classify_source_block_marker<'source>(
+    view: SourceView<'source>,
+    syntax_markers: &[SourceWordSyntaxMarker],
+    statement: SourceBlockStatement<'source>,
+) -> Result<Option<SourceBlockMarker<'source>>, SourceWordError> {
+    // #1513/#1516: structured matching is owner-declaration driven and
+    // complete-statement based. The outer reader must not raw-scan nested
+    // marker spellings or treat another source word's markers as its own.
+    let Some(token) = statement.standalone_name() else {
+        return Ok(None);
+    };
+    let source_name = view
+        .slice(token.span())
+        .map_err(|source| SourceWordError::Source { source })?;
+    let Ok(name) = NormalizedName::new(source_name) else {
+        return Ok(None);
+    };
+
+    Ok(syntax_markers
+        .iter()
+        .find(|marker| marker.name() == &name)
+        .map(|marker| SourceBlockMarker {
+            statement,
+            token,
+            name,
+            role: marker.role(),
+        }))
 }
 
 /// Forward-only reader over the body of one completed logical statement.
@@ -526,9 +518,6 @@ pub(crate) struct NativeSourceWordContext<'source, 'state> {
     local_line_number_prefix: Option<SourceSpan>,
     globals: Option<&'state mut GlobalVariables>,
     runtime_definitions: Option<&'state mut dyn RuntimeDefinitionPublisher<'source>>,
-    line_numbers: Option<&'state mut LocalLineNumberTable>,
-    source_words: Option<SourceWordLookup<'state>>,
-    statement_processor: Option<SourceBlockStatementProcessor<'source>>,
 }
 
 pub(crate) struct NativeSourceWordContextParts<'source, 'state> {
@@ -542,9 +531,6 @@ pub(crate) struct NativeSourceWordContextParts<'source, 'state> {
     pub(crate) local_line_number_prefix: Option<SourceSpan>,
     pub(crate) globals: Option<&'state mut GlobalVariables>,
     pub(crate) runtime_definitions: Option<&'state mut dyn RuntimeDefinitionPublisher<'source>>,
-    pub(crate) line_numbers: Option<&'state mut LocalLineNumberTable>,
-    pub(crate) source_words: Option<SourceWordLookup<'state>>,
-    pub(crate) statement_processor: Option<SourceBlockStatementProcessor<'source>>,
 }
 
 impl<'source, 'state> NativeSourceWordContext<'source, 'state> {
@@ -567,9 +553,6 @@ impl<'source, 'state> NativeSourceWordContext<'source, 'state> {
             local_line_number_prefix: parts.local_line_number_prefix,
             globals: parts.globals,
             runtime_definitions: parts.runtime_definitions,
-            line_numbers: parts.line_numbers,
-            source_words: parts.source_words,
-            statement_processor: parts.statement_processor,
         }
     }
 
@@ -591,27 +574,6 @@ impl<'source, 'state> NativeSourceWordContext<'source, 'state> {
 
     pub(crate) fn block_reader_mut(&mut self) -> Option<&mut SourceBlockReader<'source, 'state>> {
         self.block_reader.as_mut()
-    }
-
-    pub(crate) fn process_next_block_item(
-        &mut self,
-    ) -> Result<SourceBlockItem<'source>, SourceWordError> {
-        let Some(reader) = &mut self.block_reader else {
-            return Err(SourceWordError::UnsupportedSourceWord {
-                span: self.source_word_token.span(),
-            });
-        };
-        let item = reader.next_item()?;
-        let SourceBlockItem::Statement(statement) = item else {
-            return Ok(item);
-        };
-        let Some(process_statement) = self.statement_processor else {
-            return Err(SourceWordError::UnsupportedSourceWord {
-                span: statement.span(),
-            });
-        };
-        process_statement(self, statement)?;
-        Ok(SourceBlockItem::Statement(statement))
     }
 
     pub(crate) const fn local_line_number_prefix(&self) -> Option<SourceSpan> {
@@ -762,45 +724,11 @@ impl<'source, 'state> NativeSourceWordContext<'source, 'state> {
             NativeSourceWordBindingAccess::Write(bindings) => bindings,
         }
     }
-
-    pub(crate) fn compile_access(&mut self) -> NativeSourceWordCompileAccess<'_, 'source> {
-        NativeSourceWordCompileAccess {
-            bindings: match &mut self.bindings {
-                NativeSourceWordBindingAccess::Read(bindings) => {
-                    NativeSourceWordBindingAccess::Read(bindings)
-                }
-                NativeSourceWordBindingAccess::Write(bindings) => {
-                    NativeSourceWordBindingAccess::Write(bindings)
-                }
-            },
-            operators: self.operators,
-            code: &mut *self.code,
-            globals: self.globals.as_deref_mut(),
-            line_numbers: self.line_numbers.as_deref_mut(),
-            source_words: self.source_words,
-            statement_processor: self.statement_processor,
-            cursor: self
-                .block_reader
-                .as_mut()
-                .map(SourceBlockReader::cursor_mut),
-        }
-    }
 }
 
 pub(crate) enum NativeSourceWordBindingAccess<'a> {
     Read(&'a Bindings),
     Write(&'a mut Bindings),
-}
-
-pub(crate) struct NativeSourceWordCompileAccess<'state, 'source> {
-    pub(crate) bindings: NativeSourceWordBindingAccess<'state>,
-    pub(crate) operators: Option<OperatorLookup>,
-    pub(crate) code: &'state mut dyn InstructionBuildTarget,
-    pub(crate) globals: Option<&'state mut GlobalVariables>,
-    pub(crate) line_numbers: Option<&'state mut LocalLineNumberTable>,
-    pub(crate) source_words: Option<SourceWordLookup<'state>>,
-    pub(crate) statement_processor: Option<SourceBlockStatementProcessor<'source>>,
-    pub(crate) cursor: Option<&'state mut dyn SourceBlockCursor<'source>>,
 }
 
 pub(crate) fn var_source_word(
@@ -1147,9 +1075,6 @@ mod tests {
             local_line_number_prefix: None,
             globals: None,
             runtime_definitions: None,
-            line_numbers: None,
-            source_words: None,
-            statement_processor: None,
         });
 
         let first_body_token = context
@@ -1355,9 +1280,6 @@ mod tests {
                 local_line_number_prefix: None,
                 globals: None,
                 runtime_definitions: None,
-                line_numbers: None,
-                source_words: None,
-                statement_processor: None,
             });
 
             push_one(&mut context).expect("test source word should emit");
@@ -1393,9 +1315,6 @@ mod tests {
                     local_line_number_prefix: None,
                     globals: Some(&mut globals),
                     runtime_definitions: None,
-                    line_numbers: None,
-                    source_words: None,
-                    statement_processor: None,
                 });
 
                 var_source_word(&mut context)


### PR DESCRIPTION
## 状態

**#1542 / #1543 により置換。マージしない。**

#1534 / 本PRの実装・レビュー過程で、根拠ADR #1533 に structured source word の継続状態の寿命、入れ子、marker 配送、completion 境界に関する設計不足があることが判明した。

#1542 で構造化ソースワード一般の継続処理モデルを再設計して採用し、#1533 を置換した。実装は新しい issue #1543 で行う。

本PRの差分は #1543 へそのまま引き継ぐ前提とはせず、#1542 / #1543 に照らして必要な部分だけ再利用可否を判断する。

旧対応issue: #1534
置換ADR: #1542
置換実装issue: #1543

---

## 旧 Summary

- structured block body の通常 statement を source processor 側で処理する限定 hook を追加
- nested source word を通常 binding resolution / handler dispatch 経由で起動し、outer cursor 継続と owner marker 分離を維持
- runtime word、VAR publication、same-owner / different-owner nested source word、nested lexical failure 優先の回帰テストを追加

## Verification

- `cargo test -p tbx-next --no-fail-fast`
- `cargo clippy -p tbx-next --all-targets --all-features -- -D warnings`
- `cargo ci-fmt`
- `cargo ci-clippy`
- `cargo ci-test`
