### PR TITLE
TBX Next: STATEMENT構文定義の公開経路を実装

### DIFF
--- a/crates/tbx-next/src/bootstrap.rs
+++ b/crates/tbx-next/src/bootstrap.rs
@@ -2,9 +2,9 @@ use crate::binding::{Binding, BindingInsertError, Bindings};
 use crate::global_variable::{GlobalVarId, GlobalVariables};
 use crate::name::NormalizedName;
 use crate::source_word::{
-    def_source_word, if_source_word, let_source_word, var_source_word, NativeSourceWordHandler,
-    NativeStructuredSourceWordStartHandler, SourceWordId, SourceWordRegistry,
-    SourceWordSyntaxMarker, SourceWordSyntaxMarkerRole,
+    def_source_word, if_source_word, let_source_word, syntax_source_word, var_source_word,
+    NativeSourceWordHandler, NativeStructuredSourceWordStartHandler, SourceWordId,
+    SourceWordRegistry, SourceWordSyntaxMarker, SourceWordSyntaxMarkerRole,
 };
 use crate::structured_grammar::{
     MarkerCardinality, MarkerGroup, MarkerIdentity, StructuredGrammar,
@@ -170,6 +170,7 @@ pub(crate) fn register_builtin_source_words(
     let let_name = builtin_name("LET");
     let def_name = builtin_name("DEF");
     let if_name = builtin_name("IF");
+    let syntax_name = builtin_name("SYNTAX");
     bindings
         .validate_new_name(&var_name)
         .map_err(SourceWordBootstrapError::from_precheck_error)?;
@@ -189,6 +190,9 @@ pub(crate) fn register_builtin_source_words(
             ],
         )
         .map_err(SourceWordBootstrapError::from_precheck_error)?;
+    bindings
+        .validate_new_name(&syntax_name)
+        .map_err(SourceWordBootstrapError::from_precheck_error)?;
 
     let var = register_native_source_word(source_words, bindings, var_name, var_source_word)
         .expect("prechecked VAR source word should remain available");
@@ -196,6 +200,9 @@ pub(crate) fn register_builtin_source_words(
         .expect("prechecked LET source word should remain available");
     let def = register_native_source_word(source_words, bindings, def_name, def_source_word)
         .expect("prechecked DEF source word should remain available");
+    let syntax =
+        register_native_source_word(source_words, bindings, syntax_name, syntax_source_word)
+            .expect("prechecked SYNTAX source word should remain available");
     let if_ = register_native_structured_source_word(
         source_words,
         bindings,
@@ -223,6 +230,7 @@ pub(crate) fn register_builtin_source_words(
         var,
         let_,
         def,
+        syntax,
         if_,
     })
 }
@@ -232,6 +240,7 @@ pub(crate) struct BuiltinSourceWordIds {
     var: SourceWordId,
     let_: SourceWordId,
     def: SourceWordId,
+    syntax: SourceWordId,
     if_: SourceWordId,
 }
 
@@ -246,6 +255,10 @@ impl BuiltinSourceWordIds {
 
     pub(crate) const fn def(self) -> SourceWordId {
         self.def
+    }
+
+    pub(crate) const fn syntax(self) -> SourceWordId {
+        self.syntax
     }
 
     pub(crate) const fn if_(self) -> SourceWordId {
@@ -998,13 +1011,15 @@ mod tests {
         let ids = register_builtin_source_words(&mut source_words, &mut bindings)
             .expect("empty namespace should accept built-in source words");
 
-        assert_eq!(source_words.len(), 4);
+        assert_eq!(source_words.len(), 5);
         assert_source_word_binding(&bindings, "VAR", ids.var());
         assert_source_word_binding(&bindings, "var", ids.var());
         assert_source_word_binding(&bindings, "LET", ids.let_());
         assert_source_word_binding(&bindings, "let", ids.let_());
         assert_source_word_binding(&bindings, "DEF", ids.def());
         assert_source_word_binding(&bindings, "def", ids.def());
+        assert_source_word_binding(&bindings, "SYNTAX", ids.syntax());
+        assert_source_word_binding(&bindings, "syntax", ids.syntax());
         assert_source_word_binding(&bindings, "IF", ids.if_());
         assert_source_word_binding(&bindings, "if", ids.if_());
         assert_eq!(

--- a/crates/tbx-next/src/bootstrap.rs
+++ b/crates/tbx-next/src/bootstrap.rs
@@ -193,6 +193,16 @@ pub(crate) fn register_builtin_source_words(
     bindings
         .validate_new_name(&syntax_name)
         .map_err(SourceWordBootstrapError::from_precheck_error)?;
+    bindings
+        .validate_new_source_word_with_markers(
+            &syntax_name,
+            &[
+                builtin_name("STATEMENT"),
+                builtin_name("BLOCK"),
+                builtin_name("ENDS"),
+            ],
+        )
+        .map_err(SourceWordBootstrapError::from_precheck_error)?;
 
     let var = register_native_source_word(source_words, bindings, var_name, var_source_word)
         .expect("prechecked VAR source word should remain available");
@@ -200,9 +210,27 @@ pub(crate) fn register_builtin_source_words(
         .expect("prechecked LET source word should remain available");
     let def = register_native_source_word(source_words, bindings, def_name, def_source_word)
         .expect("prechecked DEF source word should remain available");
-    let syntax =
-        register_native_source_word(source_words, bindings, syntax_name, syntax_source_word)
-            .expect("prechecked SYNTAX source word should remain available");
+    let syntax = register_native_source_word_with_markers(
+        source_words,
+        bindings,
+        syntax_name,
+        syntax_source_word,
+        vec![
+            SourceWordSyntaxMarker::new(
+                builtin_name("STATEMENT"),
+                SourceWordSyntaxMarkerRole::BlockContinuation,
+            ),
+            SourceWordSyntaxMarker::new(
+                builtin_name("BLOCK"),
+                SourceWordSyntaxMarkerRole::BlockContinuation,
+            ),
+            SourceWordSyntaxMarker::new(
+                builtin_name("ENDS"),
+                SourceWordSyntaxMarkerRole::BlockTerminator,
+            ),
+        ],
+    )
+    .expect("prechecked SYNTAX source word should remain available");
     let if_ = register_native_structured_source_word(
         source_words,
         bindings,
@@ -1022,6 +1050,25 @@ mod tests {
         assert_source_word_binding(&bindings, "syntax", ids.syntax());
         assert_source_word_binding(&bindings, "IF", ids.if_());
         assert_source_word_binding(&bindings, "if", ids.if_());
+        assert_eq!(bindings.syntax_marker_reservation_len(), 6);
+        assert_eq!(
+            bindings
+                .syntax_marker_reservation(&name("STATEMENT"))
+                .map(|reservation| reservation.owner()),
+            Some(ids.syntax())
+        );
+        assert_eq!(
+            bindings
+                .syntax_marker_reservation(&name("BLOCK"))
+                .map(|reservation| reservation.owner()),
+            Some(ids.syntax())
+        );
+        assert_eq!(
+            bindings
+                .syntax_marker_reservation(&name("ENDS"))
+                .map(|reservation| reservation.owner()),
+            Some(ids.syntax())
+        );
         assert_eq!(
             bindings
                 .syntax_marker_reservation(&name("ELSIF"))
@@ -1039,6 +1086,26 @@ mod tests {
                 .syntax_marker_reservation(&name("ENDIF"))
                 .map(|reservation| reservation.owner()),
             Some(ids.if_())
+        );
+        let syntax_markers = source_words
+            .lookup()
+            .syntax_markers(ids.syntax())
+            .expect("SYNTAX should have marker metadata");
+        assert_eq!(syntax_markers.len(), 3);
+        assert_eq!(syntax_markers[0].name(), &name("STATEMENT"));
+        assert_eq!(
+            syntax_markers[0].role(),
+            SourceWordSyntaxMarkerRole::BlockContinuation
+        );
+        assert_eq!(syntax_markers[1].name(), &name("BLOCK"));
+        assert_eq!(
+            syntax_markers[1].role(),
+            SourceWordSyntaxMarkerRole::BlockContinuation
+        );
+        assert_eq!(syntax_markers[2].name(), &name("ENDS"));
+        assert_eq!(
+            syntax_markers[2].role(),
+            SourceWordSyntaxMarkerRole::BlockTerminator
         );
     }
 
@@ -1100,6 +1167,28 @@ mod tests {
         assert_eq!(bindings.get(&name("VAR")), None);
         assert_eq!(bindings.get(&name("LET")), None);
         assert_source_word_binding(&bindings, "DEF", existing);
+    }
+
+    #[test]
+    fn builtin_source_word_bootstrap_syntax_marker_conflict_does_not_publish_prefix() {
+        let mut source_words = SourceWordRegistry::new();
+        let mut bindings = Bindings::new();
+        let existing = register_native_source_word(
+            &mut source_words,
+            &mut bindings,
+            name("STATEMENT"),
+            source_handler,
+        )
+        .expect("test STATEMENT source word should register");
+
+        let result = register_builtin_source_words(&mut source_words, &mut bindings);
+
+        assert_eq!(result, Err(SourceWordBootstrapError::NameConflict));
+        assert_eq!(source_words.len(), 1);
+        assert_eq!(bindings.get(&name("VAR")), None);
+        assert_eq!(bindings.get(&name("SYNTAX")), None);
+        assert_source_word_binding(&bindings, "STATEMENT", existing);
+        assert_eq!(bindings.syntax_marker_reservation_len(), 0);
     }
 
     #[test]

--- a/crates/tbx-next/src/lexer.rs
+++ b/crates/tbx-next/src/lexer.rs
@@ -38,6 +38,7 @@ pub(crate) enum TokenKind {
     LessEqual,
     Greater,
     GreaterEqual,
+    FixedTokenLiteral,
     LineBoundary,
     Eof,
 }
@@ -132,6 +133,7 @@ impl<'a> Lexer<'a> {
             b'(' => self.single_byte_token(TokenKind::LParen),
             b')' => self.single_byte_token(TokenKind::RParen),
             b'=' => self.single_byte_token(TokenKind::Equal),
+            b'"' => self.fixed_token_literal(),
             b'<' => self.less_prefixed_operator(),
             b'>' => self.greater_prefixed_operator(),
             b'\n' => self.line_boundary(1),
@@ -244,6 +246,39 @@ impl<'a> Lexer<'a> {
         let start = self.offset;
         self.offset += 1;
         self.token(kind, start, self.offset)
+    }
+
+    fn fixed_token_literal(&mut self) -> Result<Token, LexError> {
+        let start = self.offset;
+        self.offset += 1;
+
+        while let Some(&byte) = self.source.as_bytes().get(self.offset) {
+            match byte {
+                b'"' => {
+                    self.offset += 1;
+                    return self.token(TokenKind::FixedTokenLiteral, start, self.offset);
+                }
+                b'\n' | b'\r' | 0x00..=0x1f | 0x7f => {
+                    let character = self.char_at(self.offset);
+                    return self.invalid_character(
+                        self.offset,
+                        character,
+                        InvalidCharacterReason::UnsupportedControl,
+                    );
+                }
+                0x80..=0xff => {
+                    let character = self.char_at(self.offset);
+                    return self.invalid_character(
+                        self.offset,
+                        character,
+                        InvalidCharacterReason::NonAscii,
+                    );
+                }
+                _ => self.offset += 1,
+            }
+        }
+
+        self.invalid_character(start, '"', InvalidCharacterReason::UnsupportedPunctuation)
     }
 
     fn less_prefixed_operator(&mut self) -> Result<Token, LexError> {
@@ -514,6 +549,28 @@ mod tests {
         assert_eq!(kinds(&tokens), [TokenKind::Comma, TokenKind::Eof]);
         assert_token(tokens[0], TokenKind::Comma, id, 0, 1);
         assert_eq!(slices(sources.view(), &tokens), [",", ""]);
+    }
+
+    #[test]
+    fn quoted_fixed_tokens_lex_as_authoring_literals() {
+        let (sources, id, tokens) = lex_all(r#""=" "," "<=""#);
+
+        assert_eq!(
+            kinds(&tokens),
+            [
+                TokenKind::FixedTokenLiteral,
+                TokenKind::FixedTokenLiteral,
+                TokenKind::FixedTokenLiteral,
+                TokenKind::Eof
+            ]
+        );
+        assert_token(tokens[0], TokenKind::FixedTokenLiteral, id, 0, 3);
+        assert_token(tokens[1], TokenKind::FixedTokenLiteral, id, 4, 7);
+        assert_token(tokens[2], TokenKind::FixedTokenLiteral, id, 8, 12);
+        assert_eq!(
+            slices(sources.view(), &tokens),
+            [r#""=""#, r#"",""#, r#""<=""#, ""]
+        );
     }
 
     #[test]

--- a/crates/tbx-next/src/source_processor.rs
+++ b/crates/tbx-next/src/source_processor.rs
@@ -6592,12 +6592,12 @@ mod tests {
         register_structured_probe(
             &mut source_words,
             &mut bindings,
-            "BLOCK",
+            "PROBE",
             start_no_publication_probe,
             vec![marker("END", SourceWordSyntaxMarkerRole::BlockTerminator)],
             structured_grammar(Vec::new(), "END"),
         );
-        let (sources, source_id) = source("BLOCK\nVAR A\nEND");
+        let (sources, source_id) = source("PROBE\nVAR A\nEND");
 
         let error = compile_source(
             sources.view(),
@@ -7338,32 +7338,58 @@ mod tests {
 
     #[test]
     fn marker_reservation_blocks_publication_through_production_source_processing() {
-        let mut source_words = SourceWordRegistry::new();
-        let mut bindings = Bindings::new();
-        let mut globals = GlobalVariables::new();
-        register_builtin_source_words(&mut source_words, &mut bindings)
-            .expect("built-in source words should bootstrap");
-        let (sources, source_id) = source("VAR ENDIF");
+        for reserved in ["ENDIF", "STATEMENT", "BLOCK", "ENDS"] {
+            let mut source_words = SourceWordRegistry::new();
+            let mut bindings = Bindings::new();
+            let mut globals = GlobalVariables::new();
+            register_builtin_source_words(&mut source_words, &mut bindings)
+                .expect("built-in source words should bootstrap");
+            let source_text = format!("VAR {reserved}");
+            let (sources, source_id) = source(&source_text);
 
-        let error = compile_source(
-            sources.view(),
-            source_id,
-            SourceCompileContext::with_source_word_publication(
-                &mut bindings,
-                source_words.lookup(),
-                &mut globals,
-            ),
-        )
-        .expect_err("syntax-marker reservation should reject variable publication");
+            let error = compile_source(
+                sources.view(),
+                source_id,
+                SourceCompileContext::with_source_word_publication(
+                    &mut bindings,
+                    source_words.lookup(),
+                    &mut globals,
+                ),
+            )
+            .expect_err("syntax-marker reservation should reject variable publication");
+
+            assert_eq!(
+                error,
+                SourceProcessorError::SourceWord(SourceWordError::VarNameConflict {
+                    span: span(sources.view(), source_id, 4, source_text.len())
+                }),
+                "{reserved} should be reserved by a structured source word"
+            );
+            assert_eq!(bindings.get(&name(reserved)), None);
+            assert_eq!(globals.len(), 0);
+        }
+    }
+
+    #[test]
+    fn syntax_body_uses_owned_marker_recognition_for_kind_lines() {
+        let (_words, _primitives, operators, mut source_words, mut bindings, mut globals, _vars) =
+            global_source_fixture();
+        let (sources, source_id, error) = publish_user_source_word_error(
+            "SYNTAX BROKEN\nBLOCK\nENDS",
+            &mut bindings,
+            &mut globals,
+            &mut source_words,
+            operators.lookup(),
+        );
 
         assert_eq!(
             error,
-            SourceProcessorError::SourceWord(SourceWordError::VarNameConflict {
-                span: span(sources.view(), source_id, 4, 9)
+            SourceProcessorError::SourceWord(SourceWordError::SyntaxDefinition {
+                span: span(sources.view(), source_id, 14, 19),
+                kind: crate::source_word::SyntaxDefinitionErrorKind::UnsupportedKind
             })
         );
-        assert_eq!(bindings.get(&name("ENDIF")), None);
-        assert_eq!(globals.len(), 0);
+        assert_eq!(bindings.get(&name("BROKEN")), None);
     }
 
     #[test]

--- a/crates/tbx-next/src/source_processor.rs
+++ b/crates/tbx-next/src/source_processor.rs
@@ -25,14 +25,21 @@ use crate::source_mapping::{
 };
 use crate::source_word::{
     NativeSourceWordBindingAccess, NativeSourceWordContext, NativeSourceWordContextParts,
-    NativeStructuredSourceWordContext, NativeStructuredSourceWordOwner, RuntimeDefinitionPublisher,
-    SourceBlockCursor, SourceBlockMarker, SourceBlockRead, SourceBlockReader, SourceBlockStatement,
-    SourceBlockTerminal, SourceWordDispatch, SourceWordError, SourceWordId, SourceWordLookup,
-    SourceWordLookupError, SourceWordSyntaxMarker, StructuredBodyCapabilities,
+    NativeSourceWordHandler, NativeStructuredSourceWordContext, NativeStructuredSourceWordOwner,
+    OneShotSourceWordDispatch, RuntimeDefinitionPublisher, SourceBlockCursor, SourceBlockMarker,
+    SourceBlockRead, SourceBlockReader, SourceBlockStatement, SourceBlockTerminal,
+    SourceWordDispatch, SourceWordError, SourceWordId, SourceWordLookup, SourceWordLookupError,
+    SourceWordRegistry, SourceWordSyntaxMarker, StructuredBodyCapabilities,
     StructuredBuildTargetScope, StructuredLineNumberScope, StructuredOwnerLocalTarget,
 };
+use crate::source_word_evaluator::{
+    evaluate_source_word, UserDefinedSourceWordContext, UserDefinedSourceWordContextParts,
+};
+use crate::source_word_ir::SourceProcessingCapabilities;
 use crate::static_quotation::{StaticQuotation, StaticQuotationBuildError};
-use crate::structured_grammar::{GrammarAccept, GrammarProgress, MarkerIdentity};
+use crate::structured_grammar::{
+    GrammarAccept, GrammarProgress, MarkerIdentity, StructuredGrammar,
+};
 use crate::value::Value;
 use crate::vm::{ExecutionView, RunOutcome, Vm, VmError};
 use crate::word::{PublishedWords, WordId};
@@ -50,7 +57,7 @@ pub(crate) struct TemporaryExecutionUnit {
 pub(crate) struct SourceCompileContext<'a> {
     bindings: BindingAccess<'a>,
     operators: Option<OperatorLookup>,
-    source_words: Option<SourceWordLookup<'a>>,
+    source_words: Option<SourceWordAccess<'a>>,
     globals: Option<&'a mut GlobalVariables>,
     runtime_definitions: Option<RuntimeDefinitionPublicationAccess<'a>>,
 }
@@ -80,6 +87,11 @@ pub(crate) struct QuotationBodyStatements<'a> {
 enum BindingAccess<'a> {
     Read(&'a Bindings),
     Write(&'a mut Bindings),
+}
+
+enum SourceWordAccess<'a> {
+    Read(SourceWordLookup<'a>),
+    Write(&'a mut SourceWordRegistry),
 }
 
 struct RuntimeDefinitionPublicationAccess<'a> {
@@ -175,6 +187,15 @@ struct StatementTraversal<'source, 'cursor, S> {
     source_id: SourceId,
     cursor: &'cursor mut LogicalStatementCursor<'source, 'source, S>,
     structured_frames: &'cursor mut Vec<StructuredSourceFrame>,
+}
+
+enum StatementSourceWordDispatch {
+    Native(NativeSourceWordHandler),
+    UserDefined(crate::source_word_ir::SourceWordImplementation),
+    Structured {
+        start: crate::source_word::NativeStructuredSourceWordStartHandler,
+        grammar: StructuredGrammar,
+    },
 }
 
 struct StructuredSourceFrame {
@@ -748,7 +769,7 @@ pub(crate) fn compile_definition_body<'source>(
     let context = SourceCompileContext {
         bindings: BindingAccess::Read(context.bindings),
         operators: context.operators,
-        source_words: context.source_words,
+        source_words: context.source_words.map(SourceWordAccess::Read),
         globals: None,
         runtime_definitions: None,
     };
@@ -772,7 +793,7 @@ pub(crate) fn compile_quotation_body<'source>(
     let context = SourceCompileContext {
         bindings: BindingAccess::Read(context.bindings),
         operators: context.operators,
-        source_words: context.source_words,
+        source_words: context.source_words.map(SourceWordAccess::Read),
         // #1516/#1500: quotation bodies reuse statement lowering but have no
         // capability to publish bindings, globals, or runtime definitions.
         globals: None,
@@ -1004,11 +1025,35 @@ where
     let ResolvedBinding::SourceWord(id) = binding else {
         return Ok(false);
     };
-    let Some(source_words) = context.source_words() else {
+    let Some(source_word_access) = &context.source_words else {
         return Err(SourceProcessorError::SourceWordContextUnavailable { id });
     };
-    let dispatch = source_words.lookup_dispatch(id)?;
-    let syntax_markers = source_words.syntax_markers(id)?;
+    let (dispatch, syntax_markers, runtime_definition_source_words) = {
+        let source_words = match source_word_access {
+            SourceWordAccess::Read(lookup) => *lookup,
+            SourceWordAccess::Write(registry) => registry.lookup(),
+        };
+        let dispatch = match source_words.lookup_dispatch(id)? {
+            SourceWordDispatch::OneShot(OneShotSourceWordDispatch::Native(handler)) => {
+                StatementSourceWordDispatch::Native(handler)
+            }
+            SourceWordDispatch::OneShot(OneShotSourceWordDispatch::UserDefined(implementation)) => {
+                StatementSourceWordDispatch::UserDefined(implementation.clone())
+            }
+            SourceWordDispatch::Structured { start, grammar } => {
+                StatementSourceWordDispatch::Structured {
+                    start,
+                    grammar: grammar.clone(),
+                }
+            }
+        };
+        let syntax_markers = source_words.syntax_markers(id)?.to_vec();
+        let runtime_definition_source_words = match source_word_access {
+            SourceWordAccess::Read(lookup) => Some(*lookup),
+            SourceWordAccess::Write(_) => None,
+        };
+        (dispatch, syntax_markers, runtime_definition_source_words)
+    };
     let operators = context.operators();
     let globals = context
         .globals
@@ -1018,11 +1063,13 @@ where
         .runtime_definitions
         .as_mut()
         .filter(|_| state.capabilities.allows_publication())
+        .filter(|_| runtime_definition_source_words.is_some())
         .map(|publication| RuntimeDefinitionPublisherAdapter {
             view: traversal.view,
             source_id: traversal.source_id,
             operators,
-            source_words,
+            source_words: runtime_definition_source_words
+                .expect("source word lookup should be available for runtime definition"),
             code: &mut *publication.code,
             words: &mut *publication.words,
         });
@@ -1040,31 +1087,72 @@ where
             BindingAccess::Write(bindings) => NativeSourceWordBindingAccess::Read(bindings),
         }
     };
-    let mut source_word_context = NativeSourceWordContext::new(NativeSourceWordContextParts {
-        view: traversal.view,
-        source_id: traversal.source_id,
-        tokens,
-        block_reader: match dispatch {
-            SourceWordDispatch::OneShot(_) => Some(SourceBlockReader::new(
-                traversal.view,
-                traversal.cursor,
-                syntax_markers,
-            )),
-            SourceWordDispatch::Structured { .. } => None,
-        },
-        bindings: binding_access,
-        operators,
-        code: state.code,
-        local_line_number_prefix,
-        globals,
-        runtime_definitions,
-    });
     match dispatch {
-        SourceWordDispatch::OneShot(handler) => handler(&mut source_word_context)?,
-        SourceWordDispatch::Structured { start, grammar } => {
+        StatementSourceWordDispatch::Native(handler) => {
+            let source_word_publication = if state.capabilities.allows_publication()
+                && source_name.eq_ignore_ascii_case("SYNTAX")
+            {
+                match &mut context.source_words {
+                    Some(SourceWordAccess::Write(registry)) => Some(&mut **registry),
+                    Some(SourceWordAccess::Read(_)) | None => None,
+                }
+            } else {
+                None
+            };
+            let mut source_word_context =
+                NativeSourceWordContext::new(NativeSourceWordContextParts {
+                    view: traversal.view,
+                    source_id: traversal.source_id,
+                    tokens,
+                    block_reader: Some(SourceBlockReader::new(
+                        traversal.view,
+                        traversal.cursor,
+                        &syntax_markers,
+                    )),
+                    bindings: binding_access,
+                    operators,
+                    code: state.code,
+                    local_line_number_prefix,
+                    globals,
+                    runtime_definitions,
+                    source_word_publication,
+                });
+            handler(&mut source_word_context)?;
+        }
+        StatementSourceWordDispatch::UserDefined(implementation) => {
+            let mut line_numbers = state.line_numbers.borrow_mut();
+            let mut source_word_context =
+                UserDefinedSourceWordContext::new(UserDefinedSourceWordContextParts {
+                    view: traversal.view,
+                    source_id: traversal.source_id,
+                    tokens,
+                    bindings: context.bindings(),
+                    operators,
+                    code: state.code,
+                    line_numbers: &mut line_numbers,
+                    capabilities: SourceProcessingCapabilities::statement_runtime(),
+                });
+            evaluate_source_word(&implementation, &mut source_word_context)
+                .map_err(|source| SourceWordError::UserDefinedEvaluation { source })?;
+        }
+        StatementSourceWordDispatch::Structured { start, grammar } => {
+            let mut source_word_context =
+                NativeSourceWordContext::new(NativeSourceWordContextParts {
+                    view: traversal.view,
+                    source_id: traversal.source_id,
+                    tokens,
+                    block_reader: None,
+                    bindings: binding_access,
+                    operators,
+                    code: state.code,
+                    local_line_number_prefix,
+                    globals,
+                    runtime_definitions,
+                    source_word_publication: None,
+                });
             let instance = start(&mut source_word_context)?;
             let mut frame = StructuredSourceFrame::new(
-                syntax_markers.to_vec(),
+                syntax_markers,
                 grammar.start(),
                 instance.into_owner(),
                 state.target.clone(),
@@ -1108,7 +1196,8 @@ fn compile_simple_tokens(
             | TokenKind::Less
             | TokenKind::LessEqual
             | TokenKind::Greater
-            | TokenKind::GreaterEqual => {
+            | TokenKind::GreaterEqual
+            | TokenKind::FixedTokenLiteral => {
                 return Err(CompileError {
                     span: token.span(),
                     kind: CompileErrorKind::UnsupportedToken { kind: token.kind() },
@@ -1719,7 +1808,7 @@ impl<'a> SourceCompileContext<'a> {
         Self {
             bindings: BindingAccess::Read(bindings),
             operators: None,
-            source_words: Some(source_words),
+            source_words: Some(SourceWordAccess::Read(source_words)),
             globals: None,
             runtime_definitions: None,
         }
@@ -1733,7 +1822,7 @@ impl<'a> SourceCompileContext<'a> {
         Self {
             bindings: BindingAccess::Read(bindings),
             operators: Some(operators),
-            source_words: Some(source_words),
+            source_words: Some(SourceWordAccess::Read(source_words)),
             globals: None,
             runtime_definitions: None,
         }
@@ -1747,7 +1836,7 @@ impl<'a> SourceCompileContext<'a> {
         Self {
             bindings: BindingAccess::Write(bindings),
             operators: None,
-            source_words: Some(source_words),
+            source_words: Some(SourceWordAccess::Read(source_words)),
             globals: Some(globals),
             runtime_definitions: None,
         }
@@ -1762,7 +1851,22 @@ impl<'a> SourceCompileContext<'a> {
         Self {
             bindings: BindingAccess::Write(bindings),
             operators: Some(operators),
-            source_words: Some(source_words),
+            source_words: Some(SourceWordAccess::Read(source_words)),
+            globals: Some(globals),
+            runtime_definitions: None,
+        }
+    }
+
+    pub(crate) fn with_user_source_word_publication_and_operators(
+        bindings: &'a mut Bindings,
+        source_words: &'a mut SourceWordRegistry,
+        operators: OperatorLookup,
+        globals: &'a mut GlobalVariables,
+    ) -> Self {
+        Self {
+            bindings: BindingAccess::Write(bindings),
+            operators: Some(operators),
+            source_words: Some(SourceWordAccess::Write(source_words)),
             globals: Some(globals),
             runtime_definitions: None,
         }
@@ -1779,7 +1883,7 @@ impl<'a> SourceCompileContext<'a> {
         Self {
             bindings: BindingAccess::Write(bindings),
             operators: Some(operators),
-            source_words: Some(source_words),
+            source_words: Some(SourceWordAccess::Read(source_words)),
             globals: Some(globals),
             runtime_definitions: Some(RuntimeDefinitionPublicationAccess { code, words }),
         }
@@ -1796,8 +1900,12 @@ impl<'a> SourceCompileContext<'a> {
         self.operators
     }
 
-    pub(crate) const fn source_words(&self) -> Option<SourceWordLookup<'a>> {
-        self.source_words
+    pub(crate) fn source_words(&self) -> Option<SourceWordLookup<'_>> {
+        match &self.source_words {
+            Some(SourceWordAccess::Read(lookup)) => Some(*lookup),
+            Some(SourceWordAccess::Write(registry)) => Some(registry.lookup()),
+            None => None,
+        }
     }
 
     fn publication_context(&mut self) -> Option<(&mut Bindings, &mut GlobalVariables)> {
@@ -2109,7 +2217,7 @@ impl<'a> SourceExecutionContext<'a> {
         SourceCompileContext {
             bindings: BindingAccess::Read(self.bindings),
             operators: self.operators,
-            source_words: self.source_words,
+            source_words: self.source_words.map(SourceWordAccess::Read),
             globals: None,
             runtime_definitions: None,
         }
@@ -2398,6 +2506,50 @@ mod tests {
         .expect("LET source should run with mutable globals");
 
         (sources, id, result)
+    }
+
+    fn publish_user_source_word(
+        text: &str,
+        bindings: &mut Bindings,
+        globals: &mut GlobalVariables,
+        source_words: &mut SourceWordRegistry,
+        operators: OperatorLookup,
+    ) -> (SourceTexts, SourceId, TemporaryExecutionUnit) {
+        let (sources, id) = source(text);
+        let unit = compile_source(
+            sources.view(),
+            id,
+            SourceCompileContext::with_user_source_word_publication_and_operators(
+                bindings,
+                source_words,
+                operators,
+                globals,
+            ),
+        )
+        .expect("user-defined source word should publish");
+        (sources, id, unit)
+    }
+
+    fn publish_user_source_word_error(
+        text: &str,
+        bindings: &mut Bindings,
+        globals: &mut GlobalVariables,
+        source_words: &mut SourceWordRegistry,
+        operators: OperatorLookup,
+    ) -> (SourceTexts, SourceId, SourceProcessorError) {
+        let (sources, id) = source(text);
+        let error = compile_source(
+            sources.view(),
+            id,
+            SourceCompileContext::with_user_source_word_publication_and_operators(
+                bindings,
+                source_words,
+                operators,
+                globals,
+            ),
+        )
+        .expect_err("user-defined source word should fail");
+        (sources, id, error)
     }
 
     fn emit_source_word_marker(
@@ -3118,6 +3270,19 @@ mod tests {
                 self.operators.lookup(),
                 &mut self.code,
                 &mut self.words,
+            )
+        }
+
+        fn publish_syntax(
+            &mut self,
+            text: &str,
+        ) -> (SourceTexts, SourceId, TemporaryExecutionUnit) {
+            publish_user_source_word(
+                text,
+                &mut self.bindings,
+                &mut self.globals,
+                &mut self.source_words,
+                self.operators.lookup(),
             )
         }
 
@@ -4515,6 +4680,114 @@ mod tests {
         assert_eq!(result.data_stack(), []);
         assert_eq!(globals.view().read(variables[0]), Ok(value(42)));
         assert_eq!(globals.view().read(variables[1]), Ok(value(43)));
+    }
+
+    #[test]
+    fn user_defined_statement_publishes_and_dispatches_let_equivalent() {
+        let (words, primitives, operators, mut source_words, mut bindings, mut globals, variables) =
+            global_source_fixture();
+        publish_user_source_word(
+            "SYNTAX SLET\nSTATEMENT\nREAD_NAME AS name\nRESOLVE_VAR name AS target\nEXPECT \"=\"\nREAD_EXPR AS expr\nEMIT_EXPR expr\nEMIT_STORE target\nENDS",
+            &mut bindings,
+            &mut globals,
+            &mut source_words,
+            operators.lookup(),
+        );
+
+        run_with_source_words_operators_and_mut_globals(
+            "SLET A = 1 + 2 * 3",
+            &bindings,
+            &mut globals,
+            &source_words,
+            &words,
+            &primitives,
+            operators.lookup(),
+        );
+
+        assert_eq!(globals.view().read(variables[0]), Ok(value(7)));
+    }
+
+    #[test]
+    fn user_defined_statement_dispatches_bif_equivalent_with_delimiter_expect() {
+        let (words, primitives, operators, mut source_words, mut bindings, mut globals, variables) =
+            global_source_fixture();
+        publish_user_source_word(
+            "SYNTAX UBIF\nSTATEMENT\nREAD_EXPR_UNTIL \",\" AS condition\nEXPECT \",\"\nREAD_LINE_NUM AS line\nEXPECT_END\nEMIT_EXPR condition\nEMIT_BRANCH_IF_FALSE line\nENDS",
+            &mut bindings,
+            &mut globals,
+            &mut source_words,
+            operators.lookup(),
+        );
+
+        run_with_source_words_operators_and_mut_globals(
+            "UBIF 0, 100\nLET A = 1\n100 LET A = 2",
+            &bindings,
+            &mut globals,
+            &source_words,
+            &words,
+            &primitives,
+            operators.lookup(),
+        );
+
+        assert_eq!(globals.view().read(variables[0]), Ok(value(2)));
+    }
+
+    #[test]
+    fn user_defined_return_equivalent_runs_through_runtime_definition_body() {
+        let mut session = RuntimeDefinitionSession::new();
+        register_builtin_global_variables(&mut session.globals, &mut session.bindings)
+            .expect("A-Z variables should bootstrap");
+        session.publish_syntax("SYNTAX URETURN\nSTATEMENT\nEXPECT_END\nEMIT_RETURN\nENDS");
+        session.publish_def("DEF STOP\nURETURN\nLET A = 1\nEND");
+
+        let (sources, source_id) = source("STOP\nLET A = 2");
+        let unit = compile_source(
+            sources.view(),
+            source_id,
+            SourceCompileContext::with_source_words_and_operators(
+                &session.bindings,
+                session.source_words.lookup(),
+                session.operators.lookup(),
+            ),
+        )
+        .expect("caller should compile with source words");
+        let code_spaces = [session.code.instruction_view()];
+        let source_mappings = [session.code.source_mapping()];
+        run_unit(
+            &unit,
+            SourceExecutionContext::with_code_spaces_and_mappings(
+                &session.bindings,
+                &code_spaces,
+                &source_mappings,
+                PublishedWordLookup::new(&session.words),
+                session.primitives.lookup(),
+            )
+            .with_mut_globals(session.globals.view_mut()),
+        )
+        .expect("caller should run against published code");
+        let Some(Binding::Variable(a)) = session.bindings.get(&name("A")).copied() else {
+            panic!("A should remain a variable binding");
+        };
+        assert_eq!(session.globals.view().read(a), Ok(value(2)));
+    }
+
+    #[test]
+    fn invalid_user_defined_statement_is_not_published() {
+        let (_words, _primitives, operators, mut source_words, mut bindings, mut globals, _vars) =
+            global_source_fixture();
+        let (_sources, _id, error) = publish_user_source_word_error(
+            "SYNTAX BROKEN\nSTATEMENT\nEMIT_STORE missing\nENDS\nBROKEN",
+            &mut bindings,
+            &mut globals,
+            &mut source_words,
+            operators.lookup(),
+        );
+
+        assert!(matches!(
+            error,
+            SourceProcessorError::SourceWord(SourceWordError::SyntaxBuild { .. })
+        ));
+        assert_eq!(bindings.get(&name("BROKEN")), None);
     }
 
     #[test]

--- a/crates/tbx-next/src/source_word.rs
+++ b/crates/tbx-next/src/source_word.rs
@@ -9,6 +9,12 @@ use crate::lexer::{LexError, Token, TokenKind};
 use crate::name::{NameError, NormalizedName};
 use crate::operator::OperatorLookup;
 use crate::source::{SourceError, SourceId, SourceSpan, SourceView};
+use crate::source_word_evaluator::SourceWordEvaluationError;
+use crate::source_word_ir::{
+    FixedToken, LocalBinding, LocalReference, SourceInstructionOrigin, SourceProcessingInstruction,
+    SourceProcessingOperation, SourceWordBuildError, SourceWordImplementation,
+    SourceWordImplementationBuilder,
+};
 use crate::word::WordId;
 use crate::word_resolution::{resolve_binding_name, ResolvedBinding, WordResolutionError};
 
@@ -132,7 +138,7 @@ impl SourceWordSyntaxMarker {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum SourceWordError {
     Source {
         source: SourceError,
@@ -217,6 +223,32 @@ pub(crate) enum SourceWordError {
         span: SourceSpan,
         kind: IfSyntaxErrorKind,
     },
+    SyntaxDefinition {
+        span: SourceSpan,
+        kind: SyntaxDefinitionErrorKind,
+    },
+    SyntaxName {
+        span: SourceSpan,
+        source: NameError,
+    },
+    SyntaxNameConflict {
+        span: SourceSpan,
+    },
+    SyntaxReservedName {
+        span: SourceSpan,
+    },
+    SyntaxPublicationContextUnavailable {
+        span: SourceSpan,
+    },
+    SyntaxBindingCommitInvariantViolated {
+        span: SourceSpan,
+    },
+    SyntaxBuild {
+        source: SourceWordBuildError,
+    },
+    UserDefinedEvaluation {
+        source: SourceWordEvaluationError,
+    },
     StructuredGrammar {
         span: SourceSpan,
         source: crate::structured_grammar::GrammarProgressError,
@@ -256,8 +288,22 @@ pub(crate) enum IfSyntaxErrorKind {
     TrailingToken { kind: TokenKind },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SyntaxDefinitionErrorKind {
+    MissingName,
+    TrailingToken { kind: TokenKind },
+    MissingKind,
+    UnsupportedKind,
+    MissingEnds,
+    UnknownOperation,
+    MissingOperand,
+    ExpectedAs,
+    ExpectedFixedToken,
+    TrailingOperationToken { kind: TokenKind },
+}
+
 impl SourceWordError {
-    pub(crate) fn primary_span(self) -> Option<SourceSpan> {
+    pub(crate) fn primary_span(&self) -> Option<SourceSpan> {
         match self {
             Self::Source { .. }
             | Self::InstructionBuild { .. }
@@ -284,11 +330,19 @@ impl SourceWordError {
             | Self::DefDefinition { span }
             | Self::DefBindingCommitInvariantViolated { span }
             | Self::IfSyntax { span, .. }
+            | Self::SyntaxDefinition { span, .. }
+            | Self::SyntaxName { span, .. }
+            | Self::SyntaxNameConflict { span }
+            | Self::SyntaxReservedName { span }
+            | Self::SyntaxPublicationContextUnavailable { span }
+            | Self::SyntaxBindingCommitInvariantViolated { span }
             | Self::StructuredGrammar { span, .. }
-            | Self::StructuredMissingTerminator { span } => Some(span),
+            | Self::StructuredMissingTerminator { span } => Some(*span),
+            Self::SyntaxBuild { source } => Some(source.primary_span()),
+            Self::UserDefinedEvaluation { source } => source.primary_span(),
             Self::DefLex { source } => match source {
                 LexError::Source(_) => None,
-                LexError::InvalidCharacter { span, .. } => Some(span),
+                LexError::InvalidCharacter { span, .. } => Some(*span),
             },
         }
     }
@@ -914,6 +968,7 @@ pub(crate) struct NativeSourceWordContext<'source, 'state> {
     local_line_number_prefix: Option<SourceSpan>,
     globals: Option<&'state mut GlobalVariables>,
     runtime_definitions: Option<&'state mut dyn RuntimeDefinitionPublisher<'source>>,
+    source_word_publication: Option<&'state mut SourceWordRegistry>,
 }
 
 pub(crate) struct NativeSourceWordContextParts<'source, 'state> {
@@ -927,6 +982,7 @@ pub(crate) struct NativeSourceWordContextParts<'source, 'state> {
     pub(crate) local_line_number_prefix: Option<SourceSpan>,
     pub(crate) globals: Option<&'state mut GlobalVariables>,
     pub(crate) runtime_definitions: Option<&'state mut dyn RuntimeDefinitionPublisher<'source>>,
+    pub(crate) source_word_publication: Option<&'state mut SourceWordRegistry>,
 }
 
 impl<'source, 'state> NativeSourceWordContext<'source, 'state> {
@@ -949,6 +1005,7 @@ impl<'source, 'state> NativeSourceWordContext<'source, 'state> {
             local_line_number_prefix: parts.local_line_number_prefix,
             globals: parts.globals,
             runtime_definitions: parts.runtime_definitions,
+            source_word_publication: parts.source_word_publication,
         }
     }
 
@@ -1078,6 +1135,46 @@ impl<'source, 'state> NativeSourceWordContext<'source, 'state> {
         };
 
         publisher.publish_runtime_definition(bindings, name, name_span, body, end_span)
+    }
+
+    pub(crate) fn publish_statement_source_word(
+        &mut self,
+        name: NormalizedName,
+        name_span: SourceSpan,
+        implementation: SourceWordImplementation,
+    ) -> Result<SourceWordId, SourceWordError> {
+        let Some(source_words) = &mut self.source_word_publication else {
+            return Err(SourceWordError::SyntaxPublicationContextUnavailable {
+                span: self.source_word_token.span(),
+            });
+        };
+        let NativeSourceWordBindingAccess::Write(bindings) = &mut self.bindings else {
+            return Err(SourceWordError::SyntaxPublicationContextUnavailable {
+                span: self.source_word_token.span(),
+            });
+        };
+
+        bindings
+            .validate_new_source_word_with_markers(&name, &[])
+            .map_err(|source| match source {
+                BindingInsertError::NameConflict => {
+                    SourceWordError::SyntaxNameConflict { span: name_span }
+                }
+                BindingInsertError::ReservedName => {
+                    SourceWordError::SyntaxReservedName { span: name_span }
+                }
+            })?;
+
+        let id = source_words.register_user_defined_statement(implementation);
+        // #1556/#1513 make binding insertion the publication point. The
+        // registry entry is unreachable until this succeeds through the shared
+        // source-word binding namespace.
+        bindings
+            .insert_new_source_word_with_markers(name, id, &[])
+            .map_err(|_| SourceWordError::SyntaxBindingCommitInvariantViolated {
+                span: name_span,
+            })?;
+        Ok(id)
     }
 
     pub(crate) fn resolve_variable_target(
@@ -1246,6 +1343,311 @@ pub(crate) fn def_source_word(
 
     context.publish_runtime_definition(name, name_token.span(), &body, end_span)?;
     Ok(())
+}
+
+pub(crate) fn syntax_source_word(
+    context: &mut NativeSourceWordContext<'_, '_>,
+) -> Result<(), SourceWordError> {
+    let name_token = {
+        let reader = context.statement_reader_mut();
+        let name_token = reader.read_name().map_err(syntax_definition_reader_error)?;
+        reader.finish().map_err(syntax_definition_reader_error)?;
+        name_token
+    };
+
+    let source_name = context
+        .view()
+        .slice(name_token.span())
+        .map_err(|source| SourceWordError::Source { source })?;
+    let name = NormalizedName::new(source_name).map_err(|source| SourceWordError::SyntaxName {
+        span: name_token.span(),
+        source,
+    })?;
+
+    let view = context.view();
+    let kind = read_syntax_body_statement(context)?;
+    require_standalone_name(
+        view,
+        kind,
+        "STATEMENT",
+        SyntaxDefinitionErrorKind::UnsupportedKind,
+    )?;
+
+    let mut builder = SourceWordImplementationBuilder::new();
+    loop {
+        let statement = read_syntax_body_statement(context)?;
+        if is_standalone_name(view, statement, "ENDS")? {
+            break;
+        }
+        builder.push(parse_source_processing_statement(view, statement)?);
+    }
+
+    let implementation = builder
+        .complete()
+        .map_err(|source| SourceWordError::SyntaxBuild { source })?;
+    context.publish_statement_source_word(name, name_token.span(), implementation)?;
+    Ok(())
+}
+
+fn read_syntax_body_statement<'source>(
+    context: &mut NativeSourceWordContext<'source, '_>,
+) -> Result<SourceBlockStatement<'source>, SourceWordError> {
+    let Some(reader) = context.block_reader_mut() else {
+        return Err(SourceWordError::SyntaxPublicationContextUnavailable {
+            span: context.source_word_token().span(),
+        });
+    };
+    match reader.next_statement()? {
+        SourceBlockRead::Statement(statement) => Ok(statement),
+        SourceBlockRead::Terminal(SourceBlockTerminal::Eof { span }) => {
+            Err(SourceWordError::SyntaxDefinition {
+                span,
+                kind: SyntaxDefinitionErrorKind::MissingEnds,
+            })
+        }
+        SourceBlockRead::Terminal(SourceBlockTerminal::LexError { error }) => {
+            Err(SourceWordError::DefLex { source: error })
+        }
+    }
+}
+
+fn parse_source_processing_statement(
+    view: SourceView<'_>,
+    statement: SourceBlockStatement<'_>,
+) -> Result<SourceProcessingInstruction, SourceWordError> {
+    let first = statement
+        .tokens()
+        .first()
+        .copied()
+        .ok_or(SourceWordError::SyntaxDefinition {
+            span: statement.span(),
+            kind: SyntaxDefinitionErrorKind::UnknownOperation,
+        })?;
+    let origin = SourceInstructionOrigin::new(first.span());
+    let mut reader = SourceStatementReader::new(&statement.tokens()[1..], first.span());
+    let operation_name = normalized_token(view, first)?;
+    let operation = match operation_name.as_str() {
+        "READ_NAME" => SourceProcessingOperation::ReadName {
+            bind: read_as_binding(view, &mut reader)?,
+        },
+        "EXPECT" => SourceProcessingOperation::Expect {
+            token: read_fixed_token(view, &mut reader)?,
+        },
+        "EXPECT_END" => {
+            reader.finish().map_err(syntax_operation_reader_error)?;
+            SourceProcessingOperation::ExpectEnd
+        }
+        "READ_LINE_NUM" => SourceProcessingOperation::ReadLineNumber {
+            bind: read_as_binding(view, &mut reader)?,
+        },
+        "READ_EXPR" => SourceProcessingOperation::ReadExpression {
+            bind: read_as_binding(view, &mut reader)?,
+        },
+        "READ_EXPR_UNTIL" => {
+            let delimiter = read_fixed_token(view, &mut reader)?;
+            SourceProcessingOperation::ReadExpressionUntil {
+                delimiter,
+                bind: read_as_binding(view, &mut reader)?,
+            }
+        }
+        "RESOLVE_VAR" => {
+            let name = read_local_reference(view, &mut reader)?;
+            SourceProcessingOperation::ResolveVariable {
+                name,
+                bind: read_as_binding(view, &mut reader)?,
+            }
+        }
+        "EMIT_EXPR" => SourceProcessingOperation::EmitExpression {
+            expression: read_only_local_reference(view, &mut reader)?,
+        },
+        "EMIT_STORE" => SourceProcessingOperation::EmitStore {
+            target: read_only_local_reference(view, &mut reader)?,
+        },
+        "EMIT_RETURN" => {
+            reader.finish().map_err(syntax_operation_reader_error)?;
+            SourceProcessingOperation::EmitReturn
+        }
+        "POSITION" => SourceProcessingOperation::Position {
+            bind: read_as_binding(view, &mut reader)?,
+        },
+        "EMIT_BRANCH" => SourceProcessingOperation::EmitBranch {
+            destination: read_only_local_reference(view, &mut reader)?,
+        },
+        "EMIT_BRANCH_IF_FALSE" => SourceProcessingOperation::EmitBranchIfFalse {
+            destination: read_only_local_reference(view, &mut reader)?,
+        },
+        "EMIT_BRANCH_FOLLOWING" => {
+            reader.finish().map_err(syntax_operation_reader_error)?;
+            SourceProcessingOperation::EmitBranchFollowing
+        }
+        "EMIT_BRANCH_IF_FALSE_FOLLOWING" => {
+            reader.finish().map_err(syntax_operation_reader_error)?;
+            SourceProcessingOperation::EmitBranchIfFalseFollowing
+        }
+        "EMIT_BRANCH_COMPLETE" => {
+            reader.finish().map_err(syntax_operation_reader_error)?;
+            SourceProcessingOperation::EmitBranchComplete
+        }
+        "EMIT_BRANCH_IF_FALSE_COMPLETE" => {
+            reader.finish().map_err(syntax_operation_reader_error)?;
+            SourceProcessingOperation::EmitBranchIfFalseComplete
+        }
+        _ => {
+            return Err(SourceWordError::SyntaxDefinition {
+                span: first.span(),
+                kind: SyntaxDefinitionErrorKind::UnknownOperation,
+            });
+        }
+    };
+    Ok(SourceProcessingInstruction::new(operation, origin))
+}
+
+fn read_as_binding(
+    view: SourceView<'_>,
+    reader: &mut SourceStatementReader<'_>,
+) -> Result<LocalBinding, SourceWordError> {
+    let as_token = reader.read_name().map_err(syntax_operation_reader_error)?;
+    require_name_token(view, as_token, "AS", SyntaxDefinitionErrorKind::ExpectedAs)?;
+    let binding = read_local_binding(view, reader)?;
+    reader.finish().map_err(syntax_operation_reader_error)?;
+    Ok(binding)
+}
+
+fn read_only_local_reference(
+    view: SourceView<'_>,
+    reader: &mut SourceStatementReader<'_>,
+) -> Result<LocalReference, SourceWordError> {
+    let reference = read_local_reference(view, reader)?;
+    reader.finish().map_err(syntax_operation_reader_error)?;
+    Ok(reference)
+}
+
+fn read_local_binding(
+    view: SourceView<'_>,
+    reader: &mut SourceStatementReader<'_>,
+) -> Result<LocalBinding, SourceWordError> {
+    let token = reader.read_name().map_err(syntax_operation_reader_error)?;
+    Ok(LocalBinding::new(
+        normalized_token(view, token)?,
+        token.span(),
+    ))
+}
+
+fn read_local_reference(
+    view: SourceView<'_>,
+    reader: &mut SourceStatementReader<'_>,
+) -> Result<LocalReference, SourceWordError> {
+    let token = reader.read_name().map_err(syntax_operation_reader_error)?;
+    Ok(LocalReference::new(
+        normalized_token(view, token)?,
+        token.span(),
+    ))
+}
+
+fn read_fixed_token(
+    view: SourceView<'_>,
+    reader: &mut SourceStatementReader<'_>,
+) -> Result<FixedToken, SourceWordError> {
+    let token = reader
+        .expect(TokenKind::FixedTokenLiteral)
+        .map_err(|error| match error {
+            SourceStatementReaderError::Missing { span, .. } => SourceWordError::SyntaxDefinition {
+                span,
+                kind: SyntaxDefinitionErrorKind::ExpectedFixedToken,
+            },
+            SourceStatementReaderError::Unexpected { actual, .. }
+            | SourceStatementReaderError::TrailingToken { actual } => {
+                SourceWordError::SyntaxDefinition {
+                    span: actual.span(),
+                    kind: SyntaxDefinitionErrorKind::ExpectedFixedToken,
+                }
+            }
+        })?;
+    let spelling = view
+        .slice(token.span())
+        .map_err(|source| SourceWordError::Source { source })?;
+    fixed_token_from_literal(spelling).ok_or(SourceWordError::SyntaxDefinition {
+        span: token.span(),
+        kind: SyntaxDefinitionErrorKind::ExpectedFixedToken,
+    })
+}
+
+fn fixed_token_from_literal(spelling: &str) -> Option<FixedToken> {
+    match spelling.strip_prefix('"')?.strip_suffix('"')? {
+        "+" => Some(FixedToken::Plus),
+        "-" => Some(FixedToken::Minus),
+        "*" => Some(FixedToken::Star),
+        "/" => Some(FixedToken::Slash),
+        "%" => Some(FixedToken::Percent),
+        "," => Some(FixedToken::Comma),
+        "(" => Some(FixedToken::LeftParen),
+        ")" => Some(FixedToken::RightParen),
+        "=" => Some(FixedToken::Equal),
+        "<>" => Some(FixedToken::NotEqual),
+        "<" => Some(FixedToken::Less),
+        "<=" => Some(FixedToken::LessEqual),
+        ">" => Some(FixedToken::Greater),
+        ">=" => Some(FixedToken::GreaterEqual),
+        _ => None,
+    }
+}
+
+fn require_standalone_name(
+    view: SourceView<'_>,
+    statement: SourceBlockStatement<'_>,
+    expected: &str,
+    error_kind: SyntaxDefinitionErrorKind,
+) -> Result<(), SourceWordError> {
+    match statement.standalone_name() {
+        Some(token) => require_name_token(view, token, expected, error_kind),
+        None => Err(SourceWordError::SyntaxDefinition {
+            span: statement.span(),
+            kind: error_kind,
+        }),
+    }
+}
+
+fn is_standalone_name(
+    view: SourceView<'_>,
+    statement: SourceBlockStatement<'_>,
+    expected: &str,
+) -> Result<bool, SourceWordError> {
+    let Some(token) = statement.standalone_name() else {
+        return Ok(false);
+    };
+    let source_name = view
+        .slice(token.span())
+        .map_err(|source| SourceWordError::Source { source })?;
+    Ok(source_name.eq_ignore_ascii_case(expected))
+}
+
+fn require_name_token(
+    view: SourceView<'_>,
+    token: Token,
+    expected: &str,
+    error_kind: SyntaxDefinitionErrorKind,
+) -> Result<(), SourceWordError> {
+    let source_name = view
+        .slice(token.span())
+        .map_err(|source| SourceWordError::Source { source })?;
+    if source_name.eq_ignore_ascii_case(expected) {
+        Ok(())
+    } else {
+        Err(SourceWordError::SyntaxDefinition {
+            span: token.span(),
+            kind: error_kind,
+        })
+    }
+}
+
+fn normalized_token(view: SourceView<'_>, token: Token) -> Result<NormalizedName, SourceWordError> {
+    let source_name = view
+        .slice(token.span())
+        .map_err(|source| SourceWordError::Source { source })?;
+    NormalizedName::new(source_name).map_err(|source| SourceWordError::SyntaxName {
+        span: token.span(),
+        source,
+    })
 }
 
 #[derive(Debug)]
@@ -1439,6 +1841,48 @@ fn if_reader_error_for_condition(error: SourceStatementReaderError) -> SourceWor
     }
 }
 
+fn syntax_definition_reader_error(error: SourceStatementReaderError) -> SourceWordError {
+    match error {
+        SourceStatementReaderError::Missing { span, .. } => SourceWordError::SyntaxDefinition {
+            span,
+            kind: SyntaxDefinitionErrorKind::MissingName,
+        },
+        SourceStatementReaderError::Unexpected { actual, .. } => {
+            SourceWordError::SyntaxDefinition {
+                span: actual.span(),
+                kind: SyntaxDefinitionErrorKind::MissingName,
+            }
+        }
+        SourceStatementReaderError::TrailingToken { actual } => SourceWordError::SyntaxDefinition {
+            span: actual.span(),
+            kind: SyntaxDefinitionErrorKind::TrailingToken {
+                kind: actual.kind(),
+            },
+        },
+    }
+}
+
+fn syntax_operation_reader_error(error: SourceStatementReaderError) -> SourceWordError {
+    match error {
+        SourceStatementReaderError::Missing { span, .. } => SourceWordError::SyntaxDefinition {
+            span,
+            kind: SyntaxDefinitionErrorKind::MissingOperand,
+        },
+        SourceStatementReaderError::Unexpected { actual, .. } => {
+            SourceWordError::SyntaxDefinition {
+                span: actual.span(),
+                kind: SyntaxDefinitionErrorKind::MissingOperand,
+            }
+        }
+        SourceStatementReaderError::TrailingToken { actual } => SourceWordError::SyntaxDefinition {
+            span: actual.span(),
+            kind: SyntaxDefinitionErrorKind::TrailingOperationToken {
+                kind: actual.kind(),
+            },
+        },
+    }
+}
+
 pub(crate) fn unsupported_source_word(
     context: &mut NativeSourceWordContext<'_, '_>,
 ) -> Result<(), SourceWordError> {
@@ -1565,11 +2009,17 @@ struct SourceWordEntry {
 
 #[derive(Debug, Clone)]
 enum SourceWordKind {
-    OneShot(NativeSourceWordHandler),
+    OneShot(OneShotSourceWordImplementation),
     Structured {
         start: NativeStructuredSourceWordStartHandler,
         grammar: crate::structured_grammar::StructuredGrammar,
     },
+}
+
+#[derive(Debug, Clone)]
+enum OneShotSourceWordImplementation {
+    Native(NativeSourceWordHandler),
+    UserDefined(SourceWordImplementation),
 }
 
 impl SourceWordRegistry {
@@ -1588,8 +2038,22 @@ impl SourceWordRegistry {
     ) -> SourceWordId {
         let id = SourceWordId::from_slot(self.entries.len());
         self.entries.push(SourceWordEntry {
-            kind: SourceWordKind::OneShot(handler),
+            kind: SourceWordKind::OneShot(OneShotSourceWordImplementation::Native(handler)),
             syntax_markers,
+        });
+        id
+    }
+
+    pub(crate) fn register_user_defined_statement(
+        &mut self,
+        implementation: SourceWordImplementation,
+    ) -> SourceWordId {
+        let id = SourceWordId::from_slot(self.entries.len());
+        self.entries.push(SourceWordEntry {
+            kind: SourceWordKind::OneShot(OneShotSourceWordImplementation::UserDefined(
+                implementation,
+            )),
+            syntax_markers: Vec::new(),
         });
         id
     }
@@ -1628,11 +2092,17 @@ pub(crate) struct SourceWordLookup<'a> {
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum SourceWordDispatch<'a> {
-    OneShot(NativeSourceWordHandler),
+    OneShot(OneShotSourceWordDispatch<'a>),
     Structured {
         start: NativeStructuredSourceWordStartHandler,
         grammar: &'a crate::structured_grammar::StructuredGrammar,
     },
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum OneShotSourceWordDispatch<'a> {
+    Native(NativeSourceWordHandler),
+    UserDefined(&'a SourceWordImplementation),
 }
 
 impl<'a> SourceWordLookup<'a> {
@@ -1646,7 +2116,16 @@ impl<'a> SourceWordLookup<'a> {
             .get(id.as_slot())
             .ok_or(SourceWordLookupError::InvalidSourceWordId { id })?;
         Ok(match &entry.kind {
-            SourceWordKind::OneShot(handler) => SourceWordDispatch::OneShot(*handler),
+            SourceWordKind::OneShot(implementation) => {
+                SourceWordDispatch::OneShot(match implementation {
+                    OneShotSourceWordImplementation::Native(handler) => {
+                        OneShotSourceWordDispatch::Native(*handler)
+                    }
+                    OneShotSourceWordImplementation::UserDefined(implementation) => {
+                        OneShotSourceWordDispatch::UserDefined(implementation)
+                    }
+                })
+            }
             SourceWordKind::Structured { start, grammar } => SourceWordDispatch::Structured {
                 start: *start,
                 grammar,
@@ -1659,7 +2138,10 @@ impl<'a> SourceWordLookup<'a> {
         id: SourceWordId,
     ) -> Result<NativeSourceWordHandler, SourceWordLookupError> {
         match self.lookup_dispatch(id)? {
-            SourceWordDispatch::OneShot(handler) => Ok(handler),
+            SourceWordDispatch::OneShot(OneShotSourceWordDispatch::Native(handler)) => Ok(handler),
+            SourceWordDispatch::OneShot(OneShotSourceWordDispatch::UserDefined(_)) => {
+                Err(SourceWordLookupError::InvalidSourceWordId { id })
+            }
             SourceWordDispatch::Structured { .. } => {
                 Err(SourceWordLookupError::InvalidSourceWordId { id })
             }
@@ -1915,6 +2397,7 @@ mod tests {
             local_line_number_prefix: None,
             globals: None,
             runtime_definitions: None,
+            source_word_publication: None,
         });
 
         let first_body_token = context
@@ -2120,6 +2603,7 @@ mod tests {
                 local_line_number_prefix: None,
                 globals: None,
                 runtime_definitions: None,
+                source_word_publication: None,
             });
 
             push_one(&mut context).expect("test source word should emit");
@@ -2155,6 +2639,7 @@ mod tests {
                     local_line_number_prefix: None,
                     globals: Some(&mut globals),
                     runtime_definitions: None,
+                    source_word_publication: None,
                 });
 
                 var_source_word(&mut context)

--- a/crates/tbx-next/src/source_word.rs
+++ b/crates/tbx-next/src/source_word.rs
@@ -1365,21 +1365,49 @@ pub(crate) fn syntax_source_word(
     })?;
 
     let view = context.view();
-    let kind = read_syntax_body_statement(context)?;
-    require_standalone_name(
-        view,
-        kind,
-        "STATEMENT",
-        SyntaxDefinitionErrorKind::UnsupportedKind,
-    )?;
+    let kind = read_syntax_body_item(context, SyntaxDefinitionErrorKind::MissingKind)?;
+    let SourceBlockItem::Marker(marker) = kind else {
+        return Err(SourceWordError::SyntaxDefinition {
+            span: syntax_item_span(kind, context.source_word_token().span()),
+            kind: SyntaxDefinitionErrorKind::MissingKind,
+        });
+    };
+    if marker.name().as_str() != "STATEMENT" {
+        return Err(SourceWordError::SyntaxDefinition {
+            span: marker.span(),
+            kind: SyntaxDefinitionErrorKind::UnsupportedKind,
+        });
+    }
+    require_empty_syntax_marker_remainder(&marker, SyntaxDefinitionErrorKind::UnsupportedKind)?;
 
     let mut builder = SourceWordImplementationBuilder::new();
     loop {
-        let statement = read_syntax_body_statement(context)?;
-        if is_standalone_name(view, statement, "ENDS")? {
-            break;
+        match read_syntax_body_item(context, SyntaxDefinitionErrorKind::MissingEnds)? {
+            SourceBlockItem::Statement(statement) => {
+                builder.push(parse_source_processing_statement(view, statement)?);
+            }
+            SourceBlockItem::Marker(marker) if marker.name().as_str() == "ENDS" => {
+                require_empty_syntax_marker_remainder_with(&marker, |token| {
+                    SyntaxDefinitionErrorKind::TrailingOperationToken { kind: token.kind() }
+                })?;
+                break;
+            }
+            SourceBlockItem::Marker(marker) => {
+                return Err(SourceWordError::SyntaxDefinition {
+                    span: marker.span(),
+                    kind: SyntaxDefinitionErrorKind::UnsupportedKind,
+                });
+            }
+            SourceBlockItem::Terminal(SourceBlockTerminal::Eof { span }) => {
+                return Err(SourceWordError::SyntaxDefinition {
+                    span,
+                    kind: SyntaxDefinitionErrorKind::MissingEnds,
+                });
+            }
+            SourceBlockItem::Terminal(SourceBlockTerminal::LexError { error }) => {
+                return Err(SourceWordError::DefLex { source: error });
+            }
         }
-        builder.push(parse_source_processing_statement(view, statement)?);
     }
 
     let implementation = builder
@@ -1389,25 +1417,58 @@ pub(crate) fn syntax_source_word(
     Ok(())
 }
 
-fn read_syntax_body_statement<'source>(
+fn read_syntax_body_item<'source>(
     context: &mut NativeSourceWordContext<'source, '_>,
-) -> Result<SourceBlockStatement<'source>, SourceWordError> {
+    eof_kind: SyntaxDefinitionErrorKind,
+) -> Result<SourceBlockItem<'source>, SourceWordError> {
     let Some(reader) = context.block_reader_mut() else {
         return Err(SourceWordError::SyntaxPublicationContextUnavailable {
             span: context.source_word_token().span(),
         });
     };
-    match reader.next_statement()? {
-        SourceBlockRead::Statement(statement) => Ok(statement),
-        SourceBlockRead::Terminal(SourceBlockTerminal::Eof { span }) => {
+    match reader.next_item()? {
+        SourceBlockItem::Terminal(SourceBlockTerminal::Eof { span }) => {
             Err(SourceWordError::SyntaxDefinition {
                 span,
-                kind: SyntaxDefinitionErrorKind::MissingEnds,
+                kind: eof_kind,
             })
         }
-        SourceBlockRead::Terminal(SourceBlockTerminal::LexError { error }) => {
+        SourceBlockItem::Terminal(SourceBlockTerminal::LexError { error }) => {
             Err(SourceWordError::DefLex { source: error })
         }
+        item => Ok(item),
+    }
+}
+
+fn require_empty_syntax_marker_remainder(
+    marker: &SourceBlockMarker<'_>,
+    kind: SyntaxDefinitionErrorKind,
+) -> Result<(), SourceWordError> {
+    require_empty_syntax_marker_remainder_with(marker, |_| kind)
+}
+
+fn require_empty_syntax_marker_remainder_with(
+    marker: &SourceBlockMarker<'_>,
+    error_kind: impl FnOnce(Token) -> SyntaxDefinitionErrorKind,
+) -> Result<(), SourceWordError> {
+    if let Some(token) = marker.remaining_tokens().first().copied() {
+        return Err(SourceWordError::SyntaxDefinition {
+            span: token.span(),
+            kind: error_kind(token),
+        });
+    }
+    Ok(())
+}
+
+fn syntax_item_span(item: SourceBlockItem<'_>, fallback: SourceSpan) -> SourceSpan {
+    match item {
+        SourceBlockItem::Statement(statement) => statement.span(),
+        SourceBlockItem::Marker(marker) => marker.span(),
+        SourceBlockItem::Terminal(SourceBlockTerminal::Eof { span }) => span,
+        SourceBlockItem::Terminal(SourceBlockTerminal::LexError { error }) => match error {
+            LexError::InvalidCharacter { span, .. } => span,
+            LexError::Source(_) => fallback,
+        },
     }
 }
 
@@ -1590,35 +1651,6 @@ fn fixed_token_from_literal(spelling: &str) -> Option<FixedToken> {
         ">=" => Some(FixedToken::GreaterEqual),
         _ => None,
     }
-}
-
-fn require_standalone_name(
-    view: SourceView<'_>,
-    statement: SourceBlockStatement<'_>,
-    expected: &str,
-    error_kind: SyntaxDefinitionErrorKind,
-) -> Result<(), SourceWordError> {
-    match statement.standalone_name() {
-        Some(token) => require_name_token(view, token, expected, error_kind),
-        None => Err(SourceWordError::SyntaxDefinition {
-            span: statement.span(),
-            kind: error_kind,
-        }),
-    }
-}
-
-fn is_standalone_name(
-    view: SourceView<'_>,
-    statement: SourceBlockStatement<'_>,
-    expected: &str,
-) -> Result<bool, SourceWordError> {
-    let Some(token) = statement.standalone_name() else {
-        return Ok(false);
-    };
-    let source_name = view
-        .slice(token.span())
-        .map_err(|source| SourceWordError::Source { source })?;
-    Ok(source_name.eq_ignore_ascii_case(expected))
 }
 
 fn require_name_token(


### PR DESCRIPTION
## Summary

- `SYNTAX ... STATEMENT ... ENDS` の authoring parser を追加し、operation spelling を `SourceWordImplementationBuilder` へ接続
- `SourceWordRegistry` の OneShot 内で native / user-defined 実装方式を分離し、公開後の user-defined statement を共通 evaluator 経路で dispatch
- fixed token literal (`"="`, `","` など) と `LET` / `RETURN` / `BIF` 相当の縦断テストを追加

Closes #1563

## Verification

- `cargo test -p tbx-next`
- `cargo ci-clippy`
- `cargo ci-test`
- `cargo ci-fmt`
