### PR TITLE
TBX Next: native IF source word を統合

### DIFF
--- a/crates/tbx-next/src/block_code.rs
+++ b/crates/tbx-next/src/block_code.rs
@@ -133,7 +133,7 @@ impl<'a> BlockCodeBuilder<'a> {
         target: InstructionAddress,
     ) -> Result<(), BlockCodeBuildError> {
         self.validate_local_target(branch)?;
-        self.validate_local_target(target)?;
+        self.validate_local_branch_target(target)?;
         let Some(position) = self
             .unresolved_patches
             .iter()
@@ -155,6 +155,18 @@ impl<'a> BlockCodeBuilder<'a> {
         address: InstructionAddress,
     ) -> Result<(), BlockCodeBuildError> {
         if address.as_index() < self.block_start.as_index() || address.as_index() >= self.code.len()
+        {
+            return Err(BlockCodeBuildError::AddressOutsideCurrentBlock { address });
+        }
+
+        Ok(())
+    }
+
+    fn validate_local_branch_target(
+        &self,
+        address: InstructionAddress,
+    ) -> Result<(), BlockCodeBuildError> {
+        if address.as_index() < self.block_start.as_index() || address.as_index() > self.code.len()
         {
             return Err(BlockCodeBuildError::AddressOutsideCurrentBlock { address });
         }

--- a/crates/tbx-next/src/bootstrap.rs
+++ b/crates/tbx-next/src/bootstrap.rs
@@ -2,8 +2,12 @@ use crate::binding::{Binding, BindingInsertError, Bindings};
 use crate::global_variable::{GlobalVarId, GlobalVariables};
 use crate::name::NormalizedName;
 use crate::source_word::{
-    def_source_word, let_source_word, var_source_word, NativeSourceWordHandler, SourceWordId,
-    SourceWordRegistry, SourceWordSyntaxMarker,
+    def_source_word, if_source_word, let_source_word, var_source_word, NativeSourceWordHandler,
+    NativeStructuredSourceWordStartHandler, SourceWordId, SourceWordRegistry,
+    SourceWordSyntaxMarker, SourceWordSyntaxMarkerRole,
+};
+use crate::structured_grammar::{
+    MarkerCardinality, MarkerGroup, MarkerIdentity, StructuredGrammar,
 };
 use crate::word::{CompletedWordDefinition, PrimitiveId, PublishedWords, WordId};
 
@@ -130,6 +134,32 @@ pub(crate) fn register_native_source_word_with_markers(
     Ok(id)
 }
 
+pub(crate) fn register_native_structured_source_word(
+    source_words: &mut SourceWordRegistry,
+    bindings: &mut Bindings,
+    name: NormalizedName,
+    start: NativeStructuredSourceWordStartHandler,
+    grammar: StructuredGrammar,
+    syntax_markers: Vec<SourceWordSyntaxMarker>,
+) -> Result<SourceWordId, SourceWordBootstrapError> {
+    let marker_names = syntax_markers
+        .iter()
+        .map(|marker| marker.name().clone())
+        .collect::<Vec<_>>();
+
+    bindings
+        .validate_new_source_word_with_markers(&name, &marker_names)
+        .map_err(SourceWordBootstrapError::from_precheck_error)?;
+
+    let id = source_words.register_structured(start, grammar, syntax_markers);
+
+    bindings
+        .insert_new_source_word_with_markers(name, id, &marker_names)
+        .map_err(SourceWordBootstrapError::from_binding_insert_error)?;
+
+    Ok(id)
+}
+
 pub(crate) fn register_builtin_source_words(
     source_words: &mut SourceWordRegistry,
     bindings: &mut Bindings,
@@ -139,6 +169,7 @@ pub(crate) fn register_builtin_source_words(
     let var_name = builtin_name("VAR");
     let let_name = builtin_name("LET");
     let def_name = builtin_name("DEF");
+    let if_name = builtin_name("IF");
     bindings
         .validate_new_name(&var_name)
         .map_err(SourceWordBootstrapError::from_precheck_error)?;
@@ -148,6 +179,16 @@ pub(crate) fn register_builtin_source_words(
     bindings
         .validate_new_name(&def_name)
         .map_err(SourceWordBootstrapError::from_precheck_error)?;
+    bindings
+        .validate_new_source_word_with_markers(
+            &if_name,
+            &[
+                builtin_name("ELSIF"),
+                builtin_name("ELSE"),
+                builtin_name("ENDIF"),
+            ],
+        )
+        .map_err(SourceWordBootstrapError::from_precheck_error)?;
 
     let var = register_native_source_word(source_words, bindings, var_name, var_source_word)
         .expect("prechecked VAR source word should remain available");
@@ -155,8 +196,35 @@ pub(crate) fn register_builtin_source_words(
         .expect("prechecked LET source word should remain available");
     let def = register_native_source_word(source_words, bindings, def_name, def_source_word)
         .expect("prechecked DEF source word should remain available");
+    let if_ = register_native_structured_source_word(
+        source_words,
+        bindings,
+        if_name,
+        if_source_word,
+        if_grammar(),
+        vec![
+            SourceWordSyntaxMarker::new(
+                builtin_name("ELSIF"),
+                SourceWordSyntaxMarkerRole::BlockContinuation,
+            ),
+            SourceWordSyntaxMarker::new(
+                builtin_name("ELSE"),
+                SourceWordSyntaxMarkerRole::BlockContinuation,
+            ),
+            SourceWordSyntaxMarker::new(
+                builtin_name("ENDIF"),
+                SourceWordSyntaxMarkerRole::BlockTerminator,
+            ),
+        ],
+    )
+    .expect("prechecked IF source word should remain available");
 
-    Ok(BuiltinSourceWordIds { var, let_, def })
+    Ok(BuiltinSourceWordIds {
+        var,
+        let_,
+        def,
+        if_,
+    })
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -164,6 +232,7 @@ pub(crate) struct BuiltinSourceWordIds {
     var: SourceWordId,
     let_: SourceWordId,
     def: SourceWordId,
+    if_: SourceWordId,
 }
 
 impl BuiltinSourceWordIds {
@@ -178,6 +247,10 @@ impl BuiltinSourceWordIds {
     pub(crate) const fn def(self) -> SourceWordId {
         self.def
     }
+
+    pub(crate) const fn if_(self) -> SourceWordId {
+        self.if_
+    }
 }
 
 fn builtin_global_variable_names() -> [NormalizedName; 26] {
@@ -188,6 +261,23 @@ fn builtin_global_variable_names() -> [NormalizedName; 26] {
 
 fn builtin_name(input: &str) -> NormalizedName {
     NormalizedName::new(input).expect("built-in source word name should be valid")
+}
+
+fn if_grammar() -> StructuredGrammar {
+    StructuredGrammar::new(
+        vec![
+            MarkerGroup::new(
+                MarkerIdentity::new(builtin_name("ELSIF")),
+                MarkerCardinality::ZeroOrMore,
+            ),
+            MarkerGroup::new(
+                MarkerIdentity::new(builtin_name("ELSE")),
+                MarkerCardinality::Optional,
+            ),
+        ],
+        Some(MarkerIdentity::new(builtin_name("ENDIF"))),
+    )
+    .expect("built-in IF grammar should be valid")
 }
 
 impl PrimitiveBootstrapError {
@@ -908,13 +998,33 @@ mod tests {
         let ids = register_builtin_source_words(&mut source_words, &mut bindings)
             .expect("empty namespace should accept built-in source words");
 
-        assert_eq!(source_words.len(), 3);
+        assert_eq!(source_words.len(), 4);
         assert_source_word_binding(&bindings, "VAR", ids.var());
         assert_source_word_binding(&bindings, "var", ids.var());
         assert_source_word_binding(&bindings, "LET", ids.let_());
         assert_source_word_binding(&bindings, "let", ids.let_());
         assert_source_word_binding(&bindings, "DEF", ids.def());
         assert_source_word_binding(&bindings, "def", ids.def());
+        assert_source_word_binding(&bindings, "IF", ids.if_());
+        assert_source_word_binding(&bindings, "if", ids.if_());
+        assert_eq!(
+            bindings
+                .syntax_marker_reservation(&name("ELSIF"))
+                .map(|reservation| reservation.owner()),
+            Some(ids.if_())
+        );
+        assert_eq!(
+            bindings
+                .syntax_marker_reservation(&name("ELSE"))
+                .map(|reservation| reservation.owner()),
+            Some(ids.if_())
+        );
+        assert_eq!(
+            bindings
+                .syntax_marker_reservation(&name("ENDIF"))
+                .map(|reservation| reservation.owner()),
+            Some(ids.if_())
+        );
     }
 
     #[test]

--- a/crates/tbx-next/src/instruction.rs
+++ b/crates/tbx-next/src/instruction.rs
@@ -167,9 +167,11 @@ impl InstructionSequence {
         branch: InstructionAddress,
         target: InstructionAddress,
     ) -> Result<(), BranchTargetPatchError> {
-        self.view()
-            .validate_address(target)
-            .map_err(|source| BranchTargetPatchError::InvalidTarget { source })?;
+        if target.as_index() > self.instructions.len() {
+            return Err(BranchTargetPatchError::InvalidTarget {
+                source: InstructionAddressError::InvalidAddress { address: target },
+            });
+        }
 
         let instruction = self
             .instructions
@@ -697,19 +699,15 @@ mod tests {
     }
 
     #[test]
-    fn branch_target_patch_rejects_end_and_out_of_range_targets() {
+    fn branch_target_patch_accepts_end_and_rejects_out_of_range_targets() {
         let mut code = InstructionSequence::new();
         let target = code.append(Instruction::Halt);
         let branch = code.append(Instruction::Jump(target));
         let end = address(2);
         let out_of_range = address(3);
 
-        assert_eq!(
-            code.patch_branch_target(branch, end),
-            Err(BranchTargetPatchError::InvalidTarget {
-                source: InstructionAddressError::EndAddress { address: end }
-            })
-        );
+        assert_eq!(code.patch_branch_target(branch, end), Ok(()));
+        assert_eq!(code.view().get(branch), Ok(&Instruction::Jump(end)));
         assert_eq!(
             code.patch_branch_target(branch, out_of_range),
             Err(BranchTargetPatchError::InvalidTarget {
@@ -718,7 +716,7 @@ mod tests {
                 }
             })
         );
-        assert_eq!(code.view().get(branch), Ok(&Instruction::Jump(target)));
+        assert_eq!(code.view().get(branch), Ok(&Instruction::Jump(end)));
     }
 
     #[test]

--- a/crates/tbx-next/src/source_processor.rs
+++ b/crates/tbx-next/src/source_processor.rs
@@ -6610,6 +6610,7 @@ mod tests {
             unit.instructions().get(address(1)),
             Ok(&Instruction::JumpIfZero(address(4)))
         );
+        assert_eq!(unit.instructions().get(address(4)), Ok(&Instruction::Halt));
         assert_eq!(
             unit.source_span(location(&unit, 1)),
             Ok(Some(span(sources.view(), source_id, 0, 4)))
@@ -6617,6 +6618,38 @@ mod tests {
         assert_eq!(
             unit.source_span(location(&unit, 2)),
             Ok(Some(span(sources.view(), source_id, 13, 14)))
+        );
+    }
+
+    #[test]
+    fn builtin_if_merge_jump_targets_final_halt_instruction_not_executable_end() {
+        let (_words, _primitives, operators, source_words, bindings, _globals, _variables) =
+            global_source_fixture();
+        let (sources, source_id) = source("IF 1\nLET A = 2\nELSE\nLET A = 3\nENDIF");
+
+        let unit = compile_source(
+            sources.view(),
+            source_id,
+            SourceCompileContext::with_source_words_and_operators(
+                &bindings,
+                source_words.lookup(),
+                operators.lookup(),
+            ),
+        )
+        .expect("IF/ELSE should compile");
+
+        assert_eq!(
+            unit.instructions().get(address(1)),
+            Ok(&Instruction::JumpIfZero(address(5)))
+        );
+        assert_eq!(
+            unit.instructions().get(address(4)),
+            Ok(&Instruction::Jump(address(7)))
+        );
+        assert_eq!(unit.instructions().get(address(7)), Ok(&Instruction::Halt));
+        assert_eq!(
+            unit.source_span(location(&unit, 4)),
+            Ok(Some(span(sources.view(), source_id, 0, 4)))
         );
     }
 

--- a/crates/tbx-next/src/source_processor.rs
+++ b/crates/tbx-next/src/source_processor.rs
@@ -343,7 +343,7 @@ impl OwnerLocalBuildTarget {
         target: InstructionAddress,
     ) -> Result<(), InstructionBuildError> {
         self.validate_local_target(branch)?;
-        self.validate_local_target(target)?;
+        self.validate_local_branch_target(target)?;
         let Some(position) = self
             .unresolved_patches
             .iter()
@@ -367,6 +367,18 @@ impl OwnerLocalBuildTarget {
         address: InstructionAddress,
     ) -> Result<(), InstructionBuildError> {
         if address.as_index() >= self.code.len() {
+            return Err(InstructionBuildError::BlockCodeBuild {
+                source: BlockCodeBuildError::AddressOutsideCurrentBlock { address },
+            });
+        }
+        Ok(())
+    }
+
+    fn validate_local_branch_target(
+        &self,
+        address: InstructionAddress,
+    ) -> Result<(), InstructionBuildError> {
+        if address.as_index() > self.code.len() {
             return Err(InstructionBuildError::BlockCodeBuild {
                 source: BlockCodeBuildError::AddressOutsideCurrentBlock { address },
             });
@@ -532,6 +544,8 @@ fn current_processing_context(
 fn dispatch_current_owner_marker<'source, S>(
     view: SourceView<'source>,
     source_id: SourceId,
+    bindings: &Bindings,
+    operators: Option<OperatorLookup>,
     statement: &'source S,
     code: &mut dyn InstructionBuildTarget,
     structured_frames: &mut Vec<StructuredSourceFrame>,
@@ -577,8 +591,14 @@ where
             &mut owner_target as &mut dyn InstructionBuildTarget
         }
     };
-    let mut owner_context =
-        NativeStructuredSourceWordContext::new(view, source_id, callback_code, owner_local_targets);
+    let mut owner_context = NativeStructuredSourceWordContext::new(
+        view,
+        source_id,
+        bindings,
+        operators,
+        callback_code,
+        owner_local_targets,
+    );
     match accept {
         GrammarAccept::Intermediate { .. } => {
             frame
@@ -789,8 +809,15 @@ where
     let mut structured_frames = Vec::new();
 
     while let Some(statement) = cursor.next_completed_statement() {
-        if dispatch_current_owner_marker(view, source_id, statement, code, &mut structured_frames)?
-        {
+        if dispatch_current_owner_marker(
+            view,
+            source_id,
+            context.bindings(),
+            context.operators(),
+            statement,
+            code,
+            &mut structured_frames,
+        )? {
             continue;
         }
 
@@ -2198,7 +2225,7 @@ mod tests {
         InstructionSourceMapping, SourceMappingLookup, SourceMappingLookupError,
     };
     use crate::source_word::{
-        DefSyntaxErrorKind, LetSyntaxErrorKind, NativeSourceWordContext,
+        DefSyntaxErrorKind, IfSyntaxErrorKind, LetSyntaxErrorKind, NativeSourceWordContext,
         NativeStructuredSourceWordContext, NativeStructuredSourceWordOwner, SourceBlockItem,
         SourceBlockMarker, SourceWordRegistry, SourceWordSyntaxMarker, SourceWordSyntaxMarkerRole,
         StructuredBodyCapabilities, StructuredBodyContext, StructuredBuildTargetScope,
@@ -6364,6 +6391,232 @@ mod tests {
         assert_eq!(
             unit.instructions().get(address(8)),
             Ok(&Instruction::Push(value(30)))
+        );
+    }
+
+    #[test]
+    fn builtin_if_runs_true_false_and_elsif_paths() {
+        let (words, primitives, operators, source_words, bindings, mut globals, variables) =
+            global_source_fixture();
+
+        run_with_source_words_operators_and_mut_globals(
+            "IF 1\nLET A = 11\nELSE\nLET A = 22\nENDIF",
+            &bindings,
+            &mut globals,
+            &source_words,
+            &words,
+            &primitives,
+            operators.lookup(),
+        );
+        assert_eq!(globals.view().read(variables[0]), Ok(value(11)));
+
+        run_with_source_words_operators_and_mut_globals(
+            "IF 0\nLET B = 11\nELSE\nLET B = 22\nENDIF",
+            &bindings,
+            &mut globals,
+            &source_words,
+            &words,
+            &primitives,
+            operators.lookup(),
+        );
+        assert_eq!(globals.view().read(variables[1]), Ok(value(22)));
+
+        run_with_source_words_operators_and_mut_globals(
+            "IF 0\nLET C = 11\nELSIF 1\nLET C = 33\nELSE\nLET C = 44\nENDIF",
+            &bindings,
+            &mut globals,
+            &source_words,
+            &words,
+            &primitives,
+            operators.lookup(),
+        );
+        assert_eq!(globals.view().read(variables[2]), Ok(value(33)));
+    }
+
+    #[test]
+    fn builtin_if_accepts_empty_branches_and_nested_if() {
+        let (words, primitives, operators, source_words, bindings, mut globals, variables) =
+            global_source_fixture();
+
+        run_with_source_words_operators_and_mut_globals(
+            "IF 0\nELSIF 0\nELSE\nENDIF\nIF 1\nIF 0\nLET A = 10\nELSE\nLET A = 20\nENDIF\nENDIF",
+            &bindings,
+            &mut globals,
+            &source_words,
+            &words,
+            &primitives,
+            operators.lookup(),
+        );
+
+        assert_eq!(globals.view().read(variables[0]), Ok(value(20)));
+    }
+
+    #[test]
+    fn builtin_if_rejects_marker_payload_and_order_errors_at_local_span() {
+        let (words, primitives, operators, source_words, bindings, _globals, _variables) =
+            global_source_fixture();
+        let (sources, source_id) = source("IF 1\nELSE\nELSIF 1\nENDIF");
+
+        let error = compile_source(
+            sources.view(),
+            source_id,
+            SourceCompileContext::with_source_words_and_operators(
+                &bindings,
+                source_words.lookup(),
+                operators.lookup(),
+            ),
+        )
+        .expect_err("ELSIF after ELSE should be rejected by common grammar");
+
+        assert_eq!(
+            error,
+            SourceProcessorError::SourceWord(SourceWordError::StructuredGrammar {
+                span: span(sources.view(), source_id, 10, 17),
+                source: crate::structured_grammar::GrammarProgressError::BackwardMarker {
+                    marker_group_index: 0,
+                    current_group_index: 1
+                },
+            })
+        );
+
+        let (sources, source_id) = source("IF 1\nELSE X\nENDIF");
+        let error = compile_source(
+            sources.view(),
+            source_id,
+            SourceCompileContext::with_source_words_and_operators(
+                &bindings,
+                source_words.lookup(),
+                operators.lookup(),
+            ),
+        )
+        .expect_err("ELSE payload should be rejected by IF semantics");
+
+        assert_eq!(
+            error,
+            SourceProcessorError::SourceWord(SourceWordError::IfSyntax {
+                span: span(sources.view(), source_id, 10, 11),
+                kind: IfSyntaxErrorKind::TrailingToken {
+                    kind: TokenKind::Name
+                },
+            })
+        );
+
+        drop((words, primitives));
+    }
+
+    #[test]
+    fn builtin_if_rejects_missing_condition_and_marker_line_number_prefix() {
+        let (_words, _primitives, operators, source_words, bindings, _globals, _variables) =
+            global_source_fixture();
+        let (sources, source_id) = source("IF 1\nELSIF\nENDIF");
+
+        let error = compile_source(
+            sources.view(),
+            source_id,
+            SourceCompileContext::with_source_words_and_operators(
+                &bindings,
+                source_words.lookup(),
+                operators.lookup(),
+            ),
+        )
+        .expect_err("ELSIF requires a condition");
+
+        assert_eq!(
+            error,
+            SourceProcessorError::SourceWord(SourceWordError::IfSyntax {
+                span: span(sources.view(), source_id, 5, 10),
+                kind: IfSyntaxErrorKind::MissingCondition,
+            })
+        );
+
+        let (sources, source_id) = source("IF 1\n100 ELSE\nENDIF");
+        let error = compile_source(
+            sources.view(),
+            source_id,
+            SourceCompileContext::with_source_words_and_operators(
+                &bindings,
+                source_words.lookup(),
+                operators.lookup(),
+            ),
+        )
+        .expect_err("line-number-prefixed marker should not classify as a marker");
+
+        assert_eq!(
+            error,
+            SourceProcessorError::Compile(CompileError {
+                span: span(sources.view(), source_id, 9, 13),
+                kind: CompileErrorKind::WordResolution {
+                    source: WordResolutionError::UndefinedName
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn builtin_if_body_cannot_publish_and_failed_if_does_not_poison_next_compile() {
+        let (_words, _primitives, operators, source_words, mut bindings, mut globals, _variables) =
+            global_source_fixture();
+        let (sources, source_id) = source("IF 1\nVAR SCORE\nENDIF");
+
+        let error = compile_source(
+            sources.view(),
+            source_id,
+            SourceCompileContext::with_source_word_publication_and_operators(
+                &mut bindings,
+                source_words.lookup(),
+                operators.lookup(),
+                &mut globals,
+            ),
+        )
+        .expect_err("IF branch publication should fail through capability");
+
+        assert_eq!(
+            error,
+            SourceProcessorError::SourceWord(SourceWordError::VarPublicationContextUnavailable)
+        );
+        assert_eq!(bindings.get(&name("SCORE")), None);
+
+        let (sources, source_id) = source("IF 1\nENDIF");
+        compile_source(
+            sources.view(),
+            source_id,
+            SourceCompileContext::with_source_words_and_operators(
+                &bindings,
+                source_words.lookup(),
+                operators.lookup(),
+            ),
+        )
+        .expect("independent source should compile after failed IF");
+    }
+
+    #[test]
+    fn builtin_if_generated_jumps_use_branch_origin_spans() {
+        let (_words, _primitives, operators, source_words, bindings, _globals, _variables) =
+            global_source_fixture();
+        let (sources, source_id) = source("IF 1\nLET A = 2\nENDIF");
+
+        let unit = compile_source(
+            sources.view(),
+            source_id,
+            SourceCompileContext::with_source_words_and_operators(
+                &bindings,
+                source_words.lookup(),
+                operators.lookup(),
+            ),
+        )
+        .expect("IF should compile");
+
+        assert_eq!(
+            unit.instructions().get(address(1)),
+            Ok(&Instruction::JumpIfZero(address(4)))
+        );
+        assert_eq!(
+            unit.source_span(location(&unit, 1)),
+            Ok(Some(span(sources.view(), source_id, 0, 4)))
+        );
+        assert_eq!(
+            unit.source_span(location(&unit, 2)),
+            Ok(Some(span(sources.view(), source_id, 13, 14)))
         );
     }
 

--- a/crates/tbx-next/src/source_word.rs
+++ b/crates/tbx-next/src/source_word.rs
@@ -89,6 +89,8 @@ pub(crate) struct StructuredBodyCapabilities {
 pub(crate) struct NativeStructuredSourceWordContext<'source, 'state> {
     view: SourceView<'source>,
     source_id: SourceId,
+    bindings: &'state Bindings,
+    operators: Option<OperatorLookup>,
     code: &'state mut dyn InstructionBuildTarget,
     owner_local_targets: Vec<StructuredOwnerLocalTarget>,
 }
@@ -211,6 +213,10 @@ pub(crate) enum SourceWordError {
     DefBindingCommitInvariantViolated {
         span: SourceSpan,
     },
+    IfSyntax {
+        span: SourceSpan,
+        kind: IfSyntaxErrorKind,
+    },
     StructuredGrammar {
         span: SourceSpan,
         source: crate::structured_grammar::GrammarProgressError,
@@ -244,6 +250,12 @@ pub(crate) enum DefSyntaxErrorKind {
     TrailingToken { kind: TokenKind },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum IfSyntaxErrorKind {
+    MissingCondition,
+    TrailingToken { kind: TokenKind },
+}
+
 impl SourceWordError {
     pub(crate) fn primary_span(self) -> Option<SourceSpan> {
         match self {
@@ -271,6 +283,7 @@ impl SourceWordError {
             | Self::DefBodyBuild { span }
             | Self::DefDefinition { span }
             | Self::DefBindingCommitInvariantViolated { span }
+            | Self::IfSyntax { span, .. }
             | Self::StructuredGrammar { span, .. }
             | Self::StructuredMissingTerminator { span } => Some(span),
             Self::DefLex { source } => match source {
@@ -510,12 +523,16 @@ impl<'source, 'state> NativeStructuredSourceWordContext<'source, 'state> {
     pub(crate) fn new(
         view: SourceView<'source>,
         source_id: SourceId,
+        bindings: &'state Bindings,
+        operators: Option<OperatorLookup>,
         code: &'state mut dyn InstructionBuildTarget,
         owner_local_targets: Vec<StructuredOwnerLocalTarget>,
     ) -> Self {
         Self {
             view,
             source_id,
+            bindings,
+            operators,
             code,
             owner_local_targets,
         }
@@ -540,6 +557,38 @@ impl<'source, 'state> NativeStructuredSourceWordContext<'source, 'state> {
             .map_err(|source| SourceWordError::InstructionBuild { source })
     }
 
+    pub(crate) fn current_address(&self) -> crate::instruction::InstructionAddress {
+        self.code.current_address()
+    }
+
+    pub(crate) fn append_mapped_jump_placeholder(
+        &mut self,
+        span: SourceSpan,
+    ) -> Result<crate::instruction::InstructionAddress, SourceWordError> {
+        self.code
+            .append_mapped_jump_placeholder(span)
+            .map_err(|source| SourceWordError::InstructionBuild { source })
+    }
+
+    pub(crate) fn append_mapped_jump_if_zero_placeholder(
+        &mut self,
+        span: SourceSpan,
+    ) -> Result<crate::instruction::InstructionAddress, SourceWordError> {
+        self.code
+            .append_mapped_jump_if_zero_placeholder(span)
+            .map_err(|source| SourceWordError::InstructionBuild { source })
+    }
+
+    pub(crate) fn patch_branch_target(
+        &mut self,
+        branch: crate::instruction::InstructionAddress,
+        target: crate::instruction::InstructionAddress,
+    ) -> Result<(), SourceWordError> {
+        self.code
+            .patch_branch_target(branch, target)
+            .map_err(|source| SourceWordError::InstructionBuild { source })
+    }
+
     pub(crate) fn append_owner_local_target(
         &mut self,
         index: usize,
@@ -549,6 +598,37 @@ impl<'source, 'state> NativeStructuredSourceWordContext<'source, 'state> {
             return Err(SourceWordError::UnsupportedSourceWord { span: anchor });
         };
         target.append_to(self.code, anchor)
+    }
+
+    pub(crate) fn stage_expression(
+        &self,
+        tokens: &[Token],
+        anchor: SourceSpan,
+    ) -> Result<ExpressionStaging, SourceWordError> {
+        let Some(operators) = self.operators else {
+            return Err(SourceWordError::LetExpressionContextUnavailable { span: anchor });
+        };
+
+        let mut expression_tokens = tokens
+            .iter()
+            .copied()
+            .filter(|token| token.kind() != TokenKind::LineBoundary)
+            .collect::<Vec<_>>();
+        let end = expression_tokens
+            .last()
+            .map_or(anchor.end(), |token| token.span().end());
+        expression_tokens.push(Token::new(
+            TokenKind::Eof,
+            self.view.span(self.source_id, end, end).map_err(|source| {
+                SourceWordError::Expression {
+                    source: ExpressionError::Source(source),
+                }
+            })?,
+        ));
+
+        let resolver = |source_name: &str| resolve_variable_name(self.bindings, source_name);
+        parse_expression(self.view, &expression_tokens, operators, &resolver)
+            .map_err(|source| SourceWordError::Expression { source })
     }
 }
 
@@ -612,7 +692,7 @@ impl StructuredOwnerLocalTarget {
         parent_start: crate::instruction::InstructionAddress,
         anchor: SourceSpan,
     ) -> Result<crate::instruction::InstructionAddress, SourceWordError> {
-        if target.as_index() >= self.instructions.len() {
+        if target.as_index() > self.instructions.len() {
             return Err(SourceWordError::UnsupportedSourceWord { span: anchor });
         }
         let parent_index = parent_start
@@ -847,6 +927,22 @@ impl<'source, 'state> NativeSourceWordContext<'source, 'state> {
 
     pub(crate) fn source_word_token(&self) -> Token {
         self.source_word_token
+    }
+
+    pub(crate) fn statement_span(&self) -> Result<SourceSpan, SourceWordError> {
+        let last = self
+            .reader
+            .tokens
+            .last()
+            .copied()
+            .unwrap_or(self.source_word_token);
+        self.view
+            .span(
+                self.source_id,
+                self.source_word_token.span().start(),
+                last.span().end(),
+            )
+            .map_err(|source| SourceWordError::Source { source })
     }
 
     pub(crate) fn statement_reader_mut(&mut self) -> &mut SourceStatementReader<'source> {
@@ -1115,6 +1211,197 @@ pub(crate) fn def_source_word(
 
     context.publish_runtime_definition(name, name_token.span(), &body, end_span)?;
     Ok(())
+}
+
+#[derive(Debug)]
+struct IfSourceWordOwner {
+    branches: Vec<IfBranch>,
+    current_body_index: usize,
+}
+
+#[derive(Debug)]
+struct IfBranch {
+    condition: Option<ExpressionStaging>,
+    origin_span: SourceSpan,
+}
+
+pub(crate) fn if_source_word(
+    context: &mut NativeSourceWordContext<'_, '_>,
+) -> Result<StructuredSourceWordInstance, SourceWordError> {
+    let condition = parse_required_if_condition_from_reader(context)?;
+    let origin_span = context.statement_span()?;
+    Ok(StructuredSourceWordInstance::new(Box::new(
+        IfSourceWordOwner {
+            branches: vec![IfBranch {
+                condition: Some(condition),
+                origin_span,
+            }],
+            current_body_index: 0,
+        },
+    )))
+}
+
+impl NativeStructuredSourceWordOwner for IfSourceWordOwner {
+    fn current_body_context(&self) -> StructuredBodyContext {
+        StructuredBodyContext::new(
+            StructuredBuildTargetScope::OwnerLocal(self.current_body_index),
+            StructuredLineNumberScope::OwnerLocal(self.current_body_index),
+            StructuredBodyCapabilities::without_publication(),
+        )
+    }
+
+    fn accept_marker(
+        &mut self,
+        context: &mut NativeStructuredSourceWordContext<'_, '_>,
+        marker: SourceBlockMarker<'_>,
+        _accept: crate::structured_grammar::GrammarAccept,
+    ) -> Result<(), SourceWordError> {
+        let condition = if marker.name().as_str() == "ELSIF" {
+            Some(parse_required_if_condition_from_tokens(
+                marker.remaining_tokens(),
+                marker.token().span(),
+                context,
+            )?)
+        } else {
+            require_empty_if_marker_remainder(&marker)?;
+            None
+        };
+
+        self.branches.push(IfBranch {
+            condition,
+            origin_span: marker.span(),
+        });
+        self.current_body_index += 1;
+        Ok(())
+    }
+
+    fn complete(
+        &mut self,
+        context: &mut NativeStructuredSourceWordContext<'_, '_>,
+        marker: SourceBlockMarker<'_>,
+    ) -> Result<(), SourceWordError> {
+        require_empty_if_marker_remainder(&marker)?;
+
+        let mut merge_jumps = Vec::new();
+        for index in 0..self.branches.len() {
+            let branch = &self.branches[index];
+            let branch_if_false = if let Some(condition) = &branch.condition {
+                commit_if_condition(context, condition)?;
+                Some(context.append_mapped_jump_if_zero_placeholder(branch.origin_span)?)
+            } else {
+                None
+            };
+
+            context.append_owner_local_target(index, branch.origin_span)?;
+
+            if index + 1 < self.branches.len() {
+                merge_jumps.push(context.append_mapped_jump_placeholder(branch.origin_span)?);
+            }
+
+            if let Some(branch_if_false) = branch_if_false {
+                context.patch_branch_target(branch_if_false, context.current_address())?;
+            }
+        }
+
+        let merge_target = context.current_address();
+        for jump in merge_jumps {
+            context.patch_branch_target(jump, merge_target)?;
+        }
+        Ok(())
+    }
+}
+
+fn parse_required_if_condition_from_reader(
+    context: &mut NativeSourceWordContext<'_, '_>,
+) -> Result<ExpressionStaging, SourceWordError> {
+    let (tokens, anchor) = {
+        let reader = context.statement_reader_mut();
+        let tokens = reader
+            .remaining_expression()
+            .map_err(if_reader_error_for_condition)?;
+        (tokens, context.source_word_token().span())
+    };
+    parse_required_if_condition_from_tokens(tokens, anchor, context)
+}
+
+fn parse_required_if_condition_from_tokens(
+    tokens: &[Token],
+    anchor: SourceSpan,
+    context: &impl IfConditionContext,
+) -> Result<ExpressionStaging, SourceWordError> {
+    if tokens.is_empty() {
+        return Err(SourceWordError::IfSyntax {
+            span: anchor,
+            kind: IfSyntaxErrorKind::MissingCondition,
+        });
+    }
+    context.stage_if_expression(tokens, anchor)
+}
+
+trait IfConditionContext {
+    fn stage_if_expression(
+        &self,
+        tokens: &[Token],
+        anchor: SourceSpan,
+    ) -> Result<ExpressionStaging, SourceWordError>;
+}
+
+impl IfConditionContext for NativeSourceWordContext<'_, '_> {
+    fn stage_if_expression(
+        &self,
+        tokens: &[Token],
+        anchor: SourceSpan,
+    ) -> Result<ExpressionStaging, SourceWordError> {
+        self.stage_expression(tokens, anchor)
+    }
+}
+
+impl IfConditionContext for NativeStructuredSourceWordContext<'_, '_> {
+    fn stage_if_expression(
+        &self,
+        tokens: &[Token],
+        anchor: SourceSpan,
+    ) -> Result<ExpressionStaging, SourceWordError> {
+        self.stage_expression(tokens, anchor)
+    }
+}
+
+fn commit_if_condition(
+    context: &mut NativeStructuredSourceWordContext<'_, '_>,
+    condition: &ExpressionStaging,
+) -> Result<(), SourceWordError> {
+    for entry in condition.entries() {
+        context.append_mapped(entry.instruction(), entry.span())?;
+    }
+    Ok(())
+}
+
+fn require_empty_if_marker_remainder(
+    marker: &SourceBlockMarker<'_>,
+) -> Result<(), SourceWordError> {
+    if let Some(token) = marker.remaining_tokens().first().copied() {
+        return Err(SourceWordError::IfSyntax {
+            span: token.span(),
+            kind: IfSyntaxErrorKind::TrailingToken { kind: token.kind() },
+        });
+    }
+    Ok(())
+}
+
+fn if_reader_error_for_condition(error: SourceStatementReaderError) -> SourceWordError {
+    match error {
+        SourceStatementReaderError::Missing { span, .. } => SourceWordError::IfSyntax {
+            span,
+            kind: IfSyntaxErrorKind::MissingCondition,
+        },
+        SourceStatementReaderError::Unexpected { actual, .. }
+        | SourceStatementReaderError::TrailingToken { actual } => SourceWordError::IfSyntax {
+            span: actual.span(),
+            kind: IfSyntaxErrorKind::TrailingToken {
+                kind: actual.kind(),
+            },
+        },
+    }
 }
 
 pub(crate) fn unsupported_source_word(

--- a/crates/tbx-next/src/static_quotation.rs
+++ b/crates/tbx-next/src/static_quotation.rs
@@ -274,6 +274,36 @@ mod tests {
     }
 
     #[test]
+    fn one_past_end_branch_targets_attach_to_parent_following_instruction() {
+        let quotation = StaticQuotation::build(|builder| {
+            let jump = builder.append_unmapped_jump_placeholder()?;
+            let jump_if_zero = builder.append_unmapped_jump_if_zero_placeholder()?;
+            let end = builder.current_address();
+            builder.patch_branch_target(jump, end)?;
+            builder.patch_branch_target(jump_if_zero, end)?;
+            Ok(())
+        })
+        .expect("quotation can complete with local end boundary targets");
+
+        let parent = build_parent(|builder| {
+            builder.append_unmapped(push(99))?;
+            quotation.attach_to(builder).map_err(|_| unreachable!())?;
+            builder.append_unmapped(push(7))?;
+            Ok(())
+        });
+
+        assert_eq!(
+            parent.instruction_view().get(address(1)),
+            Ok(&Instruction::Jump(address(3)))
+        );
+        assert_eq!(
+            parent.instruction_view().get(address(2)),
+            Ok(&Instruction::JumpIfZero(address(3)))
+        );
+        assert_eq!(parent.instruction_view().get(address(3)), Ok(&push(7)));
+    }
+
+    #[test]
     fn unresolved_branch_rejects_quotation_completion() {
         let error = StaticQuotation::build(|builder| {
             builder.append_unmapped_jump_placeholder()?;
@@ -309,6 +339,30 @@ mod tests {
             Err(StaticQuotationAttachError::InvalidLocalTarget {
                 target: address(99)
             })
+        );
+        assert_eq!(parent.current_len(), 1);
+        parent.finish().expect("parent should still complete");
+        assert_eq!(parent_code.len(), 1);
+    }
+
+    #[test]
+    fn one_past_end_plus_one_rejects_attachment_without_parent_mutation() {
+        let mut code = SourceMappedCode::new();
+        code.append_unmapped(Instruction::Jump(address(2)))
+            .expect("test quotation instruction should append");
+        let quotation = StaticQuotation {
+            code,
+            completed: CompletedBlockCode::test_new(address(0), address(1)),
+        };
+        let mut parent_code = SourceMappedCode::new();
+        let mut parent = BlockCodeBuilder::new(&mut parent_code);
+        parent
+            .append_unmapped(push(10))
+            .expect("prefix should append");
+
+        assert_eq!(
+            quotation.attach_to(&mut parent),
+            Err(StaticQuotationAttachError::InvalidLocalTarget { target: address(2) })
         );
         assert_eq!(parent.current_len(), 1);
         parent.finish().expect("parent should still complete");

--- a/crates/tbx-next/src/static_quotation.rs
+++ b/crates/tbx-next/src/static_quotation.rs
@@ -143,7 +143,7 @@ impl StaticQuotation {
         target: InstructionAddress,
         parent_start: InstructionAddress,
     ) -> Result<InstructionAddress, StaticQuotationAttachError> {
-        if !self.completed.contains(target) {
+        if !self.completed.contains(target) && target != self.completed.end() {
             return Err(StaticQuotationAttachError::InvalidLocalTarget { target });
         }
 


### PR DESCRIPTION
## Summary

- bootstrap に native `IF` structured source word と `ELSIF* ELSE? ENDIF` grammar / marker reservation を登録
- `IF` owner で条件式を staging し、branch body を owner-local target として保持して、`ENDIF` 成功時だけ親 target へ lowering
- `JumpIfZero` / merge `Jump` の forward-to-end target を扱えるよう branch patch / attachment 境界を拡張
- IF / ELSE / ELSIF runtime path、nested IF、empty branch、marker error、publication capability、source mapping の統合テストを追加

Closes #1525

## Verification

- `cargo test -p tbx-next --no-fail-fast`
- `cargo clippy -p tbx-next --all-targets --all-features -- -D warnings`
- `cargo ci-fmt`
- `cargo ci-clippy`
- `cargo ci-test`
