### PR TITLE
TBX Next: IF quotation基盤の縦断検証を追加

### DIFF
--- a/crates/tbx-next/src/line_number.rs
+++ b/crates/tbx-next/src/line_number.rs
@@ -130,7 +130,7 @@ impl LocalLineNumberTable {
                     span: patch.span,
                     source,
                 })?;
-            self.patches.swap_remove(0);
+            self.patches.remove(0);
         }
 
         Ok(())
@@ -251,6 +251,47 @@ mod tests {
         assert_eq!(
             code.instruction_view().get(second_branch),
             Ok(&Instruction::JumpIfZero(second_target))
+        );
+    }
+
+    #[test]
+    fn resolve_preserves_source_order_after_consuming_successful_prefix() {
+        let (sources, source_id) = source("BIF 0, 100\n100 BODY\nBIF 0, 200\nBIF 0, 300");
+        let first_branch_span = span(sources.view(), source_id, 7, 10);
+        let first_target_span = span(sources.view(), source_id, 11, 14);
+        let second_branch_span = span(sources.view(), source_id, 27, 30);
+        let third_branch_span = span(sources.view(), source_id, 38, 41);
+        let mut code = SourceMappedCode::new();
+        let mut builder = BlockCodeBuilder::new(&mut code);
+        let first_branch = builder
+            .append_unmapped_jump_if_zero_placeholder()
+            .expect("first branch should append");
+        let first_target = append(&mut builder, Instruction::Push(Value::integer(1)));
+        let second_branch = builder
+            .append_unmapped_jump_if_zero_placeholder()
+            .expect("second branch should append");
+        let third_branch = builder
+            .append_unmapped_jump_if_zero_placeholder()
+            .expect("third branch should append");
+        let mut table = LocalLineNumberTable::new();
+
+        table.add_patch(line(100), first_branch, first_branch_span);
+        table.add_patch(line(200), second_branch, second_branch_span);
+        table.add_patch(line(300), third_branch, third_branch_span);
+        table
+            .define(&builder, line(100), first_target, first_target_span)
+            .expect("first target should define");
+
+        assert_eq!(
+            table.resolve(&mut builder),
+            Err(LineNumberError::Undefined {
+                line_number: line(200),
+                span: second_branch_span,
+            })
+        );
+        assert_eq!(
+            code.instruction_view().get(first_branch),
+            Ok(&Instruction::JumpIfZero(first_target))
         );
     }
 

--- a/crates/tbx-next/src/line_number.rs
+++ b/crates/tbx-next/src/line_number.rs
@@ -112,28 +112,25 @@ impl LocalLineNumberTable {
     }
 
     pub(crate) fn resolve(
-        &self,
+        &mut self,
         target: &mut dyn InstructionBuildTarget,
     ) -> Result<(), LineNumberError> {
-        let mut resolved = Vec::with_capacity(self.patches.len());
-        for patch in &self.patches {
+        while let Some(patch) = self.patches.first().copied() {
             let Some(definition) = self.definitions.get(&patch.line_number) else {
                 return Err(LineNumberError::Undefined {
                     line_number: patch.line_number,
                     span: patch.span,
                 });
             };
-            resolved.push((*patch, definition.target));
-        }
 
-        for (patch, target_address) in resolved {
             target
-                .patch_branch_target(patch.branch, target_address)
+                .patch_branch_target(patch.branch, definition.target)
                 .map_err(|source| LineNumberError::Patch {
                     line_number: patch.line_number,
                     span: patch.span,
                     source,
                 })?;
+            self.patches.swap_remove(0);
         }
 
         Ok(())
@@ -208,6 +205,52 @@ mod tests {
         assert_eq!(
             code.instruction_view().get(branch),
             Ok(&Instruction::JumpIfZero(target))
+        );
+    }
+
+    #[test]
+    fn resolve_consumes_only_current_pending_patches() {
+        let (sources, source_id) = source("BIF 0, 100\n100 BODY\nBIF 0, 200\n200 BODY");
+        let first_branch_span = span(sources.view(), source_id, 7, 10);
+        let first_target_span = span(sources.view(), source_id, 11, 14);
+        let second_branch_span = span(sources.view(), source_id, 28, 31);
+        let second_target_span = span(sources.view(), source_id, 32, 35);
+        let mut code = SourceMappedCode::new();
+        let mut builder = BlockCodeBuilder::new(&mut code);
+        let first_branch = builder
+            .append_unmapped_jump_if_zero_placeholder()
+            .expect("first branch should append");
+        let first_target = append(&mut builder, Instruction::Push(Value::integer(1)));
+        let mut table = LocalLineNumberTable::new();
+
+        table.add_patch(line(100), first_branch, first_branch_span);
+        table
+            .define(&builder, line(100), first_target, first_target_span)
+            .expect("first target should define");
+        table
+            .resolve(&mut builder)
+            .expect("first pending patch should resolve");
+
+        let second_branch = builder
+            .append_unmapped_jump_if_zero_placeholder()
+            .expect("second branch should append");
+        let second_target = append(&mut builder, Instruction::Push(Value::integer(2)));
+        table.add_patch(line(200), second_branch, second_branch_span);
+        table
+            .define(&builder, line(200), second_target, second_target_span)
+            .expect("second target should define");
+        table
+            .resolve(&mut builder)
+            .expect("later pending patch should resolve without repatching the first");
+        builder.finish().expect("block should complete");
+
+        assert_eq!(
+            code.instruction_view().get(first_branch),
+            Ok(&Instruction::JumpIfZero(first_target))
+        );
+        assert_eq!(
+            code.instruction_view().get(second_branch),
+            Ok(&Instruction::JumpIfZero(second_target))
         );
     }
 

--- a/crates/tbx-next/src/source_processor.rs
+++ b/crates/tbx-next/src/source_processor.rs
@@ -201,6 +201,7 @@ enum BuildTargetHandle {
 struct OwnerLocalLineNumberScope {
     table: Rc<RefCell<LocalLineNumberTable>>,
     target: BuildTargetHandle,
+    resolved: bool,
 }
 
 #[derive(Debug)]
@@ -258,10 +259,13 @@ impl StructuredSourceFrame {
     }
 
     fn resolve_owner_line_numbers(
-        &self,
+        &mut self,
         code: &mut dyn InstructionBuildTarget,
     ) -> Result<(), SourceProcessorError> {
-        for scope in &self.owner_line_numbers {
+        for scope in &mut self.owner_line_numbers {
+            if scope.resolved {
+                continue;
+            }
             let mut owner_target;
             let target = match &scope.target {
                 BuildTargetHandle::Parent => &mut *code,
@@ -277,6 +281,7 @@ impl StructuredSourceFrame {
                 .borrow_mut()
                 .resolve(target)
                 .map_err(|source| SourceProcessorError::from(line_number_compile_error(source)))?;
+            scope.resolved = true;
         }
         Ok(())
     }
@@ -294,6 +299,7 @@ impl StructuredSourceFrame {
             self.owner_line_numbers.push(OwnerLocalLineNumberScope {
                 table: Rc::new(RefCell::new(LocalLineNumberTable::new())),
                 target: self.body_target.clone(),
+                resolved: false,
             });
         }
         &self.owner_line_numbers[index]
@@ -573,12 +579,10 @@ where
                 source,
             })?;
 
+    frame.resolve_owner_line_numbers(code)?;
     let callback_target = match accept {
         GrammarAccept::Intermediate { .. } => frame.body_target.clone(),
-        GrammarAccept::Terminator => {
-            frame.resolve_owner_line_numbers(code)?;
-            frame.enclosing_target.clone()
-        }
+        GrammarAccept::Terminator => frame.enclosing_target.clone(),
     };
     let owner_local_targets = frame.owner_local_target_snapshots()?;
     let mut owner_target;
@@ -6434,6 +6438,35 @@ mod tests {
     }
 
     #[test]
+    fn builtin_if_source_to_vm_covers_simple_false_and_multiple_elsif_selection() {
+        let (words, primitives, operators, source_words, bindings, mut globals, variables) =
+            global_source_fixture();
+
+        run_with_source_words_operators_and_mut_globals(
+            "IF 1\nLET A = 1\nENDIF\nIF 0\nLET B = 1\nENDIF",
+            &bindings,
+            &mut globals,
+            &source_words,
+            &words,
+            &primitives,
+            operators.lookup(),
+        );
+        assert_eq!(globals.view().read(variables[0]), Ok(value(1)));
+        assert_eq!(globals.view().read(variables[1]), Ok(value(0)));
+
+        run_with_source_words_operators_and_mut_globals(
+            "IF 0\nLET C = 10\nELSIF 0\nLET C = 20\nELSIF 1\nLET C = 30\nELSE\nLET C = 40\nENDIF",
+            &bindings,
+            &mut globals,
+            &source_words,
+            &words,
+            &primitives,
+            operators.lookup(),
+        );
+        assert_eq!(globals.view().read(variables[2]), Ok(value(30)));
+    }
+
+    #[test]
     fn builtin_if_accepts_empty_branches_and_nested_if() {
         let (words, primitives, operators, source_words, bindings, mut globals, variables) =
             global_source_fixture();
@@ -6449,6 +6482,146 @@ mod tests {
         );
 
         assert_eq!(globals.view().read(variables[0]), Ok(value(20)));
+    }
+
+    #[test]
+    fn builtin_if_quotation_local_line_number_branch_runs_inside_body_only() {
+        let (mut words, mut primitives, operators) = operator_fixture();
+        let mut source_words = SourceWordRegistry::new();
+        let mut bindings = Bindings::new();
+        register_builtin_source_words(&mut source_words, &mut bindings)
+            .expect("built-in source words should bootstrap");
+        let push7 = primitives.register(push_7);
+        let fail = primitives.register(fail_after_partial_stack_update);
+        register_primitive(&mut words, &mut bindings, name("PUSH7"), push7)
+            .expect("PUSH7 primitive should register");
+        register_primitive(&mut words, &mut bindings, name("FAIL"), fail)
+            .expect("FAIL primitive should register");
+        let (sources, source_id) = source("IF 1\nBIF 0, 20\nFAIL\n20 PUSH7\nENDIF");
+
+        let result = run_source(
+            sources.view(),
+            source_id,
+            SourceExecutionContext::with_source_words_and_operators(
+                &bindings,
+                source_words.lookup(),
+                operators.lookup(),
+                PublishedWordLookup::new(&words),
+                primitives.lookup(),
+            ),
+        )
+        .expect("quotation-local line-number branch should run inside the branch body");
+        assert_eq!(result.data_stack(), [value(7)]);
+
+        let (sources, source_id) = source("IF 1\nBIF 0, 99\nENDIF\n99 PUSH7");
+        let error = compile_source(
+            sources.view(),
+            source_id,
+            SourceCompileContext::with_source_words_and_operators(
+                &bindings,
+                source_words.lookup(),
+                operators.lookup(),
+            ),
+        )
+        .expect_err("quotation-local branch should not resolve a parent line number");
+        assert_eq!(
+            error,
+            SourceProcessorError::Compile(CompileError {
+                span: span(sources.view(), source_id, 12, 14),
+                kind: CompileErrorKind::LineNumber {
+                    source: Box::new(LineNumberError::Undefined {
+                        line_number: LocalLineNumber::new(99),
+                        span: span(sources.view(), source_id, 12, 14),
+                    }),
+                },
+            })
+        );
+
+        let (sources, source_id) = source("IF 0\nELSE\nBIF 0, 20\nFAIL\n20 PUSH7\nENDIF");
+        let result = run_source(
+            sources.view(),
+            source_id,
+            SourceExecutionContext::with_source_words_and_operators(
+                &bindings,
+                source_words.lookup(),
+                operators.lookup(),
+                PublishedWordLookup::new(&words),
+                primitives.lookup(),
+            ),
+        )
+        .expect("same local line number should work in a later IF branch body");
+        assert_eq!(result.data_stack(), [value(7)]);
+    }
+
+    #[test]
+    fn builtin_if_rejects_parent_jump_into_branch_body_line_number() {
+        let (mut words, mut primitives, operators) = operator_fixture();
+        let mut source_words = SourceWordRegistry::new();
+        let mut bindings = Bindings::new();
+        register_builtin_source_words(&mut source_words, &mut bindings)
+            .expect("built-in source words should bootstrap");
+        let push7 = primitives.register(push_7);
+        register_primitive(&mut words, &mut bindings, name("PUSH7"), push7)
+            .expect("PUSH7 primitive should register");
+        let (sources, source_id) = source("BIF 0, 20\nIF 1\n20 PUSH7\nENDIF");
+
+        let error = compile_source(
+            sources.view(),
+            source_id,
+            SourceCompileContext::with_source_words_and_operators(
+                &bindings,
+                source_words.lookup(),
+                operators.lookup(),
+            ),
+        )
+        .expect_err("parent scope should not resolve a quotation-local line number");
+
+        assert_eq!(
+            error,
+            SourceProcessorError::Compile(CompileError {
+                span: span(sources.view(), source_id, 7, 9),
+                kind: CompileErrorKind::LineNumber {
+                    source: Box::new(LineNumberError::Undefined {
+                        line_number: LocalLineNumber::new(20),
+                        span: span(sources.view(), source_id, 7, 9),
+                    }),
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn builtin_if_allows_same_line_number_in_separate_branch_quotations() {
+        let (mut words, mut primitives, operators) = operator_fixture();
+        let mut source_words = SourceWordRegistry::new();
+        let mut bindings = Bindings::new();
+        register_builtin_source_words(&mut source_words, &mut bindings)
+            .expect("built-in source words should bootstrap");
+        let push7 = primitives.register(push_7);
+        let push5 = primitives.register(push_5);
+        let fail = primitives.register(fail_after_partial_stack_update);
+        register_primitive(&mut words, &mut bindings, name("PUSH7"), push7)
+            .expect("PUSH7 primitive should register");
+        register_primitive(&mut words, &mut bindings, name("PUSH5"), push5)
+            .expect("PUSH5 primitive should register");
+        register_primitive(&mut words, &mut bindings, name("FAIL"), fail)
+            .expect("FAIL primitive should register");
+
+        let (sources, source_id) =
+            source("IF 1\nBIF 0, 10\nFAIL\n10 PUSH7\nELSE\nBIF 0, 10\nFAIL\n10 PUSH5\nENDIF");
+        let result = run_source(
+            sources.view(),
+            source_id,
+            SourceExecutionContext::with_source_words_and_operators(
+                &bindings,
+                source_words.lookup(),
+                operators.lookup(),
+                PublishedWordLookup::new(&words),
+                primitives.lookup(),
+            ),
+        )
+        .expect("same local line number should be valid in separate IF branch quotations");
+        assert_eq!(result.data_stack(), [value(7)]);
     }
 
     #[test]
@@ -6590,6 +6763,146 @@ mod tests {
     }
 
     #[test]
+    fn builtin_if_body_def_capability_failure_does_not_publish_runtime_definition() {
+        let (mut words, _primitives, operators) = operator_fixture();
+        let mut source_words = SourceWordRegistry::new();
+        let mut bindings = Bindings::new();
+        let mut globals = GlobalVariables::new();
+        register_builtin_source_words(&mut source_words, &mut bindings)
+            .expect("built-in source words should bootstrap");
+        let mut code = PublishedCode::new();
+        let initial_words_len = words.len();
+
+        let (sources, source_id) = source("IF 1\nDEF INNER\nEND\nENDIF");
+        let error = compile_source(
+            sources.view(),
+            source_id,
+            SourceCompileContext::with_runtime_definition_publication_and_operators(
+                &mut bindings,
+                source_words.lookup(),
+                operators.lookup(),
+                &mut globals,
+                &mut code,
+                &mut words,
+            ),
+        )
+        .expect_err("IF branch DEF should fail through missing publication capability");
+
+        assert_eq!(
+            error,
+            SourceProcessorError::SourceWord(SourceWordError::DefPublicationContextUnavailable {
+                span: span(sources.view(), source_id, 5, 8)
+            })
+        );
+        assert_eq!(bindings.get(&name("INNER")), None);
+        assert_eq!(words.len(), initial_words_len);
+        assert_eq!(code.len(), 0);
+
+        compile_with_def(
+            "DEF OK\nEND",
+            &mut bindings,
+            &mut globals,
+            &source_words,
+            operators.lookup(),
+            &mut code,
+            &mut words,
+        );
+        assert!(matches!(bindings.get(&name("OK")), Some(Binding::Word(_))));
+    }
+
+    #[test]
+    fn failed_if_lexical_input_returns_no_unit_and_independent_source_runs() {
+        let (words, primitives, operators, source_words, bindings, mut globals, variables) =
+            global_source_fixture();
+        let (sources, source_id) = source("IF 1\nLET A = 2\n@");
+
+        let error = compile_source(
+            sources.view(),
+            source_id,
+            SourceCompileContext::with_source_words_and_operators(
+                &bindings,
+                source_words.lookup(),
+                operators.lookup(),
+            ),
+        )
+        .expect_err("malformed IF source should not return a completed unit");
+        assert!(matches!(error, SourceProcessorError::Lex(_)));
+
+        run_with_source_words_operators_and_mut_globals(
+            "IF 1\nLET A = 12\nENDIF",
+            &bindings,
+            &mut globals,
+            &source_words,
+            &words,
+            &primitives,
+            operators.lookup(),
+        );
+        assert_eq!(globals.view().read(variables[0]), Ok(value(12)));
+    }
+
+    #[test]
+    fn builtin_if_runtime_errors_map_to_original_branch_body_spans() {
+        for (source_text, expected_start, expected_end) in [
+            ("IF 1\nFAIL\nELSE\nENDIF", 5, 9),
+            ("IF 0\nELSIF 1\nFAIL\nELSE\nENDIF", 13, 17),
+            ("IF 0\nELSIF 0\nELSE\nFAIL\nENDIF", 18, 22),
+        ] {
+            let mut words = PublishedWords::new();
+            let mut primitives = PrimitiveRegistry::new();
+            let fail = primitives.register(fail_after_partial_stack_update);
+            let mut source_words = SourceWordRegistry::new();
+            let mut bindings = Bindings::new();
+            register_builtin_source_words(&mut source_words, &mut bindings)
+                .expect("built-in source words should bootstrap");
+            register_primitive(&mut words, &mut bindings, name("FAIL"), fail)
+                .expect("FAIL primitive should register");
+            let (sources, source_id) = source(source_text);
+
+            let unit = compile_source(
+                sources.view(),
+                source_id,
+                SourceCompileContext::with_source_words_and_operators(
+                    &bindings,
+                    source_words.lookup(),
+                    register_operator_primitives(&mut primitives, &mut words).lookup(),
+                ),
+            )
+            .expect("IF source should compile");
+            let error = run_unit(
+                &unit,
+                SourceExecutionContext::new(
+                    &bindings,
+                    PublishedWordLookup::new(&words),
+                    primitives.lookup(),
+                ),
+            )
+            .expect_err("selected IF branch should fail at runtime");
+
+            let SourceProcessorError::Runtime(error) = error else {
+                panic!("expected runtime error");
+            };
+            assert_eq!(
+                unit.source_span(error.vm().location()),
+                Ok(Some(span(
+                    sources.view(),
+                    source_id,
+                    expected_start,
+                    expected_end,
+                )))
+            );
+            assert_eq!(
+                error.source_span(),
+                Ok(Some(span(
+                    sources.view(),
+                    source_id,
+                    expected_start,
+                    expected_end,
+                )))
+            );
+        }
+    }
+
+    #[test]
     fn builtin_if_generated_jumps_use_branch_origin_spans() {
         let (_words, _primitives, operators, source_words, bindings, _globals, _variables) =
             global_source_fixture();
@@ -6618,6 +6931,62 @@ mod tests {
         assert_eq!(
             unit.source_span(location(&unit, 2)),
             Ok(Some(span(sources.view(), source_id, 13, 14)))
+        );
+    }
+
+    #[test]
+    fn builtin_if_generated_jumps_map_if_elsif_and_merge_origins() {
+        let (_words, _primitives, operators, source_words, bindings, _globals, _variables) =
+            global_source_fixture();
+        let (sources, source_id) =
+            source("IF 0\nLET A = 1\nELSIF 1\nLET A = 2\nELSE\nLET A = 3\nENDIF");
+
+        let unit = compile_source(
+            sources.view(),
+            source_id,
+            SourceCompileContext::with_source_words_and_operators(
+                &bindings,
+                source_words.lookup(),
+                operators.lookup(),
+            ),
+        )
+        .expect("IF/ELSIF/ELSE should compile");
+
+        assert_eq!(
+            unit.instructions().get(address(1)),
+            Ok(&Instruction::JumpIfZero(address(5)))
+        );
+        assert_eq!(
+            unit.instructions().get(address(4)),
+            Ok(&Instruction::Jump(address(12)))
+        );
+        assert_eq!(
+            unit.instructions().get(address(6)),
+            Ok(&Instruction::JumpIfZero(address(10)))
+        );
+        assert_eq!(
+            unit.instructions().get(address(9)),
+            Ok(&Instruction::Jump(address(12)))
+        );
+        assert_eq!(
+            unit.source_span(location(&unit, 1)),
+            Ok(Some(span(sources.view(), source_id, 0, 4)))
+        );
+        assert_eq!(
+            unit.source_span(location(&unit, 4)),
+            Ok(Some(span(sources.view(), source_id, 0, 4)))
+        );
+        assert_eq!(
+            unit.source_span(location(&unit, 6)),
+            Ok(Some(span(sources.view(), source_id, 15, 22)))
+        );
+        assert_eq!(
+            unit.source_span(location(&unit, 9)),
+            Ok(Some(span(sources.view(), source_id, 15, 22)))
+        );
+        assert_eq!(
+            unit.source_span(location(&unit, 7)),
+            Ok(Some(span(sources.view(), source_id, 31, 32)))
         );
     }
 
@@ -6651,6 +7020,70 @@ mod tests {
             unit.source_span(location(&unit, 4)),
             Ok(Some(span(sources.view(), source_id, 0, 4)))
         );
+    }
+
+    #[test]
+    fn marker_reservation_blocks_publication_through_production_source_processing() {
+        let mut source_words = SourceWordRegistry::new();
+        let mut bindings = Bindings::new();
+        let mut globals = GlobalVariables::new();
+        register_builtin_source_words(&mut source_words, &mut bindings)
+            .expect("built-in source words should bootstrap");
+        let (sources, source_id) = source("VAR ENDIF");
+
+        let error = compile_source(
+            sources.view(),
+            source_id,
+            SourceCompileContext::with_source_word_publication(
+                &mut bindings,
+                source_words.lookup(),
+                &mut globals,
+            ),
+        )
+        .expect_err("syntax-marker reservation should reject variable publication");
+
+        assert_eq!(
+            error,
+            SourceProcessorError::SourceWord(SourceWordError::VarNameConflict {
+                span: span(sources.view(), source_id, 4, 9)
+            })
+        );
+        assert_eq!(bindings.get(&name("ENDIF")), None);
+        assert_eq!(globals.len(), 0);
+    }
+
+    #[test]
+    fn builtin_if_can_call_published_runtime_word_from_branch_body() {
+        let mut session = RuntimeDefinitionSession::new();
+        session.register_primitive("PUSH7", push_7);
+        session.publish_def("DEF MARK\nPUSH7\nEND");
+        let (sources, source_id) = source("IF 1\nMARK\nENDIF");
+
+        let unit = compile_source(
+            sources.view(),
+            source_id,
+            SourceCompileContext::with_source_words_and_operators(
+                &session.bindings,
+                session.source_words.lookup(),
+                session.operators.lookup(),
+            ),
+        )
+        .expect("IF source should compile");
+        let code_spaces = [session.code.instruction_view()];
+        let source_mappings = [session.code.source_mapping()];
+        let result = run_unit(
+            &unit,
+            SourceExecutionContext::with_code_spaces_and_mappings(
+                &session.bindings,
+                &code_spaces,
+                &source_mappings,
+                PublishedWordLookup::new(&session.words),
+                session.primitives.lookup(),
+            ),
+        )
+        .expect("IF branch should execute published runtime word");
+
+        assert_eq!(result.data_stack(), [value(7)]);
     }
 
     #[test]

--- a/crates/tbx-next/src/source_processor.rs
+++ b/crates/tbx-next/src/source_processor.rs
@@ -201,7 +201,6 @@ enum BuildTargetHandle {
 struct OwnerLocalLineNumberScope {
     table: Rc<RefCell<LocalLineNumberTable>>,
     target: BuildTargetHandle,
-    resolved: bool,
 }
 
 #[derive(Debug)]
@@ -263,9 +262,6 @@ impl StructuredSourceFrame {
         code: &mut dyn InstructionBuildTarget,
     ) -> Result<(), SourceProcessorError> {
         for scope in &mut self.owner_line_numbers {
-            if scope.resolved {
-                continue;
-            }
             let mut owner_target;
             let target = match &scope.target {
                 BuildTargetHandle::Parent => &mut *code,
@@ -281,7 +277,6 @@ impl StructuredSourceFrame {
                 .borrow_mut()
                 .resolve(target)
                 .map_err(|source| SourceProcessorError::from(line_number_compile_error(source)))?;
-            scope.resolved = true;
         }
         Ok(())
     }
@@ -299,7 +294,6 @@ impl StructuredSourceFrame {
             self.owner_line_numbers.push(OwnerLocalLineNumberScope {
                 table: Rc::new(RefCell::new(LocalLineNumberTable::new())),
                 target: self.body_target.clone(),
-                resolved: false,
             });
         }
         &self.owner_line_numbers[index]
@@ -6396,6 +6390,53 @@ mod tests {
             unit.instructions().get(address(8)),
             Ok(&Instruction::Push(value(30)))
         );
+    }
+
+    #[test]
+    fn structured_reused_owner_local_scope_resolves_new_patches_incrementally() {
+        let mut words = PublishedWords::new();
+        let mut primitives = PrimitiveRegistry::new();
+        let mut bindings = Bindings::new();
+        let operators = register_operator_primitives(&mut primitives, &mut words);
+        let push7 = primitives.register(push_7);
+        let push5 = primitives.register(push_5);
+        let fail = primitives.register(fail_after_partial_stack_update);
+        register_primitive(&mut words, &mut bindings, name("PUSH7"), push7)
+            .expect("PUSH7 primitive should register");
+        register_primitive(&mut words, &mut bindings, name("PUSH5"), push5)
+            .expect("PUSH5 primitive should register");
+        register_primitive(&mut words, &mut bindings, name("FAIL"), fail)
+            .expect("FAIL primitive should register");
+        let mut source_words = SourceWordRegistry::new();
+        register_structured_probe(
+            &mut source_words,
+            &mut bindings,
+            "BLOCK",
+            start_owner_local_target_probe,
+            vec![
+                marker("ELSE", SourceWordSyntaxMarkerRole::BlockContinuation),
+                marker("END", SourceWordSyntaxMarkerRole::BlockTerminator),
+            ],
+            structured_grammar(vec![("ELSE", MarkerCardinality::Optional)], "END"),
+        );
+        let (sources, source_id) = source(
+            "BLOCK\nBIF 0, 10\nFAIL\n10 PUSH7\nBIF 1, 10\nELSE\nBIF 0, 20\nFAIL\n20 PUSH5\nBIF 1, 20\nEND",
+        );
+
+        let result = run_source(
+            sources.view(),
+            source_id,
+            SourceExecutionContext::with_source_words_and_operators(
+                &bindings,
+                source_words.lookup(),
+                operators.lookup(),
+                PublishedWordLookup::new(&words),
+                primitives.lookup(),
+            ),
+        )
+        .expect("reused owner-local scope should resolve marker and terminator patches");
+
+        assert_eq!(result.data_stack(), [value(7), value(20), value(5)]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add production source-processing/source-to-VM IF integration coverage for true/false, multiple `ELSIF`, nested/empty branches, runtime branch diagnostics, generated jump mappings, marker reservation, and runtime word regression paths.
- Verify failed IF processing does not publish `VAR`/`DEF` artifacts and does not prevent later independent source processing.
- Resolve owner-local line-number scopes when structured markers switch branches so completed branch snapshots cannot retain unresolved local patches.

Closes #1526

## Verification

- `cargo test -p tbx-next --no-fail-fast`
- `cargo clippy -p tbx-next --all-targets --all-features -- -D warnings`
- `cargo ci-fmt`
- `cargo ci-clippy`
- `cargo ci-test`
