### PR TITLE
TBX Next: 利用者定義source word評価器を追加

### DIFF
--- a/crates/tbx-next/src/lib.rs
+++ b/crates/tbx-next/src/lib.rs
@@ -107,6 +107,11 @@ mod source_word;
 #[allow(dead_code)]
 mod source_word_ir;
 
+// #1556/#1559 evaluate completed user-defined source-word IR through a small
+// source-processing evaluator instead of reusing the runtime VM or data stack.
+#[allow(dead_code)]
+mod source_word_evaluator;
+
 // #1543 keeps ordered syntax-marker grammar legality separate from source
 // traversal, statement payload parsing, and owner-specific lowering state.
 #[allow(dead_code)]

--- a/crates/tbx-next/src/source_processor.rs
+++ b/crates/tbx-next/src/source_processor.rs
@@ -31,6 +31,11 @@ use crate::source_word::{
     SourceWordLookupError, SourceWordSyntaxMarker, StructuredBodyCapabilities,
     StructuredBuildTargetScope, StructuredLineNumberScope, StructuredOwnerLocalTarget,
 };
+use crate::source_word_evaluator::{
+    evaluate_source_word, SourceWordEvaluationError, UserDefinedSourceWordContext,
+    UserDefinedSourceWordContextParts,
+};
+use crate::source_word_ir::SourceProcessingCapabilities;
 use crate::static_quotation::{StaticQuotation, StaticQuotationBuildError};
 use crate::structured_grammar::{GrammarAccept, GrammarProgress, MarkerIdentity};
 use crate::value::Value;
@@ -129,6 +134,7 @@ pub(crate) enum SourceProcessorError {
     SourceWordContextUnavailable { id: SourceWordId },
     SourceWordLookup(SourceWordLookupError),
     SourceWord(SourceWordError),
+    SourceWordEvaluation(SourceWordEvaluationError),
     Runtime(RuntimeError),
 }
 
@@ -704,6 +710,12 @@ impl From<SourceWordError> for SourceProcessorError {
     }
 }
 
+impl From<SourceWordEvaluationError> for SourceProcessorError {
+    fn from(error: SourceWordEvaluationError) -> Self {
+        Self::SourceWordEvaluation(error)
+    }
+}
+
 pub(crate) fn compile_source(
     view: SourceView<'_>,
     source_id: SourceId,
@@ -1008,6 +1020,22 @@ where
         return Err(SourceProcessorError::SourceWordContextUnavailable { id });
     };
     let dispatch = source_words.lookup_dispatch(id)?;
+    if let SourceWordDispatch::UserDefinedOneShot(implementation) = dispatch {
+        let mut line_numbers = state.line_numbers.borrow_mut();
+        let mut source_word_context =
+            UserDefinedSourceWordContext::new(UserDefinedSourceWordContextParts {
+                view: traversal.view,
+                source_id: traversal.source_id,
+                tokens,
+                bindings: context.bindings(),
+                operators: context.operators(),
+                code: state.code,
+                line_numbers: &mut line_numbers,
+                capabilities: SourceProcessingCapabilities::statement_runtime(),
+            });
+        evaluate_source_word(implementation, &mut source_word_context)?;
+        return Ok(true);
+    }
     let syntax_markers = source_words.syntax_markers(id)?;
     let operators = context.operators();
     let globals = context
@@ -1050,6 +1078,9 @@ where
                 traversal.cursor,
                 syntax_markers,
             )),
+            SourceWordDispatch::UserDefinedOneShot(_) => {
+                unreachable!("user-defined source words are evaluated before native context setup")
+            }
             SourceWordDispatch::Structured { .. } => None,
         },
         bindings: binding_access,
@@ -1061,6 +1092,9 @@ where
     });
     match dispatch {
         SourceWordDispatch::OneShot(handler) => handler(&mut source_word_context)?,
+        SourceWordDispatch::UserDefinedOneShot(_) => {
+            unreachable!("user-defined source words are evaluated before native dispatch")
+        }
         SourceWordDispatch::Structured { start, grammar } => {
             let instance = start(&mut source_word_context)?;
             let mut frame = StructuredSourceFrame::new(
@@ -2144,6 +2178,7 @@ impl SourceProcessorError {
             Self::InstructionBuild(_) => None,
             Self::SourceWordContextUnavailable { .. } | Self::SourceWordLookup(_) => None,
             Self::SourceWord(error) => error.primary_span(),
+            Self::SourceWordEvaluation(error) => error.primary_span(),
             Self::Runtime(error) => error.source_span().ok().flatten(),
         }
     }
@@ -2228,6 +2263,11 @@ mod tests {
         SourceBlockMarker, SourceWordRegistry, SourceWordSyntaxMarker, SourceWordSyntaxMarkerRole,
         StructuredBodyCapabilities, StructuredBodyContext, StructuredBuildTargetScope,
         StructuredLineNumberScope, StructuredSourceWordInstance, VarSyntaxErrorKind,
+    };
+    use crate::source_word_ir::{
+        FixedToken, LocalBinding, LocalReference, SourceInstructionOrigin,
+        SourceProcessingInstruction, SourceProcessingOperation, SourceWordImplementation,
+        SourceWordImplementationBuilder,
     };
     use crate::structured_grammar::{
         MarkerCardinality, MarkerGroup, MarkerIdentity, StructuredGrammar,
@@ -2821,6 +2861,19 @@ mod tests {
         bindings
             .insert_new(name(word_name), Binding::SourceWord(id))
             .expect("structured source word binding should register");
+        id
+    }
+
+    fn register_user_defined_probe(
+        source_words: &mut SourceWordRegistry,
+        bindings: &mut Bindings,
+        word_name: &str,
+        implementation: SourceWordImplementation,
+    ) -> SourceWordId {
+        let id = source_words.register_user_defined(implementation);
+        bindings
+            .insert_new(name(word_name), Binding::SourceWord(id))
+            .expect("user-defined source word binding should register");
         id
     }
 
@@ -4461,6 +4514,84 @@ mod tests {
             unit.source_span(location(&unit, 5)),
             Ok(Some(span(sources.view(), id, 4, 5)))
         );
+    }
+
+    #[test]
+    fn user_defined_one_shot_source_word_dispatches_completed_ir() {
+        let (words, primitives, operators) = operator_fixture();
+        let mut source_words = SourceWordRegistry::new();
+        let mut bindings = Bindings::new();
+        let mut globals = GlobalVariables::new();
+        let variables = register_builtin_global_variables(&mut globals, &mut bindings)
+            .expect("A-Z variables should bootstrap");
+        let (sources, id) = source("SET A = 1 + 2");
+        let view = sources.view();
+        let mut implementation = SourceWordImplementationBuilder::new();
+        for instruction in [
+            SourceProcessingInstruction::new(
+                SourceProcessingOperation::ReadName {
+                    bind: LocalBinding::new(name("target_name"), span(view, id, 4, 5)),
+                },
+                SourceInstructionOrigin::new(span(view, id, 0, 3)),
+            ),
+            SourceProcessingInstruction::new(
+                SourceProcessingOperation::ResolveVariable {
+                    name: LocalReference::new(name("target_name"), span(view, id, 4, 5)),
+                    bind: LocalBinding::new(name("target"), span(view, id, 4, 5)),
+                },
+                SourceInstructionOrigin::new(span(view, id, 0, 3)),
+            ),
+            SourceProcessingInstruction::new(
+                SourceProcessingOperation::Expect {
+                    token: FixedToken::Equal,
+                },
+                SourceInstructionOrigin::new(span(view, id, 6, 7)),
+            ),
+            SourceProcessingInstruction::new(
+                SourceProcessingOperation::ReadExpression {
+                    bind: LocalBinding::new(name("expr"), span(view, id, 8, 13)),
+                },
+                SourceInstructionOrigin::new(span(view, id, 8, 13)),
+            ),
+            SourceProcessingInstruction::new(
+                SourceProcessingOperation::EmitExpression {
+                    expression: LocalReference::new(name("expr"), span(view, id, 8, 13)),
+                },
+                SourceInstructionOrigin::new(span(view, id, 8, 13)),
+            ),
+            SourceProcessingInstruction::new(
+                SourceProcessingOperation::EmitStore {
+                    target: LocalReference::new(name("target"), span(view, id, 4, 5)),
+                },
+                SourceInstructionOrigin::new(span(view, id, 0, 3)),
+            ),
+        ] {
+            implementation.push(instruction);
+        }
+        register_user_defined_probe(
+            &mut source_words,
+            &mut bindings,
+            "SET",
+            implementation
+                .complete()
+                .expect("user-defined source word should validate"),
+        );
+
+        run_source(
+            view,
+            id,
+            SourceExecutionContext::with_source_words_and_operators(
+                &bindings,
+                source_words.lookup(),
+                operators.lookup(),
+                PublishedWordLookup::new(&words),
+                primitives.lookup(),
+            )
+            .with_mut_globals(globals.view_mut()),
+        )
+        .expect("user-defined source word should compile and run");
+
+        assert_eq!(globals.view().read(variables[0]), Ok(value(3)));
     }
 
     #[test]

--- a/crates/tbx-next/src/source_processor.rs
+++ b/crates/tbx-next/src/source_processor.rs
@@ -31,11 +31,6 @@ use crate::source_word::{
     SourceWordLookupError, SourceWordSyntaxMarker, StructuredBodyCapabilities,
     StructuredBuildTargetScope, StructuredLineNumberScope, StructuredOwnerLocalTarget,
 };
-use crate::source_word_evaluator::{
-    evaluate_source_word, SourceWordEvaluationError, UserDefinedSourceWordContext,
-    UserDefinedSourceWordContextParts,
-};
-use crate::source_word_ir::SourceProcessingCapabilities;
 use crate::static_quotation::{StaticQuotation, StaticQuotationBuildError};
 use crate::structured_grammar::{GrammarAccept, GrammarProgress, MarkerIdentity};
 use crate::value::Value;
@@ -134,7 +129,6 @@ pub(crate) enum SourceProcessorError {
     SourceWordContextUnavailable { id: SourceWordId },
     SourceWordLookup(SourceWordLookupError),
     SourceWord(SourceWordError),
-    SourceWordEvaluation(SourceWordEvaluationError),
     Runtime(RuntimeError),
 }
 
@@ -710,12 +704,6 @@ impl From<SourceWordError> for SourceProcessorError {
     }
 }
 
-impl From<SourceWordEvaluationError> for SourceProcessorError {
-    fn from(error: SourceWordEvaluationError) -> Self {
-        Self::SourceWordEvaluation(error)
-    }
-}
-
 pub(crate) fn compile_source(
     view: SourceView<'_>,
     source_id: SourceId,
@@ -1020,22 +1008,6 @@ where
         return Err(SourceProcessorError::SourceWordContextUnavailable { id });
     };
     let dispatch = source_words.lookup_dispatch(id)?;
-    if let SourceWordDispatch::UserDefinedOneShot(implementation) = dispatch {
-        let mut line_numbers = state.line_numbers.borrow_mut();
-        let mut source_word_context =
-            UserDefinedSourceWordContext::new(UserDefinedSourceWordContextParts {
-                view: traversal.view,
-                source_id: traversal.source_id,
-                tokens,
-                bindings: context.bindings(),
-                operators: context.operators(),
-                code: state.code,
-                line_numbers: &mut line_numbers,
-                capabilities: SourceProcessingCapabilities::statement_runtime(),
-            });
-        evaluate_source_word(implementation, &mut source_word_context)?;
-        return Ok(true);
-    }
     let syntax_markers = source_words.syntax_markers(id)?;
     let operators = context.operators();
     let globals = context
@@ -1078,9 +1050,6 @@ where
                 traversal.cursor,
                 syntax_markers,
             )),
-            SourceWordDispatch::UserDefinedOneShot(_) => {
-                unreachable!("user-defined source words are evaluated before native context setup")
-            }
             SourceWordDispatch::Structured { .. } => None,
         },
         bindings: binding_access,
@@ -1092,9 +1061,6 @@ where
     });
     match dispatch {
         SourceWordDispatch::OneShot(handler) => handler(&mut source_word_context)?,
-        SourceWordDispatch::UserDefinedOneShot(_) => {
-            unreachable!("user-defined source words are evaluated before native dispatch")
-        }
         SourceWordDispatch::Structured { start, grammar } => {
             let instance = start(&mut source_word_context)?;
             let mut frame = StructuredSourceFrame::new(
@@ -2178,7 +2144,6 @@ impl SourceProcessorError {
             Self::InstructionBuild(_) => None,
             Self::SourceWordContextUnavailable { .. } | Self::SourceWordLookup(_) => None,
             Self::SourceWord(error) => error.primary_span(),
-            Self::SourceWordEvaluation(error) => error.primary_span(),
             Self::Runtime(error) => error.source_span().ok().flatten(),
         }
     }
@@ -2263,11 +2228,6 @@ mod tests {
         SourceBlockMarker, SourceWordRegistry, SourceWordSyntaxMarker, SourceWordSyntaxMarkerRole,
         StructuredBodyCapabilities, StructuredBodyContext, StructuredBuildTargetScope,
         StructuredLineNumberScope, StructuredSourceWordInstance, VarSyntaxErrorKind,
-    };
-    use crate::source_word_ir::{
-        FixedToken, LocalBinding, LocalReference, SourceInstructionOrigin,
-        SourceProcessingInstruction, SourceProcessingOperation, SourceWordImplementation,
-        SourceWordImplementationBuilder,
     };
     use crate::structured_grammar::{
         MarkerCardinality, MarkerGroup, MarkerIdentity, StructuredGrammar,
@@ -2861,19 +2821,6 @@ mod tests {
         bindings
             .insert_new(name(word_name), Binding::SourceWord(id))
             .expect("structured source word binding should register");
-        id
-    }
-
-    fn register_user_defined_probe(
-        source_words: &mut SourceWordRegistry,
-        bindings: &mut Bindings,
-        word_name: &str,
-        implementation: SourceWordImplementation,
-    ) -> SourceWordId {
-        let id = source_words.register_user_defined(implementation);
-        bindings
-            .insert_new(name(word_name), Binding::SourceWord(id))
-            .expect("user-defined source word binding should register");
         id
     }
 
@@ -4514,84 +4461,6 @@ mod tests {
             unit.source_span(location(&unit, 5)),
             Ok(Some(span(sources.view(), id, 4, 5)))
         );
-    }
-
-    #[test]
-    fn user_defined_one_shot_source_word_dispatches_completed_ir() {
-        let (words, primitives, operators) = operator_fixture();
-        let mut source_words = SourceWordRegistry::new();
-        let mut bindings = Bindings::new();
-        let mut globals = GlobalVariables::new();
-        let variables = register_builtin_global_variables(&mut globals, &mut bindings)
-            .expect("A-Z variables should bootstrap");
-        let (sources, id) = source("SET A = 1 + 2");
-        let view = sources.view();
-        let mut implementation = SourceWordImplementationBuilder::new();
-        for instruction in [
-            SourceProcessingInstruction::new(
-                SourceProcessingOperation::ReadName {
-                    bind: LocalBinding::new(name("target_name"), span(view, id, 4, 5)),
-                },
-                SourceInstructionOrigin::new(span(view, id, 0, 3)),
-            ),
-            SourceProcessingInstruction::new(
-                SourceProcessingOperation::ResolveVariable {
-                    name: LocalReference::new(name("target_name"), span(view, id, 4, 5)),
-                    bind: LocalBinding::new(name("target"), span(view, id, 4, 5)),
-                },
-                SourceInstructionOrigin::new(span(view, id, 0, 3)),
-            ),
-            SourceProcessingInstruction::new(
-                SourceProcessingOperation::Expect {
-                    token: FixedToken::Equal,
-                },
-                SourceInstructionOrigin::new(span(view, id, 6, 7)),
-            ),
-            SourceProcessingInstruction::new(
-                SourceProcessingOperation::ReadExpression {
-                    bind: LocalBinding::new(name("expr"), span(view, id, 8, 13)),
-                },
-                SourceInstructionOrigin::new(span(view, id, 8, 13)),
-            ),
-            SourceProcessingInstruction::new(
-                SourceProcessingOperation::EmitExpression {
-                    expression: LocalReference::new(name("expr"), span(view, id, 8, 13)),
-                },
-                SourceInstructionOrigin::new(span(view, id, 8, 13)),
-            ),
-            SourceProcessingInstruction::new(
-                SourceProcessingOperation::EmitStore {
-                    target: LocalReference::new(name("target"), span(view, id, 4, 5)),
-                },
-                SourceInstructionOrigin::new(span(view, id, 0, 3)),
-            ),
-        ] {
-            implementation.push(instruction);
-        }
-        register_user_defined_probe(
-            &mut source_words,
-            &mut bindings,
-            "SET",
-            implementation
-                .complete()
-                .expect("user-defined source word should validate"),
-        );
-
-        run_source(
-            view,
-            id,
-            SourceExecutionContext::with_source_words_and_operators(
-                &bindings,
-                source_words.lookup(),
-                operators.lookup(),
-                PublishedWordLookup::new(&words),
-                primitives.lookup(),
-            )
-            .with_mut_globals(globals.view_mut()),
-        )
-        .expect("user-defined source word should compile and run");
-
-        assert_eq!(globals.view().read(variables[0]), Ok(value(3)));
     }
 
     #[test]

--- a/crates/tbx-next/src/source_word.rs
+++ b/crates/tbx-next/src/source_word.rs
@@ -9,6 +9,7 @@ use crate::lexer::{LexError, Token, TokenKind};
 use crate::name::{NameError, NormalizedName};
 use crate::operator::OperatorLookup;
 use crate::source::{SourceError, SourceId, SourceSpan, SourceView};
+use crate::source_word_ir::SourceWordImplementation;
 use crate::word::WordId;
 use crate::word_resolution::{resolve_binding_name, ResolvedBinding, WordResolutionError};
 
@@ -779,7 +780,7 @@ pub(crate) struct SourceStatementReader<'source> {
 }
 
 impl<'source> SourceStatementReader<'source> {
-    const fn new(tokens: &'source [Token], missing_anchor: SourceSpan) -> Self {
+    pub(crate) const fn new(tokens: &'source [Token], missing_anchor: SourceSpan) -> Self {
         Self {
             tokens,
             position: 0,
@@ -828,6 +829,41 @@ impl<'source> SourceStatementReader<'source> {
         let remaining = &self.tokens[self.position..];
         self.position = self.tokens.len();
         Ok(remaining)
+    }
+
+    pub(crate) fn expression_until(
+        &mut self,
+        delimiter: TokenKind,
+    ) -> Result<&'source [Token], SourceStatementReaderError> {
+        if self.is_exhausted() {
+            return Err(SourceStatementReaderError::Missing {
+                expected: SourceStatementExpected::Expression,
+                span: self.missing_anchor,
+            });
+        }
+
+        let start = self.position;
+        let mut depth = 0usize;
+        while let Some(token) = self.tokens.get(self.position).copied() {
+            match token.kind() {
+                TokenKind::LParen => depth += 1,
+                TokenKind::RParen => {
+                    depth = depth.saturating_sub(1);
+                }
+                kind if kind == delimiter && depth == 0 => break,
+                _ => {}
+            }
+            self.position += 1;
+        }
+
+        if start == self.position {
+            return Err(SourceStatementReaderError::Missing {
+                expected: SourceStatementExpected::Expression,
+                span: self.missing_anchor,
+            });
+        }
+
+        Ok(&self.tokens[start..self.position])
     }
 
     pub(crate) fn finish(&self) -> Result<(), SourceStatementReaderError> {
@@ -1531,6 +1567,7 @@ struct SourceWordEntry {
 #[derive(Debug, Clone)]
 enum SourceWordKind {
     OneShot(NativeSourceWordHandler),
+    UserDefinedOneShot(SourceWordImplementation),
     Structured {
         start: NativeStructuredSourceWordStartHandler,
         grammar: crate::structured_grammar::StructuredGrammar,
@@ -1555,6 +1592,18 @@ impl SourceWordRegistry {
         self.entries.push(SourceWordEntry {
             kind: SourceWordKind::OneShot(handler),
             syntax_markers,
+        });
+        id
+    }
+
+    pub(crate) fn register_user_defined(
+        &mut self,
+        implementation: SourceWordImplementation,
+    ) -> SourceWordId {
+        let id = SourceWordId::from_slot(self.entries.len());
+        self.entries.push(SourceWordEntry {
+            kind: SourceWordKind::UserDefinedOneShot(implementation),
+            syntax_markers: Vec::new(),
         });
         id
     }
@@ -1594,6 +1643,7 @@ pub(crate) struct SourceWordLookup<'a> {
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum SourceWordDispatch<'a> {
     OneShot(NativeSourceWordHandler),
+    UserDefinedOneShot(&'a SourceWordImplementation),
     Structured {
         start: NativeStructuredSourceWordStartHandler,
         grammar: &'a crate::structured_grammar::StructuredGrammar,
@@ -1612,6 +1662,9 @@ impl<'a> SourceWordLookup<'a> {
             .ok_or(SourceWordLookupError::InvalidSourceWordId { id })?;
         Ok(match &entry.kind {
             SourceWordKind::OneShot(handler) => SourceWordDispatch::OneShot(*handler),
+            SourceWordKind::UserDefinedOneShot(implementation) => {
+                SourceWordDispatch::UserDefinedOneShot(implementation)
+            }
             SourceWordKind::Structured { start, grammar } => SourceWordDispatch::Structured {
                 start: *start,
                 grammar,
@@ -1625,7 +1678,7 @@ impl<'a> SourceWordLookup<'a> {
     ) -> Result<NativeSourceWordHandler, SourceWordLookupError> {
         match self.lookup_dispatch(id)? {
             SourceWordDispatch::OneShot(handler) => Ok(handler),
-            SourceWordDispatch::Structured { .. } => {
+            SourceWordDispatch::UserDefinedOneShot(_) | SourceWordDispatch::Structured { .. } => {
                 Err(SourceWordLookupError::InvalidSourceWordId { id })
             }
         }

--- a/crates/tbx-next/src/source_word.rs
+++ b/crates/tbx-next/src/source_word.rs
@@ -9,7 +9,6 @@ use crate::lexer::{LexError, Token, TokenKind};
 use crate::name::{NameError, NormalizedName};
 use crate::operator::OperatorLookup;
 use crate::source::{SourceError, SourceId, SourceSpan, SourceView};
-use crate::source_word_ir::SourceWordImplementation;
 use crate::word::WordId;
 use crate::word_resolution::{resolve_binding_name, ResolvedBinding, WordResolutionError};
 
@@ -1567,7 +1566,6 @@ struct SourceWordEntry {
 #[derive(Debug, Clone)]
 enum SourceWordKind {
     OneShot(NativeSourceWordHandler),
-    UserDefinedOneShot(SourceWordImplementation),
     Structured {
         start: NativeStructuredSourceWordStartHandler,
         grammar: crate::structured_grammar::StructuredGrammar,
@@ -1592,18 +1590,6 @@ impl SourceWordRegistry {
         self.entries.push(SourceWordEntry {
             kind: SourceWordKind::OneShot(handler),
             syntax_markers,
-        });
-        id
-    }
-
-    pub(crate) fn register_user_defined(
-        &mut self,
-        implementation: SourceWordImplementation,
-    ) -> SourceWordId {
-        let id = SourceWordId::from_slot(self.entries.len());
-        self.entries.push(SourceWordEntry {
-            kind: SourceWordKind::UserDefinedOneShot(implementation),
-            syntax_markers: Vec::new(),
         });
         id
     }
@@ -1643,7 +1629,6 @@ pub(crate) struct SourceWordLookup<'a> {
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum SourceWordDispatch<'a> {
     OneShot(NativeSourceWordHandler),
-    UserDefinedOneShot(&'a SourceWordImplementation),
     Structured {
         start: NativeStructuredSourceWordStartHandler,
         grammar: &'a crate::structured_grammar::StructuredGrammar,
@@ -1662,9 +1647,6 @@ impl<'a> SourceWordLookup<'a> {
             .ok_or(SourceWordLookupError::InvalidSourceWordId { id })?;
         Ok(match &entry.kind {
             SourceWordKind::OneShot(handler) => SourceWordDispatch::OneShot(*handler),
-            SourceWordKind::UserDefinedOneShot(implementation) => {
-                SourceWordDispatch::UserDefinedOneShot(implementation)
-            }
             SourceWordKind::Structured { start, grammar } => SourceWordDispatch::Structured {
                 start: *start,
                 grammar,
@@ -1678,7 +1660,7 @@ impl<'a> SourceWordLookup<'a> {
     ) -> Result<NativeSourceWordHandler, SourceWordLookupError> {
         match self.lookup_dispatch(id)? {
             SourceWordDispatch::OneShot(handler) => Ok(handler),
-            SourceWordDispatch::UserDefinedOneShot(_) | SourceWordDispatch::Structured { .. } => {
+            SourceWordDispatch::Structured { .. } => {
                 Err(SourceWordLookupError::InvalidSourceWordId { id })
             }
         }

--- a/crates/tbx-next/src/source_word_evaluator.rs
+++ b/crates/tbx-next/src/source_word_evaluator.rs
@@ -1,0 +1,981 @@
+use std::collections::HashMap;
+
+use crate::binding::Bindings;
+use crate::expression::{parse_expression, ExpressionError, ExpressionStaging};
+use crate::global_variable::GlobalVarId;
+use crate::instruction::{Instruction, InstructionAddress};
+use crate::instruction_builder::{InstructionBuildError, InstructionBuildTarget};
+use crate::lexer::{Token, TokenKind};
+use crate::line_number::LocalLineNumber;
+use crate::line_number::LocalLineNumberTable;
+use crate::name::{NameError, NormalizedName};
+use crate::operator::OperatorLookup;
+use crate::source::{SourceError, SourceId, SourceSpan, SourceView};
+use crate::source_word::{
+    SourceStatementExpected, SourceStatementReader, SourceStatementReaderError,
+};
+use crate::source_word_ir::{
+    LocalBinding, LocalReference, SourceInstructionOrigin, SourceProcessingCapabilities,
+    SourceProcessingOperation, SourceWordImplementation,
+};
+use crate::word_resolution::{resolve_binding_name, ResolvedBinding, WordResolutionError};
+
+pub(crate) struct UserDefinedSourceWordContext<'source, 'state> {
+    view: SourceView<'source>,
+    source_id: SourceId,
+    reader: SourceStatementReader<'source>,
+    bindings: &'state Bindings,
+    operators: Option<OperatorLookup>,
+    code: &'state mut dyn InstructionBuildTarget,
+    line_numbers: &'state mut LocalLineNumberTable,
+    capabilities: SourceProcessingCapabilities,
+}
+
+pub(crate) struct UserDefinedSourceWordContextParts<'source, 'state> {
+    pub(crate) view: SourceView<'source>,
+    pub(crate) source_id: SourceId,
+    pub(crate) tokens: &'source [Token],
+    pub(crate) bindings: &'state Bindings,
+    pub(crate) operators: Option<OperatorLookup>,
+    pub(crate) code: &'state mut dyn InstructionBuildTarget,
+    pub(crate) line_numbers: &'state mut LocalLineNumberTable,
+    pub(crate) capabilities: SourceProcessingCapabilities,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SourceWordEvaluationError {
+    CapabilityUnavailable {
+        required: SourceProcessingCapabilities,
+        available: SourceProcessingCapabilities,
+        origin: SourceInstructionOrigin,
+    },
+    Source {
+        source: SourceError,
+    },
+    Reader {
+        source: SourceStatementReaderError,
+        origin: SourceInstructionOrigin,
+    },
+    Name {
+        span: SourceSpan,
+        source: NameError,
+        origin: SourceInstructionOrigin,
+    },
+    LineNumberLiteralOutOfRange {
+        span: SourceSpan,
+        origin: SourceInstructionOrigin,
+    },
+    LineNumberLiteralConversion {
+        span: SourceSpan,
+        origin: SourceInstructionOrigin,
+    },
+    VariableResolution {
+        span: SourceSpan,
+        source: crate::expression::ExpressionVariableErrorKind,
+        origin: SourceInstructionOrigin,
+    },
+    Expression {
+        source: ExpressionError,
+        origin: SourceInstructionOrigin,
+    },
+    InstructionBuild {
+        source: InstructionBuildError,
+        origin: SourceInstructionOrigin,
+    },
+    UndefinedLocal {
+        reference: LocalReference,
+        origin: SourceInstructionOrigin,
+    },
+    LocalTypeMismatch {
+        reference: LocalReference,
+        expected: RuntimeLocalType,
+        actual: RuntimeLocalType,
+        origin: SourceInstructionOrigin,
+    },
+    UnsupportedStructuralBranch {
+        origin: SourceInstructionOrigin,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RuntimeLocalType {
+    NameInput,
+    VariableTarget,
+    ExpressionArtifact,
+    OwnerLocalCodePosition,
+    LocalLineTarget,
+}
+
+impl SourceWordEvaluationError {
+    pub(crate) fn primary_span(&self) -> Option<SourceSpan> {
+        match self {
+            Self::CapabilityUnavailable { origin, .. }
+            | Self::UnsupportedStructuralBranch { origin } => Some(origin.span()),
+            Self::Source { .. } => None,
+            Self::Reader { source, origin: _ } => Some(match source {
+                SourceStatementReaderError::Missing { span, .. } => *span,
+                SourceStatementReaderError::Unexpected { actual, .. }
+                | SourceStatementReaderError::TrailingToken { actual } => actual.span(),
+            }),
+            Self::Name { span, .. }
+            | Self::LineNumberLiteralOutOfRange { span, .. }
+            | Self::LineNumberLiteralConversion { span, .. }
+            | Self::VariableResolution { span, .. } => Some(*span),
+            Self::InstructionBuild { origin, .. } => Some(origin.span()),
+            Self::Expression { source, origin } => match source {
+                ExpressionError::Source(_) | ExpressionError::InstructionBuild(_) => {
+                    Some(origin.span())
+                }
+                ExpressionError::Syntax(error) => Some(error.span()),
+                ExpressionError::Variable(error) => Some(error.span()),
+            },
+            Self::UndefinedLocal { reference, .. } | Self::LocalTypeMismatch { reference, .. } => {
+                Some(reference.span())
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+enum RuntimeLocal {
+    NameInput {
+        name: NormalizedName,
+        span: SourceSpan,
+    },
+    VariableTarget {
+        id: GlobalVarId,
+        span: SourceSpan,
+    },
+    ExpressionArtifact(ExpressionStaging),
+    OwnerLocalCodePosition(InstructionAddress),
+    LocalLineTarget(LocalLineNumber),
+}
+
+#[derive(Debug, Default)]
+struct RuntimeLocals {
+    values: HashMap<NormalizedName, RuntimeLocal>,
+}
+
+impl<'source, 'state> UserDefinedSourceWordContext<'source, 'state> {
+    pub(crate) fn new(parts: UserDefinedSourceWordContextParts<'source, 'state>) -> Self {
+        let source_word_token = parts
+            .tokens
+            .first()
+            .copied()
+            .expect("user-defined source word context requires its leading token");
+        Self {
+            view: parts.view,
+            source_id: parts.source_id,
+            reader: SourceStatementReader::new(&parts.tokens[1..], source_word_token.span()),
+            bindings: parts.bindings,
+            operators: parts.operators,
+            code: parts.code,
+            line_numbers: parts.line_numbers,
+            capabilities: parts.capabilities,
+        }
+    }
+}
+
+pub(crate) fn evaluate_source_word(
+    implementation: &SourceWordImplementation,
+    context: &mut UserDefinedSourceWordContext<'_, '_>,
+) -> Result<(), SourceWordEvaluationError> {
+    if !context.capabilities.allows(implementation.capabilities()) {
+        return Err(SourceWordEvaluationError::CapabilityUnavailable {
+            required: implementation.capabilities(),
+            available: context.capabilities,
+            origin: implementation
+                .instructions()
+                .first()
+                .expect("non-empty required capability set needs an instruction")
+                .origin(),
+        });
+    }
+
+    let mut locals = RuntimeLocals::default();
+    for instruction in implementation.instructions() {
+        evaluate_instruction(
+            instruction.operation(),
+            instruction.origin(),
+            context,
+            &mut locals,
+        )?;
+    }
+    Ok(())
+}
+
+fn evaluate_instruction(
+    operation: &SourceProcessingOperation,
+    origin: SourceInstructionOrigin,
+    context: &mut UserDefinedSourceWordContext<'_, '_>,
+    locals: &mut RuntimeLocals,
+) -> Result<(), SourceWordEvaluationError> {
+    // #1556/#1559 keep this as a small source-processing evaluator: operations
+    // are connected only to the current context capabilities, not to runtime VM
+    // values or a generic source-processing stack.
+    match operation {
+        SourceProcessingOperation::ReadName { bind } => {
+            let token = context
+                .reader
+                .read_name()
+                .map_err(|source| SourceWordEvaluationError::Reader { source, origin })?;
+            let source_name = context
+                .view
+                .slice(token.span())
+                .map_err(|source| SourceWordEvaluationError::Source { source })?;
+            let name = NormalizedName::new(source_name).map_err(|source| {
+                SourceWordEvaluationError::Name {
+                    span: token.span(),
+                    source,
+                    origin,
+                }
+            })?;
+            locals.bind(
+                bind,
+                RuntimeLocal::NameInput {
+                    name,
+                    span: token.span(),
+                },
+            );
+        }
+        SourceProcessingOperation::Expect { token } => {
+            context
+                .reader
+                .expect(token.token_kind())
+                .map_err(|source| SourceWordEvaluationError::Reader { source, origin })?;
+        }
+        SourceProcessingOperation::ExpectEnd => {
+            context
+                .reader
+                .finish()
+                .map_err(|source| SourceWordEvaluationError::Reader { source, origin })?;
+        }
+        SourceProcessingOperation::ReadLineNumber { bind } => {
+            let token = context
+                .reader
+                .expect(TokenKind::IntegerLiteral)
+                .map_err(|source| SourceWordEvaluationError::Reader { source, origin })?;
+            let line_number = parse_line_number(context.view, token, origin)?;
+            locals.bind(bind, RuntimeLocal::LocalLineTarget(line_number));
+        }
+        SourceProcessingOperation::ReadExpression { bind } => {
+            let tokens = context
+                .reader
+                .remaining_expression()
+                .map_err(|source| SourceWordEvaluationError::Reader { source, origin })?;
+            let expression = stage_expression(context, tokens, origin.span(), origin)?;
+            locals.bind(bind, RuntimeLocal::ExpressionArtifact(expression));
+        }
+        SourceProcessingOperation::ReadExpressionUntil { delimiter, bind } => {
+            let tokens = context
+                .reader
+                .expression_until(delimiter.token_kind())
+                .map_err(|source| SourceWordEvaluationError::Reader { source, origin })?;
+            let expression = stage_expression(context, tokens, origin.span(), origin)?;
+            locals.bind(bind, RuntimeLocal::ExpressionArtifact(expression));
+        }
+        SourceProcessingOperation::ResolveVariable { name, bind } => {
+            let (source_name, span) = locals.name(name, origin)?;
+            let id = resolve_variable_name(context.bindings, source_name.as_str()).map_err(
+                |source| SourceWordEvaluationError::VariableResolution {
+                    span,
+                    source,
+                    origin,
+                },
+            )?;
+            locals.bind(bind, RuntimeLocal::VariableTarget { id, span });
+        }
+        SourceProcessingOperation::EmitExpression { expression } => {
+            let expression = locals.expression(expression, origin)?;
+            expression
+                .commit_to(context.code)
+                .map_err(|source| match source {
+                    ExpressionError::InstructionBuild(source) => {
+                        SourceWordEvaluationError::InstructionBuild { source, origin }
+                    }
+                    source => SourceWordEvaluationError::Expression { source, origin },
+                })?;
+        }
+        SourceProcessingOperation::EmitStore { target } => {
+            let (id, span) = locals.variable_target(target, origin)?;
+            context
+                .code
+                .append_mapped(Instruction::StoreVar(id), span)
+                .map_err(|source| SourceWordEvaluationError::InstructionBuild { source, origin })?;
+        }
+        SourceProcessingOperation::EmitReturn => {
+            context
+                .code
+                .append_mapped(Instruction::Return, origin.span())
+                .map_err(|source| SourceWordEvaluationError::InstructionBuild { source, origin })?;
+        }
+        SourceProcessingOperation::Position { bind } => {
+            locals.bind(
+                bind,
+                RuntimeLocal::OwnerLocalCodePosition(context.code.current_address()),
+            );
+        }
+        SourceProcessingOperation::EmitBranch { destination } => {
+            match locals.branch_destination(destination, origin)? {
+                BranchDestination::OwnerLocalCodePosition(target) => {
+                    let branch = context
+                        .code
+                        .append_mapped_jump_placeholder(origin.span())
+                        .map_err(|source| SourceWordEvaluationError::InstructionBuild {
+                            source,
+                            origin,
+                        })?;
+                    context
+                        .code
+                        .patch_branch_target(branch, target)
+                        .map_err(|source| SourceWordEvaluationError::InstructionBuild {
+                            source,
+                            origin,
+                        })?;
+                }
+                BranchDestination::LocalLineTarget(line_number) => {
+                    let branch = context
+                        .code
+                        .append_mapped_jump_placeholder(origin.span())
+                        .map_err(|source| SourceWordEvaluationError::InstructionBuild {
+                            source,
+                            origin,
+                        })?;
+                    context
+                        .line_numbers
+                        .add_patch(line_number, branch, destination.span());
+                }
+            }
+        }
+        SourceProcessingOperation::EmitBranchIfFalse { destination } => {
+            match locals.branch_destination(destination, origin)? {
+                BranchDestination::OwnerLocalCodePosition(target) => {
+                    let branch = context
+                        .code
+                        .append_mapped_jump_if_zero_placeholder(origin.span())
+                        .map_err(|source| SourceWordEvaluationError::InstructionBuild {
+                            source,
+                            origin,
+                        })?;
+                    context
+                        .code
+                        .patch_branch_target(branch, target)
+                        .map_err(|source| SourceWordEvaluationError::InstructionBuild {
+                            source,
+                            origin,
+                        })?;
+                }
+                BranchDestination::LocalLineTarget(line_number) => {
+                    let branch = context
+                        .code
+                        .append_mapped_jump_if_zero_placeholder(origin.span())
+                        .map_err(|source| SourceWordEvaluationError::InstructionBuild {
+                            source,
+                            origin,
+                        })?;
+                    context
+                        .line_numbers
+                        .add_patch(line_number, branch, destination.span());
+                }
+            }
+        }
+        SourceProcessingOperation::EmitBranchFollowing
+        | SourceProcessingOperation::EmitBranchIfFalseFollowing
+        | SourceProcessingOperation::EmitBranchComplete
+        | SourceProcessingOperation::EmitBranchIfFalseComplete => {
+            return Err(SourceWordEvaluationError::UnsupportedStructuralBranch { origin });
+        }
+    }
+    Ok(())
+}
+
+fn stage_expression(
+    context: &UserDefinedSourceWordContext<'_, '_>,
+    tokens: &[Token],
+    anchor: SourceSpan,
+    origin: SourceInstructionOrigin,
+) -> Result<ExpressionStaging, SourceWordEvaluationError> {
+    let Some(operators) = context.operators else {
+        return Err(SourceWordEvaluationError::Reader {
+            source: SourceStatementReaderError::Missing {
+                expected: SourceStatementExpected::Expression,
+                span: anchor,
+            },
+            origin,
+        });
+    };
+
+    let mut expression_tokens = tokens
+        .iter()
+        .copied()
+        .filter(|token| token.kind() != TokenKind::LineBoundary)
+        .collect::<Vec<_>>();
+    let end = expression_tokens
+        .last()
+        .map_or(anchor.end(), |token| token.span().end());
+    expression_tokens.push(Token::new(
+        TokenKind::Eof,
+        context
+            .view
+            .span(context.source_id, end, end)
+            .map_err(|source| SourceWordEvaluationError::Expression {
+                source: ExpressionError::Source(source),
+                origin,
+            })?,
+    ));
+
+    let resolver = |source_name: &str| resolve_variable_name(context.bindings, source_name);
+    parse_expression(context.view, &expression_tokens, operators, &resolver)
+        .map_err(|source| SourceWordEvaluationError::Expression { source, origin })
+}
+
+fn parse_line_number(
+    view: SourceView<'_>,
+    token: Token,
+    origin: SourceInstructionOrigin,
+) -> Result<LocalLineNumber, SourceWordEvaluationError> {
+    let source = view
+        .slice(token.span())
+        .map_err(|source| SourceWordEvaluationError::Source { source })?;
+    let value = source.parse::<u64>().map_err(|_| {
+        SourceWordEvaluationError::LineNumberLiteralConversion {
+            span: token.span(),
+            origin,
+        }
+    })?;
+    if value > u64::from(u16::MAX) {
+        return Err(SourceWordEvaluationError::LineNumberLiteralOutOfRange {
+            span: token.span(),
+            origin,
+        });
+    }
+    Ok(LocalLineNumber::new(value))
+}
+
+fn resolve_variable_name(
+    bindings: &Bindings,
+    source_name: &str,
+) -> Result<GlobalVarId, crate::expression::ExpressionVariableErrorKind> {
+    match resolve_binding_name(bindings, source_name) {
+        Ok(ResolvedBinding::Variable(id)) => Ok(id),
+        Ok(ResolvedBinding::RuntimeWord(_) | ResolvedBinding::SourceWord(_)) => {
+            Err(crate::expression::ExpressionVariableErrorKind::TargetIsNotVariable)
+        }
+        Err(WordResolutionError::InvalidWordName) => {
+            Err(crate::expression::ExpressionVariableErrorKind::InvalidName)
+        }
+        Err(WordResolutionError::UndefinedName) => {
+            Err(crate::expression::ExpressionVariableErrorKind::UndefinedName)
+        }
+        Err(WordResolutionError::TargetIsNotWord) => {
+            unreachable!("binding lookup does not require a runtime word target")
+        }
+    }
+}
+
+impl RuntimeLocals {
+    fn bind(&mut self, binding: &LocalBinding, local: RuntimeLocal) {
+        self.values.insert(binding.name().clone(), local);
+    }
+
+    fn get(
+        &self,
+        reference: &LocalReference,
+        origin: SourceInstructionOrigin,
+    ) -> Result<&RuntimeLocal, SourceWordEvaluationError> {
+        self.values
+            .get(reference.name())
+            .ok_or_else(|| SourceWordEvaluationError::UndefinedLocal {
+                reference: reference.clone(),
+                origin,
+            })
+    }
+
+    fn name(
+        &self,
+        reference: &LocalReference,
+        origin: SourceInstructionOrigin,
+    ) -> Result<(NormalizedName, SourceSpan), SourceWordEvaluationError> {
+        match self.get(reference, origin)? {
+            RuntimeLocal::NameInput { name, span } => Ok((name.clone(), *span)),
+            actual => Err(SourceWordEvaluationError::LocalTypeMismatch {
+                reference: reference.clone(),
+                expected: RuntimeLocalType::NameInput,
+                actual: actual.local_type(),
+                origin,
+            }),
+        }
+    }
+
+    fn expression(
+        &self,
+        reference: &LocalReference,
+        origin: SourceInstructionOrigin,
+    ) -> Result<&ExpressionStaging, SourceWordEvaluationError> {
+        match self.get(reference, origin)? {
+            RuntimeLocal::ExpressionArtifact(expression) => Ok(expression),
+            actual => Err(SourceWordEvaluationError::LocalTypeMismatch {
+                reference: reference.clone(),
+                expected: RuntimeLocalType::ExpressionArtifact,
+                actual: actual.local_type(),
+                origin,
+            }),
+        }
+    }
+
+    fn variable_target(
+        &self,
+        reference: &LocalReference,
+        origin: SourceInstructionOrigin,
+    ) -> Result<(GlobalVarId, SourceSpan), SourceWordEvaluationError> {
+        match self.get(reference, origin)? {
+            RuntimeLocal::VariableTarget { id, span } => Ok((*id, *span)),
+            actual => Err(SourceWordEvaluationError::LocalTypeMismatch {
+                reference: reference.clone(),
+                expected: RuntimeLocalType::VariableTarget,
+                actual: actual.local_type(),
+                origin,
+            }),
+        }
+    }
+
+    fn branch_destination(
+        &self,
+        reference: &LocalReference,
+        origin: SourceInstructionOrigin,
+    ) -> Result<BranchDestination, SourceWordEvaluationError> {
+        match self.get(reference, origin)? {
+            RuntimeLocal::OwnerLocalCodePosition(address) => {
+                Ok(BranchDestination::OwnerLocalCodePosition(*address))
+            }
+            RuntimeLocal::LocalLineTarget(line_number) => {
+                Ok(BranchDestination::LocalLineTarget(*line_number))
+            }
+            actual => Err(SourceWordEvaluationError::LocalTypeMismatch {
+                reference: reference.clone(),
+                expected: RuntimeLocalType::OwnerLocalCodePosition,
+                actual: actual.local_type(),
+                origin,
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BranchDestination {
+    OwnerLocalCodePosition(InstructionAddress),
+    LocalLineTarget(LocalLineNumber),
+}
+
+impl RuntimeLocal {
+    const fn local_type(&self) -> RuntimeLocalType {
+        match self {
+            Self::NameInput { .. } => RuntimeLocalType::NameInput,
+            Self::VariableTarget { .. } => RuntimeLocalType::VariableTarget,
+            Self::ExpressionArtifact(_) => RuntimeLocalType::ExpressionArtifact,
+            Self::OwnerLocalCodePosition(_) => RuntimeLocalType::OwnerLocalCodePosition,
+            Self::LocalLineTarget(_) => RuntimeLocalType::LocalLineTarget,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::binding::{Binding, Bindings};
+    use crate::block_code::BlockCodeBuilder;
+    use crate::global_variable::GlobalVariables;
+    use crate::instruction::Instruction;
+    use crate::lexer::Lexer;
+    use crate::operator::register_operator_primitives;
+    use crate::primitive::PrimitiveRegistry;
+    use crate::source::SourceTexts;
+    use crate::source_mapping::SourceMappedCode;
+    use crate::source_word_ir::{
+        FixedToken, LocalBinding, LocalReference, SourceProcessingInstruction,
+        SourceWordImplementationBuilder,
+    };
+    use crate::value::Value;
+    use crate::word::PublishedWords;
+
+    fn name(input: &str) -> NormalizedName {
+        NormalizedName::new(input).expect("test name should normalize")
+    }
+
+    fn local(input: &str, span: SourceSpan) -> LocalBinding {
+        LocalBinding::new(name(input), span)
+    }
+
+    fn local_ref(input: &str, span: SourceSpan) -> LocalReference {
+        LocalReference::new(name(input), span)
+    }
+
+    fn span(view: SourceView<'_>, source_id: SourceId, start: usize, end: usize) -> SourceSpan {
+        view.span(source_id, start, end)
+            .expect("test span should be valid")
+    }
+
+    fn origin(span: SourceSpan) -> SourceInstructionOrigin {
+        SourceInstructionOrigin::new(span)
+    }
+
+    fn instruction(
+        operation: SourceProcessingOperation,
+        span: SourceSpan,
+    ) -> SourceProcessingInstruction {
+        SourceProcessingInstruction::new(operation, origin(span))
+    }
+
+    fn lex(text: &str) -> (SourceTexts, SourceId, Vec<Token>) {
+        let mut sources = SourceTexts::new();
+        let source_id = sources.register(text);
+        let mut lexer = Lexer::new(sources.view(), source_id).expect("lexer should construct");
+        let mut tokens = Vec::new();
+        loop {
+            let token = lexer.next_token().expect("source should lex");
+            if token.kind() == TokenKind::Eof {
+                break;
+            }
+            tokens.push(token);
+        }
+        (sources, source_id, tokens)
+    }
+
+    fn complete(
+        instructions: impl IntoIterator<Item = SourceProcessingInstruction>,
+    ) -> SourceWordImplementation {
+        let mut builder = SourceWordImplementationBuilder::new();
+        for instruction in instructions {
+            builder.push(instruction);
+        }
+        builder
+            .complete()
+            .expect("test implementation should validate")
+    }
+
+    fn operator_lookup() -> OperatorLookup {
+        let mut primitives = PrimitiveRegistry::new();
+        let mut words = PublishedWords::new();
+        register_operator_primitives(&mut primitives, &mut words).lookup()
+    }
+
+    #[test]
+    fn evaluates_read_name_resolve_var_expression_and_store() {
+        let (sources, source_id, tokens) = lex("LET A = 1 + 2");
+        let view = sources.view();
+        let mut globals = GlobalVariables::new();
+        let variable = globals.allocate();
+        let mut bindings = Bindings::new();
+        bindings
+            .insert_new(name("A"), Binding::Variable(variable))
+            .expect("variable binding should insert");
+        let implementation = complete([
+            instruction(
+                SourceProcessingOperation::ReadName {
+                    bind: local("name", span(view, source_id, 4, 5)),
+                },
+                span(view, source_id, 0, 3),
+            ),
+            instruction(
+                SourceProcessingOperation::ResolveVariable {
+                    name: local_ref("name", span(view, source_id, 4, 5)),
+                    bind: local("target", span(view, source_id, 4, 5)),
+                },
+                span(view, source_id, 0, 3),
+            ),
+            instruction(
+                SourceProcessingOperation::Expect {
+                    token: FixedToken::Equal,
+                },
+                span(view, source_id, 6, 7),
+            ),
+            instruction(
+                SourceProcessingOperation::ReadExpression {
+                    bind: local("expr", span(view, source_id, 8, 13)),
+                },
+                span(view, source_id, 8, 13),
+            ),
+            instruction(
+                SourceProcessingOperation::EmitExpression {
+                    expression: local_ref("expr", span(view, source_id, 8, 13)),
+                },
+                span(view, source_id, 8, 13),
+            ),
+            instruction(
+                SourceProcessingOperation::EmitStore {
+                    target: local_ref("target", span(view, source_id, 4, 5)),
+                },
+                span(view, source_id, 0, 3),
+            ),
+        ]);
+        let operators = operator_lookup();
+        let mut code = SourceMappedCode::new();
+        {
+            let mut builder = BlockCodeBuilder::new(&mut code);
+            let mut line_numbers = LocalLineNumberTable::new();
+            let mut context =
+                UserDefinedSourceWordContext::new(UserDefinedSourceWordContextParts {
+                    view,
+                    source_id,
+                    tokens: &tokens,
+                    bindings: &bindings,
+                    operators: Some(operators),
+                    code: &mut builder,
+                    line_numbers: &mut line_numbers,
+                    capabilities: SourceProcessingCapabilities::statement_runtime(),
+                });
+
+            evaluate_source_word(&implementation, &mut context).expect("evaluation should succeed");
+            builder.finish().expect("block should complete");
+        }
+
+        assert_eq!(
+            code.instruction_view()
+                .get(InstructionAddress::from_index(0)),
+            Ok(&Instruction::Push(Value::integer(1)))
+        );
+        assert_eq!(
+            code.instruction_view()
+                .get(InstructionAddress::from_index(2)),
+            Ok(&Instruction::Call(
+                operators.resolve(crate::operator::OperatorSemantic::Add)
+            ))
+        );
+        assert_eq!(
+            code.instruction_view()
+                .get(InstructionAddress::from_index(3)),
+            Ok(&Instruction::StoreVar(variable))
+        );
+    }
+
+    #[test]
+    fn read_expression_until_leaves_delimiter_for_following_expect() {
+        let (sources, source_id, tokens) = lex("BIF 0, 100");
+        let view = sources.view();
+        let bindings = Bindings::new();
+        let implementation = complete([
+            instruction(
+                SourceProcessingOperation::ReadExpressionUntil {
+                    delimiter: FixedToken::Comma,
+                    bind: local("condition", span(view, source_id, 4, 5)),
+                },
+                span(view, source_id, 0, 3),
+            ),
+            instruction(
+                SourceProcessingOperation::Expect {
+                    token: FixedToken::Comma,
+                },
+                span(view, source_id, 5, 6),
+            ),
+            instruction(
+                SourceProcessingOperation::ReadLineNumber {
+                    bind: local("line", span(view, source_id, 7, 10)),
+                },
+                span(view, source_id, 7, 10),
+            ),
+            instruction(
+                SourceProcessingOperation::ExpectEnd,
+                span(view, source_id, 10, 10),
+            ),
+            instruction(
+                SourceProcessingOperation::EmitExpression {
+                    expression: local_ref("condition", span(view, source_id, 4, 5)),
+                },
+                span(view, source_id, 4, 5),
+            ),
+            instruction(
+                SourceProcessingOperation::EmitBranchIfFalse {
+                    destination: local_ref("line", span(view, source_id, 7, 10)),
+                },
+                span(view, source_id, 0, 3),
+            ),
+        ]);
+        let mut code = SourceMappedCode::new();
+        let target;
+        {
+            let mut builder = BlockCodeBuilder::new(&mut code);
+            let mut line_numbers = LocalLineNumberTable::new();
+            let mut context =
+                UserDefinedSourceWordContext::new(UserDefinedSourceWordContextParts {
+                    view,
+                    source_id,
+                    tokens: &tokens,
+                    bindings: &bindings,
+                    operators: Some(operator_lookup()),
+                    code: &mut builder,
+                    line_numbers: &mut line_numbers,
+                    capabilities: SourceProcessingCapabilities::statement_runtime(),
+                });
+
+            evaluate_source_word(&implementation, &mut context).expect("evaluation should succeed");
+            target = builder
+                .append_mapped(Instruction::Return, span(view, source_id, 7, 10))
+                .expect("target should append");
+            line_numbers
+                .define(
+                    &builder,
+                    LocalLineNumber::new(100),
+                    target,
+                    span(view, source_id, 7, 10),
+                )
+                .expect("line should define");
+            line_numbers
+                .resolve(&mut builder)
+                .expect("line target should patch");
+            builder.finish().expect("block should complete");
+        }
+
+        assert_eq!(
+            code.instruction_view()
+                .get(InstructionAddress::from_index(1)),
+            Ok(&Instruction::JumpIfZero(target))
+        );
+    }
+
+    #[test]
+    fn position_can_feed_explicit_branch_destination() {
+        let (sources, source_id, tokens) = lex("LOOP");
+        let view = sources.view();
+        let bindings = Bindings::new();
+        let implementation = complete([
+            instruction(
+                SourceProcessingOperation::Position {
+                    bind: local("start", span(view, source_id, 0, 4)),
+                },
+                span(view, source_id, 0, 4),
+            ),
+            instruction(
+                SourceProcessingOperation::EmitBranch {
+                    destination: local_ref("start", span(view, source_id, 0, 4)),
+                },
+                span(view, source_id, 0, 4),
+            ),
+        ]);
+        let mut code = SourceMappedCode::new();
+        {
+            let mut builder = BlockCodeBuilder::new(&mut code);
+            let mut line_numbers = LocalLineNumberTable::new();
+            let mut context =
+                UserDefinedSourceWordContext::new(UserDefinedSourceWordContextParts {
+                    view,
+                    source_id,
+                    tokens: &tokens,
+                    bindings: &bindings,
+                    operators: Some(operator_lookup()),
+                    code: &mut builder,
+                    line_numbers: &mut line_numbers,
+                    capabilities: SourceProcessingCapabilities::statement_runtime(),
+                });
+
+            evaluate_source_word(&implementation, &mut context).expect("evaluation should succeed");
+            builder.finish().expect("block should complete");
+        }
+
+        assert_eq!(
+            code.instruction_view()
+                .get(InstructionAddress::from_index(0)),
+            Ok(&Instruction::Jump(InstructionAddress::from_index(0)))
+        );
+    }
+
+    #[test]
+    fn rejects_missing_capability_before_reading_or_emitting() {
+        let (sources, source_id, tokens) = lex("RETURN");
+        let view = sources.view();
+        let bindings = Bindings::new();
+        let implementation = complete([instruction(
+            SourceProcessingOperation::EmitReturn,
+            span(view, source_id, 0, 6),
+        )]);
+        let mut code = SourceMappedCode::new();
+        let error = {
+            let mut builder = BlockCodeBuilder::new(&mut code);
+            let mut line_numbers = LocalLineNumberTable::new();
+            let mut context =
+                UserDefinedSourceWordContext::new(UserDefinedSourceWordContextParts {
+                    view,
+                    source_id,
+                    tokens: &tokens,
+                    bindings: &bindings,
+                    operators: Some(operator_lookup()),
+                    code: &mut builder,
+                    line_numbers: &mut line_numbers,
+                    capabilities: SourceProcessingCapabilities::empty(),
+                });
+
+            evaluate_source_word(&implementation, &mut context)
+                .expect_err("missing capability should fail")
+        };
+
+        assert!(matches!(
+            error,
+            SourceWordEvaluationError::CapabilityUnavailable { .. }
+        ));
+        assert_eq!(code.len(), 0);
+    }
+
+    #[test]
+    fn failed_resolution_does_not_emit_partial_runtime_code() {
+        let (sources, source_id, tokens) = lex("LET MISSING = 1");
+        let view = sources.view();
+        let bindings = Bindings::new();
+        let implementation = complete([
+            instruction(
+                SourceProcessingOperation::ReadName {
+                    bind: local("name", span(view, source_id, 4, 11)),
+                },
+                span(view, source_id, 0, 3),
+            ),
+            instruction(
+                SourceProcessingOperation::ResolveVariable {
+                    name: local_ref("name", span(view, source_id, 4, 11)),
+                    bind: local("target", span(view, source_id, 4, 11)),
+                },
+                span(view, source_id, 0, 3),
+            ),
+            instruction(
+                SourceProcessingOperation::Expect {
+                    token: FixedToken::Equal,
+                },
+                span(view, source_id, 12, 13),
+            ),
+            instruction(
+                SourceProcessingOperation::ReadExpression {
+                    bind: local("expr", span(view, source_id, 14, 15)),
+                },
+                span(view, source_id, 14, 15),
+            ),
+            instruction(
+                SourceProcessingOperation::EmitExpression {
+                    expression: local_ref("expr", span(view, source_id, 14, 15)),
+                },
+                span(view, source_id, 14, 15),
+            ),
+        ]);
+        let mut code = SourceMappedCode::new();
+        let error = {
+            let mut builder = BlockCodeBuilder::new(&mut code);
+            let mut line_numbers = LocalLineNumberTable::new();
+            let mut context =
+                UserDefinedSourceWordContext::new(UserDefinedSourceWordContextParts {
+                    view,
+                    source_id,
+                    tokens: &tokens,
+                    bindings: &bindings,
+                    operators: Some(operator_lookup()),
+                    code: &mut builder,
+                    line_numbers: &mut line_numbers,
+                    capabilities: SourceProcessingCapabilities::statement_runtime(),
+                });
+
+            evaluate_source_word(&implementation, &mut context)
+                .expect_err("undefined variable should fail")
+        };
+
+        assert!(matches!(
+            error,
+            SourceWordEvaluationError::VariableResolution { .. }
+        ));
+        assert_eq!(code.len(), 0);
+    }
+}

--- a/crates/tbx-next/src/source_word_ir.rs
+++ b/crates/tbx-next/src/source_word_ir.rs
@@ -456,6 +456,30 @@ impl SourceProcessingCapabilities {
         self.emit_structural_branch
     }
 
+    pub(crate) const fn allows(self, required: Self) -> bool {
+        (!required.read_name || self.read_name)
+            && (!required.expect_fixed_token || self.expect_fixed_token)
+            && (!required.expect_end || self.expect_end)
+            && (!required.read_line_number || self.read_line_number)
+            && (!required.read_expression || self.read_expression)
+            && (!required.resolve_variable || self.resolve_variable)
+            && (!required.emit_runtime_code || self.emit_runtime_code)
+            && (!required.emit_structural_branch || self.emit_structural_branch)
+    }
+
+    pub(crate) const fn statement_runtime() -> Self {
+        Self {
+            read_name: true,
+            expect_fixed_token: true,
+            expect_end: true,
+            read_line_number: true,
+            read_expression: true,
+            resolve_variable: true,
+            emit_runtime_code: true,
+            emit_structural_branch: false,
+        }
+    }
+
     fn include(&mut self, other: Self) {
         self.read_name |= other.read_name;
         self.expect_fixed_token |= other.expect_fixed_token;


### PR DESCRIPTION
## Summary

- Add a crate-internal evaluator for completed user-defined source word IR.
- Keep evaluator state as typed source-processing locals instead of runtime VM values or a generic stack.
- Connect the evaluator context to the safe statement reader, expression staging, binding lookup, runtime build target, and local line-number patching so later #1563 / #1564 work can call the same entry point.
- Add tests for typed local evaluation, `READ_EXPR_UNTIL` delimiter non-consumption, explicit branch destinations, capability rejection, and failure atomicity.

## Verification

- `cargo ci-clippy`
- `cargo ci-test`
- `cargo ci-fmt`

Closes #1567
