### PR TITLE
TBX Next: 構造化ソースワードの最内側owner処理を統合

### DIFF
--- a/crates/tbx-next/src/block_code.rs
+++ b/crates/tbx-next/src/block_code.rs
@@ -13,6 +13,20 @@ pub(crate) struct BlockCodeBuilder<'a> {
     unresolved_patches: Vec<InstructionAddress>,
 }
 
+/// Owned variant of `BlockCodeBuilder` for processor-managed nested contexts.
+///
+/// Structured source words need a build destination that can live in an owner
+/// frame across multiple statements. The borrow-based `BlockCodeBuilder` stays
+/// the ordinary boundary; this owned form preserves the same local block
+/// contract without giving source-word handlers cursor traversal or parent
+/// target access.
+#[derive(Debug)]
+pub(crate) struct OwnedBlockCodeBuilder {
+    code: SourceMappedCode,
+    block_start: InstructionAddress,
+    unresolved_patches: Vec<InstructionAddress>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct CompletedBlockCode {
     entry: InstructionAddress,
@@ -187,6 +201,157 @@ impl<'a> BlockCodeBuilder<'a> {
 
         self.unresolved_patches.push(branch);
         Ok(branch)
+    }
+}
+
+impl OwnedBlockCodeBuilder {
+    pub(crate) fn new() -> Self {
+        let code = SourceMappedCode::new();
+        let block_start = InstructionAddress::from_index(code.len());
+        Self {
+            code,
+            block_start,
+            unresolved_patches: Vec::new(),
+        }
+    }
+
+    pub(crate) fn current_address(&self) -> InstructionAddress {
+        InstructionAddress::from_index(self.code.len())
+    }
+
+    pub(crate) fn current_len(&self) -> usize {
+        self.code.len()
+    }
+
+    pub(crate) fn append_mapped(
+        &mut self,
+        instruction: Instruction,
+        span: SourceSpan,
+    ) -> Result<InstructionAddress, BlockCodeBuildError> {
+        reject_direct_branch_instruction(instruction)?;
+        self.code
+            .append_mapped(instruction, span)
+            .map_err(|source| BlockCodeBuildError::SourceMappingAppend { source })
+    }
+
+    pub(crate) fn append_unmapped(
+        &mut self,
+        instruction: Instruction,
+    ) -> Result<InstructionAddress, BlockCodeBuildError> {
+        reject_direct_branch_instruction(instruction)?;
+        self.code
+            .append_unmapped(instruction)
+            .map_err(|source| BlockCodeBuildError::SourceMappingAppend { source })
+    }
+
+    pub(crate) fn append_resolved_mapped(
+        &mut self,
+        instruction: Instruction,
+        span: SourceSpan,
+    ) -> Result<InstructionAddress, BlockCodeBuildError> {
+        self.code
+            .append_mapped(instruction, span)
+            .map_err(|source| BlockCodeBuildError::SourceMappingAppend { source })
+    }
+
+    pub(crate) fn append_resolved_unmapped(
+        &mut self,
+        instruction: Instruction,
+    ) -> Result<InstructionAddress, BlockCodeBuildError> {
+        self.code
+            .append_unmapped(instruction)
+            .map_err(|source| BlockCodeBuildError::SourceMappingAppend { source })
+    }
+
+    pub(crate) fn append_mapped_jump_placeholder(
+        &mut self,
+        span: SourceSpan,
+    ) -> Result<InstructionAddress, BlockCodeBuildError> {
+        self.append_branch_placeholder(
+            Instruction::Jump(InstructionAddress::from_index(0)),
+            Some(span),
+        )
+    }
+
+    pub(crate) fn append_mapped_jump_if_zero_placeholder(
+        &mut self,
+        span: SourceSpan,
+    ) -> Result<InstructionAddress, BlockCodeBuildError> {
+        self.append_branch_placeholder(
+            Instruction::JumpIfZero(InstructionAddress::from_index(0)),
+            Some(span),
+        )
+    }
+
+    pub(crate) fn patch_branch_target(
+        &mut self,
+        branch: InstructionAddress,
+        target: InstructionAddress,
+    ) -> Result<(), BlockCodeBuildError> {
+        self.validate_local_target(branch)?;
+        self.validate_local_target(target)?;
+        let Some(position) = self
+            .unresolved_patches
+            .iter()
+            .position(|pending| *pending == branch)
+        else {
+            return Err(BlockCodeBuildError::UnknownBranchPatch { branch });
+        };
+
+        self.code
+            .patch_branch_target(branch, target)
+            .map_err(|source| BlockCodeBuildError::BranchTargetPatch { source })?;
+
+        self.unresolved_patches.swap_remove(position);
+        Ok(())
+    }
+
+    pub(crate) fn validate_local_target(
+        &self,
+        address: InstructionAddress,
+    ) -> Result<(), BlockCodeBuildError> {
+        if address.as_index() < self.block_start.as_index() || address.as_index() >= self.code.len()
+        {
+            return Err(BlockCodeBuildError::AddressOutsideCurrentBlock { address });
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn finish(
+        self,
+    ) -> Result<(SourceMappedCode, CompletedBlockCode), BlockCodeBuildError> {
+        if let Some(branch) = self.unresolved_patches.first().copied() {
+            return Err(BlockCodeBuildError::UnresolvedBranchPatch { branch });
+        }
+
+        let completed = CompletedBlockCode {
+            entry: self.block_start,
+            end: self.current_address(),
+        };
+        Ok((self.code, completed))
+    }
+
+    fn append_branch_placeholder(
+        &mut self,
+        instruction: Instruction,
+        span: Option<SourceSpan>,
+    ) -> Result<InstructionAddress, BlockCodeBuildError> {
+        let branch = if let Some(span) = span {
+            self.code.append_mapped(instruction, span)
+        } else {
+            self.code.append_unmapped(instruction)
+        }
+        .map_err(|source| BlockCodeBuildError::SourceMappingAppend { source })?;
+
+        self.unresolved_patches.push(branch);
+        Ok(branch)
+    }
+}
+
+impl Default for OwnedBlockCodeBuilder {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/crates/tbx-next/src/bootstrap.rs
+++ b/crates/tbx-next/src/bootstrap.rs
@@ -2,9 +2,12 @@ use crate::binding::{Binding, BindingInsertError, Bindings};
 use crate::global_variable::{GlobalVarId, GlobalVariables};
 use crate::name::NormalizedName;
 use crate::source_word::{
-    def_source_word, let_source_word, var_source_word, NativeSourceWordHandler, SourceWordId,
-    SourceWordRegistry, SourceWordSyntaxMarker,
+    def_source_word, let_source_word, syntax_markers_for_grammar, var_source_word,
+    NativeSourceWordHandler, NativeStructuredSourceWordMarkerHandler,
+    NativeStructuredSourceWordStartHandler, SourceWordId, SourceWordRegistry,
+    SourceWordSyntaxMarker,
 };
+use crate::structured_grammar::StructuredGrammar;
 use crate::word::{CompletedWordDefinition, PrimitiveId, PublishedWords, WordId};
 
 const BUILTIN_GLOBAL_VARIABLE_NAMES: [&str; 26] = [
@@ -122,6 +125,38 @@ pub(crate) fn register_native_source_word_with_markers(
         .map_err(SourceWordBootstrapError::from_precheck_error)?;
 
     let id = source_words.register_with_markers(handler, syntax_markers);
+
+    bindings
+        .insert_new_source_word_with_markers(name, id, &marker_names)
+        .map_err(SourceWordBootstrapError::from_binding_insert_error)?;
+
+    Ok(id)
+}
+
+pub(crate) fn register_native_structured_source_word(
+    source_words: &mut SourceWordRegistry,
+    bindings: &mut Bindings,
+    name: NormalizedName,
+    grammar: StructuredGrammar,
+    start_handler: NativeStructuredSourceWordStartHandler,
+    marker_handler: NativeStructuredSourceWordMarkerHandler,
+    completion_handler: NativeStructuredSourceWordMarkerHandler,
+) -> Result<SourceWordId, SourceWordBootstrapError> {
+    let marker_names = syntax_markers_for_grammar(&grammar)
+        .iter()
+        .map(|marker| marker.name().clone())
+        .collect::<Vec<_>>();
+
+    bindings
+        .validate_new_source_word_with_markers(&name, &marker_names)
+        .map_err(SourceWordBootstrapError::from_precheck_error)?;
+
+    let id = source_words.register_structured(
+        grammar,
+        start_handler,
+        marker_handler,
+        completion_handler,
+    );
 
     bindings
         .insert_new_source_word_with_markers(name, id, &marker_names)

--- a/crates/tbx-next/src/instruction_builder.rs
+++ b/crates/tbx-next/src/instruction_builder.rs
@@ -1,4 +1,4 @@
-use crate::block_code::{BlockCodeBuildError, BlockCodeBuilder};
+use crate::block_code::{BlockCodeBuildError, BlockCodeBuilder, OwnedBlockCodeBuilder};
 use crate::instruction::{Instruction, InstructionAddress};
 use crate::published_code::{PublishedWordBuilder, WordBodyBuildError};
 use crate::source::SourceSpan;
@@ -29,6 +29,17 @@ pub(crate) trait InstructionBuildTarget {
     ) -> Result<InstructionAddress, InstructionBuildError>;
 
     fn append_unmapped(
+        &mut self,
+        instruction: Instruction,
+    ) -> Result<InstructionAddress, InstructionBuildError>;
+
+    fn append_resolved_mapped(
+        &mut self,
+        instruction: Instruction,
+        span: SourceSpan,
+    ) -> Result<InstructionAddress, InstructionBuildError>;
+
+    fn append_resolved_unmapped(
         &mut self,
         instruction: Instruction,
     ) -> Result<InstructionAddress, InstructionBuildError>;
@@ -77,6 +88,23 @@ impl InstructionBuildTarget for BlockCodeBuilder<'_> {
             .map_err(|source| InstructionBuildError::BlockCodeBuild { source })
     }
 
+    fn append_resolved_mapped(
+        &mut self,
+        instruction: Instruction,
+        span: SourceSpan,
+    ) -> Result<InstructionAddress, InstructionBuildError> {
+        BlockCodeBuilder::append_resolved_mapped(self, instruction, span)
+            .map_err(|source| InstructionBuildError::BlockCodeBuild { source })
+    }
+
+    fn append_resolved_unmapped(
+        &mut self,
+        instruction: Instruction,
+    ) -> Result<InstructionAddress, InstructionBuildError> {
+        BlockCodeBuilder::append_resolved_unmapped(self, instruction)
+            .map_err(|source| InstructionBuildError::BlockCodeBuild { source })
+    }
+
     fn append_mapped_jump_placeholder(
         &mut self,
         span: SourceSpan,
@@ -111,6 +139,79 @@ impl InstructionBuildTarget for BlockCodeBuilder<'_> {
     }
 }
 
+impl InstructionBuildTarget for OwnedBlockCodeBuilder {
+    fn current_len(&self) -> usize {
+        self.current_len()
+    }
+
+    fn append_mapped(
+        &mut self,
+        instruction: Instruction,
+        span: SourceSpan,
+    ) -> Result<InstructionAddress, InstructionBuildError> {
+        OwnedBlockCodeBuilder::append_mapped(self, instruction, span)
+            .map_err(|source| InstructionBuildError::BlockCodeBuild { source })
+    }
+
+    fn append_unmapped(
+        &mut self,
+        instruction: Instruction,
+    ) -> Result<InstructionAddress, InstructionBuildError> {
+        OwnedBlockCodeBuilder::append_unmapped(self, instruction)
+            .map_err(|source| InstructionBuildError::BlockCodeBuild { source })
+    }
+
+    fn append_resolved_mapped(
+        &mut self,
+        instruction: Instruction,
+        span: SourceSpan,
+    ) -> Result<InstructionAddress, InstructionBuildError> {
+        OwnedBlockCodeBuilder::append_resolved_mapped(self, instruction, span)
+            .map_err(|source| InstructionBuildError::BlockCodeBuild { source })
+    }
+
+    fn append_resolved_unmapped(
+        &mut self,
+        instruction: Instruction,
+    ) -> Result<InstructionAddress, InstructionBuildError> {
+        OwnedBlockCodeBuilder::append_resolved_unmapped(self, instruction)
+            .map_err(|source| InstructionBuildError::BlockCodeBuild { source })
+    }
+
+    fn append_mapped_jump_placeholder(
+        &mut self,
+        span: SourceSpan,
+    ) -> Result<InstructionAddress, InstructionBuildError> {
+        OwnedBlockCodeBuilder::append_mapped_jump_placeholder(self, span)
+            .map_err(|source| InstructionBuildError::BlockCodeBuild { source })
+    }
+
+    fn append_mapped_jump_if_zero_placeholder(
+        &mut self,
+        span: SourceSpan,
+    ) -> Result<InstructionAddress, InstructionBuildError> {
+        OwnedBlockCodeBuilder::append_mapped_jump_if_zero_placeholder(self, span)
+            .map_err(|source| InstructionBuildError::BlockCodeBuild { source })
+    }
+
+    fn patch_branch_target(
+        &mut self,
+        branch: InstructionAddress,
+        target: InstructionAddress,
+    ) -> Result<(), InstructionBuildError> {
+        OwnedBlockCodeBuilder::patch_branch_target(self, branch, target)
+            .map_err(|source| InstructionBuildError::BlockCodeBuild { source })
+    }
+
+    fn validate_local_target(
+        &self,
+        address: InstructionAddress,
+    ) -> Result<(), InstructionBuildError> {
+        OwnedBlockCodeBuilder::validate_local_target(self, address)
+            .map_err(|source| InstructionBuildError::BlockCodeBuild { source })
+    }
+}
+
 impl InstructionBuildTarget for PublishedWordBuilder<'_> {
     fn current_len(&self) -> usize {
         self.current_len()
@@ -130,6 +231,23 @@ impl InstructionBuildTarget for PublishedWordBuilder<'_> {
         instruction: Instruction,
     ) -> Result<InstructionAddress, InstructionBuildError> {
         PublishedWordBuilder::append_unmapped(self, instruction)
+            .map_err(|source| InstructionBuildError::WordBodyBuild { source })
+    }
+
+    fn append_resolved_mapped(
+        &mut self,
+        instruction: Instruction,
+        span: SourceSpan,
+    ) -> Result<InstructionAddress, InstructionBuildError> {
+        PublishedWordBuilder::append_resolved_mapped(self, instruction, span)
+            .map_err(|source| InstructionBuildError::WordBodyBuild { source })
+    }
+
+    fn append_resolved_unmapped(
+        &mut self,
+        instruction: Instruction,
+    ) -> Result<InstructionAddress, InstructionBuildError> {
+        PublishedWordBuilder::append_resolved_unmapped(self, instruction)
             .map_err(|source| InstructionBuildError::WordBodyBuild { source })
     }
 

--- a/crates/tbx-next/src/published_code.rs
+++ b/crates/tbx-next/src/published_code.rs
@@ -230,6 +230,25 @@ impl PublishedWordBuilder<'_> {
             .map_err(WordBodyBuildError::from)
     }
 
+    pub(crate) fn append_resolved_mapped(
+        &mut self,
+        instruction: Instruction,
+        span: SourceSpan,
+    ) -> Result<InstructionAddress, WordBodyBuildError> {
+        self.block
+            .append_resolved_mapped(instruction, span)
+            .map_err(WordBodyBuildError::from)
+    }
+
+    pub(crate) fn append_resolved_unmapped(
+        &mut self,
+        instruction: Instruction,
+    ) -> Result<InstructionAddress, WordBodyBuildError> {
+        self.block
+            .append_resolved_unmapped(instruction)
+            .map_err(WordBodyBuildError::from)
+    }
+
     pub(crate) fn append_mapped_jump_placeholder(
         &mut self,
         span: SourceSpan,

--- a/crates/tbx-next/src/source_processor.rs
+++ b/crates/tbx-next/src/source_processor.rs
@@ -1,5 +1,6 @@
 use crate::binding::Bindings;
 use crate::block_code::BlockCodeBuilder;
+use crate::block_code::OwnedBlockCodeBuilder;
 use crate::expression::{
     parse_expression, ExpressionError, ExpressionSyntaxErrorKind, ExpressionVariableErrorKind,
 };
@@ -28,7 +29,9 @@ use crate::source_word::{
     SourceBlockStatement, SourceBlockTerminal, SourceWordError, SourceWordId, SourceWordKind,
     SourceWordLookup, SourceWordLookupError, SourceWordSyntaxMarker,
 };
-use crate::static_quotation::{StaticQuotation, StaticQuotationBuildError};
+use crate::static_quotation::{
+    StaticQuotation, StaticQuotationAttachError, StaticQuotationBuildError,
+};
 use crate::structured_grammar::{GrammarAccept, GrammarProgress, MarkerIdentity};
 use crate::value::Value;
 use crate::vm::{ExecutionView, RunOutcome, Vm, VmError};
@@ -126,6 +129,7 @@ pub(crate) enum SourceProcessorError {
     SourceWordContextUnavailable { id: SourceWordId },
     SourceWordLookup(SourceWordLookupError),
     SourceWord(SourceWordError),
+    StaticQuotationAttach(StaticQuotationAttachError),
     Runtime(RuntimeError),
 }
 
@@ -168,6 +172,8 @@ struct StatementCompileState<'a> {
 struct StructuredSourceWordFrame {
     progress: GrammarProgress,
     syntax_markers: Vec<SourceWordSyntaxMarker>,
+    code: OwnedBlockCodeBuilder,
+    line_numbers: LocalLineNumberTable,
     state: Box<dyn NativeStructuredSourceWordState>,
     marker_handler: NativeStructuredSourceWordMarkerHandler,
     completion_handler: NativeStructuredSourceWordMarkerHandler,
@@ -175,7 +181,7 @@ struct StructuredSourceWordFrame {
 
 enum StatementCompileOutcome {
     Complete,
-    StartedStructured(StructuredSourceWordFrame),
+    StartedStructured(Box<StructuredSourceWordFrame>),
 }
 
 impl From<SourceError> for SourceProcessorError {
@@ -221,6 +227,12 @@ impl From<StaticQuotationBuildError> for SourceProcessorError {
                 Self::InstructionBuild(InstructionBuildError::BlockCodeBuild { source })
             }
         }
+    }
+}
+
+impl From<StaticQuotationAttachError> for SourceProcessorError {
+    fn from(error: StaticQuotationAttachError) -> Self {
+        Self::StaticQuotationAttach(error)
     }
 }
 
@@ -356,19 +368,18 @@ where
             continue;
         }
 
+        let mut statement_state =
+            current_statement_compile_state(code, &mut line_numbers, &mut structured_frames);
         match compile_statement(
             view,
             source_id,
             statement.tokens(),
             &mut context,
-            &mut StatementCompileState {
-                code,
-                line_numbers: &mut line_numbers,
-            },
+            &mut statement_state,
             &mut cursor,
         )? {
             StatementCompileOutcome::Complete => {}
-            StatementCompileOutcome::StartedStructured(frame) => structured_frames.push(frame),
+            StatementCompileOutcome::StartedStructured(frame) => structured_frames.push(*frame),
         }
     }
 
@@ -386,14 +397,32 @@ where
         .map_err(|source| line_number_compile_error(source).into())
 }
 
+fn current_statement_compile_state<'a>(
+    root_code: &'a mut dyn InstructionBuildTarget,
+    root_line_numbers: &'a mut LocalLineNumberTable,
+    structured_frames: &'a mut [StructuredSourceWordFrame],
+) -> StatementCompileState<'a> {
+    if let Some(frame) = structured_frames.last_mut() {
+        StatementCompileState {
+            code: &mut frame.code,
+            line_numbers: &mut frame.line_numbers,
+        }
+    } else {
+        StatementCompileState {
+            code: root_code,
+            line_numbers: root_line_numbers,
+        }
+    }
+}
+
 fn process_current_owner_marker<'source>(
     view: SourceView<'source>,
     source_id: SourceId,
     statement: SourceBlockStatement<'source>,
     structured_frames: &mut Vec<StructuredSourceWordFrame>,
-    code: &mut dyn InstructionBuildTarget,
+    root_code: &mut dyn InstructionBuildTarget,
 ) -> Result<bool, SourceProcessorError> {
-    let Some(frame) = structured_frames.last_mut() else {
+    let Some(frame) = structured_frames.last() else {
         return Ok(false);
     };
 
@@ -403,30 +432,70 @@ fn process_current_owner_marker<'source>(
 
     let marker_identity = MarkerIdentity::new(marker.name().clone());
     let marker_span = marker.span();
-    let accepted = frame.progress.accept(&marker_identity).map_err(|source| {
-        SourceWordError::StructuredGrammar {
-            span: marker_span,
-            source,
-        }
-    })?;
-    let handler = match accepted {
-        GrammarAccept::Intermediate { .. } => frame.marker_handler,
-        GrammarAccept::Terminator => frame.completion_handler,
+    let terminator = {
+        let frame = structured_frames
+            .last_mut()
+            .expect("current owner should still exist");
+        let accepted = frame.progress.accept(&marker_identity).map_err(|source| {
+            SourceWordError::StructuredGrammar {
+                span: marker_span,
+                source,
+            }
+        })?;
+        let handler = match accepted {
+            GrammarAccept::Intermediate { .. } => frame.marker_handler,
+            GrammarAccept::Terminator => frame.completion_handler,
+        };
+        let mut marker_context = NativeStructuredSourceWordMarkerContext::new(
+            view,
+            source_id,
+            marker,
+            &mut *frame.state,
+            &mut frame.code,
+        );
+        handler(&mut marker_context)?;
+        matches!(accepted, GrammarAccept::Terminator)
     };
-    let mut marker_context = NativeStructuredSourceWordMarkerContext::new(
-        view,
-        source_id,
-        marker,
-        &mut *frame.state,
-        code,
-    );
-    handler(&mut marker_context)?;
 
-    if matches!(accepted, GrammarAccept::Terminator) {
-        structured_frames.pop();
+    if terminator {
+        let quotation = complete_structured_frame(
+            structured_frames
+                .pop()
+                .expect("terminator requires a current owner frame"),
+        )?;
+        attach_to_current_target(quotation, root_code, structured_frames)?;
     }
 
     Ok(true)
+}
+
+fn complete_structured_frame(
+    mut frame: StructuredSourceWordFrame,
+) -> Result<StaticQuotation, SourceProcessorError> {
+    frame
+        .line_numbers
+        .resolve(&mut frame.code)
+        .map_err(|source| SourceProcessorError::from(line_number_compile_error(source)))?;
+    let (code, completed) = frame
+        .code
+        .finish()
+        .map_err(|source| InstructionBuildError::BlockCodeBuild { source })?;
+    Ok(StaticQuotation::from_completed(code, completed))
+}
+
+fn attach_to_current_target(
+    quotation: StaticQuotation,
+    root_code: &mut dyn InstructionBuildTarget,
+    structured_frames: &mut [StructuredSourceWordFrame],
+) -> Result<(), SourceProcessorError> {
+    let target: &mut dyn InstructionBuildTarget = if let Some(frame) = structured_frames.last_mut()
+    {
+        &mut frame.code
+    } else {
+        root_code
+    };
+    quotation.attach_to_target(target)?;
+    Ok(())
 }
 
 fn compile_statement<'source, S>(
@@ -635,6 +704,7 @@ where
             Ok(Some(StatementCompileOutcome::Complete))
         }
         SourceWordKind::Structured(structured) => {
+            let mut structured_code = OwnedBlockCodeBuilder::new();
             let mut source_word_context =
                 NativeSourceWordContext::new(NativeSourceWordContextParts {
                     view,
@@ -645,22 +715,24 @@ where
                     block_reader: None,
                     bindings: binding_access,
                     operators,
-                    code,
+                    code: &mut structured_code,
                     local_line_number_prefix,
                     globals,
                     runtime_definitions,
                 });
             let start_handler = structured.start_handler();
             let state = start_handler(&mut source_word_context)?;
-            Ok(Some(StatementCompileOutcome::StartedStructured(
+            Ok(Some(StatementCompileOutcome::StartedStructured(Box::new(
                 StructuredSourceWordFrame {
                     progress: structured.grammar().start(),
                     syntax_markers,
+                    code: structured_code,
+                    line_numbers: LocalLineNumberTable::new(),
                     state,
                     marker_handler: structured.marker_handler(),
                     completion_handler: structured.completion_handler(),
                 },
-            )))
+            ))))
         }
     }
 }
@@ -1422,6 +1494,17 @@ impl<'a> DefinitionBodyCompileContext<'a> {
         }
     }
 
+    pub(crate) const fn with_source_words(
+        bindings: &'a Bindings,
+        source_words: SourceWordLookup<'a>,
+    ) -> Self {
+        Self {
+            bindings,
+            operators: None,
+            source_words: Some(source_words),
+        }
+    }
+
     pub(crate) const fn with_source_words_and_operators(
         bindings: &'a Bindings,
         source_words: SourceWordLookup<'a>,
@@ -1449,6 +1532,17 @@ impl<'a> QuotationBodyCompileContext<'a> {
             bindings,
             operators: Some(operators),
             source_words: None,
+        }
+    }
+
+    pub(crate) const fn with_source_words(
+        bindings: &'a Bindings,
+        source_words: SourceWordLookup<'a>,
+    ) -> Self {
+        Self {
+            bindings,
+            operators: None,
+            source_words: Some(source_words),
         }
     }
 
@@ -1729,7 +1823,10 @@ impl<'a> SourceExecutionContext<'a> {
 impl SourceProcessorError {
     fn primary_span(&self) -> Option<SourceSpan> {
         match self {
-            Self::Source(_) | Self::CodeSpaceLookup(_) | Self::SourceMappingLookup(_) => None,
+            Self::Source(_)
+            | Self::CodeSpaceLookup(_)
+            | Self::SourceMappingLookup(_)
+            | Self::StaticQuotationAttach(_) => None,
             Self::Lex(error) => match error {
                 LexError::Source(_) => None,
                 LexError::InvalidCharacter { span, .. } => Some(*span),
@@ -5545,6 +5642,59 @@ mod tests {
     }
 
     #[test]
+    fn structured_body_statement_stays_owner_local_until_successful_completion() {
+        let mut source_words = SourceWordRegistry::new();
+        let mut bindings = Bindings::new();
+        register_native_structured_source_word(
+            &mut source_words,
+            &mut bindings,
+            name("BOX"),
+            structured_grammar(Vec::new(), "ENDBOX"),
+            start_structured_fixture,
+            handle_structured_marker_fixture,
+            complete_structured_fixture,
+        )
+        .expect("structured source word should register");
+        register_native_source_word(
+            &mut source_words,
+            &mut bindings,
+            name("SOURCE_MARKER"),
+            emit_source_word_marker,
+        )
+        .expect("source word should register");
+        let (sources, source_id) = source("BOX\nSOURCE_MARKER\nENDBOX FAIL");
+        let segmented =
+            SegmentedSource::collect(sources.view(), source_id).expect("source should segment");
+        let mut parent_code = SourceMappedCode::new();
+        let error = {
+            let mut parent_builder = BlockCodeBuilder::new(&mut parent_code);
+            let error = compile_statements(
+                sources.view(),
+                source_id,
+                segmented.completed_statements(),
+                segmented.terminal(),
+                SourceCompileContext::with_source_words(&bindings, source_words.lookup()),
+                &mut parent_builder,
+            )
+            .expect_err("completion failure should reject the structured instance");
+            assert_eq!(
+                parent_builder.current_len(),
+                0,
+                "body instructions must remain owner-local until completion succeeds"
+            );
+            error
+        };
+
+        assert_eq!(
+            error,
+            SourceProcessorError::SourceWord(SourceWordError::UnsupportedSourceWord {
+                span: span(sources.view(), source_id, 25, 29)
+            })
+        );
+        assert_eq!(parent_code.len(), 0);
+    }
+
+    #[test]
     fn nested_same_owner_structured_words_suspend_and_resume_parent() {
         let mut source_words = SourceWordRegistry::new();
         let mut bindings = Bindings::new();
@@ -5735,6 +5885,36 @@ mod tests {
                 span: span(sources.view(), source_id, 11, 15)
             })
         );
+    }
+
+    #[test]
+    fn structured_child_in_quotation_context_does_not_gain_publication_capability() {
+        let mut source_words = SourceWordRegistry::new();
+        let mut bindings = Bindings::new();
+        let globals = GlobalVariables::new();
+        register_builtin_source_words(&mut source_words, &mut bindings)
+            .expect("built-in source words should bootstrap");
+        register_native_structured_source_word(
+            &mut source_words,
+            &mut bindings,
+            name("BOX"),
+            structured_grammar(Vec::new(), "ENDBOX"),
+            start_structured_fixture,
+            handle_structured_marker_fixture,
+            complete_structured_fixture,
+        )
+        .expect("structured source word should register");
+        let (_sources, _source_id, error) = compile_quotation_error(
+            "BOX\nVAR SCORE\nENDBOX",
+            QuotationBodyCompileContext::with_source_words(&bindings, source_words.lookup()),
+        );
+
+        assert_eq!(
+            error,
+            SourceProcessorError::SourceWord(SourceWordError::VarPublicationContextUnavailable)
+        );
+        assert!(bindings.get(&name("SCORE")).is_none());
+        assert!(globals.is_empty());
     }
 
     #[test]

--- a/crates/tbx-next/src/source_processor.rs
+++ b/crates/tbx-next/src/source_processor.rs
@@ -21,12 +21,15 @@ use crate::source_mapping::{
     InstructionSourceMappingView, SourceMappedCode, SourceMappingLookup, SourceMappingLookupError,
 };
 use crate::source_word::{
-    NativeSourceWordBindingAccess, NativeSourceWordContext, NativeSourceWordContextParts,
+    classify_source_block_marker, NativeSourceWordBindingAccess, NativeSourceWordContext,
+    NativeSourceWordContextParts, NativeStructuredSourceWordMarkerContext,
+    NativeStructuredSourceWordMarkerHandler, NativeStructuredSourceWordState,
     RuntimeDefinitionPublisher, SourceBlockCursor, SourceBlockRead, SourceBlockReader,
-    SourceBlockStatement, SourceBlockTerminal, SourceWordError, SourceWordId, SourceWordLookup,
-    SourceWordLookupError,
+    SourceBlockStatement, SourceBlockTerminal, SourceWordError, SourceWordId, SourceWordKind,
+    SourceWordLookup, SourceWordLookupError, SourceWordSyntaxMarker,
 };
 use crate::static_quotation::{StaticQuotation, StaticQuotationBuildError};
+use crate::structured_grammar::{GrammarAccept, GrammarProgress, MarkerIdentity};
 use crate::value::Value;
 use crate::vm::{ExecutionView, RunOutcome, Vm, VmError};
 use crate::word::{PublishedWords, WordId};
@@ -160,6 +163,19 @@ type OptionalLineNumberPrefix = Option<(LocalLineNumber, SourceSpan)>;
 struct StatementCompileState<'a> {
     code: &'a mut dyn InstructionBuildTarget,
     line_numbers: &'a mut LocalLineNumberTable,
+}
+
+struct StructuredSourceWordFrame {
+    progress: GrammarProgress,
+    syntax_markers: Vec<SourceWordSyntaxMarker>,
+    state: Box<dyn NativeStructuredSourceWordState>,
+    marker_handler: NativeStructuredSourceWordMarkerHandler,
+    completion_handler: NativeStructuredSourceWordMarkerHandler,
+}
+
+enum StatementCompileOutcome {
+    Complete,
+    StartedStructured(StructuredSourceWordFrame),
 }
 
 impl From<SourceError> for SourceProcessorError {
@@ -326,9 +342,21 @@ where
 {
     let mut line_numbers = LocalLineNumberTable::new();
     let mut cursor = LogicalStatementCursor::new(view, source_id, statements, terminal);
+    let mut structured_frames = Vec::new();
 
     while let Some(statement) = cursor.next_completed_statement() {
-        compile_statement(
+        let block_statement = cursor.block_statement(statement)?;
+        if process_current_owner_marker(
+            view,
+            source_id,
+            block_statement,
+            &mut structured_frames,
+            code,
+        )? {
+            continue;
+        }
+
+        match compile_statement(
             view,
             source_id,
             statement.tokens(),
@@ -338,12 +366,67 @@ where
                 line_numbers: &mut line_numbers,
             },
             &mut cursor,
-        )?;
+        )? {
+            StatementCompileOutcome::Complete => {}
+            StatementCompileOutcome::StartedStructured(frame) => structured_frames.push(frame),
+        }
+    }
+
+    if structured_frames.last().is_some() {
+        match terminal {
+            Terminal::Eof { span } => {
+                return Err(SourceWordError::StructuredMissingTerminator { span }.into());
+            }
+            Terminal::LexError(error) => return Err(error.into()),
+        }
     }
 
     line_numbers
         .resolve(code)
         .map_err(|source| line_number_compile_error(source).into())
+}
+
+fn process_current_owner_marker<'source>(
+    view: SourceView<'source>,
+    source_id: SourceId,
+    statement: SourceBlockStatement<'source>,
+    structured_frames: &mut Vec<StructuredSourceWordFrame>,
+    code: &mut dyn InstructionBuildTarget,
+) -> Result<bool, SourceProcessorError> {
+    let Some(frame) = structured_frames.last_mut() else {
+        return Ok(false);
+    };
+
+    let Some(marker) = classify_source_block_marker(view, statement, &frame.syntax_markers)? else {
+        return Ok(false);
+    };
+
+    let marker_identity = MarkerIdentity::new(marker.name().clone());
+    let marker_span = marker.span();
+    let accepted = frame.progress.accept(&marker_identity).map_err(|source| {
+        SourceWordError::StructuredGrammar {
+            span: marker_span,
+            source,
+        }
+    })?;
+    let handler = match accepted {
+        GrammarAccept::Intermediate { .. } => frame.marker_handler,
+        GrammarAccept::Terminator => frame.completion_handler,
+    };
+    let mut marker_context = NativeStructuredSourceWordMarkerContext::new(
+        view,
+        source_id,
+        marker,
+        &mut *frame.state,
+        code,
+    );
+    handler(&mut marker_context)?;
+
+    if matches!(accepted, GrammarAccept::Terminator) {
+        structured_frames.pop();
+    }
+
+    Ok(true)
 }
 
 fn compile_statement<'source, S>(
@@ -353,18 +436,18 @@ fn compile_statement<'source, S>(
     context: &mut SourceCompileContext<'_>,
     state: &mut StatementCompileState<'_>,
     cursor: &mut LogicalStatementCursor<'source, 'source, S>,
-) -> Result<(), SourceProcessorError>
+) -> Result<StatementCompileOutcome, SourceProcessorError>
 where
     S: LogicalStatementView,
 {
     if statement.is_empty() {
-        return Ok(());
+        return Ok(StatementCompileOutcome::Complete);
     }
 
     let (line_number, body) = split_statement_line_number(view, statement)?;
     let start = state.code.current_address();
     let local_line_number_prefix = line_number.map(|(_, span)| span);
-    compile_statement_body(
+    let outcome = compile_statement_body(
         view,
         source_id,
         body,
@@ -378,10 +461,10 @@ where
         state
             .line_numbers
             .define(state.code, line_number, start, span)
-            .map_err(|source| line_number_compile_error(source).into())
-    } else {
-        Ok(())
+            .map_err(|source| SourceProcessorError::from(line_number_compile_error(source)))?;
     }
+
+    Ok(outcome)
 }
 
 fn split_statement_line_number<'a>(
@@ -426,26 +509,27 @@ fn compile_statement_body<'source, S>(
     local_line_number_prefix: Option<SourceSpan>,
     state: &mut StatementCompileState<'_>,
     cursor: &mut LogicalStatementCursor<'source, 'source, S>,
-) -> Result<(), SourceProcessorError>
+) -> Result<StatementCompileOutcome, SourceProcessorError>
 where
     S: LogicalStatementView,
 {
     let Some((&first, _)) = tokens.split_first() else {
-        return Ok(());
+        return Ok(StatementCompileOutcome::Complete);
     };
 
     if is_bif_keyword(view, first)? {
-        return compile_bif(
+        compile_bif(
             view,
             source_id,
             tokens,
             context,
             state.code,
             state.line_numbers,
-        );
+        )?;
+        return Ok(StatementCompileOutcome::Complete);
     }
 
-    if compile_statement_leading_source_word(
+    if let Some(outcome) = compile_statement_leading_source_word(
         view,
         source_id,
         tokens,
@@ -454,7 +538,7 @@ where
         state.code,
         cursor,
     )? {
-        return Ok(());
+        return Ok(outcome);
     }
 
     if contains_expression_syntax(tokens) {
@@ -465,7 +549,8 @@ where
         .into());
     }
 
-    compile_simple_tokens(view, tokens, context, state.code)
+    compile_simple_tokens(view, tokens, context, state.code)?;
+    Ok(StatementCompileOutcome::Complete)
 }
 
 fn compile_statement_leading_source_word<'source, S>(
@@ -476,22 +561,22 @@ fn compile_statement_leading_source_word<'source, S>(
     local_line_number_prefix: Option<SourceSpan>,
     code: &mut dyn InstructionBuildTarget,
     cursor: &mut LogicalStatementCursor<'source, 'source, S>,
-) -> Result<bool, SourceProcessorError>
+) -> Result<Option<StatementCompileOutcome>, SourceProcessorError>
 where
     S: LogicalStatementView,
 {
     let Some(first) = tokens.first().copied() else {
-        return Ok(false);
+        return Ok(None);
     };
     if first.kind() != TokenKind::Name {
-        return Ok(false);
+        return Ok(None);
     }
 
     let source_name = view.slice(first.span())?;
     let binding = match resolve_binding_name(context.bindings(), source_name) {
         Ok(binding) => binding,
         Err(WordResolutionError::InvalidWordName | WordResolutionError::UndefinedName) => {
-            return Ok(false);
+            return Ok(None);
         }
         Err(WordResolutionError::TargetIsNotWord) => {
             unreachable!("binding-kind resolution does not classify published bindings as non-word")
@@ -499,13 +584,13 @@ where
     };
 
     let ResolvedBinding::SourceWord(id) = binding else {
-        return Ok(false);
+        return Ok(None);
     };
     let Some(source_words) = context.source_words() else {
         return Err(SourceProcessorError::SourceWordContextUnavailable { id });
     };
-    let handler = source_words.lookup_handler(id)?;
-    let syntax_markers = source_words.syntax_markers(id)?;
+    let syntax_markers = source_words.syntax_markers(id)?.to_vec();
+    let source_word_kind = source_words.kind(id)?;
     let operators = context.operators();
     let globals = context.globals.as_deref_mut();
     let mut runtime_publisher =
@@ -527,20 +612,57 @@ where
         BindingAccess::Read(bindings) => NativeSourceWordBindingAccess::Read(bindings),
         BindingAccess::Write(bindings) => NativeSourceWordBindingAccess::Write(bindings),
     };
-    let mut source_word_context = NativeSourceWordContext::new(NativeSourceWordContextParts {
-        view,
-        source_id,
-        tokens,
-        block_reader: Some(SourceBlockReader::new(view, cursor, syntax_markers)),
-        bindings: binding_access,
-        operators,
-        code,
-        local_line_number_prefix,
-        globals,
-        runtime_definitions,
-    });
-    handler(&mut source_word_context)?;
-    Ok(true)
+    match source_word_kind {
+        SourceWordKind::OneShot(handler) => {
+            let mut source_word_context =
+                NativeSourceWordContext::new(NativeSourceWordContextParts {
+                    view,
+                    source_id,
+                    tokens,
+                    block_reader: Some(SourceBlockReader::new(
+                        view,
+                        cursor,
+                        syntax_markers.as_slice(),
+                    )),
+                    bindings: binding_access,
+                    operators,
+                    code,
+                    local_line_number_prefix,
+                    globals,
+                    runtime_definitions,
+                });
+            handler(&mut source_word_context)?;
+            Ok(Some(StatementCompileOutcome::Complete))
+        }
+        SourceWordKind::Structured(structured) => {
+            let mut source_word_context =
+                NativeSourceWordContext::new(NativeSourceWordContextParts {
+                    view,
+                    source_id,
+                    tokens,
+                    // #1546 keeps structured starter validation statement-local:
+                    // source traversal remains owned by the source processor.
+                    block_reader: None,
+                    bindings: binding_access,
+                    operators,
+                    code,
+                    local_line_number_prefix,
+                    globals,
+                    runtime_definitions,
+                });
+            let start_handler = structured.start_handler();
+            let state = start_handler(&mut source_word_context)?;
+            Ok(Some(StatementCompileOutcome::StartedStructured(
+                StructuredSourceWordFrame {
+                    progress: structured.grammar().start(),
+                    syntax_markers,
+                    state,
+                    marker_handler: structured.marker_handler(),
+                    completion_handler: structured.completion_handler(),
+                },
+            )))
+        }
+    }
 }
 
 fn compile_simple_tokens(
@@ -1036,6 +1158,19 @@ impl<'source, 'statements, S> LogicalStatementCursor<'source, 'statements, S> {
         self.position += 1;
         Some(statement)
     }
+
+    fn block_statement(
+        &self,
+        statement: &'statements S,
+    ) -> Result<SourceBlockStatement<'statements>, SourceWordError>
+    where
+        S: LogicalStatementView,
+    {
+        let span = statement
+            .span(self.view, self.source_id)
+            .map_err(|source| SourceWordError::Source { source })?;
+        Ok(SourceBlockStatement::new(statement.tokens(), span))
+    }
 }
 
 impl<'statements, S> SourceBlockCursor<'statements> for LogicalStatementCursor<'_, 'statements, S>
@@ -1052,13 +1187,7 @@ where
             }));
         };
 
-        let span = statement
-            .span(self.view, self.source_id)
-            .map_err(|source| SourceWordError::Source { source })?;
-        Ok(SourceBlockRead::Statement(SourceBlockStatement::new(
-            statement.tokens(),
-            span,
-        )))
+        Ok(SourceBlockRead::Statement(self.block_statement(statement)?))
     }
 }
 
@@ -1673,7 +1802,8 @@ mod tests {
     use crate::binding::{Binding, Bindings};
     use crate::bootstrap::{
         register_builtin_global_variables, register_builtin_source_words,
-        register_native_source_word, register_native_source_word_with_markers, register_primitive,
+        register_native_source_word, register_native_source_word_with_markers,
+        register_native_structured_source_word, register_primitive,
     };
     use crate::global_variable::{GlobalVarId, GlobalVariables};
     use crate::instruction::InstructionSequence;
@@ -1688,8 +1818,12 @@ mod tests {
         InstructionSourceMapping, SourceMappingLookup, SourceMappingLookupError,
     };
     use crate::source_word::{
-        DefSyntaxErrorKind, LetSyntaxErrorKind, NativeSourceWordContext, SourceBlockItem,
+        DefSyntaxErrorKind, LetSyntaxErrorKind, NativeSourceWordContext,
+        NativeStructuredSourceWordMarkerContext, NativeStructuredSourceWordState, SourceBlockItem,
         SourceWordRegistry, SourceWordSyntaxMarker, SourceWordSyntaxMarkerRole, VarSyntaxErrorKind,
+    };
+    use crate::structured_grammar::{
+        GrammarProgressError, MarkerCardinality, MarkerGroup, MarkerIdentity, StructuredGrammar,
     };
     use crate::word::{CompletedWordDefinition, PrimitiveId, PublishedWords, WordId};
     use crate::word_lookup::PublishedWordLookup;
@@ -2266,6 +2400,63 @@ mod tests {
 
     fn marker(input: &str, role: SourceWordSyntaxMarkerRole) -> SourceWordSyntaxMarker {
         SourceWordSyntaxMarker::new(name(input), role)
+    }
+
+    fn marker_identity(input: &str) -> MarkerIdentity {
+        MarkerIdentity::new(name(input))
+    }
+
+    fn marker_group(input: &str, cardinality: MarkerCardinality) -> MarkerGroup {
+        MarkerGroup::new(marker_identity(input), cardinality)
+    }
+
+    fn structured_grammar(groups: Vec<MarkerGroup>, terminator: &str) -> StructuredGrammar {
+        StructuredGrammar::new(groups, Some(marker_identity(terminator)))
+            .expect("test structured grammar should be valid")
+    }
+
+    #[derive(Debug)]
+    struct TestStructuredState {
+        marker_count: i16,
+    }
+
+    impl NativeStructuredSourceWordState for TestStructuredState {
+        fn as_any(&mut self) -> &mut dyn std::any::Any {
+            self
+        }
+    }
+
+    fn start_structured_fixture(
+        context: &mut NativeSourceWordContext<'_, '_>,
+    ) -> Result<Box<dyn NativeStructuredSourceWordState>, SourceWordError> {
+        assert!(
+            context.block_reader_mut().is_none(),
+            "structured starters must not receive cursor traversal"
+        );
+        let first = context.source_word_token();
+        context.append_mapped(Instruction::Push(value(40)), first.span())?;
+        Ok(Box::new(TestStructuredState { marker_count: 0 }))
+    }
+
+    fn handle_structured_marker_fixture(
+        context: &mut NativeStructuredSourceWordMarkerContext<'_, '_>,
+    ) -> Result<(), SourceWordError> {
+        let remaining_len = context.remaining_tokens().len() as i16;
+        let state = context
+            .state_mut::<TestStructuredState>()
+            .expect("test structured state should downcast");
+        state.marker_count += 1;
+        let emitted = 10 + state.marker_count + remaining_len;
+        context.append_mapped(Instruction::Push(value(emitted)), context.marker().span())
+    }
+
+    fn complete_structured_fixture(
+        context: &mut NativeStructuredSourceWordMarkerContext<'_, '_>,
+    ) -> Result<(), SourceWordError> {
+        if let Some(token) = context.remaining_tokens().first().copied() {
+            return Err(SourceWordError::UnsupportedSourceWord { span: token.span() });
+        }
+        context.append_mapped(Instruction::Push(value(30)), context.marker().span())
     }
 
     fn completed_primitive(slot: usize) -> CompletedWordDefinition {
@@ -5285,6 +5476,264 @@ mod tests {
         assert_eq!(
             unit.instructions().get(address(1)),
             Ok(&Instruction::Push(value(99)))
+        );
+    }
+
+    #[test]
+    fn structured_source_word_processes_body_marker_completion_and_resume_in_source_order() {
+        let mut source_words = SourceWordRegistry::new();
+        let mut bindings = Bindings::new();
+        register_native_structured_source_word(
+            &mut source_words,
+            &mut bindings,
+            name("STRUCT"),
+            structured_grammar(
+                vec![marker_group("PART", MarkerCardinality::ZeroOrMore)],
+                "ENDSTRUCT",
+            ),
+            start_structured_fixture,
+            handle_structured_marker_fixture,
+            complete_structured_fixture,
+        )
+        .expect("structured source word should register");
+        register_native_source_word(
+            &mut source_words,
+            &mut bindings,
+            name("SOURCE_MARKER"),
+            emit_source_word_marker,
+        )
+        .expect("source word should register");
+        let mut words = PublishedWords::new();
+        let primitive = words.add(completed_primitive(0));
+        bindings
+            .insert_new(name("PUSH7"), Binding::Word(primitive))
+            .expect("runtime word should register");
+        let (sources, source_id) = source("STRUCT\nPUSH7\nPART BODY\nENDSTRUCT\nSOURCE_MARKER");
+
+        let unit = compile_source(
+            sources.view(),
+            source_id,
+            SourceCompileContext::with_source_words(&bindings, source_words.lookup()),
+        )
+        .expect("structured source should compile");
+
+        assert_eq!(
+            unit.instructions().get(address(0)),
+            Ok(&Instruction::Push(value(40)))
+        );
+        assert_eq!(
+            unit.instructions().get(address(1)),
+            Ok(&Instruction::Call(primitive))
+        );
+        assert_eq!(
+            unit.instructions().get(address(2)),
+            Ok(&Instruction::Push(value(12)))
+        );
+        assert_eq!(
+            unit.instructions().get(address(3)),
+            Ok(&Instruction::Push(value(30)))
+        );
+        assert_eq!(
+            unit.instructions().get(address(4)),
+            Ok(&Instruction::Push(value(99)))
+        );
+        assert_eq!(unit.instructions().get(address(5)), Ok(&Instruction::Halt));
+        assert_eq!(
+            unit.source_span(location(&unit, 2)),
+            Ok(Some(span(sources.view(), source_id, 13, 22)))
+        );
+    }
+
+    #[test]
+    fn nested_same_owner_structured_words_suspend_and_resume_parent() {
+        let mut source_words = SourceWordRegistry::new();
+        let mut bindings = Bindings::new();
+        register_native_structured_source_word(
+            &mut source_words,
+            &mut bindings,
+            name("BOX"),
+            structured_grammar(
+                vec![marker_group("CUT", MarkerCardinality::ZeroOrMore)],
+                "ENDBOX",
+            ),
+            start_structured_fixture,
+            handle_structured_marker_fixture,
+            complete_structured_fixture,
+        )
+        .expect("structured source word should register");
+        let (sources, source_id) = source("BOX\nBOX\nCUT\nENDBOX\nCUT\nENDBOX");
+
+        let unit = compile_source(
+            sources.view(),
+            source_id,
+            SourceCompileContext::with_source_words(&bindings, source_words.lookup()),
+        )
+        .expect("nested structured source should compile");
+
+        assert_eq!(
+            (0..6)
+                .map(|index| unit.instructions().get(address(index)).copied())
+                .collect::<Result<Vec<_>, _>>()
+                .expect("instructions should exist"),
+            [
+                Instruction::Push(value(40)),
+                Instruction::Push(value(40)),
+                Instruction::Push(value(11)),
+                Instruction::Push(value(30)),
+                Instruction::Push(value(11)),
+                Instruction::Push(value(30)),
+            ]
+        );
+    }
+
+    #[test]
+    fn current_owner_marker_grammar_error_does_not_fallback_to_normal_statement() {
+        let mut source_words = SourceWordRegistry::new();
+        let mut bindings = Bindings::new();
+        register_native_structured_source_word(
+            &mut source_words,
+            &mut bindings,
+            name("IFX"),
+            structured_grammar(
+                vec![marker_group("ELSE", MarkerCardinality::Optional)],
+                "ENDIF",
+            ),
+            start_structured_fixture,
+            handle_structured_marker_fixture,
+            complete_structured_fixture,
+        )
+        .expect("structured source word should register");
+        let (sources, source_id) = source("IFX\nELSE\nELSE\nENDIF");
+
+        let error = compile_source(
+            sources.view(),
+            source_id,
+            SourceCompileContext::with_source_words(&bindings, source_words.lookup()),
+        )
+        .expect_err("second ELSE should be rejected by structured grammar");
+
+        assert_eq!(
+            error,
+            SourceProcessorError::SourceWord(SourceWordError::StructuredGrammar {
+                span: span(sources.view(), source_id, 9, 13),
+                source: GrammarProgressError::CardinalityExceeded { group_index: 0 }
+            })
+        );
+    }
+
+    #[test]
+    fn child_processing_does_not_classify_ancestor_marker() {
+        let mut source_words = SourceWordRegistry::new();
+        let mut bindings = Bindings::new();
+        register_native_structured_source_word(
+            &mut source_words,
+            &mut bindings,
+            name("OUTER"),
+            structured_grammar(Vec::new(), "OUT_END"),
+            start_structured_fixture,
+            handle_structured_marker_fixture,
+            complete_structured_fixture,
+        )
+        .expect("outer source word should register");
+        register_native_structured_source_word(
+            &mut source_words,
+            &mut bindings,
+            name("INNER"),
+            structured_grammar(Vec::new(), "IN_END"),
+            start_structured_fixture,
+            handle_structured_marker_fixture,
+            complete_structured_fixture,
+        )
+        .expect("inner source word should register");
+        let (sources, source_id) = source("OUTER\nINNER\nOUT_END\nIN_END\nOUT_END");
+
+        let error = compile_source(
+            sources.view(),
+            source_id,
+            SourceCompileContext::with_source_words(&bindings, source_words.lookup()),
+        )
+        .expect_err("ancestor marker should be an ordinary child-body statement");
+
+        assert_eq!(
+            error,
+            SourceProcessorError::Compile(CompileError {
+                span: span(sources.view(), source_id, 12, 19),
+                kind: CompileErrorKind::WordResolution {
+                    source: WordResolutionError::UndefinedName
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn eof_reports_missing_terminator_for_innermost_structured_owner() {
+        let mut source_words = SourceWordRegistry::new();
+        let mut bindings = Bindings::new();
+        register_native_structured_source_word(
+            &mut source_words,
+            &mut bindings,
+            name("OUTER"),
+            structured_grammar(Vec::new(), "OUT_END"),
+            start_structured_fixture,
+            handle_structured_marker_fixture,
+            complete_structured_fixture,
+        )
+        .expect("outer source word should register");
+        register_native_structured_source_word(
+            &mut source_words,
+            &mut bindings,
+            name("INNER"),
+            structured_grammar(Vec::new(), "IN_END"),
+            start_structured_fixture,
+            handle_structured_marker_fixture,
+            complete_structured_fixture,
+        )
+        .expect("inner source word should register");
+        let (sources, source_id) = source("OUTER\nINNER");
+
+        let error = compile_source(
+            sources.view(),
+            source_id,
+            SourceCompileContext::with_source_words(&bindings, source_words.lookup()),
+        )
+        .expect_err("innermost unfinished owner should report missing terminator");
+
+        assert_eq!(
+            error,
+            SourceProcessorError::SourceWord(SourceWordError::StructuredMissingTerminator {
+                span: span(sources.view(), source_id, 11, 11)
+            })
+        );
+    }
+
+    #[test]
+    fn legal_terminator_owner_completion_failure_keeps_structured_instance_failed() {
+        let mut source_words = SourceWordRegistry::new();
+        let mut bindings = Bindings::new();
+        register_native_structured_source_word(
+            &mut source_words,
+            &mut bindings,
+            name("BOX"),
+            structured_grammar(Vec::new(), "ENDBOX"),
+            start_structured_fixture,
+            handle_structured_marker_fixture,
+            complete_structured_fixture,
+        )
+        .expect("structured source word should register");
+        let (sources, source_id) = source("BOX\nENDBOX FAIL\nENDBOX");
+
+        let error = compile_source(
+            sources.view(),
+            source_id,
+            SourceCompileContext::with_source_words(&bindings, source_words.lookup()),
+        )
+        .expect_err("terminator payload should fail owner completion");
+
+        assert_eq!(
+            error,
+            SourceProcessorError::SourceWord(SourceWordError::UnsupportedSourceWord {
+                span: span(sources.view(), source_id, 11, 15)
+            })
         );
     }
 

--- a/crates/tbx-next/src/source_word.rs
+++ b/crates/tbx-next/src/source_word.rs
@@ -9,6 +9,7 @@ use crate::lexer::{LexError, Token, TokenKind};
 use crate::name::{NameError, NormalizedName};
 use crate::operator::OperatorLookup;
 use crate::source::{SourceError, SourceId, SourceSpan, SourceView};
+use crate::structured_grammar::StructuredGrammar;
 use crate::word::WordId;
 use crate::word_resolution::{resolve_binding_name, ResolvedBinding, WordResolutionError};
 
@@ -34,6 +35,18 @@ impl SourceWordId {
 
 pub(crate) type NativeSourceWordHandler =
     fn(&mut NativeSourceWordContext<'_, '_>) -> Result<(), SourceWordError>;
+
+pub(crate) type NativeStructuredSourceWordStartHandler =
+    fn(
+        &mut NativeSourceWordContext<'_, '_>,
+    ) -> Result<Box<dyn NativeStructuredSourceWordState>, SourceWordError>;
+
+pub(crate) type NativeStructuredSourceWordMarkerHandler =
+    fn(&mut NativeStructuredSourceWordMarkerContext<'_, '_>) -> Result<(), SourceWordError>;
+
+pub(crate) trait NativeStructuredSourceWordState {
+    fn as_any(&mut self) -> &mut dyn std::any::Any;
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SourceWordSyntaxMarkerRole {
@@ -142,11 +155,19 @@ pub(crate) enum SourceWordError {
     DefBindingCommitInvariantViolated {
         span: SourceSpan,
     },
+    StructuredMissingTerminator {
+        span: SourceSpan,
+    },
+    StructuredGrammar {
+        span: SourceSpan,
+        source: crate::structured_grammar::GrammarProgressError,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SourceWordLookupError {
     InvalidSourceWordId { id: SourceWordId },
+    SourceWordKindMismatch { id: SourceWordId },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -194,7 +215,9 @@ impl SourceWordError {
             | Self::DefBodyCompile { span }
             | Self::DefBodyBuild { span }
             | Self::DefDefinition { span }
-            | Self::DefBindingCommitInvariantViolated { span } => Some(span),
+            | Self::DefBindingCommitInvariantViolated { span }
+            | Self::StructuredMissingTerminator { span }
+            | Self::StructuredGrammar { span, .. } => Some(span),
             Self::DefLex { source } => match source {
                 LexError::Source(_) => None,
                 LexError::InvalidCharacter { span, .. } => Some(span),
@@ -387,28 +410,34 @@ impl<'source, 'cursor> SourceBlockReader<'source, 'cursor> {
         // #1513/#1516: structured matching is owner-declaration driven and
         // complete-statement based. The outer reader must not raw-scan nested
         // marker spellings or treat another source word's markers as its own.
-        let Some(token) = statement.leading_name() else {
-            return Ok(None);
-        };
-        let source_name = self
-            .view
-            .slice(token.span())
-            .map_err(|source| SourceWordError::Source { source })?;
-        let Ok(name) = NormalizedName::new(source_name) else {
-            return Ok(None);
-        };
-
-        Ok(self
-            .syntax_markers
-            .iter()
-            .find(|marker| marker.name() == &name)
-            .map(|marker| SourceBlockMarker {
-                statement,
-                token,
-                name,
-                role: marker.role(),
-            }))
+        classify_source_block_marker(self.view, statement, self.syntax_markers)
     }
+}
+
+pub(crate) fn classify_source_block_marker<'source>(
+    view: SourceView<'source>,
+    statement: SourceBlockStatement<'source>,
+    syntax_markers: &[SourceWordSyntaxMarker],
+) -> Result<Option<SourceBlockMarker<'source>>, SourceWordError> {
+    let Some(token) = statement.leading_name() else {
+        return Ok(None);
+    };
+    let source_name = view
+        .slice(token.span())
+        .map_err(|source| SourceWordError::Source { source })?;
+    let Ok(name) = NormalizedName::new(source_name) else {
+        return Ok(None);
+    };
+
+    Ok(syntax_markers
+        .iter()
+        .find(|marker| marker.name() == &name)
+        .map(|marker| SourceBlockMarker {
+            statement,
+            token,
+            name,
+            role: marker.role(),
+        }))
 }
 
 /// Forward-only reader over the body of one completed logical statement.
@@ -524,6 +553,14 @@ pub(crate) struct NativeSourceWordContext<'source, 'state> {
     local_line_number_prefix: Option<SourceSpan>,
     globals: Option<&'state mut GlobalVariables>,
     runtime_definitions: Option<&'state mut dyn RuntimeDefinitionPublisher<'source>>,
+}
+
+pub(crate) struct NativeStructuredSourceWordMarkerContext<'source, 'state> {
+    view: SourceView<'source>,
+    source_id: SourceId,
+    marker: SourceBlockMarker<'source>,
+    state: &'state mut dyn NativeStructuredSourceWordState,
+    code: &'state mut dyn InstructionBuildTarget,
 }
 
 pub(crate) struct NativeSourceWordContextParts<'source, 'state> {
@@ -729,6 +766,55 @@ impl<'source, 'state> NativeSourceWordContext<'source, 'state> {
             NativeSourceWordBindingAccess::Read(bindings) => bindings,
             NativeSourceWordBindingAccess::Write(bindings) => bindings,
         }
+    }
+}
+
+impl<'source, 'state> NativeStructuredSourceWordMarkerContext<'source, 'state> {
+    pub(crate) const fn new(
+        view: SourceView<'source>,
+        source_id: SourceId,
+        marker: SourceBlockMarker<'source>,
+        state: &'state mut dyn NativeStructuredSourceWordState,
+        code: &'state mut dyn InstructionBuildTarget,
+    ) -> Self {
+        Self {
+            view,
+            source_id,
+            marker,
+            state,
+            code,
+        }
+    }
+
+    pub(crate) const fn view(&self) -> SourceView<'source> {
+        self.view
+    }
+
+    pub(crate) const fn source_id(&self) -> SourceId {
+        self.source_id
+    }
+
+    pub(crate) const fn marker(&self) -> &SourceBlockMarker<'source> {
+        &self.marker
+    }
+
+    pub(crate) fn remaining_tokens(&self) -> &'source [Token] {
+        self.marker.remaining_tokens()
+    }
+
+    pub(crate) fn state_mut<T: 'static>(&mut self) -> Option<&mut T> {
+        self.state.as_any().downcast_mut::<T>()
+    }
+
+    pub(crate) fn append_mapped(
+        &mut self,
+        instruction: Instruction,
+        span: SourceSpan,
+    ) -> Result<(), SourceWordError> {
+        self.code
+            .append_mapped(instruction, span)
+            .map(|_| ())
+            .map_err(|source| SourceWordError::InstructionBuild { source })
     }
 }
 
@@ -962,8 +1048,70 @@ pub(crate) struct SourceWordRegistry {
 
 #[derive(Debug, Clone)]
 struct SourceWordEntry {
-    handler: NativeSourceWordHandler,
+    kind: SourceWordEntryKind,
     syntax_markers: Vec<SourceWordSyntaxMarker>,
+}
+
+#[derive(Debug, Clone)]
+enum SourceWordEntryKind {
+    OneShot(NativeSourceWordHandler),
+    Structured(NativeStructuredSourceWord),
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct NativeStructuredSourceWord {
+    grammar: StructuredGrammar,
+    start_handler: NativeStructuredSourceWordStartHandler,
+    marker_handler: NativeStructuredSourceWordMarkerHandler,
+    completion_handler: NativeStructuredSourceWordMarkerHandler,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum SourceWordKind<'a> {
+    OneShot(NativeSourceWordHandler),
+    Structured(NativeStructuredSourceWordRef<'a>),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct NativeStructuredSourceWordRef<'a> {
+    grammar: &'a StructuredGrammar,
+    start_handler: NativeStructuredSourceWordStartHandler,
+    marker_handler: NativeStructuredSourceWordMarkerHandler,
+    completion_handler: NativeStructuredSourceWordMarkerHandler,
+}
+
+impl NativeStructuredSourceWord {
+    fn new(
+        grammar: StructuredGrammar,
+        start_handler: NativeStructuredSourceWordStartHandler,
+        marker_handler: NativeStructuredSourceWordMarkerHandler,
+        completion_handler: NativeStructuredSourceWordMarkerHandler,
+    ) -> Self {
+        Self {
+            grammar,
+            start_handler,
+            marker_handler,
+            completion_handler,
+        }
+    }
+}
+
+impl<'a> NativeStructuredSourceWordRef<'a> {
+    pub(crate) const fn grammar(self) -> &'a StructuredGrammar {
+        self.grammar
+    }
+
+    pub(crate) const fn start_handler(self) -> NativeStructuredSourceWordStartHandler {
+        self.start_handler
+    }
+
+    pub(crate) const fn marker_handler(self) -> NativeStructuredSourceWordMarkerHandler {
+        self.marker_handler
+    }
+
+    pub(crate) const fn completion_handler(self) -> NativeStructuredSourceWordMarkerHandler {
+        self.completion_handler
+    }
 }
 
 impl SourceWordRegistry {
@@ -982,7 +1130,28 @@ impl SourceWordRegistry {
     ) -> SourceWordId {
         let id = SourceWordId::from_slot(self.entries.len());
         self.entries.push(SourceWordEntry {
-            handler,
+            kind: SourceWordEntryKind::OneShot(handler),
+            syntax_markers,
+        });
+        id
+    }
+
+    pub(crate) fn register_structured(
+        &mut self,
+        grammar: StructuredGrammar,
+        start_handler: NativeStructuredSourceWordStartHandler,
+        marker_handler: NativeStructuredSourceWordMarkerHandler,
+        completion_handler: NativeStructuredSourceWordMarkerHandler,
+    ) -> SourceWordId {
+        let syntax_markers = syntax_markers_for_grammar(&grammar);
+        let id = SourceWordId::from_slot(self.entries.len());
+        self.entries.push(SourceWordEntry {
+            kind: SourceWordEntryKind::Structured(NativeStructuredSourceWord::new(
+                grammar,
+                start_handler,
+                marker_handler,
+                completion_handler,
+            )),
             syntax_markers,
         });
         id
@@ -1007,6 +1176,28 @@ pub(crate) struct SourceWordLookup<'a> {
 }
 
 impl<'a> SourceWordLookup<'a> {
+    pub(crate) fn kind(
+        self,
+        id: SourceWordId,
+    ) -> Result<SourceWordKind<'a>, SourceWordLookupError> {
+        let entry = self
+            .registry
+            .entries
+            .get(id.as_slot())
+            .ok_or(SourceWordLookupError::InvalidSourceWordId { id })?;
+        Ok(match &entry.kind {
+            SourceWordEntryKind::OneShot(handler) => SourceWordKind::OneShot(*handler),
+            SourceWordEntryKind::Structured(word) => {
+                SourceWordKind::Structured(NativeStructuredSourceWordRef {
+                    grammar: &word.grammar,
+                    start_handler: word.start_handler,
+                    marker_handler: word.marker_handler,
+                    completion_handler: word.completion_handler,
+                })
+            }
+        })
+    }
+
     pub(crate) fn lookup_handler(
         self,
         id: SourceWordId,
@@ -1014,8 +1205,13 @@ impl<'a> SourceWordLookup<'a> {
         self.registry
             .entries
             .get(id.as_slot())
-            .map(|entry| entry.handler)
             .ok_or(SourceWordLookupError::InvalidSourceWordId { id })
+            .and_then(|entry| match entry.kind {
+                SourceWordEntryKind::OneShot(handler) => Ok(handler),
+                SourceWordEntryKind::Structured(_) => {
+                    Err(SourceWordLookupError::SourceWordKindMismatch { id })
+                }
+            })
     }
 
     pub(crate) fn syntax_markers(
@@ -1028,6 +1224,26 @@ impl<'a> SourceWordLookup<'a> {
             .map(|entry| entry.syntax_markers.as_slice())
             .ok_or(SourceWordLookupError::InvalidSourceWordId { id })
     }
+}
+
+pub(crate) fn syntax_markers_for_grammar(
+    grammar: &StructuredGrammar,
+) -> Vec<SourceWordSyntaxMarker> {
+    let mut markers = grammar
+        .groups()
+        .iter()
+        .map(|group| {
+            SourceWordSyntaxMarker::new(
+                group.marker().name().clone(),
+                SourceWordSyntaxMarkerRole::BlockContinuation,
+            )
+        })
+        .collect::<Vec<_>>();
+    markers.push(SourceWordSyntaxMarker::new(
+        grammar.terminator().name().clone(),
+        SourceWordSyntaxMarkerRole::BlockTerminator,
+    ));
+    markers
 }
 
 #[cfg(test)]

--- a/crates/tbx-next/src/static_quotation.rs
+++ b/crates/tbx-next/src/static_quotation.rs
@@ -1,5 +1,6 @@
 use crate::block_code::{BlockCodeBuildError, BlockCodeBuilder, CompletedBlockCode};
 use crate::instruction::{Instruction, InstructionAddress, InstructionView};
+use crate::instruction_builder::{InstructionBuildError, InstructionBuildTarget};
 use crate::source::SourceSpan;
 use crate::source_mapping::{
     InstructionSourceMappingView, SourceMappedCode, SourceMappingLookupError,
@@ -28,9 +29,14 @@ pub(crate) enum StaticQuotationAttachError {
     InvalidLocalTarget { target: InstructionAddress },
     TargetRebaseOverflow { target: InstructionAddress },
     ParentAppend { source: BlockCodeBuildError },
+    TargetAppend { source: InstructionBuildError },
 }
 
 impl StaticQuotation {
+    pub(crate) fn from_completed(code: SourceMappedCode, completed: CompletedBlockCode) -> Self {
+        Self { code, completed }
+    }
+
     pub(crate) fn build(
         build: impl FnOnce(&mut BlockCodeBuilder<'_>) -> Result<(), BlockCodeBuildError>,
     ) -> Result<Self, StaticQuotationBuildError> {
@@ -80,6 +86,28 @@ impl StaticQuotation {
                 parent
                     .append_resolved_unmapped(instruction)
                     .map_err(|source| StaticQuotationAttachError::ParentAppend { source })?;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn attach_to_target(
+        &self,
+        target: &mut dyn InstructionBuildTarget,
+    ) -> Result<(), StaticQuotationAttachError> {
+        let parent_start = target.current_address();
+        let instructions = self.rebased_instructions(parent_start)?;
+
+        for MappedInstruction { instruction, span } in instructions {
+            if let Some(span) = span {
+                target
+                    .append_resolved_mapped(instruction, span)
+                    .map_err(|source| StaticQuotationAttachError::TargetAppend { source })?;
+            } else {
+                target
+                    .append_resolved_unmapped(instruction)
+                    .map_err(|source| StaticQuotationAttachError::TargetAppend { source })?;
             }
         }
 


### PR DESCRIPTION
## Summary

- Add structured source word registration alongside existing one-shot source words.
- Move current-owner marker classification, grammar progress, nesting, resume, and EOF missing-terminator handling into the source processor.
- Add integration tests for body statements, marker payload delivery, same-owner nesting, no-fallback grammar errors, ancestor marker isolation, innermost EOF errors, and completion failure.

Closes #1546

## Verification

- `cargo test -p tbx-next --no-fail-fast`
- `cargo clippy -p tbx-next --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
- `cargo ci-fmt`
- `cargo ci-clippy`
- `cargo ci-test`
