### PR TITLE
TBX Next: 構造化ソースワードをsource processorへ統合

### DIFF
--- a/crates/tbx-next/src/instruction_builder.rs
+++ b/crates/tbx-next/src/instruction_builder.rs
@@ -33,6 +33,17 @@ pub(crate) trait InstructionBuildTarget {
         instruction: Instruction,
     ) -> Result<InstructionAddress, InstructionBuildError>;
 
+    fn append_resolved_mapped(
+        &mut self,
+        instruction: Instruction,
+        span: SourceSpan,
+    ) -> Result<InstructionAddress, InstructionBuildError>;
+
+    fn append_resolved_unmapped(
+        &mut self,
+        instruction: Instruction,
+    ) -> Result<InstructionAddress, InstructionBuildError>;
+
     fn append_mapped_jump_placeholder(
         &mut self,
         span: SourceSpan,
@@ -74,6 +85,23 @@ impl InstructionBuildTarget for BlockCodeBuilder<'_> {
         instruction: Instruction,
     ) -> Result<InstructionAddress, InstructionBuildError> {
         BlockCodeBuilder::append_unmapped(self, instruction)
+            .map_err(|source| InstructionBuildError::BlockCodeBuild { source })
+    }
+
+    fn append_resolved_mapped(
+        &mut self,
+        instruction: Instruction,
+        span: SourceSpan,
+    ) -> Result<InstructionAddress, InstructionBuildError> {
+        BlockCodeBuilder::append_resolved_mapped(self, instruction, span)
+            .map_err(|source| InstructionBuildError::BlockCodeBuild { source })
+    }
+
+    fn append_resolved_unmapped(
+        &mut self,
+        instruction: Instruction,
+    ) -> Result<InstructionAddress, InstructionBuildError> {
+        BlockCodeBuilder::append_resolved_unmapped(self, instruction)
             .map_err(|source| InstructionBuildError::BlockCodeBuild { source })
     }
 
@@ -130,6 +158,23 @@ impl InstructionBuildTarget for PublishedWordBuilder<'_> {
         instruction: Instruction,
     ) -> Result<InstructionAddress, InstructionBuildError> {
         PublishedWordBuilder::append_unmapped(self, instruction)
+            .map_err(|source| InstructionBuildError::WordBodyBuild { source })
+    }
+
+    fn append_resolved_mapped(
+        &mut self,
+        instruction: Instruction,
+        span: SourceSpan,
+    ) -> Result<InstructionAddress, InstructionBuildError> {
+        PublishedWordBuilder::append_resolved_mapped(self, instruction, span)
+            .map_err(|source| InstructionBuildError::WordBodyBuild { source })
+    }
+
+    fn append_resolved_unmapped(
+        &mut self,
+        instruction: Instruction,
+    ) -> Result<InstructionAddress, InstructionBuildError> {
+        PublishedWordBuilder::append_resolved_unmapped(self, instruction)
             .map_err(|source| InstructionBuildError::WordBodyBuild { source })
     }
 

--- a/crates/tbx-next/src/published_code.rs
+++ b/crates/tbx-next/src/published_code.rs
@@ -230,6 +230,25 @@ impl PublishedWordBuilder<'_> {
             .map_err(WordBodyBuildError::from)
     }
 
+    pub(crate) fn append_resolved_mapped(
+        &mut self,
+        instruction: Instruction,
+        span: SourceSpan,
+    ) -> Result<InstructionAddress, WordBodyBuildError> {
+        self.block
+            .append_resolved_mapped(instruction, span)
+            .map_err(WordBodyBuildError::from)
+    }
+
+    pub(crate) fn append_resolved_unmapped(
+        &mut self,
+        instruction: Instruction,
+    ) -> Result<InstructionAddress, WordBodyBuildError> {
+        self.block
+            .append_resolved_unmapped(instruction)
+            .map_err(WordBodyBuildError::from)
+    }
+
     pub(crate) fn append_mapped_jump_placeholder(
         &mut self,
         span: SourceSpan,

--- a/crates/tbx-next/src/source_processor.rs
+++ b/crates/tbx-next/src/source_processor.rs
@@ -1,3 +1,6 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
 use crate::binding::Bindings;
 use crate::block_code::BlockCodeBuilder;
 use crate::expression::{
@@ -22,11 +25,14 @@ use crate::source_mapping::{
 };
 use crate::source_word::{
     NativeSourceWordBindingAccess, NativeSourceWordContext, NativeSourceWordContextParts,
-    RuntimeDefinitionPublisher, SourceBlockCursor, SourceBlockRead, SourceBlockReader,
-    SourceBlockStatement, SourceBlockTerminal, SourceWordError, SourceWordId, SourceWordLookup,
-    SourceWordLookupError,
+    NativeStructuredSourceWordContext, NativeStructuredSourceWordOwner, RuntimeDefinitionPublisher,
+    SourceBlockCursor, SourceBlockMarker, SourceBlockRead, SourceBlockReader, SourceBlockStatement,
+    SourceBlockTerminal, SourceWordDispatch, SourceWordError, SourceWordId, SourceWordLookup,
+    SourceWordLookupError, SourceWordSyntaxMarker, StructuredBodyCapabilities,
+    StructuredLineNumberScope,
 };
 use crate::static_quotation::{StaticQuotation, StaticQuotationBuildError};
+use crate::structured_grammar::{GrammarAccept, GrammarProgress, MarkerIdentity};
 use crate::value::Value;
 use crate::vm::{ExecutionView, RunOutcome, Vm, VmError};
 use crate::word::{PublishedWords, WordId};
@@ -159,7 +165,168 @@ type OptionalLineNumberPrefix = Option<(LocalLineNumber, SourceSpan)>;
 
 struct StatementCompileState<'a> {
     code: &'a mut dyn InstructionBuildTarget,
-    line_numbers: &'a mut LocalLineNumberTable,
+    line_numbers: Rc<RefCell<LocalLineNumberTable>>,
+    capabilities: StructuredBodyCapabilities,
+}
+
+struct StatementTraversal<'source, 'cursor, S> {
+    view: SourceView<'source>,
+    source_id: SourceId,
+    cursor: &'cursor mut LogicalStatementCursor<'source, 'source, S>,
+    structured_frames: &'cursor mut Vec<StructuredSourceFrame>,
+}
+
+struct StructuredSourceFrame {
+    syntax_markers: Vec<SourceWordSyntaxMarker>,
+    progress: GrammarProgress,
+    owner: Box<dyn NativeStructuredSourceWordOwner>,
+    enclosing_capabilities: StructuredBodyCapabilities,
+    body_capabilities: StructuredBodyCapabilities,
+    enclosing_line_numbers: Rc<RefCell<LocalLineNumberTable>>,
+    current_line_numbers: Rc<RefCell<LocalLineNumberTable>>,
+    owner_line_numbers: Vec<Rc<RefCell<LocalLineNumberTable>>>,
+}
+
+impl StructuredSourceFrame {
+    fn new(
+        syntax_markers: Vec<SourceWordSyntaxMarker>,
+        progress: GrammarProgress,
+        owner: Box<dyn NativeStructuredSourceWordOwner>,
+        enclosing_line_numbers: Rc<RefCell<LocalLineNumberTable>>,
+        enclosing_capabilities: StructuredBodyCapabilities,
+    ) -> Self {
+        Self {
+            syntax_markers,
+            progress,
+            owner,
+            enclosing_capabilities,
+            body_capabilities: enclosing_capabilities,
+            current_line_numbers: enclosing_line_numbers.clone(),
+            enclosing_line_numbers,
+            owner_line_numbers: Vec::new(),
+        }
+    }
+
+    fn apply_owner_context(&mut self) {
+        let context = self.owner.current_body_context();
+        self.body_capabilities = context
+            .capabilities()
+            .intersect(self.enclosing_capabilities);
+        self.current_line_numbers = match context.line_number_scope() {
+            StructuredLineNumberScope::Enclosing => self.enclosing_line_numbers.clone(),
+            StructuredLineNumberScope::OwnerLocal(index) => {
+                while self.owner_line_numbers.len() <= index {
+                    self.owner_line_numbers
+                        .push(Rc::new(RefCell::new(LocalLineNumberTable::new())));
+                }
+                self.owner_line_numbers[index].clone()
+            }
+        };
+    }
+
+    fn resolve_owner_line_numbers(
+        &self,
+        code: &mut dyn InstructionBuildTarget,
+    ) -> Result<(), SourceProcessorError> {
+        for line_numbers in &self.owner_line_numbers {
+            line_numbers
+                .borrow_mut()
+                .resolve(code)
+                .map_err(|source| SourceProcessorError::from(line_number_compile_error(source)))?;
+        }
+        Ok(())
+    }
+}
+
+fn current_processing_context(
+    structured_frames: &[StructuredSourceFrame],
+    root_line_numbers: &Rc<RefCell<LocalLineNumberTable>>,
+) -> (
+    Rc<RefCell<LocalLineNumberTable>>,
+    StructuredBodyCapabilities,
+) {
+    structured_frames.last().map_or(
+        (
+            root_line_numbers.clone(),
+            StructuredBodyCapabilities::inherit(),
+        ),
+        |frame| (frame.current_line_numbers.clone(), frame.body_capabilities),
+    )
+}
+
+fn dispatch_current_owner_marker<'source, S>(
+    view: SourceView<'source>,
+    source_id: SourceId,
+    statement: &'source S,
+    code: &mut dyn InstructionBuildTarget,
+    structured_frames: &mut Vec<StructuredSourceFrame>,
+) -> Result<bool, SourceProcessorError>
+where
+    S: LogicalStatementView,
+{
+    let Some(frame) = structured_frames.last_mut() else {
+        return Ok(false);
+    };
+    let span = statement.span(view, source_id)?;
+    let block_statement = SourceBlockStatement::new(statement.tokens(), span);
+    let Some(marker) = classify_current_owner_marker(view, block_statement, &frame.syntax_markers)?
+    else {
+        return Ok(false);
+    };
+
+    let identity = MarkerIdentity::new(marker.name().clone());
+    let accept =
+        frame
+            .progress
+            .accept(&identity)
+            .map_err(|source| SourceWordError::StructuredGrammar {
+                span: marker.span(),
+                source,
+            })?;
+
+    let mut owner_context = NativeStructuredSourceWordContext::new(view, source_id, code);
+    match accept {
+        GrammarAccept::Intermediate { .. } => {
+            frame
+                .owner
+                .accept_marker(&mut owner_context, marker, accept)?;
+            frame.apply_owner_context();
+        }
+        GrammarAccept::Terminator => {
+            frame.owner.complete(&mut owner_context, marker)?;
+        }
+    }
+
+    if matches!(accept, GrammarAccept::Terminator) {
+        let frame = structured_frames
+            .pop()
+            .expect("terminator handling requires current frame");
+        frame.resolve_owner_line_numbers(code)?;
+    }
+
+    Ok(true)
+}
+
+fn classify_current_owner_marker<'source>(
+    view: SourceView<'source>,
+    statement: SourceBlockStatement<'source>,
+    syntax_markers: &[SourceWordSyntaxMarker],
+) -> Result<Option<SourceBlockMarker<'source>>, SourceProcessorError> {
+    // #1544/#1545: only the innermost current owner's marker declarations are
+    // considered before ordinary binding dispatch. Ancestor marker spelling is
+    // intentionally invisible while a child owner is active.
+    let Some(token) = statement.leading_name() else {
+        return Ok(None);
+    };
+    let source_name = view.slice(token.span())?;
+    let Ok(name) = crate::name::NormalizedName::new(source_name) else {
+        return Ok(None);
+    };
+
+    Ok(syntax_markers
+        .iter()
+        .find(|marker| marker.name() == &name)
+        .map(|marker| SourceBlockMarker::new(statement, token, name, marker.role())))
 }
 
 impl From<SourceError> for SourceProcessorError {
@@ -324,35 +491,64 @@ fn compile_statements<'source, S>(
 where
     S: LogicalStatementView,
 {
-    let mut line_numbers = LocalLineNumberTable::new();
+    let root_line_numbers = Rc::new(RefCell::new(LocalLineNumberTable::new()));
     let mut cursor = LogicalStatementCursor::new(view, source_id, statements, terminal);
+    let mut structured_frames = Vec::new();
 
     while let Some(statement) = cursor.next_completed_statement() {
+        if dispatch_current_owner_marker(view, source_id, statement, code, &mut structured_frames)?
+        {
+            continue;
+        }
+
+        let (line_numbers, capabilities) =
+            current_processing_context(&structured_frames, &root_line_numbers);
         compile_statement(
-            view,
-            source_id,
             statement.tokens(),
             &mut context,
             &mut StatementCompileState {
                 code,
-                line_numbers: &mut line_numbers,
+                line_numbers,
+                capabilities,
             },
-            &mut cursor,
+            &mut StatementTraversal {
+                view,
+                source_id,
+                cursor: &mut cursor,
+                structured_frames: &mut structured_frames,
+            },
         )?;
     }
 
-    line_numbers
+    match terminal {
+        Terminal::Eof { span } if !structured_frames.is_empty() => {
+            return Err(SourceWordError::StructuredMissingTerminator { span }.into());
+        }
+        Terminal::LexError(error) => return Err(error.into()),
+        Terminal::Eof { .. } => {}
+    }
+
+    for frame in &structured_frames {
+        for line_numbers in &frame.owner_line_numbers {
+            line_numbers
+                .borrow_mut()
+                .resolve(code)
+                .map_err(|source| SourceProcessorError::from(line_number_compile_error(source)))?;
+        }
+    }
+
+    let result = root_line_numbers
+        .borrow_mut()
         .resolve(code)
-        .map_err(|source| line_number_compile_error(source).into())
+        .map_err(|source| SourceProcessorError::from(line_number_compile_error(source)));
+    result
 }
 
 fn compile_statement<'source, S>(
-    view: SourceView<'source>,
-    source_id: SourceId,
     statement: &'source [Token],
     context: &mut SourceCompileContext<'_>,
     state: &mut StatementCompileState<'_>,
-    cursor: &mut LogicalStatementCursor<'source, 'source, S>,
+    traversal: &mut StatementTraversal<'source, '_, S>,
 ) -> Result<(), SourceProcessorError>
 where
     S: LogicalStatementView,
@@ -361,22 +557,15 @@ where
         return Ok(());
     }
 
-    let (line_number, body) = split_statement_line_number(view, statement)?;
+    let (line_number, body) = split_statement_line_number(traversal.view, statement)?;
     let start = state.code.current_address();
     let local_line_number_prefix = line_number.map(|(_, span)| span);
-    compile_statement_body(
-        view,
-        source_id,
-        body,
-        context,
-        local_line_number_prefix,
-        state,
-        cursor,
-    )?;
+    compile_statement_body(body, context, local_line_number_prefix, state, traversal)?;
 
     if let Some((line_number, span)) = line_number {
         state
             .line_numbers
+            .borrow_mut()
             .define(state.code, line_number, start, span)
             .map_err(|source| line_number_compile_error(source).into())
     } else {
@@ -419,13 +608,11 @@ fn split_statement_line_number<'a>(
 }
 
 fn compile_statement_body<'source, S>(
-    view: SourceView<'source>,
-    source_id: SourceId,
     tokens: &'source [Token],
     context: &mut SourceCompileContext<'_>,
     local_line_number_prefix: Option<SourceSpan>,
     state: &mut StatementCompileState<'_>,
-    cursor: &mut LogicalStatementCursor<'source, 'source, S>,
+    traversal: &mut StatementTraversal<'source, '_, S>,
 ) -> Result<(), SourceProcessorError>
 where
     S: LogicalStatementView,
@@ -434,25 +621,25 @@ where
         return Ok(());
     };
 
-    if is_bif_keyword(view, first)? {
+    if is_bif_keyword(traversal.view, first)? {
         return compile_bif(
-            view,
-            source_id,
+            traversal.view,
+            traversal.source_id,
             tokens,
             context,
             state.code,
-            state.line_numbers,
+            &mut state.line_numbers.borrow_mut(),
         );
     }
 
     if compile_statement_leading_source_word(
-        view,
-        source_id,
         tokens,
         context,
         local_line_number_prefix,
         state.code,
-        cursor,
+        traversal,
+        state.line_numbers.clone(),
+        state.capabilities,
     )? {
         return Ok(());
     }
@@ -465,17 +652,17 @@ where
         .into());
     }
 
-    compile_simple_tokens(view, tokens, context, state.code)
+    compile_simple_tokens(traversal.view, tokens, context, state.code)
 }
 
 fn compile_statement_leading_source_word<'source, S>(
-    view: SourceView<'source>,
-    source_id: SourceId,
     tokens: &'source [Token],
     context: &mut SourceCompileContext<'_>,
     local_line_number_prefix: Option<SourceSpan>,
     code: &mut dyn InstructionBuildTarget,
-    cursor: &mut LogicalStatementCursor<'source, 'source, S>,
+    traversal: &mut StatementTraversal<'source, '_, S>,
+    current_line_numbers: Rc<RefCell<LocalLineNumberTable>>,
+    current_capabilities: StructuredBodyCapabilities,
 ) -> Result<bool, SourceProcessorError>
 where
     S: LogicalStatementView,
@@ -487,7 +674,7 @@ where
         return Ok(false);
     }
 
-    let source_name = view.slice(first.span())?;
+    let source_name = traversal.view.slice(first.span())?;
     let binding = match resolve_binding_name(context.bindings(), source_name) {
         Ok(binding) => binding,
         Err(WordResolutionError::InvalidWordName | WordResolutionError::UndefinedName) => {
@@ -504,34 +691,51 @@ where
     let Some(source_words) = context.source_words() else {
         return Err(SourceProcessorError::SourceWordContextUnavailable { id });
     };
-    let handler = source_words.lookup_handler(id)?;
+    let dispatch = source_words.lookup_dispatch(id)?;
     let syntax_markers = source_words.syntax_markers(id)?;
     let operators = context.operators();
-    let globals = context.globals.as_deref_mut();
-    let mut runtime_publisher =
-        context
-            .runtime_definitions
-            .as_mut()
-            .map(|publication| RuntimeDefinitionPublisherAdapter {
-                view,
-                source_id,
-                operators,
-                source_words,
-                code: &mut *publication.code,
-                words: &mut *publication.words,
-            });
+    let globals = context
+        .globals
+        .as_deref_mut()
+        .filter(|_| current_capabilities.allows_publication());
+    let mut runtime_publisher = context
+        .runtime_definitions
+        .as_mut()
+        .filter(|_| current_capabilities.allows_publication())
+        .map(|publication| RuntimeDefinitionPublisherAdapter {
+            view: traversal.view,
+            source_id: traversal.source_id,
+            operators,
+            source_words,
+            code: &mut *publication.code,
+            words: &mut *publication.words,
+        });
     let runtime_definitions = runtime_publisher
         .as_mut()
         .map(|publisher| publisher as &mut dyn RuntimeDefinitionPublisher<'source>);
-    let binding_access = match &mut context.bindings {
-        BindingAccess::Read(bindings) => NativeSourceWordBindingAccess::Read(bindings),
-        BindingAccess::Write(bindings) => NativeSourceWordBindingAccess::Write(bindings),
+    let binding_access = if current_capabilities.allows_publication() {
+        match &mut context.bindings {
+            BindingAccess::Read(bindings) => NativeSourceWordBindingAccess::Read(bindings),
+            BindingAccess::Write(bindings) => NativeSourceWordBindingAccess::Write(bindings),
+        }
+    } else {
+        match &mut context.bindings {
+            BindingAccess::Read(bindings) => NativeSourceWordBindingAccess::Read(bindings),
+            BindingAccess::Write(bindings) => NativeSourceWordBindingAccess::Read(bindings),
+        }
     };
     let mut source_word_context = NativeSourceWordContext::new(NativeSourceWordContextParts {
-        view,
-        source_id,
+        view: traversal.view,
+        source_id: traversal.source_id,
         tokens,
-        block_reader: Some(SourceBlockReader::new(view, cursor, syntax_markers)),
+        block_reader: match dispatch {
+            SourceWordDispatch::OneShot(_) => Some(SourceBlockReader::new(
+                traversal.view,
+                traversal.cursor,
+                syntax_markers,
+            )),
+            SourceWordDispatch::Structured { .. } => None,
+        },
         bindings: binding_access,
         operators,
         code,
@@ -539,7 +743,21 @@ where
         globals,
         runtime_definitions,
     });
-    handler(&mut source_word_context)?;
+    match dispatch {
+        SourceWordDispatch::OneShot(handler) => handler(&mut source_word_context)?,
+        SourceWordDispatch::Structured { start, grammar } => {
+            let instance = start(&mut source_word_context)?;
+            let mut frame = StructuredSourceFrame::new(
+                syntax_markers.to_vec(),
+                grammar.start(),
+                instance.into_owner(),
+                current_line_numbers,
+                current_capabilities,
+            );
+            frame.apply_owner_context();
+            traversal.structured_frames.push(frame);
+        }
+    }
     Ok(true)
 }
 
@@ -1688,8 +1906,14 @@ mod tests {
         InstructionSourceMapping, SourceMappingLookup, SourceMappingLookupError,
     };
     use crate::source_word::{
-        DefSyntaxErrorKind, LetSyntaxErrorKind, NativeSourceWordContext, SourceBlockItem,
-        SourceWordRegistry, SourceWordSyntaxMarker, SourceWordSyntaxMarkerRole, VarSyntaxErrorKind,
+        DefSyntaxErrorKind, LetSyntaxErrorKind, NativeSourceWordContext,
+        NativeStructuredSourceWordContext, NativeStructuredSourceWordOwner, SourceBlockItem,
+        SourceBlockMarker, SourceWordRegistry, SourceWordSyntaxMarker, SourceWordSyntaxMarkerRole,
+        StructuredBodyCapabilities, StructuredBodyContext, StructuredLineNumberScope,
+        StructuredSourceWordInstance, VarSyntaxErrorKind,
+    };
+    use crate::structured_grammar::{
+        MarkerCardinality, MarkerGroup, MarkerIdentity, StructuredGrammar,
     };
     use crate::word::{CompletedWordDefinition, PrimitiveId, PublishedWords, WordId};
     use crate::word_lookup::PublishedWordLookup;
@@ -2052,6 +2276,144 @@ mod tests {
             });
         };
         context.append_mapped(Instruction::Push(value(2)), statement.span())
+    }
+
+    #[derive(Debug)]
+    struct StructuredProbeOwner {
+        body_contexts: Vec<StructuredBodyContext>,
+        context_index: usize,
+        marker_value: i16,
+        complete_value: i16,
+    }
+
+    impl StructuredProbeOwner {
+        fn inherited() -> Self {
+            Self {
+                body_contexts: vec![StructuredBodyContext::inherited()],
+                context_index: 0,
+                marker_value: 20,
+                complete_value: 30,
+            }
+        }
+
+        fn without_publication() -> Self {
+            Self {
+                body_contexts: vec![StructuredBodyContext::new(
+                    StructuredLineNumberScope::Enclosing,
+                    StructuredBodyCapabilities::without_publication(),
+                )],
+                context_index: 0,
+                marker_value: 20,
+                complete_value: 30,
+            }
+        }
+
+        fn split_line_number_scopes() -> Self {
+            Self {
+                body_contexts: vec![
+                    StructuredBodyContext::new(
+                        StructuredLineNumberScope::OwnerLocal(0),
+                        StructuredBodyCapabilities::inherit(),
+                    ),
+                    StructuredBodyContext::new(
+                        StructuredLineNumberScope::OwnerLocal(1),
+                        StructuredBodyCapabilities::inherit(),
+                    ),
+                ],
+                context_index: 0,
+                marker_value: 20,
+                complete_value: 30,
+            }
+        }
+    }
+
+    impl NativeStructuredSourceWordOwner for StructuredProbeOwner {
+        fn current_body_context(&self) -> StructuredBodyContext {
+            self.body_contexts[self.context_index]
+        }
+
+        fn accept_marker(
+            &mut self,
+            context: &mut NativeStructuredSourceWordContext<'_, '_>,
+            marker: SourceBlockMarker<'_>,
+            _accept: GrammarAccept,
+        ) -> Result<(), SourceWordError> {
+            context.append_mapped(Instruction::Push(value(self.marker_value)), marker.span())?;
+            self.context_index = (self.context_index + 1).min(self.body_contexts.len() - 1);
+            Ok(())
+        }
+
+        fn complete(
+            &mut self,
+            context: &mut NativeStructuredSourceWordContext<'_, '_>,
+            marker: SourceBlockMarker<'_>,
+        ) -> Result<(), SourceWordError> {
+            context.append_mapped(Instruction::Push(value(self.complete_value)), marker.span())
+        }
+    }
+
+    fn start_structured_probe(
+        context: &mut NativeSourceWordContext<'_, '_>,
+    ) -> Result<StructuredSourceWordInstance, SourceWordError> {
+        assert!(context.block_reader_mut().is_none());
+        context.append_mapped(
+            Instruction::Push(value(10)),
+            context.source_word_token().span(),
+        )?;
+        Ok(StructuredSourceWordInstance::new(Box::new(
+            StructuredProbeOwner::inherited(),
+        )))
+    }
+
+    fn start_no_publication_probe(
+        _context: &mut NativeSourceWordContext<'_, '_>,
+    ) -> Result<StructuredSourceWordInstance, SourceWordError> {
+        Ok(StructuredSourceWordInstance::new(Box::new(
+            StructuredProbeOwner::without_publication(),
+        )))
+    }
+
+    fn start_split_scope_probe(
+        context: &mut NativeSourceWordContext<'_, '_>,
+    ) -> Result<StructuredSourceWordInstance, SourceWordError> {
+        context.append_mapped(
+            Instruction::Push(value(10)),
+            context.source_word_token().span(),
+        )?;
+        Ok(StructuredSourceWordInstance::new(Box::new(
+            StructuredProbeOwner::split_line_number_scopes(),
+        )))
+    }
+
+    fn structured_grammar(
+        groups: Vec<(&str, MarkerCardinality)>,
+        terminator: &str,
+    ) -> StructuredGrammar {
+        StructuredGrammar::new(
+            groups
+                .into_iter()
+                .map(|(marker_name, cardinality)| {
+                    MarkerGroup::new(MarkerIdentity::new(name(marker_name)), cardinality)
+                })
+                .collect(),
+            Some(MarkerIdentity::new(name(terminator))),
+        )
+        .expect("test grammar should be valid")
+    }
+
+    fn register_structured_probe(
+        source_words: &mut SourceWordRegistry,
+        bindings: &mut Bindings,
+        word_name: &str,
+        start: crate::source_word::NativeStructuredSourceWordStartHandler,
+        markers: Vec<SourceWordSyntaxMarker>,
+        grammar: StructuredGrammar,
+    ) -> SourceWordId {
+        let id = source_words.register_structured(start, grammar, markers);
+        bindings
+            .insert_new(name(word_name), Binding::SourceWord(id))
+            .expect("structured source word binding should register");
+        id
     }
 
     fn compile_with_var(
@@ -5249,6 +5611,222 @@ mod tests {
             error,
             SourceProcessorError::Lex(LexError::InvalidCharacter { .. })
         ));
+    }
+
+    #[test]
+    fn structured_source_word_body_uses_processor_owned_forward_traversal() {
+        let mut words = PublishedWords::new();
+        let mut bindings = Bindings::new();
+        let body_word = publish_initial(&mut words, &mut bindings, "BODY", completed_primitive(7));
+        let mut source_words = SourceWordRegistry::new();
+        register_structured_probe(
+            &mut source_words,
+            &mut bindings,
+            "BLOCK",
+            start_structured_probe,
+            vec![marker("END", SourceWordSyntaxMarkerRole::BlockTerminator)],
+            structured_grammar(Vec::new(), "END"),
+        );
+        let (sources, source_id) = source("BLOCK\nBODY\nEND");
+
+        let unit = compile_source(
+            sources.view(),
+            source_id,
+            SourceCompileContext::with_source_words(&bindings, source_words.lookup()),
+        )
+        .expect("structured source word should compile");
+
+        assert_eq!(
+            unit.instructions().get(address(0)),
+            Ok(&Instruction::Push(value(10)))
+        );
+        assert_eq!(
+            unit.instructions().get(address(1)),
+            Ok(&Instruction::Call(body_word))
+        );
+        assert_eq!(
+            unit.instructions().get(address(2)),
+            Ok(&Instruction::Push(value(30)))
+        );
+        assert_eq!(unit.instructions().get(address(3)), Ok(&Instruction::Halt));
+    }
+
+    #[test]
+    fn structured_current_owner_marker_uses_grammar_without_binding_fallback() {
+        let mut source_words = SourceWordRegistry::new();
+        let mut bindings = Bindings::new();
+        register_structured_probe(
+            &mut source_words,
+            &mut bindings,
+            "BLOCK",
+            start_structured_probe,
+            vec![
+                marker("ELSE", SourceWordSyntaxMarkerRole::BlockContinuation),
+                marker("END", SourceWordSyntaxMarkerRole::BlockTerminator),
+            ],
+            structured_grammar(vec![("ELSE", MarkerCardinality::Optional)], "END"),
+        );
+        let (sources, source_id) = source("BLOCK\nELSE\nELSE\nEND");
+
+        let error = compile_source(
+            sources.view(),
+            source_id,
+            SourceCompileContext::with_source_words(&bindings, source_words.lookup()),
+        )
+        .expect_err("second optional marker should be a grammar error");
+
+        assert_eq!(
+            error,
+            SourceProcessorError::SourceWord(SourceWordError::StructuredGrammar {
+                span: span(sources.view(), source_id, 11, 15),
+                source: crate::structured_grammar::GrammarProgressError::CardinalityExceeded {
+                    group_index: 0
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn nested_structured_source_word_isolates_ancestor_markers_until_child_completes() {
+        let mut words = PublishedWords::new();
+        let mut bindings = Bindings::new();
+        let outer_end_word =
+            publish_initial(&mut words, &mut bindings, "OUT_END", completed_primitive(8));
+        let mut source_words = SourceWordRegistry::new();
+        register_structured_probe(
+            &mut source_words,
+            &mut bindings,
+            "OUTER",
+            start_structured_probe,
+            vec![marker(
+                "OUT_END",
+                SourceWordSyntaxMarkerRole::BlockTerminator,
+            )],
+            structured_grammar(Vec::new(), "OUT_END"),
+        );
+        register_structured_probe(
+            &mut source_words,
+            &mut bindings,
+            "INNER",
+            start_structured_probe,
+            vec![marker(
+                "IN_END",
+                SourceWordSyntaxMarkerRole::BlockTerminator,
+            )],
+            structured_grammar(Vec::new(), "IN_END"),
+        );
+        let (sources, source_id) = source("OUTER\nINNER\nOUT_END\nIN_END\nOUT_END");
+
+        let unit = compile_source(
+            sources.view(),
+            source_id,
+            SourceCompileContext::with_source_words(&bindings, source_words.lookup()),
+        )
+        .expect("nested structured source words should compile");
+
+        assert_eq!(
+            unit.instructions().get(address(0)),
+            Ok(&Instruction::Push(value(10)))
+        );
+        assert_eq!(
+            unit.instructions().get(address(1)),
+            Ok(&Instruction::Push(value(10)))
+        );
+        assert_eq!(
+            unit.instructions().get(address(2)),
+            Ok(&Instruction::Call(outer_end_word))
+        );
+        assert_eq!(
+            unit.instructions().get(address(3)),
+            Ok(&Instruction::Push(value(30)))
+        );
+        assert_eq!(
+            unit.instructions().get(address(4)),
+            Ok(&Instruction::Push(value(30)))
+        );
+    }
+
+    #[test]
+    fn structured_body_context_can_remove_publication_capability() {
+        let mut source_words = SourceWordRegistry::new();
+        let mut bindings = Bindings::new();
+        let mut globals = GlobalVariables::new();
+        register_builtin_source_words(&mut source_words, &mut bindings)
+            .expect("built-in source words should bootstrap");
+        register_structured_probe(
+            &mut source_words,
+            &mut bindings,
+            "BLOCK",
+            start_no_publication_probe,
+            vec![marker("END", SourceWordSyntaxMarkerRole::BlockTerminator)],
+            structured_grammar(Vec::new(), "END"),
+        );
+        let (sources, source_id) = source("BLOCK\nVAR A\nEND");
+
+        let error = compile_source(
+            sources.view(),
+            source_id,
+            SourceCompileContext::with_source_word_publication(
+                &mut bindings,
+                source_words.lookup(),
+                &mut globals,
+            ),
+        )
+        .expect_err("body VAR should fail through capability, not spelling special-case");
+
+        assert_eq!(
+            error,
+            SourceProcessorError::SourceWord(SourceWordError::VarPublicationContextUnavailable)
+        );
+        assert_eq!(bindings.get(&name("A")), None);
+        assert_eq!(globals.len(), 0);
+    }
+
+    #[test]
+    fn structured_marker_can_switch_owner_local_line_number_scope() {
+        let mut words = PublishedWords::new();
+        let mut primitives = PrimitiveRegistry::new();
+        let mut bindings = Bindings::new();
+        let operators = register_operator_primitives(&mut primitives, &mut words);
+        publish_initial(&mut words, &mut bindings, "BODY", completed_primitive(7));
+        let mut source_words = SourceWordRegistry::new();
+        register_structured_probe(
+            &mut source_words,
+            &mut bindings,
+            "BLOCK",
+            start_split_scope_probe,
+            vec![
+                marker("ELSE", SourceWordSyntaxMarkerRole::BlockContinuation),
+                marker("END", SourceWordSyntaxMarkerRole::BlockTerminator),
+            ],
+            structured_grammar(vec![("ELSE", MarkerCardinality::Optional)], "END"),
+        );
+        let (sources, source_id) =
+            source("BLOCK\n10 BODY\nBIF 1, 10\nELSE\n10 BODY\nBIF 1, 10\nEND");
+
+        let unit = compile_source(
+            sources.view(),
+            source_id,
+            SourceCompileContext::with_source_words_and_operators(
+                &bindings,
+                source_words.lookup(),
+                operators.lookup(),
+            ),
+        )
+        .expect("same local line number should be valid in separate owner scopes");
+
+        assert_eq!(
+            unit.instructions().get(address(0)),
+            Ok(&Instruction::Push(value(10)))
+        );
+        assert_eq!(
+            unit.instructions().get(address(4)),
+            Ok(&Instruction::Push(value(20)))
+        );
+        assert_eq!(
+            unit.instructions().get(address(8)),
+            Ok(&Instruction::Push(value(30)))
+        );
     }
 
     #[test]

--- a/crates/tbx-next/src/source_processor.rs
+++ b/crates/tbx-next/src/source_processor.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use crate::binding::Bindings;
-use crate::block_code::BlockCodeBuilder;
+use crate::block_code::{BlockCodeBuildError, BlockCodeBuilder};
 use crate::expression::{
     parse_expression, ExpressionError, ExpressionSyntaxErrorKind, ExpressionVariableErrorKind,
 };
@@ -29,7 +29,7 @@ use crate::source_word::{
     SourceBlockCursor, SourceBlockMarker, SourceBlockRead, SourceBlockReader, SourceBlockStatement,
     SourceBlockTerminal, SourceWordDispatch, SourceWordError, SourceWordId, SourceWordLookup,
     SourceWordLookupError, SourceWordSyntaxMarker, StructuredBodyCapabilities,
-    StructuredLineNumberScope,
+    StructuredBuildTargetScope, StructuredLineNumberScope,
 };
 use crate::static_quotation::{StaticQuotation, StaticQuotationBuildError};
 use crate::structured_grammar::{GrammarAccept, GrammarProgress, MarkerIdentity};
@@ -167,6 +167,7 @@ struct StatementCompileState<'a> {
     code: &'a mut dyn InstructionBuildTarget,
     line_numbers: Rc<RefCell<LocalLineNumberTable>>,
     capabilities: StructuredBodyCapabilities,
+    target: BuildTargetHandle,
 }
 
 struct StatementTraversal<'source, 'cursor, S> {
@@ -180,11 +181,36 @@ struct StructuredSourceFrame {
     syntax_markers: Vec<SourceWordSyntaxMarker>,
     progress: GrammarProgress,
     owner: Box<dyn NativeStructuredSourceWordOwner>,
+    enclosing_target: BuildTargetHandle,
+    body_target: BuildTargetHandle,
     enclosing_capabilities: StructuredBodyCapabilities,
     body_capabilities: StructuredBodyCapabilities,
     enclosing_line_numbers: Rc<RefCell<LocalLineNumberTable>>,
     current_line_numbers: Rc<RefCell<LocalLineNumberTable>>,
-    owner_line_numbers: Vec<Rc<RefCell<LocalLineNumberTable>>>,
+    owner_line_numbers: Vec<OwnerLocalLineNumberScope>,
+    owner_targets: Vec<Rc<RefCell<OwnerLocalBuildTarget>>>,
+}
+
+#[derive(Debug, Clone)]
+enum BuildTargetHandle {
+    Parent,
+    OwnerLocal(Rc<RefCell<OwnerLocalBuildTarget>>),
+}
+
+#[derive(Debug)]
+struct OwnerLocalLineNumberScope {
+    table: Rc<RefCell<LocalLineNumberTable>>,
+    target: BuildTargetHandle,
+}
+
+#[derive(Debug)]
+struct OwnerLocalBuildTarget {
+    code: SourceMappedCode,
+    unresolved_patches: Vec<InstructionAddress>,
+}
+
+struct SharedOwnerLocalBuildTarget {
+    target: Rc<RefCell<OwnerLocalBuildTarget>>,
 }
 
 impl StructuredSourceFrame {
@@ -192,6 +218,7 @@ impl StructuredSourceFrame {
         syntax_markers: Vec<SourceWordSyntaxMarker>,
         progress: GrammarProgress,
         owner: Box<dyn NativeStructuredSourceWordOwner>,
+        enclosing_target: BuildTargetHandle,
         enclosing_line_numbers: Rc<RefCell<LocalLineNumberTable>>,
         enclosing_capabilities: StructuredBodyCapabilities,
     ) -> Self {
@@ -199,27 +226,33 @@ impl StructuredSourceFrame {
             syntax_markers,
             progress,
             owner,
+            enclosing_target: enclosing_target.clone(),
+            body_target: enclosing_target,
             enclosing_capabilities,
             body_capabilities: enclosing_capabilities,
             current_line_numbers: enclosing_line_numbers.clone(),
             enclosing_line_numbers,
             owner_line_numbers: Vec::new(),
+            owner_targets: Vec::new(),
         }
     }
 
     fn apply_owner_context(&mut self) {
         let context = self.owner.current_body_context();
+        self.body_target = match context.build_target() {
+            StructuredBuildTargetScope::Enclosing => self.enclosing_target.clone(),
+            StructuredBuildTargetScope::OwnerLocal(index) => {
+                self.owner_target(index);
+                BuildTargetHandle::OwnerLocal(self.owner_targets[index].clone())
+            }
+        };
         self.body_capabilities = context
             .capabilities()
             .intersect(self.enclosing_capabilities);
         self.current_line_numbers = match context.line_number_scope() {
             StructuredLineNumberScope::Enclosing => self.enclosing_line_numbers.clone(),
             StructuredLineNumberScope::OwnerLocal(index) => {
-                while self.owner_line_numbers.len() <= index {
-                    self.owner_line_numbers
-                        .push(Rc::new(RefCell::new(LocalLineNumberTable::new())));
-                }
-                self.owner_line_numbers[index].clone()
+                self.owner_line_number_scope(index).table.clone()
             }
         };
     }
@@ -228,13 +261,201 @@ impl StructuredSourceFrame {
         &self,
         code: &mut dyn InstructionBuildTarget,
     ) -> Result<(), SourceProcessorError> {
-        for line_numbers in &self.owner_line_numbers {
-            line_numbers
+        for scope in &self.owner_line_numbers {
+            let mut owner_target;
+            let target = match &scope.target {
+                BuildTargetHandle::Parent => &mut *code,
+                BuildTargetHandle::OwnerLocal(target) => {
+                    owner_target = SharedOwnerLocalBuildTarget {
+                        target: target.clone(),
+                    };
+                    &mut owner_target as &mut dyn InstructionBuildTarget
+                }
+            };
+            scope
+                .table
                 .borrow_mut()
-                .resolve(code)
+                .resolve(target)
                 .map_err(|source| SourceProcessorError::from(line_number_compile_error(source)))?;
         }
         Ok(())
+    }
+
+    fn owner_target(&mut self, index: usize) -> Rc<RefCell<OwnerLocalBuildTarget>> {
+        while self.owner_targets.len() <= index {
+            self.owner_targets
+                .push(Rc::new(RefCell::new(OwnerLocalBuildTarget::new())));
+        }
+        self.owner_targets[index].clone()
+    }
+
+    fn owner_line_number_scope(&mut self, index: usize) -> &OwnerLocalLineNumberScope {
+        while self.owner_line_numbers.len() <= index {
+            self.owner_line_numbers.push(OwnerLocalLineNumberScope {
+                table: Rc::new(RefCell::new(LocalLineNumberTable::new())),
+                target: self.body_target.clone(),
+            });
+        }
+        &self.owner_line_numbers[index]
+    }
+
+    fn owner_local_target_lengths(&self) -> Vec<usize> {
+        self.owner_targets
+            .iter()
+            .map(|target| target.borrow().current_len())
+            .collect()
+    }
+}
+
+impl OwnerLocalBuildTarget {
+    fn new() -> Self {
+        Self {
+            code: SourceMappedCode::new(),
+            unresolved_patches: Vec::new(),
+        }
+    }
+
+    fn current_len(&self) -> usize {
+        self.code.len()
+    }
+
+    fn append_branch_placeholder(
+        &mut self,
+        instruction: Instruction,
+        span: Option<SourceSpan>,
+    ) -> Result<InstructionAddress, InstructionBuildError> {
+        let branch = match span {
+            Some(span) => self.code.append_mapped(instruction, span),
+            None => self.code.append_unmapped(instruction),
+        }
+        .map_err(|source| InstructionBuildError::BlockCodeBuild {
+            source: BlockCodeBuildError::SourceMappingAppend { source },
+        })?;
+        self.unresolved_patches.push(branch);
+        Ok(branch)
+    }
+
+    fn patch_branch_target(
+        &mut self,
+        branch: InstructionAddress,
+        target: InstructionAddress,
+    ) -> Result<(), InstructionBuildError> {
+        self.validate_local_target(branch)?;
+        self.validate_local_target(target)?;
+        let Some(position) = self
+            .unresolved_patches
+            .iter()
+            .position(|pending| *pending == branch)
+        else {
+            return Err(InstructionBuildError::BlockCodeBuild {
+                source: BlockCodeBuildError::UnknownBranchPatch { branch },
+            });
+        };
+        self.code
+            .patch_branch_target(branch, target)
+            .map_err(|source| InstructionBuildError::BlockCodeBuild {
+                source: BlockCodeBuildError::BranchTargetPatch { source },
+            })?;
+        self.unresolved_patches.swap_remove(position);
+        Ok(())
+    }
+
+    fn validate_local_target(
+        &self,
+        address: InstructionAddress,
+    ) -> Result<(), InstructionBuildError> {
+        if address.as_index() >= self.code.len() {
+            return Err(InstructionBuildError::BlockCodeBuild {
+                source: BlockCodeBuildError::AddressOutsideCurrentBlock { address },
+            });
+        }
+        Ok(())
+    }
+}
+
+impl InstructionBuildTarget for SharedOwnerLocalBuildTarget {
+    fn current_len(&self) -> usize {
+        self.target.borrow().current_len()
+    }
+
+    fn append_mapped(
+        &mut self,
+        instruction: Instruction,
+        span: SourceSpan,
+    ) -> Result<InstructionAddress, InstructionBuildError> {
+        reject_owner_local_direct_branch(instruction)?;
+        self.target
+            .borrow_mut()
+            .code
+            .append_mapped(instruction, span)
+            .map_err(|source| InstructionBuildError::BlockCodeBuild {
+                source: BlockCodeBuildError::SourceMappingAppend { source },
+            })
+    }
+
+    fn append_unmapped(
+        &mut self,
+        instruction: Instruction,
+    ) -> Result<InstructionAddress, InstructionBuildError> {
+        reject_owner_local_direct_branch(instruction)?;
+        self.target
+            .borrow_mut()
+            .code
+            .append_unmapped(instruction)
+            .map_err(|source| InstructionBuildError::BlockCodeBuild {
+                source: BlockCodeBuildError::SourceMappingAppend { source },
+            })
+    }
+
+    fn append_mapped_jump_placeholder(
+        &mut self,
+        span: SourceSpan,
+    ) -> Result<InstructionAddress, InstructionBuildError> {
+        self.target.borrow_mut().append_branch_placeholder(
+            Instruction::Jump(InstructionAddress::from_index(0)),
+            Some(span),
+        )
+    }
+
+    fn append_mapped_jump_if_zero_placeholder(
+        &mut self,
+        span: SourceSpan,
+    ) -> Result<InstructionAddress, InstructionBuildError> {
+        self.target.borrow_mut().append_branch_placeholder(
+            Instruction::JumpIfZero(InstructionAddress::from_index(0)),
+            Some(span),
+        )
+    }
+
+    fn patch_branch_target(
+        &mut self,
+        branch: InstructionAddress,
+        target: InstructionAddress,
+    ) -> Result<(), InstructionBuildError> {
+        self.target.borrow_mut().patch_branch_target(branch, target)
+    }
+
+    fn validate_local_target(
+        &self,
+        address: InstructionAddress,
+    ) -> Result<(), InstructionBuildError> {
+        self.target.borrow().validate_local_target(address)
+    }
+}
+
+fn reject_owner_local_direct_branch(instruction: Instruction) -> Result<(), InstructionBuildError> {
+    match instruction {
+        Instruction::Jump(_) | Instruction::JumpIfZero(_) => {
+            Err(InstructionBuildError::BlockCodeBuild {
+                source: BlockCodeBuildError::BranchInstructionRequiresPatch { instruction },
+            })
+        }
+        Instruction::Push(_)
+        | Instruction::LoadVar(_)
+        | Instruction::StoreVar(_)
+        | Instruction::Call(_)
+        | Instruction::Return
+        | Instruction::Halt => Ok(()),
     }
 }
 
@@ -242,15 +463,23 @@ fn current_processing_context(
     structured_frames: &[StructuredSourceFrame],
     root_line_numbers: &Rc<RefCell<LocalLineNumberTable>>,
 ) -> (
+    BuildTargetHandle,
     Rc<RefCell<LocalLineNumberTable>>,
     StructuredBodyCapabilities,
 ) {
     structured_frames.last().map_or(
         (
+            BuildTargetHandle::Parent,
             root_line_numbers.clone(),
             StructuredBodyCapabilities::inherit(),
         ),
-        |frame| (frame.current_line_numbers.clone(), frame.body_capabilities),
+        |frame| {
+            (
+                frame.body_target.clone(),
+                frame.current_line_numbers.clone(),
+                frame.body_capabilities,
+            )
+        },
     )
 }
 
@@ -284,7 +513,9 @@ where
                 source,
             })?;
 
-    let mut owner_context = NativeStructuredSourceWordContext::new(view, source_id, code);
+    let owner_local_target_lengths = frame.owner_local_target_lengths();
+    let mut owner_context =
+        NativeStructuredSourceWordContext::new(view, source_id, code, owner_local_target_lengths);
     match accept {
         GrammarAccept::Intermediate { .. } => {
             frame
@@ -501,15 +732,26 @@ where
             continue;
         }
 
-        let (line_numbers, capabilities) =
+        let (target_handle, line_numbers, capabilities) =
             current_processing_context(&structured_frames, &root_line_numbers);
+        let mut owner_target;
+        let statement_code = match &target_handle {
+            BuildTargetHandle::Parent => &mut *code,
+            BuildTargetHandle::OwnerLocal(target) => {
+                owner_target = SharedOwnerLocalBuildTarget {
+                    target: target.clone(),
+                };
+                &mut owner_target as &mut dyn InstructionBuildTarget
+            }
+        };
         compile_statement(
             statement.tokens(),
             &mut context,
             &mut StatementCompileState {
-                code,
+                code: statement_code,
                 line_numbers,
                 capabilities,
+                target: target_handle,
             },
             &mut StatementTraversal {
                 view,
@@ -526,15 +768,6 @@ where
         }
         Terminal::LexError(error) => return Err(error.into()),
         Terminal::Eof { .. } => {}
-    }
-
-    for frame in &structured_frames {
-        for line_numbers in &frame.owner_line_numbers {
-            line_numbers
-                .borrow_mut()
-                .resolve(code)
-                .map_err(|source| SourceProcessorError::from(line_number_compile_error(source)))?;
-        }
     }
 
     let result = root_line_numbers
@@ -636,10 +869,8 @@ where
         tokens,
         context,
         local_line_number_prefix,
-        state.code,
+        state,
         traversal,
-        state.line_numbers.clone(),
-        state.capabilities,
     )? {
         return Ok(());
     }
@@ -659,10 +890,8 @@ fn compile_statement_leading_source_word<'source, S>(
     tokens: &'source [Token],
     context: &mut SourceCompileContext<'_>,
     local_line_number_prefix: Option<SourceSpan>,
-    code: &mut dyn InstructionBuildTarget,
+    state: &mut StatementCompileState<'_>,
     traversal: &mut StatementTraversal<'source, '_, S>,
-    current_line_numbers: Rc<RefCell<LocalLineNumberTable>>,
-    current_capabilities: StructuredBodyCapabilities,
 ) -> Result<bool, SourceProcessorError>
 where
     S: LogicalStatementView,
@@ -697,11 +926,11 @@ where
     let globals = context
         .globals
         .as_deref_mut()
-        .filter(|_| current_capabilities.allows_publication());
+        .filter(|_| state.capabilities.allows_publication());
     let mut runtime_publisher = context
         .runtime_definitions
         .as_mut()
-        .filter(|_| current_capabilities.allows_publication())
+        .filter(|_| state.capabilities.allows_publication())
         .map(|publication| RuntimeDefinitionPublisherAdapter {
             view: traversal.view,
             source_id: traversal.source_id,
@@ -713,7 +942,7 @@ where
     let runtime_definitions = runtime_publisher
         .as_mut()
         .map(|publisher| publisher as &mut dyn RuntimeDefinitionPublisher<'source>);
-    let binding_access = if current_capabilities.allows_publication() {
+    let binding_access = if state.capabilities.allows_publication() {
         match &mut context.bindings {
             BindingAccess::Read(bindings) => NativeSourceWordBindingAccess::Read(bindings),
             BindingAccess::Write(bindings) => NativeSourceWordBindingAccess::Write(bindings),
@@ -738,7 +967,7 @@ where
         },
         bindings: binding_access,
         operators,
-        code,
+        code: state.code,
         local_line_number_prefix,
         globals,
         runtime_definitions,
@@ -751,8 +980,9 @@ where
                 syntax_markers.to_vec(),
                 grammar.start(),
                 instance.into_owner(),
-                current_line_numbers,
-                current_capabilities,
+                state.target.clone(),
+                state.line_numbers.clone(),
+                state.capabilities,
             );
             frame.apply_owner_context();
             traversal.structured_frames.push(frame);
@@ -1909,8 +2139,8 @@ mod tests {
         DefSyntaxErrorKind, LetSyntaxErrorKind, NativeSourceWordContext,
         NativeStructuredSourceWordContext, NativeStructuredSourceWordOwner, SourceBlockItem,
         SourceBlockMarker, SourceWordRegistry, SourceWordSyntaxMarker, SourceWordSyntaxMarkerRole,
-        StructuredBodyCapabilities, StructuredBodyContext, StructuredLineNumberScope,
-        StructuredSourceWordInstance, VarSyntaxErrorKind,
+        StructuredBodyCapabilities, StructuredBodyContext, StructuredBuildTargetScope,
+        StructuredLineNumberScope, StructuredSourceWordInstance, VarSyntaxErrorKind,
     };
     use crate::structured_grammar::{
         MarkerCardinality, MarkerGroup, MarkerIdentity, StructuredGrammar,
@@ -2284,6 +2514,8 @@ mod tests {
         context_index: usize,
         marker_value: i16,
         complete_value: i16,
+        complete_with_target0_len: bool,
+        fail_completion: bool,
     }
 
     impl StructuredProbeOwner {
@@ -2293,18 +2525,23 @@ mod tests {
                 context_index: 0,
                 marker_value: 20,
                 complete_value: 30,
+                complete_with_target0_len: false,
+                fail_completion: false,
             }
         }
 
         fn without_publication() -> Self {
             Self {
                 body_contexts: vec![StructuredBodyContext::new(
+                    StructuredBuildTargetScope::Enclosing,
                     StructuredLineNumberScope::Enclosing,
                     StructuredBodyCapabilities::without_publication(),
                 )],
                 context_index: 0,
                 marker_value: 20,
                 complete_value: 30,
+                complete_with_target0_len: false,
+                fail_completion: false,
             }
         }
 
@@ -2312,10 +2549,12 @@ mod tests {
             Self {
                 body_contexts: vec![
                     StructuredBodyContext::new(
+                        StructuredBuildTargetScope::Enclosing,
                         StructuredLineNumberScope::OwnerLocal(0),
                         StructuredBodyCapabilities::inherit(),
                     ),
                     StructuredBodyContext::new(
+                        StructuredBuildTargetScope::Enclosing,
                         StructuredLineNumberScope::OwnerLocal(1),
                         StructuredBodyCapabilities::inherit(),
                     ),
@@ -2323,6 +2562,30 @@ mod tests {
                 context_index: 0,
                 marker_value: 20,
                 complete_value: 30,
+                complete_with_target0_len: false,
+                fail_completion: false,
+            }
+        }
+
+        fn owner_local_target() -> Self {
+            Self {
+                body_contexts: vec![StructuredBodyContext::new(
+                    StructuredBuildTargetScope::OwnerLocal(0),
+                    StructuredLineNumberScope::OwnerLocal(0),
+                    StructuredBodyCapabilities::inherit(),
+                )],
+                context_index: 0,
+                marker_value: 20,
+                complete_value: 30,
+                complete_with_target0_len: true,
+                fail_completion: false,
+            }
+        }
+
+        fn failing_owner_local_target() -> Self {
+            Self {
+                fail_completion: true,
+                ..Self::owner_local_target()
             }
         }
     }
@@ -2348,7 +2611,19 @@ mod tests {
             context: &mut NativeStructuredSourceWordContext<'_, '_>,
             marker: SourceBlockMarker<'_>,
         ) -> Result<(), SourceWordError> {
-            context.append_mapped(Instruction::Push(value(self.complete_value)), marker.span())
+            if self.fail_completion {
+                return Err(SourceWordError::UnsupportedSourceWord {
+                    span: marker.span(),
+                });
+            }
+            let emitted = if self.complete_with_target0_len {
+                context
+                    .owner_local_target_len(0)
+                    .expect("owner-local target should exist") as i16
+            } else {
+                self.complete_value
+            };
+            context.append_mapped(Instruction::Push(value(emitted)), marker.span())
         }
     }
 
@@ -2382,6 +2657,22 @@ mod tests {
         )?;
         Ok(StructuredSourceWordInstance::new(Box::new(
             StructuredProbeOwner::split_line_number_scopes(),
+        )))
+    }
+
+    fn start_owner_local_target_probe(
+        _context: &mut NativeSourceWordContext<'_, '_>,
+    ) -> Result<StructuredSourceWordInstance, SourceWordError> {
+        Ok(StructuredSourceWordInstance::new(Box::new(
+            StructuredProbeOwner::owner_local_target(),
+        )))
+    }
+
+    fn start_failing_owner_local_target_probe(
+        _context: &mut NativeSourceWordContext<'_, '_>,
+    ) -> Result<StructuredSourceWordInstance, SourceWordError> {
+        Ok(StructuredSourceWordInstance::new(Box::new(
+            StructuredProbeOwner::failing_owner_local_target(),
         )))
     }
 
@@ -5649,6 +5940,71 @@ mod tests {
             Ok(&Instruction::Push(value(30)))
         );
         assert_eq!(unit.instructions().get(address(3)), Ok(&Instruction::Halt));
+    }
+
+    #[test]
+    fn structured_body_context_can_select_owner_local_build_target() {
+        let mut words = PublishedWords::new();
+        let mut bindings = Bindings::new();
+        let body_word = publish_initial(&mut words, &mut bindings, "BODY", completed_primitive(7));
+        let mut source_words = SourceWordRegistry::new();
+        register_structured_probe(
+            &mut source_words,
+            &mut bindings,
+            "BLOCK",
+            start_owner_local_target_probe,
+            vec![marker("END", SourceWordSyntaxMarkerRole::BlockTerminator)],
+            structured_grammar(Vec::new(), "END"),
+        );
+        let (sources, source_id) = source("BLOCK\nBODY\nEND\nBODY");
+
+        let unit = compile_source(
+            sources.view(),
+            source_id,
+            SourceCompileContext::with_source_words(&bindings, source_words.lookup()),
+        )
+        .expect("owner-local body target should compile");
+
+        assert_eq!(
+            unit.instructions().get(address(0)),
+            Ok(&Instruction::Push(value(1)))
+        );
+        assert_eq!(
+            unit.instructions().get(address(1)),
+            Ok(&Instruction::Call(body_word))
+        );
+        assert_eq!(unit.instructions().get(address(2)), Ok(&Instruction::Halt));
+    }
+
+    #[test]
+    fn structured_completion_failure_does_not_commit_owner_local_target() {
+        let mut words = PublishedWords::new();
+        let mut bindings = Bindings::new();
+        publish_initial(&mut words, &mut bindings, "BODY", completed_primitive(7));
+        let mut source_words = SourceWordRegistry::new();
+        register_structured_probe(
+            &mut source_words,
+            &mut bindings,
+            "BLOCK",
+            start_failing_owner_local_target_probe,
+            vec![marker("END", SourceWordSyntaxMarkerRole::BlockTerminator)],
+            structured_grammar(Vec::new(), "END"),
+        );
+        let (sources, source_id) = source("BLOCK\nBODY\nEND");
+
+        let error = compile_source(
+            sources.view(),
+            source_id,
+            SourceCompileContext::with_source_words(&bindings, source_words.lookup()),
+        )
+        .expect_err("owner completion failure should reject the structured instance");
+
+        assert_eq!(
+            error,
+            SourceProcessorError::SourceWord(SourceWordError::UnsupportedSourceWord {
+                span: span(sources.view(), source_id, 11, 14)
+            })
+        );
     }
 
     #[test]

--- a/crates/tbx-next/src/source_processor.rs
+++ b/crates/tbx-next/src/source_processor.rs
@@ -29,7 +29,7 @@ use crate::source_word::{
     SourceBlockCursor, SourceBlockMarker, SourceBlockRead, SourceBlockReader, SourceBlockStatement,
     SourceBlockTerminal, SourceWordDispatch, SourceWordError, SourceWordId, SourceWordLookup,
     SourceWordLookupError, SourceWordSyntaxMarker, StructuredBodyCapabilities,
-    StructuredBuildTargetScope, StructuredLineNumberScope,
+    StructuredBuildTargetScope, StructuredLineNumberScope, StructuredOwnerLocalTarget,
 };
 use crate::static_quotation::{StaticQuotation, StaticQuotationBuildError};
 use crate::structured_grammar::{GrammarAccept, GrammarProgress, MarkerIdentity};
@@ -299,10 +299,12 @@ impl StructuredSourceFrame {
         &self.owner_line_numbers[index]
     }
 
-    fn owner_local_target_lengths(&self) -> Vec<usize> {
+    fn owner_local_target_snapshots(
+        &self,
+    ) -> Result<Vec<StructuredOwnerLocalTarget>, SourceProcessorError> {
         self.owner_targets
             .iter()
-            .map(|target| target.borrow().current_len())
+            .map(|target| target.borrow().snapshot())
             .collect()
     }
 }
@@ -371,6 +373,23 @@ impl OwnerLocalBuildTarget {
         }
         Ok(())
     }
+
+    fn snapshot(&self) -> Result<StructuredOwnerLocalTarget, SourceProcessorError> {
+        if let Some(branch) = self.unresolved_patches.first().copied() {
+            return Err(InstructionBuildError::BlockCodeBuild {
+                source: BlockCodeBuildError::UnresolvedBranchPatch { branch },
+            }
+            .into());
+        }
+
+        let mut instructions = Vec::with_capacity(self.code.len());
+        for index in 0..self.code.len() {
+            let address = InstructionAddress::from_index(index);
+            let (instruction, span) = self.code.mapped_instruction(address)?;
+            instructions.push((*instruction, span));
+        }
+        Ok(StructuredOwnerLocalTarget::new(instructions))
+    }
 }
 
 impl InstructionBuildTarget for SharedOwnerLocalBuildTarget {
@@ -398,6 +417,33 @@ impl InstructionBuildTarget for SharedOwnerLocalBuildTarget {
         instruction: Instruction,
     ) -> Result<InstructionAddress, InstructionBuildError> {
         reject_owner_local_direct_branch(instruction)?;
+        self.target
+            .borrow_mut()
+            .code
+            .append_unmapped(instruction)
+            .map_err(|source| InstructionBuildError::BlockCodeBuild {
+                source: BlockCodeBuildError::SourceMappingAppend { source },
+            })
+    }
+
+    fn append_resolved_mapped(
+        &mut self,
+        instruction: Instruction,
+        span: SourceSpan,
+    ) -> Result<InstructionAddress, InstructionBuildError> {
+        self.target
+            .borrow_mut()
+            .code
+            .append_mapped(instruction, span)
+            .map_err(|source| InstructionBuildError::BlockCodeBuild {
+                source: BlockCodeBuildError::SourceMappingAppend { source },
+            })
+    }
+
+    fn append_resolved_unmapped(
+        &mut self,
+        instruction: Instruction,
+    ) -> Result<InstructionAddress, InstructionBuildError> {
         self.target
             .borrow_mut()
             .code
@@ -513,9 +559,26 @@ where
                 source,
             })?;
 
-    let owner_local_target_lengths = frame.owner_local_target_lengths();
+    let callback_target = match accept {
+        GrammarAccept::Intermediate { .. } => frame.body_target.clone(),
+        GrammarAccept::Terminator => {
+            frame.resolve_owner_line_numbers(code)?;
+            frame.enclosing_target.clone()
+        }
+    };
+    let owner_local_targets = frame.owner_local_target_snapshots()?;
+    let mut owner_target;
+    let callback_code = match &callback_target {
+        BuildTargetHandle::Parent => &mut *code,
+        BuildTargetHandle::OwnerLocal(target) => {
+            owner_target = SharedOwnerLocalBuildTarget {
+                target: target.clone(),
+            };
+            &mut owner_target as &mut dyn InstructionBuildTarget
+        }
+    };
     let mut owner_context =
-        NativeStructuredSourceWordContext::new(view, source_id, code, owner_local_target_lengths);
+        NativeStructuredSourceWordContext::new(view, source_id, callback_code, owner_local_targets);
     match accept {
         GrammarAccept::Intermediate { .. } => {
             frame
@@ -529,10 +592,9 @@ where
     }
 
     if matches!(accept, GrammarAccept::Terminator) {
-        let frame = structured_frames
+        structured_frames
             .pop()
             .expect("terminator handling requires current frame");
-        frame.resolve_owner_line_numbers(code)?;
     }
 
     Ok(true)
@@ -2514,7 +2576,7 @@ mod tests {
         context_index: usize,
         marker_value: i16,
         complete_value: i16,
-        complete_with_target0_len: bool,
+        commit_targets: Vec<usize>,
         fail_completion: bool,
     }
 
@@ -2525,7 +2587,7 @@ mod tests {
                 context_index: 0,
                 marker_value: 20,
                 complete_value: 30,
-                complete_with_target0_len: false,
+                commit_targets: Vec::new(),
                 fail_completion: false,
             }
         }
@@ -2540,7 +2602,7 @@ mod tests {
                 context_index: 0,
                 marker_value: 20,
                 complete_value: 30,
-                complete_with_target0_len: false,
+                commit_targets: Vec::new(),
                 fail_completion: false,
             }
         }
@@ -2562,7 +2624,7 @@ mod tests {
                 context_index: 0,
                 marker_value: 20,
                 complete_value: 30,
-                complete_with_target0_len: false,
+                commit_targets: Vec::new(),
                 fail_completion: false,
             }
         }
@@ -2577,7 +2639,29 @@ mod tests {
                 context_index: 0,
                 marker_value: 20,
                 complete_value: 30,
-                complete_with_target0_len: true,
+                commit_targets: vec![0],
+                fail_completion: false,
+            }
+        }
+
+        fn split_owner_local_targets() -> Self {
+            Self {
+                body_contexts: vec![
+                    StructuredBodyContext::new(
+                        StructuredBuildTargetScope::OwnerLocal(0),
+                        StructuredLineNumberScope::OwnerLocal(0),
+                        StructuredBodyCapabilities::inherit(),
+                    ),
+                    StructuredBodyContext::new(
+                        StructuredBuildTargetScope::OwnerLocal(1),
+                        StructuredLineNumberScope::OwnerLocal(1),
+                        StructuredBodyCapabilities::inherit(),
+                    ),
+                ],
+                context_index: 0,
+                marker_value: 20,
+                complete_value: 30,
+                commit_targets: vec![0, 1],
                 fail_completion: false,
             }
         }
@@ -2616,14 +2700,14 @@ mod tests {
                     span: marker.span(),
                 });
             }
-            let emitted = if self.complete_with_target0_len {
-                context
-                    .owner_local_target_len(0)
-                    .expect("owner-local target should exist") as i16
-            } else {
-                self.complete_value
-            };
-            context.append_mapped(Instruction::Push(value(emitted)), marker.span())
+            if self.commit_targets.is_empty() {
+                return context
+                    .append_mapped(Instruction::Push(value(self.complete_value)), marker.span());
+            }
+            for target in &self.commit_targets {
+                context.append_owner_local_target(*target, marker.span())?;
+            }
+            Ok(())
         }
     }
 
@@ -2665,6 +2749,14 @@ mod tests {
     ) -> Result<StructuredSourceWordInstance, SourceWordError> {
         Ok(StructuredSourceWordInstance::new(Box::new(
             StructuredProbeOwner::owner_local_target(),
+        )))
+    }
+
+    fn start_split_owner_local_targets_probe(
+        _context: &mut NativeSourceWordContext<'_, '_>,
+    ) -> Result<StructuredSourceWordInstance, SourceWordError> {
+        Ok(StructuredSourceWordInstance::new(Box::new(
+            StructuredProbeOwner::split_owner_local_targets(),
         )))
     }
 
@@ -5967,13 +6059,103 @@ mod tests {
 
         assert_eq!(
             unit.instructions().get(address(0)),
-            Ok(&Instruction::Push(value(1)))
+            Ok(&Instruction::Call(body_word))
         );
         assert_eq!(
             unit.instructions().get(address(1)),
             Ok(&Instruction::Call(body_word))
         );
         assert_eq!(unit.instructions().get(address(2)), Ok(&Instruction::Halt));
+    }
+
+    #[test]
+    fn nested_child_completion_inside_owner_local_target_stays_in_enclosing_target() {
+        let mut source_words = SourceWordRegistry::new();
+        let mut bindings = Bindings::new();
+        register_structured_probe(
+            &mut source_words,
+            &mut bindings,
+            "OUTER",
+            start_owner_local_target_probe,
+            vec![marker(
+                "OUT_END",
+                SourceWordSyntaxMarkerRole::BlockTerminator,
+            )],
+            structured_grammar(Vec::new(), "OUT_END"),
+        );
+        register_structured_probe(
+            &mut source_words,
+            &mut bindings,
+            "INNER",
+            start_structured_probe,
+            vec![marker(
+                "IN_END",
+                SourceWordSyntaxMarkerRole::BlockTerminator,
+            )],
+            structured_grammar(Vec::new(), "IN_END"),
+        );
+        let (sources, source_id) = source("OUTER\nINNER\nIN_END\nOUT_END");
+
+        let unit = compile_source(
+            sources.view(),
+            source_id,
+            SourceCompileContext::with_source_words(&bindings, source_words.lookup()),
+        )
+        .expect("nested child completion should stay inside parent owner-local target");
+
+        assert_eq!(
+            unit.instructions().get(address(0)),
+            Ok(&Instruction::Push(value(10)))
+        );
+        assert_eq!(
+            unit.instructions().get(address(1)),
+            Ok(&Instruction::Push(value(30)))
+        );
+        assert_eq!(unit.instructions().get(address(2)), Ok(&Instruction::Halt));
+    }
+
+    #[test]
+    fn structured_owner_can_commit_distinct_owner_local_targets_after_marker_switch() {
+        let mut words = PublishedWords::new();
+        let mut bindings = Bindings::new();
+        let first_word =
+            publish_initial(&mut words, &mut bindings, "FIRST", completed_primitive(7));
+        let second_word =
+            publish_initial(&mut words, &mut bindings, "SECOND", completed_primitive(8));
+        let mut source_words = SourceWordRegistry::new();
+        register_structured_probe(
+            &mut source_words,
+            &mut bindings,
+            "BLOCK",
+            start_split_owner_local_targets_probe,
+            vec![
+                marker("ELSE", SourceWordSyntaxMarkerRole::BlockContinuation),
+                marker("END", SourceWordSyntaxMarkerRole::BlockTerminator),
+            ],
+            structured_grammar(vec![("ELSE", MarkerCardinality::Optional)], "END"),
+        );
+        let (sources, source_id) = source("BLOCK\nFIRST\nELSE\nSECOND\nEND");
+
+        let unit = compile_source(
+            sources.view(),
+            source_id,
+            SourceCompileContext::with_source_words(&bindings, source_words.lookup()),
+        )
+        .expect("owner should commit both owner-local body targets");
+
+        assert_eq!(
+            unit.instructions().get(address(0)),
+            Ok(&Instruction::Call(first_word))
+        );
+        assert_eq!(
+            unit.instructions().get(address(1)),
+            Ok(&Instruction::Push(value(20)))
+        );
+        assert_eq!(
+            unit.instructions().get(address(2)),
+            Ok(&Instruction::Call(second_word))
+        );
+        assert_eq!(unit.instructions().get(address(3)), Ok(&Instruction::Halt));
     }
 
     #[test]

--- a/crates/tbx-next/src/source_word.rs
+++ b/crates/tbx-next/src/source_word.rs
@@ -90,7 +90,18 @@ pub(crate) struct NativeStructuredSourceWordContext<'source, 'state> {
     view: SourceView<'source>,
     source_id: SourceId,
     code: &'state mut dyn InstructionBuildTarget,
-    owner_local_target_lengths: Vec<usize>,
+    owner_local_targets: Vec<StructuredOwnerLocalTarget>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct StructuredOwnerLocalTarget {
+    instructions: Vec<StructuredOwnerLocalInstruction>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct StructuredOwnerLocalInstruction {
+    instruction: Instruction,
+    span: Option<SourceSpan>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -500,13 +511,13 @@ impl<'source, 'state> NativeStructuredSourceWordContext<'source, 'state> {
         view: SourceView<'source>,
         source_id: SourceId,
         code: &'state mut dyn InstructionBuildTarget,
-        owner_local_target_lengths: Vec<usize>,
+        owner_local_targets: Vec<StructuredOwnerLocalTarget>,
     ) -> Self {
         Self {
             view,
             source_id,
             code,
-            owner_local_target_lengths,
+            owner_local_targets,
         }
     }
 
@@ -529,8 +540,88 @@ impl<'source, 'state> NativeStructuredSourceWordContext<'source, 'state> {
             .map_err(|source| SourceWordError::InstructionBuild { source })
     }
 
-    pub(crate) fn owner_local_target_len(&self, index: usize) -> Option<usize> {
-        self.owner_local_target_lengths.get(index).copied()
+    pub(crate) fn append_owner_local_target(
+        &mut self,
+        index: usize,
+        anchor: SourceSpan,
+    ) -> Result<(), SourceWordError> {
+        let Some(target) = self.owner_local_targets.get(index) else {
+            return Err(SourceWordError::UnsupportedSourceWord { span: anchor });
+        };
+        target.append_to(self.code, anchor)
+    }
+}
+
+impl StructuredOwnerLocalTarget {
+    pub(crate) fn new(instructions: Vec<(Instruction, Option<SourceSpan>)>) -> Self {
+        Self {
+            instructions: instructions
+                .into_iter()
+                .map(|(instruction, span)| StructuredOwnerLocalInstruction { instruction, span })
+                .collect(),
+        }
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.instructions.len()
+    }
+
+    fn append_to(
+        &self,
+        code: &mut dyn InstructionBuildTarget,
+        anchor: SourceSpan,
+    ) -> Result<(), SourceWordError> {
+        let parent_start = code.current_address();
+        for mapped in &self.instructions {
+            let instruction = self.rebase_instruction(mapped.instruction, parent_start, anchor)?;
+            if let Some(span) = mapped.span {
+                code.append_resolved_mapped(instruction, span)
+            } else {
+                code.append_resolved_unmapped(instruction)
+            }
+            .map_err(|source| SourceWordError::InstructionBuild { source })?;
+        }
+        Ok(())
+    }
+
+    fn rebase_instruction(
+        &self,
+        instruction: Instruction,
+        parent_start: crate::instruction::InstructionAddress,
+        anchor: SourceSpan,
+    ) -> Result<Instruction, SourceWordError> {
+        match instruction {
+            Instruction::Jump(target) => self
+                .rebase_target(target, parent_start, anchor)
+                .map(Instruction::Jump),
+            Instruction::JumpIfZero(target) => self
+                .rebase_target(target, parent_start, anchor)
+                .map(Instruction::JumpIfZero),
+            Instruction::Push(_)
+            | Instruction::LoadVar(_)
+            | Instruction::StoreVar(_)
+            | Instruction::Call(_)
+            | Instruction::Return
+            | Instruction::Halt => Ok(instruction),
+        }
+    }
+
+    fn rebase_target(
+        &self,
+        target: crate::instruction::InstructionAddress,
+        parent_start: crate::instruction::InstructionAddress,
+        anchor: SourceSpan,
+    ) -> Result<crate::instruction::InstructionAddress, SourceWordError> {
+        if target.as_index() >= self.instructions.len() {
+            return Err(SourceWordError::UnsupportedSourceWord { span: anchor });
+        }
+        let parent_index = parent_start
+            .as_index()
+            .checked_add(target.as_index())
+            .ok_or(SourceWordError::UnsupportedSourceWord { span: anchor })?;
+        Ok(crate::instruction::InstructionAddress::from_index(
+            parent_index,
+        ))
     }
 }
 

--- a/crates/tbx-next/src/source_word.rs
+++ b/crates/tbx-next/src/source_word.rs
@@ -64,8 +64,15 @@ pub(crate) struct StructuredSourceWordInstance {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct StructuredBodyContext {
+    build_target: StructuredBuildTargetScope,
     line_number_scope: StructuredLineNumberScope,
     capabilities: StructuredBodyCapabilities,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StructuredBuildTargetScope {
+    Enclosing,
+    OwnerLocal(usize),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -83,6 +90,7 @@ pub(crate) struct NativeStructuredSourceWordContext<'source, 'state> {
     view: SourceView<'source>,
     source_id: SourceId,
     code: &'state mut dyn InstructionBuildTarget,
+    owner_local_target_lengths: Vec<usize>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -436,19 +444,26 @@ impl StructuredSourceWordInstance {
 impl StructuredBodyContext {
     pub(crate) const fn inherited() -> Self {
         Self {
+            build_target: StructuredBuildTargetScope::Enclosing,
             line_number_scope: StructuredLineNumberScope::Enclosing,
             capabilities: StructuredBodyCapabilities::inherit(),
         }
     }
 
     pub(crate) const fn new(
+        build_target: StructuredBuildTargetScope,
         line_number_scope: StructuredLineNumberScope,
         capabilities: StructuredBodyCapabilities,
     ) -> Self {
         Self {
+            build_target,
             line_number_scope,
             capabilities,
         }
+    }
+
+    pub(crate) const fn build_target(self) -> StructuredBuildTargetScope {
+        self.build_target
     }
 
     pub(crate) const fn line_number_scope(self) -> StructuredLineNumberScope {
@@ -485,11 +500,13 @@ impl<'source, 'state> NativeStructuredSourceWordContext<'source, 'state> {
         view: SourceView<'source>,
         source_id: SourceId,
         code: &'state mut dyn InstructionBuildTarget,
+        owner_local_target_lengths: Vec<usize>,
     ) -> Self {
         Self {
             view,
             source_id,
             code,
+            owner_local_target_lengths,
         }
     }
 
@@ -510,6 +527,10 @@ impl<'source, 'state> NativeStructuredSourceWordContext<'source, 'state> {
             .append_mapped(instruction, span)
             .map(|_| ())
             .map_err(|source| SourceWordError::InstructionBuild { source })
+    }
+
+    pub(crate) fn owner_local_target_len(&self, index: usize) -> Option<usize> {
+        self.owner_local_target_lengths.get(index).copied()
     }
 }
 

--- a/crates/tbx-next/src/source_word.rs
+++ b/crates/tbx-next/src/source_word.rs
@@ -35,6 +35,56 @@ impl SourceWordId {
 pub(crate) type NativeSourceWordHandler =
     fn(&mut NativeSourceWordContext<'_, '_>) -> Result<(), SourceWordError>;
 
+pub(crate) type NativeStructuredSourceWordStartHandler =
+    fn(
+        &mut NativeSourceWordContext<'_, '_>,
+    ) -> Result<StructuredSourceWordInstance, SourceWordError>;
+
+pub(crate) trait NativeStructuredSourceWordOwner: std::fmt::Debug {
+    fn current_body_context(&self) -> StructuredBodyContext;
+
+    fn accept_marker(
+        &mut self,
+        context: &mut NativeStructuredSourceWordContext<'_, '_>,
+        marker: SourceBlockMarker<'_>,
+        accept: crate::structured_grammar::GrammarAccept,
+    ) -> Result<(), SourceWordError>;
+
+    fn complete(
+        &mut self,
+        context: &mut NativeStructuredSourceWordContext<'_, '_>,
+        marker: SourceBlockMarker<'_>,
+    ) -> Result<(), SourceWordError>;
+}
+
+#[derive(Debug)]
+pub(crate) struct StructuredSourceWordInstance {
+    owner: Box<dyn NativeStructuredSourceWordOwner>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct StructuredBodyContext {
+    line_number_scope: StructuredLineNumberScope,
+    capabilities: StructuredBodyCapabilities,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StructuredLineNumberScope {
+    Enclosing,
+    OwnerLocal(usize),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct StructuredBodyCapabilities {
+    publication: bool,
+}
+
+pub(crate) struct NativeStructuredSourceWordContext<'source, 'state> {
+    view: SourceView<'source>,
+    source_id: SourceId,
+    code: &'state mut dyn InstructionBuildTarget,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SourceWordSyntaxMarkerRole {
     BlockContinuation,
@@ -142,6 +192,13 @@ pub(crate) enum SourceWordError {
     DefBindingCommitInvariantViolated {
         span: SourceSpan,
     },
+    StructuredGrammar {
+        span: SourceSpan,
+        source: crate::structured_grammar::GrammarProgressError,
+    },
+    StructuredMissingTerminator {
+        span: SourceSpan,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -194,7 +251,9 @@ impl SourceWordError {
             | Self::DefBodyCompile { span }
             | Self::DefBodyBuild { span }
             | Self::DefDefinition { span }
-            | Self::DefBindingCommitInvariantViolated { span } => Some(span),
+            | Self::DefBindingCommitInvariantViolated { span }
+            | Self::StructuredGrammar { span, .. }
+            | Self::StructuredMissingTerminator { span } => Some(span),
             Self::DefLex { source } => match source {
                 LexError::Source(_) => None,
                 LexError::InvalidCharacter { span, .. } => Some(span),
@@ -308,6 +367,20 @@ impl<'source> SourceBlockStatement<'source> {
 }
 
 impl<'source> SourceBlockMarker<'source> {
+    pub(crate) fn new(
+        statement: SourceBlockStatement<'source>,
+        token: Token,
+        name: NormalizedName,
+        role: SourceWordSyntaxMarkerRole,
+    ) -> Self {
+        Self {
+            statement,
+            token,
+            name,
+            role,
+        }
+    }
+
     pub(crate) const fn statement(&self) -> SourceBlockStatement<'source> {
         self.statement
     }
@@ -347,6 +420,96 @@ impl SourceBlockTerminal {
             Self::Eof { .. } => None,
             Self::LexError { error } => Some(error),
         }
+    }
+}
+
+impl StructuredSourceWordInstance {
+    pub(crate) fn new(owner: Box<dyn NativeStructuredSourceWordOwner>) -> Self {
+        Self { owner }
+    }
+
+    pub(crate) fn into_owner(self) -> Box<dyn NativeStructuredSourceWordOwner> {
+        self.owner
+    }
+}
+
+impl StructuredBodyContext {
+    pub(crate) const fn inherited() -> Self {
+        Self {
+            line_number_scope: StructuredLineNumberScope::Enclosing,
+            capabilities: StructuredBodyCapabilities::inherit(),
+        }
+    }
+
+    pub(crate) const fn new(
+        line_number_scope: StructuredLineNumberScope,
+        capabilities: StructuredBodyCapabilities,
+    ) -> Self {
+        Self {
+            line_number_scope,
+            capabilities,
+        }
+    }
+
+    pub(crate) const fn line_number_scope(self) -> StructuredLineNumberScope {
+        self.line_number_scope
+    }
+
+    pub(crate) const fn capabilities(self) -> StructuredBodyCapabilities {
+        self.capabilities
+    }
+}
+
+impl StructuredBodyCapabilities {
+    pub(crate) const fn inherit() -> Self {
+        Self { publication: true }
+    }
+
+    pub(crate) const fn without_publication() -> Self {
+        Self { publication: false }
+    }
+
+    pub(crate) const fn allows_publication(self) -> bool {
+        self.publication
+    }
+
+    pub(crate) const fn intersect(self, enclosing: Self) -> Self {
+        Self {
+            publication: self.publication && enclosing.publication,
+        }
+    }
+}
+
+impl<'source, 'state> NativeStructuredSourceWordContext<'source, 'state> {
+    pub(crate) fn new(
+        view: SourceView<'source>,
+        source_id: SourceId,
+        code: &'state mut dyn InstructionBuildTarget,
+    ) -> Self {
+        Self {
+            view,
+            source_id,
+            code,
+        }
+    }
+
+    pub(crate) const fn view(&self) -> SourceView<'source> {
+        self.view
+    }
+
+    pub(crate) const fn source_id(&self) -> SourceId {
+        self.source_id
+    }
+
+    pub(crate) fn append_mapped(
+        &mut self,
+        instruction: Instruction,
+        span: SourceSpan,
+    ) -> Result<(), SourceWordError> {
+        self.code
+            .append_mapped(instruction, span)
+            .map(|_| ())
+            .map_err(|source| SourceWordError::InstructionBuild { source })
     }
 }
 
@@ -962,8 +1125,17 @@ pub(crate) struct SourceWordRegistry {
 
 #[derive(Debug, Clone)]
 struct SourceWordEntry {
-    handler: NativeSourceWordHandler,
+    kind: SourceWordKind,
     syntax_markers: Vec<SourceWordSyntaxMarker>,
+}
+
+#[derive(Debug, Clone)]
+enum SourceWordKind {
+    OneShot(NativeSourceWordHandler),
+    Structured {
+        start: NativeStructuredSourceWordStartHandler,
+        grammar: crate::structured_grammar::StructuredGrammar,
+    },
 }
 
 impl SourceWordRegistry {
@@ -982,7 +1154,21 @@ impl SourceWordRegistry {
     ) -> SourceWordId {
         let id = SourceWordId::from_slot(self.entries.len());
         self.entries.push(SourceWordEntry {
-            handler,
+            kind: SourceWordKind::OneShot(handler),
+            syntax_markers,
+        });
+        id
+    }
+
+    pub(crate) fn register_structured(
+        &mut self,
+        start: NativeStructuredSourceWordStartHandler,
+        grammar: crate::structured_grammar::StructuredGrammar,
+        syntax_markers: Vec<SourceWordSyntaxMarker>,
+    ) -> SourceWordId {
+        let id = SourceWordId::from_slot(self.entries.len());
+        self.entries.push(SourceWordEntry {
+            kind: SourceWordKind::Structured { start, grammar },
             syntax_markers,
         });
         id
@@ -1006,16 +1192,44 @@ pub(crate) struct SourceWordLookup<'a> {
     registry: &'a SourceWordRegistry,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum SourceWordDispatch<'a> {
+    OneShot(NativeSourceWordHandler),
+    Structured {
+        start: NativeStructuredSourceWordStartHandler,
+        grammar: &'a crate::structured_grammar::StructuredGrammar,
+    },
+}
+
 impl<'a> SourceWordLookup<'a> {
+    pub(crate) fn lookup_dispatch(
+        self,
+        id: SourceWordId,
+    ) -> Result<SourceWordDispatch<'a>, SourceWordLookupError> {
+        let entry = self
+            .registry
+            .entries
+            .get(id.as_slot())
+            .ok_or(SourceWordLookupError::InvalidSourceWordId { id })?;
+        Ok(match &entry.kind {
+            SourceWordKind::OneShot(handler) => SourceWordDispatch::OneShot(*handler),
+            SourceWordKind::Structured { start, grammar } => SourceWordDispatch::Structured {
+                start: *start,
+                grammar,
+            },
+        })
+    }
+
     pub(crate) fn lookup_handler(
         self,
         id: SourceWordId,
     ) -> Result<NativeSourceWordHandler, SourceWordLookupError> {
-        self.registry
-            .entries
-            .get(id.as_slot())
-            .map(|entry| entry.handler)
-            .ok_or(SourceWordLookupError::InvalidSourceWordId { id })
+        match self.lookup_dispatch(id)? {
+            SourceWordDispatch::OneShot(handler) => Ok(handler),
+            SourceWordDispatch::Structured { .. } => {
+                Err(SourceWordLookupError::InvalidSourceWordId { id })
+            }
+        }
     }
 
     pub(crate) fn syntax_markers(


### PR DESCRIPTION
## Summary

- Add structured source word dispatch alongside existing one-shot source words.
- Move structured owner marker handling into the source processor with an innermost-owner frame stack and grammar progress checks.
- Add body processing context support for publication capability narrowing and owner-local line-number scopes.
- Cover normal body dispatch, grammar no-fallback, nested marker isolation, capability narrowing, and marker-driven line-number scope switching with tests.

Closes #1546

## Verification

- `cargo test -p tbx-next --no-fail-fast`
- `cargo clippy -p tbx-next --all-targets --all-features -- -D warnings`
- `cargo ci-fmt`
- `cargo ci-clippy`
- `cargo ci-test`
