### PR TITLE
TBX NextのBLOCK利用者定義source wordを実装する

### DIFF
--- a/crates/tbx-next/src/bootstrap.rs
+++ b/crates/tbx-next/src/bootstrap.rs
@@ -199,6 +199,12 @@ pub(crate) fn register_builtin_source_words(
             &[
                 builtin_name("STATEMENT"),
                 builtin_name("BLOCK"),
+                builtin_name("START"),
+                builtin_name("MARK"),
+                builtin_name("MARK_OPTIONAL"),
+                builtin_name("MARK_ANY"),
+                builtin_name("MARK_SOME"),
+                builtin_name("LAST"),
                 builtin_name("ENDS"),
             ],
         )
@@ -222,6 +228,30 @@ pub(crate) fn register_builtin_source_words(
             ),
             SourceWordSyntaxMarker::new(
                 builtin_name("BLOCK"),
+                SourceWordSyntaxMarkerRole::BlockContinuation,
+            ),
+            SourceWordSyntaxMarker::new(
+                builtin_name("START"),
+                SourceWordSyntaxMarkerRole::BlockContinuation,
+            ),
+            SourceWordSyntaxMarker::new(
+                builtin_name("MARK"),
+                SourceWordSyntaxMarkerRole::BlockContinuation,
+            ),
+            SourceWordSyntaxMarker::new(
+                builtin_name("MARK_OPTIONAL"),
+                SourceWordSyntaxMarkerRole::BlockContinuation,
+            ),
+            SourceWordSyntaxMarker::new(
+                builtin_name("MARK_ANY"),
+                SourceWordSyntaxMarkerRole::BlockContinuation,
+            ),
+            SourceWordSyntaxMarker::new(
+                builtin_name("MARK_SOME"),
+                SourceWordSyntaxMarkerRole::BlockContinuation,
+            ),
+            SourceWordSyntaxMarker::new(
+                builtin_name("LAST"),
                 SourceWordSyntaxMarkerRole::BlockContinuation,
             ),
             SourceWordSyntaxMarker::new(
@@ -1050,25 +1080,26 @@ mod tests {
         assert_source_word_binding(&bindings, "syntax", ids.syntax());
         assert_source_word_binding(&bindings, "IF", ids.if_());
         assert_source_word_binding(&bindings, "if", ids.if_());
-        assert_eq!(bindings.syntax_marker_reservation_len(), 6);
-        assert_eq!(
-            bindings
-                .syntax_marker_reservation(&name("STATEMENT"))
-                .map(|reservation| reservation.owner()),
-            Some(ids.syntax())
-        );
-        assert_eq!(
-            bindings
-                .syntax_marker_reservation(&name("BLOCK"))
-                .map(|reservation| reservation.owner()),
-            Some(ids.syntax())
-        );
-        assert_eq!(
-            bindings
-                .syntax_marker_reservation(&name("ENDS"))
-                .map(|reservation| reservation.owner()),
-            Some(ids.syntax())
-        );
+        assert_eq!(bindings.syntax_marker_reservation_len(), 12);
+        for reserved in [
+            "STATEMENT",
+            "BLOCK",
+            "START",
+            "MARK",
+            "MARK_OPTIONAL",
+            "MARK_ANY",
+            "MARK_SOME",
+            "LAST",
+            "ENDS",
+        ] {
+            assert_eq!(
+                bindings
+                    .syntax_marker_reservation(&name(reserved))
+                    .map(|reservation| reservation.owner()),
+                Some(ids.syntax()),
+                "{reserved} should be owned by SYNTAX"
+            );
+        }
         assert_eq!(
             bindings
                 .syntax_marker_reservation(&name("ELSIF"))
@@ -1091,7 +1122,7 @@ mod tests {
             .lookup()
             .syntax_markers(ids.syntax())
             .expect("SYNTAX should have marker metadata");
-        assert_eq!(syntax_markers.len(), 3);
+        assert_eq!(syntax_markers.len(), 9);
         assert_eq!(syntax_markers[0].name(), &name("STATEMENT"));
         assert_eq!(
             syntax_markers[0].role(),
@@ -1102,9 +1133,9 @@ mod tests {
             syntax_markers[1].role(),
             SourceWordSyntaxMarkerRole::BlockContinuation
         );
-        assert_eq!(syntax_markers[2].name(), &name("ENDS"));
+        assert_eq!(syntax_markers[8].name(), &name("ENDS"));
         assert_eq!(
-            syntax_markers[2].role(),
+            syntax_markers[8].role(),
             SourceWordSyntaxMarkerRole::BlockTerminator
         );
     }

--- a/crates/tbx-next/src/source_processor.rs
+++ b/crates/tbx-next/src/source_processor.rs
@@ -5006,6 +5006,152 @@ mod tests {
     }
 
     #[test]
+    fn user_defined_block_allows_start_local_in_later_sections() {
+        let (words, primitives, operators, mut source_words, mut bindings, mut globals, variables) =
+            global_source_fixture();
+        publish_user_source_word(
+            "SYNTAX ASSIGNBLOCK\nBLOCK\nSTART\nREAD_NAME AS name\nRESOLVE_VAR name AS target\nEXPECT_END\nLAST ENDASSIGN\nREAD_EXPR AS expr\nEXPECT_END\nEMIT_EXPR expr\nEMIT_STORE target\nENDS",
+            &mut bindings,
+            &mut globals,
+            &mut source_words,
+            operators.lookup(),
+        );
+
+        run_with_source_words_operators_and_mut_globals(
+            "ASSIGNBLOCK A\nENDASSIGN 8",
+            &bindings,
+            &mut globals,
+            &source_words,
+            &words,
+            &primitives,
+            operators.lookup(),
+        );
+
+        assert_eq!(globals.view().read(variables[0]), Ok(value(8)));
+    }
+
+    #[test]
+    fn user_defined_block_allows_required_marker_local_in_later_sections() {
+        let (words, primitives, operators, mut source_words, mut bindings, mut globals, variables) =
+            global_source_fixture();
+        publish_user_source_word(
+            "SYNTAX MARKASSIGN\nBLOCK\nSTART\nEXPECT_END\nMARK TARGET\nREAD_NAME AS name\nRESOLVE_VAR name AS target\nEXPECT_END\nLAST ENDMARKASSIGN\nREAD_EXPR AS expr\nEXPECT_END\nEMIT_EXPR expr\nEMIT_STORE target\nENDS",
+            &mut bindings,
+            &mut globals,
+            &mut source_words,
+            operators.lookup(),
+        );
+
+        run_with_source_words_operators_and_mut_globals(
+            "MARKASSIGN\nTARGET A\nENDMARKASSIGN 9",
+            &bindings,
+            &mut globals,
+            &source_words,
+            &words,
+            &primitives,
+            operators.lookup(),
+        );
+
+        assert_eq!(globals.view().read(variables[0]), Ok(value(9)));
+    }
+
+    #[test]
+    fn user_defined_block_rejects_optional_marker_local_in_later_sections() {
+        let (_words, _primitives, operators, mut source_words, mut bindings, mut globals, _vars) =
+            global_source_fixture();
+        let (_sources, _source_id, error) = publish_user_source_word_error(
+            "SYNTAX BROKEN\nBLOCK\nSTART\nEXPECT_END\nMARK_OPTIONAL TARGET\nREAD_NAME AS name\nRESOLVE_VAR name AS target\nEXPECT_END\nLAST ENDBROKEN\nREAD_EXPR AS expr\nEXPECT_END\nEMIT_EXPR expr\nEMIT_STORE target\nENDS",
+            &mut bindings,
+            &mut globals,
+            &mut source_words,
+            operators.lookup(),
+        );
+
+        assert!(matches!(
+            error,
+            SourceProcessorError::SourceWord(SourceWordError::SyntaxBuild {
+                source: crate::source_word_ir::SourceWordBuildError::UndefinedLocal { .. }
+            })
+        ));
+        assert_eq!(bindings.get(&name("BROKEN")), None);
+    }
+
+    #[test]
+    fn user_defined_block_rejects_repeating_marker_local_in_later_sections() {
+        for marker_header in ["MARK_ANY TARGET", "MARK_SOME TARGET"] {
+            let (
+                _words,
+                _primitives,
+                operators,
+                mut source_words,
+                mut bindings,
+                mut globals,
+                _vars,
+            ) = global_source_fixture();
+            let source = format!(
+                "SYNTAX BROKEN\nBLOCK\nSTART\nEXPECT_END\n{marker_header}\nREAD_NAME AS name\nRESOLVE_VAR name AS target\nEXPECT_END\nLAST ENDBROKEN\nREAD_EXPR AS expr\nEXPECT_END\nEMIT_EXPR expr\nEMIT_STORE target\nENDS"
+            );
+            let (_sources, _source_id, error) = publish_user_source_word_error(
+                &source,
+                &mut bindings,
+                &mut globals,
+                &mut source_words,
+                operators.lookup(),
+            );
+
+            assert!(matches!(
+                error,
+                SourceProcessorError::SourceWord(SourceWordError::SyntaxBuild {
+                    source: crate::source_word_ir::SourceWordBuildError::UndefinedLocal { .. }
+                })
+            ));
+            assert_eq!(bindings.get(&name("BROKEN")), None);
+        }
+    }
+
+    #[test]
+    fn user_defined_block_allows_optional_and_repeating_marker_local_inside_same_section() {
+        for (marker_header, expected) in [
+            ("MARK_OPTIONAL TARGET", 10),
+            ("MARK_ANY TARGET", 11),
+            ("MARK_SOME TARGET", 12),
+        ] {
+            let (
+                words,
+                primitives,
+                operators,
+                mut source_words,
+                mut bindings,
+                mut globals,
+                variables,
+            ) = global_source_fixture();
+            let source = format!(
+                "SYNTAX LOCALONLY\nBLOCK\nSTART\nEXPECT_END\n{marker_header}\nREAD_NAME AS name\nRESOLVE_VAR name AS target\nEXPECT \"=\"\nREAD_EXPR AS expr\nEXPECT_END\nEMIT_EXPR expr\nEMIT_STORE target\nLAST ENDLOCALONLY\nEXPECT_END\nENDS"
+            );
+
+            publish_user_source_word(
+                &source,
+                &mut bindings,
+                &mut globals,
+                &mut source_words,
+                operators.lookup(),
+            );
+
+            run_with_source_words_operators_and_mut_globals(
+                &format!("LOCALONLY\nTARGET A = {expected}\nENDLOCALONLY"),
+                &bindings,
+                &mut globals,
+                &source_words,
+                &words,
+                &primitives,
+                operators.lookup(),
+            );
+
+            assert_eq!(globals.view().read(variables[0]), Ok(value(expected)));
+        }
+    }
+
+    #[test]
     fn user_defined_return_equivalent_runs_through_runtime_definition_body() {
         let mut session = RuntimeDefinitionSession::new();
         register_builtin_global_variables(&mut session.globals, &mut session.bindings)

--- a/crates/tbx-next/src/source_processor.rs
+++ b/crates/tbx-next/src/source_processor.rs
@@ -25,15 +25,18 @@ use crate::source_mapping::{
 };
 use crate::source_word::{
     NativeSourceWordBindingAccess, NativeSourceWordContext, NativeSourceWordContextParts,
-    NativeSourceWordHandler, NativeStructuredSourceWordContext, NativeStructuredSourceWordOwner,
+    NativeSourceWordHandler, NativeStructuredSourceWordContext,
+    NativeStructuredSourceWordContextParts, NativeStructuredSourceWordOwner,
     OneShotSourceWordDispatch, RuntimeDefinitionPublisher, SourceBlockCursor, SourceBlockMarker,
     SourceBlockRead, SourceBlockReader, SourceBlockStatement, SourceBlockTerminal,
     SourceWordDispatch, SourceWordError, SourceWordId, SourceWordLookup, SourceWordLookupError,
     SourceWordRegistry, SourceWordSyntaxMarker, StructuredBodyCapabilities,
     StructuredBuildTargetScope, StructuredLineNumberScope, StructuredOwnerLocalTarget,
+    StructuredSourceWordDispatch, StructuredSourceWordInstance,
 };
 use crate::source_word_evaluator::{
-    evaluate_source_word, UserDefinedSourceWordContext, UserDefinedSourceWordContextParts,
+    evaluate_source_word, evaluate_source_word_with_state, UserDefinedSourceWordContext,
+    UserDefinedSourceWordContextParts,
 };
 use crate::source_word_ir::SourceProcessingCapabilities;
 use crate::static_quotation::{StaticQuotation, StaticQuotationBuildError};
@@ -193,9 +196,14 @@ enum StatementSourceWordDispatch {
     Native(NativeSourceWordHandler),
     UserDefined(crate::source_word_ir::SourceWordImplementation),
     Structured {
-        start: crate::source_word::NativeStructuredSourceWordStartHandler,
+        implementation: StatementStructuredSourceWordDispatch,
         grammar: StructuredGrammar,
     },
+}
+
+enum StatementStructuredSourceWordDispatch {
+    Native(crate::source_word::NativeStructuredSourceWordStartHandler),
+    UserDefined(crate::source_word::UserDefinedStructuredSourceWordImplementation),
 }
 
 struct StructuredSourceFrame {
@@ -599,6 +607,10 @@ where
         GrammarAccept::Intermediate { .. } => frame.body_target.clone(),
         GrammarAccept::Terminator => frame.enclosing_target.clone(),
     };
+    let callback_line_numbers = match accept {
+        GrammarAccept::Intermediate { .. } => frame.current_line_numbers.clone(),
+        GrammarAccept::Terminator => frame.enclosing_line_numbers.clone(),
+    };
     let owner_local_targets = frame.owner_local_target_snapshots()?;
     let mut owner_target;
     let callback_code = match &callback_target {
@@ -610,14 +622,18 @@ where
             &mut owner_target as &mut dyn InstructionBuildTarget
         }
     };
-    let mut owner_context = NativeStructuredSourceWordContext::new(
-        view,
-        source_id,
-        bindings,
-        operators,
-        callback_code,
-        owner_local_targets,
-    );
+    let mut callback_line_numbers = callback_line_numbers.borrow_mut();
+    let mut owner_context =
+        NativeStructuredSourceWordContext::new(NativeStructuredSourceWordContextParts {
+            view,
+            source_id,
+            bindings,
+            operators,
+            code: callback_code,
+            line_numbers: &mut callback_line_numbers,
+            capabilities: SourceProcessingCapabilities::structured_runtime(),
+            owner_local_targets,
+        });
     match accept {
         GrammarAccept::Intermediate { .. } => {
             frame
@@ -1040,12 +1056,20 @@ where
             SourceWordDispatch::OneShot(OneShotSourceWordDispatch::UserDefined(implementation)) => {
                 StatementSourceWordDispatch::UserDefined(implementation.clone())
             }
-            SourceWordDispatch::Structured { start, grammar } => {
-                StatementSourceWordDispatch::Structured {
-                    start,
-                    grammar: grammar.clone(),
-                }
-            }
+            SourceWordDispatch::Structured {
+                implementation,
+                grammar,
+            } => StatementSourceWordDispatch::Structured {
+                implementation: match implementation {
+                    StructuredSourceWordDispatch::Native(start) => {
+                        StatementStructuredSourceWordDispatch::Native(start)
+                    }
+                    StructuredSourceWordDispatch::UserDefined(implementation) => {
+                        StatementStructuredSourceWordDispatch::UserDefined(implementation.clone())
+                    }
+                },
+                grammar: grammar.clone(),
+            },
         };
         let syntax_markers = source_words.syntax_markers(id)?.to_vec();
         let runtime_definition_source_words = match source_word_access {
@@ -1135,22 +1159,59 @@ where
             evaluate_source_word(&implementation, &mut source_word_context)
                 .map_err(|source| SourceWordError::UserDefinedEvaluation { source })?;
         }
-        StatementSourceWordDispatch::Structured { start, grammar } => {
-            let mut source_word_context =
-                NativeSourceWordContext::new(NativeSourceWordContextParts {
-                    view: traversal.view,
-                    source_id: traversal.source_id,
-                    tokens,
-                    block_reader: None,
-                    bindings: binding_access,
-                    operators,
-                    code: state.code,
-                    local_line_number_prefix,
-                    globals,
-                    runtime_definitions,
-                    source_word_publication: None,
-                });
-            let instance = start(&mut source_word_context)?;
+        StatementSourceWordDispatch::Structured {
+            implementation,
+            grammar,
+        } => {
+            let instance = match implementation {
+                StatementStructuredSourceWordDispatch::Native(start) => {
+                    let mut source_word_context =
+                        NativeSourceWordContext::new(NativeSourceWordContextParts {
+                            view: traversal.view,
+                            source_id: traversal.source_id,
+                            tokens,
+                            block_reader: None,
+                            bindings: binding_access,
+                            operators,
+                            code: state.code,
+                            local_line_number_prefix,
+                            globals,
+                            runtime_definitions,
+                            source_word_publication: None,
+                        });
+                    start(&mut source_word_context)?
+                }
+                StatementStructuredSourceWordDispatch::UserDefined(implementation) => {
+                    let mut evaluation_state =
+                        crate::source_word_evaluator::SourceWordEvaluationState::new();
+                    {
+                        let mut line_numbers = state.line_numbers.borrow_mut();
+                        let mut source_word_context =
+                            UserDefinedSourceWordContext::new(UserDefinedSourceWordContextParts {
+                                view: traversal.view,
+                                source_id: traversal.source_id,
+                                tokens,
+                                bindings: context.bindings(),
+                                operators,
+                                code: state.code,
+                                line_numbers: &mut line_numbers,
+                                capabilities: SourceProcessingCapabilities::structured_runtime(),
+                            });
+                        evaluate_source_word_with_state(
+                            implementation.start(),
+                            &mut source_word_context,
+                            &mut evaluation_state,
+                        )
+                        .map_err(|source| SourceWordError::UserDefinedEvaluation { source })?;
+                    }
+                    StructuredSourceWordInstance::new(Box::new(
+                        crate::source_word::UserDefinedStructuredSourceWordOwner::new(
+                            implementation,
+                            evaluation_state,
+                        ),
+                    ))
+                }
+            };
             let mut frame = StructuredSourceFrame::new(
                 syntax_markers,
                 grammar.start(),
@@ -2856,10 +2917,10 @@ mod tests {
             self.body_contexts[self.context_index]
         }
 
-        fn accept_marker(
+        fn accept_marker<'source>(
             &mut self,
-            context: &mut NativeStructuredSourceWordContext<'_, '_>,
-            marker: SourceBlockMarker<'_>,
+            context: &mut NativeStructuredSourceWordContext<'source, '_>,
+            marker: SourceBlockMarker<'source>,
             _accept: GrammarAccept,
         ) -> Result<(), SourceWordError> {
             context.append_mapped(Instruction::Push(value(self.marker_value)), marker.span())?;
@@ -2867,10 +2928,10 @@ mod tests {
             Ok(())
         }
 
-        fn complete(
+        fn complete<'source>(
             &mut self,
-            context: &mut NativeStructuredSourceWordContext<'_, '_>,
-            marker: SourceBlockMarker<'_>,
+            context: &mut NativeStructuredSourceWordContext<'source, '_>,
+            marker: SourceBlockMarker<'source>,
         ) -> Result<(), SourceWordError> {
             if self.fail_completion {
                 return Err(SourceWordError::UnsupportedSourceWord {
@@ -4730,6 +4791,218 @@ mod tests {
         );
 
         assert_eq!(globals.view().read(variables[0]), Ok(value(2)));
+    }
+
+    #[test]
+    fn user_defined_block_with_only_terminator_dispatches_as_structured_source_word() {
+        let (words, primitives, operators, mut source_words, mut bindings, mut globals, variables) =
+            global_source_fixture();
+        publish_user_source_word(
+            "SYNTAX WRAP\nBLOCK\nSTART\nEXPECT_END\nLAST ENDWRAP\nEXPECT_END\nENDS",
+            &mut bindings,
+            &mut globals,
+            &mut source_words,
+            operators.lookup(),
+        );
+
+        run_with_source_words_operators_and_mut_globals(
+            "WRAP\nLET A = 4\nENDWRAP",
+            &bindings,
+            &mut globals,
+            &source_words,
+            &words,
+            &primitives,
+            operators.lookup(),
+        );
+
+        assert_eq!(globals.view().read(variables[0]), Ok(value(4)));
+    }
+
+    #[test]
+    fn user_defined_block_declares_marker_grammar_and_reservations_from_sections() {
+        let (words, primitives, operators, mut source_words, mut bindings, mut globals, variables) =
+            global_source_fixture();
+        publish_user_source_word(
+            "SYNTAX TWOPART\nBLOCK\nSTART\nEXPECT_END\nMARK MID\nEXPECT_END\nLAST ENDTWO\nEXPECT_END\nENDS",
+            &mut bindings,
+            &mut globals,
+            &mut source_words,
+            operators.lookup(),
+        );
+
+        let Some(Binding::SourceWord(id)) = bindings.get(&name("TWOPART")).copied() else {
+            panic!("TWOPART should publish as a source word");
+        };
+        let SourceWordDispatch::Structured { grammar, .. } = source_words
+            .lookup()
+            .lookup_dispatch(id)
+            .expect("published source word should dispatch")
+        else {
+            panic!("TWOPART should keep the structured source word kind");
+        };
+        assert_eq!(grammar.groups().len(), 1);
+        assert_eq!(grammar.groups()[0].cardinality(), MarkerCardinality::One);
+        assert_eq!(
+            bindings
+                .syntax_marker_reservation(&name("MID"))
+                .map(|reservation| reservation.owner()),
+            Some(id)
+        );
+        assert_eq!(
+            bindings
+                .syntax_marker_reservation(&name("ENDTWO"))
+                .map(|reservation| reservation.owner()),
+            Some(id)
+        );
+
+        run_with_source_words_operators_and_mut_globals(
+            "TWOPART\nLET A = 1\nMID\nLET A = 2\nENDTWO",
+            &bindings,
+            &mut globals,
+            &source_words,
+            &words,
+            &primitives,
+            operators.lookup(),
+        );
+
+        assert_eq!(globals.view().read(variables[0]), Ok(value(2)));
+    }
+
+    #[test]
+    fn user_defined_block_nests_with_native_structured_source_words_both_directions() {
+        let (words, primitives, operators, mut source_words, mut bindings, mut globals, variables) =
+            global_source_fixture();
+        publish_user_source_word(
+            "SYNTAX WRAP\nBLOCK\nSTART\nEXPECT_END\nLAST ENDWRAP\nEXPECT_END\nENDS",
+            &mut bindings,
+            &mut globals,
+            &mut source_words,
+            operators.lookup(),
+        );
+
+        run_with_source_words_operators_and_mut_globals(
+            "IF 1\nWRAP\nLET A = 5\nENDWRAP\nENDIF",
+            &bindings,
+            &mut globals,
+            &source_words,
+            &words,
+            &primitives,
+            operators.lookup(),
+        );
+        assert_eq!(globals.view().read(variables[0]), Ok(value(5)));
+
+        run_with_source_words_operators_and_mut_globals(
+            "WRAP\nIF 1\nLET A = 6\nENDIF\nENDWRAP",
+            &bindings,
+            &mut globals,
+            &source_words,
+            &words,
+            &primitives,
+            operators.lookup(),
+        );
+        assert_eq!(globals.view().read(variables[0]), Ok(value(6)));
+    }
+
+    #[test]
+    fn user_defined_blocks_nest_without_confusing_outer_markers() {
+        let (words, primitives, operators, mut source_words, mut bindings, mut globals, variables) =
+            global_source_fixture();
+        publish_user_source_word(
+            "SYNTAX WRAP\nBLOCK\nSTART\nEXPECT_END\nLAST ENDWRAP\nEXPECT_END\nENDS",
+            &mut bindings,
+            &mut globals,
+            &mut source_words,
+            operators.lookup(),
+        );
+
+        run_with_source_words_operators_and_mut_globals(
+            "WRAP\nWRAP\nLET A = 7\nENDWRAP\nENDWRAP",
+            &bindings,
+            &mut globals,
+            &source_words,
+            &words,
+            &primitives,
+            operators.lookup(),
+        );
+
+        assert_eq!(globals.view().read(variables[0]), Ok(value(7)));
+    }
+
+    #[test]
+    fn user_defined_block_rejects_marker_order_violation_without_binding_fallback() {
+        let (_words, _primitives, operators, mut source_words, mut bindings, mut globals, _vars) =
+            global_source_fixture();
+        publish_user_source_word(
+            "SYNTAX ORDERED\nBLOCK\nSTART\nEXPECT_END\nMARK FIRST\nEXPECT_END\nMARK_OPTIONAL SECOND\nEXPECT_END\nLAST ENDORDER\nEXPECT_END\nENDS",
+            &mut bindings,
+            &mut globals,
+            &mut source_words,
+            operators.lookup(),
+        );
+        let (sources, source_id) = source("ORDERED\nSECOND\nFIRST\nENDORDER");
+
+        let error = compile_source(
+            sources.view(),
+            source_id,
+            SourceCompileContext::with_source_words_and_operators(
+                &bindings,
+                source_words.lookup(),
+                operators.lookup(),
+            ),
+        )
+        .expect_err("out-of-order marker should fail grammar validation");
+
+        assert_eq!(
+            error,
+            SourceProcessorError::SourceWord(SourceWordError::StructuredGrammar {
+                span: span(sources.view(), source_id, 8, 14),
+                source: crate::structured_grammar::GrammarProgressError::RequiredGroupUnmet {
+                    required_group_index: 0,
+                    attempted_group_index: 1,
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn user_defined_block_publication_is_atomic_when_marker_reservation_conflicts() {
+        let (_words, _primitives, operators, mut source_words, mut bindings, mut globals, _vars) =
+            global_source_fixture();
+        let (_sources, _source_id, error) = publish_user_source_word_error(
+            "SYNTAX BROKEN\nBLOCK\nSTART\nEXPECT_END\nLAST ENDIF\nEXPECT_END\nENDS",
+            &mut bindings,
+            &mut globals,
+            &mut source_words,
+            operators.lookup(),
+        );
+
+        assert!(matches!(
+            error,
+            SourceProcessorError::SourceWord(SourceWordError::SyntaxNameConflict { .. })
+        ));
+        assert_eq!(bindings.get(&name("BROKEN")), None);
+    }
+
+    #[test]
+    fn user_defined_block_rejects_missing_last_without_binding_fallback() {
+        let (_words, _primitives, operators, mut source_words, mut bindings, mut globals, _vars) =
+            global_source_fixture();
+        let (_sources, _source_id, error) = publish_user_source_word_error(
+            "SYNTAX BROKEN\nBLOCK\nSTART\nEXPECT_END\nENDS",
+            &mut bindings,
+            &mut globals,
+            &mut source_words,
+            operators.lookup(),
+        );
+
+        assert!(matches!(
+            error,
+            SourceProcessorError::SourceWord(SourceWordError::SyntaxDefinition {
+                kind: crate::source_word::SyntaxDefinitionErrorKind::MissingKind,
+                ..
+            })
+        ));
+        assert_eq!(bindings.get(&name("BROKEN")), None);
     }
 
     #[test]
@@ -7386,7 +7659,7 @@ mod tests {
             error,
             SourceProcessorError::SourceWord(SourceWordError::SyntaxDefinition {
                 span: span(sources.view(), source_id, 14, 19),
-                kind: crate::source_word::SyntaxDefinitionErrorKind::UnsupportedKind
+                kind: crate::source_word::SyntaxDefinitionErrorKind::MissingKind
             })
         );
         assert_eq!(bindings.get(&name("BROKEN")), None);
@@ -7396,8 +7669,8 @@ mod tests {
     fn builtin_if_can_call_published_runtime_word_from_branch_body() {
         let mut session = RuntimeDefinitionSession::new();
         session.register_primitive("PUSH7", push_7);
-        session.publish_def("DEF MARK\nPUSH7\nEND");
-        let (sources, source_id) = source("IF 1\nMARK\nENDIF");
+        session.publish_def("DEF TOUCH\nPUSH7\nEND");
+        let (sources, source_id) = source("IF 1\nTOUCH\nENDIF");
 
         let unit = compile_source(
             sources.view(),

--- a/crates/tbx-next/src/source_word.rs
+++ b/crates/tbx-next/src/source_word.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::binding::{Binding, BindingInsertError, Bindings};
 use crate::expression::{
     parse_expression, ExpressionError, ExpressionStaging, ExpressionVariableErrorKind,
@@ -1626,6 +1628,12 @@ enum BlockSyntaxSectionKind {
     },
 }
 
+#[derive(Debug, Clone, Copy)]
+struct BlockSectionLocalDefinition {
+    section_index: usize,
+    visible_outside_section: bool,
+}
+
 fn read_block_syntax_sections(
     context: &mut NativeSourceWordContext<'_, '_>,
     view: SourceView<'_>,
@@ -1756,6 +1764,8 @@ fn complete_block_syntax_sections(
     validation
         .complete()
         .map_err(|source| SourceWordError::SyntaxBuild { source })?;
+    validate_block_section_local_visibility(&sections)
+        .map_err(|source| SourceWordError::SyntaxBuild { source })?;
 
     let mut sections = sections.into_iter();
     let start = sections.next().expect("start section was validated above");
@@ -1848,6 +1858,54 @@ fn complete_block_syntax_sections(
             terminator_implementation,
         ),
     })
+}
+
+fn validate_block_section_local_visibility(
+    sections: &[BlockSyntaxSection],
+) -> Result<(), SourceWordBuildError> {
+    let mut locals: HashMap<NormalizedName, BlockSectionLocalDefinition> = HashMap::new();
+
+    for (section_index, section) in sections.iter().enumerate() {
+        let visible_outside_section = block_section_locals_are_visible_outside(section);
+        for instruction in &section.instructions {
+            for reference in instruction.operation().consumed_local_references() {
+                let Some(definition) = locals.get(reference.name()) else {
+                    return Err(SourceWordBuildError::UndefinedLocal {
+                        reference: reference.clone(),
+                    });
+                };
+                if definition.section_index != section_index && !definition.visible_outside_section
+                {
+                    return Err(SourceWordBuildError::UndefinedLocal {
+                        reference: reference.clone(),
+                    });
+                }
+            }
+
+            if let Some(binding) = instruction.operation().produced_binding_for_validation() {
+                locals.insert(
+                    binding.name().clone(),
+                    BlockSectionLocalDefinition {
+                        section_index,
+                        visible_outside_section,
+                    },
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn block_section_locals_are_visible_outside(section: &BlockSyntaxSection) -> bool {
+    match &section.kind {
+        BlockSyntaxSectionKind::Start => true,
+        BlockSyntaxSectionKind::Marker {
+            cardinality: MarkerCardinality::One,
+            ..
+        } => true,
+        BlockSyntaxSectionKind::Marker { .. } | BlockSyntaxSectionKind::Last { .. } => false,
+    }
 }
 
 fn section_origin_span(section: &BlockSyntaxSection) -> SourceSpan {

--- a/crates/tbx-next/src/source_word.rs
+++ b/crates/tbx-next/src/source_word.rs
@@ -9,11 +9,17 @@ use crate::lexer::{LexError, Token, TokenKind};
 use crate::name::{NameError, NormalizedName};
 use crate::operator::OperatorLookup;
 use crate::source::{SourceError, SourceId, SourceSpan, SourceView};
-use crate::source_word_evaluator::SourceWordEvaluationError;
+use crate::source_word_evaluator::{
+    evaluate_source_word_with_state, SourceWordEvaluationError, SourceWordEvaluationState,
+    UserDefinedSourceWordContext, UserDefinedSourceWordContextParts,
+};
 use crate::source_word_ir::{
-    FixedToken, LocalBinding, LocalReference, SourceInstructionOrigin, SourceProcessingInstruction,
-    SourceProcessingOperation, SourceWordBuildError, SourceWordImplementation,
-    SourceWordImplementationBuilder,
+    FixedToken, LocalBinding, LocalReference, SourceInstructionOrigin,
+    SourceProcessingCapabilities, SourceProcessingInstruction, SourceProcessingOperation,
+    SourceWordBuildError, SourceWordImplementation, SourceWordImplementationBuilder,
+};
+use crate::structured_grammar::{
+    MarkerCardinality, MarkerGroup, MarkerIdentity, StructuredGrammar,
 };
 use crate::word::WordId;
 use crate::word_resolution::{resolve_binding_name, ResolvedBinding, WordResolutionError};
@@ -46,20 +52,39 @@ pub(crate) type NativeStructuredSourceWordStartHandler =
         &mut NativeSourceWordContext<'_, '_>,
     ) -> Result<StructuredSourceWordInstance, SourceWordError>;
 
+#[derive(Debug, Clone)]
+pub(crate) struct UserDefinedStructuredSourceWordImplementation {
+    start: SourceWordImplementation,
+    markers: Vec<UserDefinedStructuredMarkerImplementation>,
+    terminator: UserDefinedStructuredTerminatorImplementation,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct UserDefinedStructuredMarkerImplementation {
+    name: NormalizedName,
+    implementation: SourceWordImplementation,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct UserDefinedStructuredTerminatorImplementation {
+    name: NormalizedName,
+    implementation: SourceWordImplementation,
+}
+
 pub(crate) trait NativeStructuredSourceWordOwner: std::fmt::Debug {
     fn current_body_context(&self) -> StructuredBodyContext;
 
-    fn accept_marker(
+    fn accept_marker<'source>(
         &mut self,
-        context: &mut NativeStructuredSourceWordContext<'_, '_>,
-        marker: SourceBlockMarker<'_>,
+        context: &mut NativeStructuredSourceWordContext<'source, '_>,
+        marker: SourceBlockMarker<'source>,
         accept: crate::structured_grammar::GrammarAccept,
     ) -> Result<(), SourceWordError>;
 
-    fn complete(
+    fn complete<'source>(
         &mut self,
-        context: &mut NativeStructuredSourceWordContext<'_, '_>,
-        marker: SourceBlockMarker<'_>,
+        context: &mut NativeStructuredSourceWordContext<'source, '_>,
+        marker: SourceBlockMarker<'source>,
     ) -> Result<(), SourceWordError>;
 }
 
@@ -98,7 +123,20 @@ pub(crate) struct NativeStructuredSourceWordContext<'source, 'state> {
     bindings: &'state Bindings,
     operators: Option<OperatorLookup>,
     code: &'state mut dyn InstructionBuildTarget,
+    line_numbers: &'state mut crate::line_number::LocalLineNumberTable,
+    capabilities: SourceProcessingCapabilities,
     owner_local_targets: Vec<StructuredOwnerLocalTarget>,
+}
+
+pub(crate) struct NativeStructuredSourceWordContextParts<'source, 'state> {
+    pub(crate) view: SourceView<'source>,
+    pub(crate) source_id: SourceId,
+    pub(crate) bindings: &'state Bindings,
+    pub(crate) operators: Option<OperatorLookup>,
+    pub(crate) code: &'state mut dyn InstructionBuildTarget,
+    pub(crate) line_numbers: &'state mut crate::line_number::LocalLineNumberTable,
+    pub(crate) capabilities: SourceProcessingCapabilities,
+    pub(crate) owner_local_targets: Vec<StructuredOwnerLocalTarget>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -574,21 +612,16 @@ impl StructuredBodyCapabilities {
 }
 
 impl<'source, 'state> NativeStructuredSourceWordContext<'source, 'state> {
-    pub(crate) fn new(
-        view: SourceView<'source>,
-        source_id: SourceId,
-        bindings: &'state Bindings,
-        operators: Option<OperatorLookup>,
-        code: &'state mut dyn InstructionBuildTarget,
-        owner_local_targets: Vec<StructuredOwnerLocalTarget>,
-    ) -> Self {
+    pub(crate) fn new(parts: NativeStructuredSourceWordContextParts<'source, 'state>) -> Self {
         Self {
-            view,
-            source_id,
-            bindings,
-            operators,
-            code,
-            owner_local_targets,
+            view: parts.view,
+            source_id: parts.source_id,
+            bindings: parts.bindings,
+            operators: parts.operators,
+            code: parts.code,
+            line_numbers: parts.line_numbers,
+            capabilities: parts.capabilities,
+            owner_local_targets: parts.owner_local_targets,
         }
     }
 
@@ -683,6 +716,72 @@ impl<'source, 'state> NativeStructuredSourceWordContext<'source, 'state> {
         let resolver = |source_name: &str| resolve_variable_name(self.bindings, source_name);
         parse_expression(self.view, &expression_tokens, operators, &resolver)
             .map_err(|source| SourceWordError::Expression { source })
+    }
+
+    fn evaluate_user_defined_source_word(
+        &mut self,
+        implementation: &SourceWordImplementation,
+        state: &mut SourceWordEvaluationState,
+        tokens: &'source [Token],
+    ) -> Result<(), SourceWordError> {
+        let mut context = UserDefinedSourceWordContext::new(UserDefinedSourceWordContextParts {
+            view: self.view,
+            source_id: self.source_id,
+            tokens,
+            bindings: self.bindings,
+            operators: self.operators,
+            code: self.code,
+            line_numbers: self.line_numbers,
+            capabilities: self.capabilities,
+        });
+        evaluate_source_word_with_state(implementation, &mut context, state)
+            .map_err(|source| SourceWordError::UserDefinedEvaluation { source })
+    }
+}
+
+impl UserDefinedStructuredSourceWordImplementation {
+    fn new(
+        start: SourceWordImplementation,
+        markers: Vec<UserDefinedStructuredMarkerImplementation>,
+        terminator: UserDefinedStructuredTerminatorImplementation,
+    ) -> Self {
+        Self {
+            start,
+            markers,
+            terminator,
+        }
+    }
+
+    pub(crate) fn start(&self) -> &SourceWordImplementation {
+        &self.start
+    }
+
+    fn marker(&self, group_index: usize) -> Option<&SourceWordImplementation> {
+        self.markers
+            .get(group_index)
+            .map(|marker| &marker.implementation)
+    }
+
+    fn terminator(&self) -> &SourceWordImplementation {
+        &self.terminator.implementation
+    }
+}
+
+impl UserDefinedStructuredMarkerImplementation {
+    fn new(name: NormalizedName, implementation: SourceWordImplementation) -> Self {
+        Self {
+            name,
+            implementation,
+        }
+    }
+}
+
+impl UserDefinedStructuredTerminatorImplementation {
+    fn new(name: NormalizedName, implementation: SourceWordImplementation) -> Self {
+        Self {
+            name,
+            implementation,
+        }
     }
 }
 
@@ -1177,6 +1276,52 @@ impl<'source, 'state> NativeSourceWordContext<'source, 'state> {
         Ok(id)
     }
 
+    pub(crate) fn publish_structured_source_word(
+        &mut self,
+        name: NormalizedName,
+        name_span: SourceSpan,
+        grammar: StructuredGrammar,
+        syntax_markers: Vec<SourceWordSyntaxMarker>,
+        implementation: UserDefinedStructuredSourceWordImplementation,
+    ) -> Result<SourceWordId, SourceWordError> {
+        let Some(source_words) = &mut self.source_word_publication else {
+            return Err(SourceWordError::SyntaxPublicationContextUnavailable {
+                span: self.source_word_token.span(),
+            });
+        };
+        let NativeSourceWordBindingAccess::Write(bindings) = &mut self.bindings else {
+            return Err(SourceWordError::SyntaxPublicationContextUnavailable {
+                span: self.source_word_token.span(),
+            });
+        };
+        let marker_names = syntax_markers
+            .iter()
+            .map(|marker| marker.name().clone())
+            .collect::<Vec<_>>();
+
+        bindings
+            .validate_new_source_word_with_markers(&name, &marker_names)
+            .map_err(|source| match source {
+                BindingInsertError::NameConflict => {
+                    SourceWordError::SyntaxNameConflict { span: name_span }
+                }
+                BindingInsertError::ReservedName => {
+                    SourceWordError::SyntaxReservedName { span: name_span }
+                }
+            })?;
+
+        let id =
+            source_words.register_user_defined_structured(grammar, syntax_markers, implementation);
+        // #1513/#1556 require the user-defined structured artifact, binding,
+        // and marker reservations to become visible as a single unit.
+        bindings
+            .insert_new_source_word_with_markers(name, id, &marker_names)
+            .map_err(|_| SourceWordError::SyntaxBindingCommitInvariantViolated {
+                span: name_span,
+            })?;
+        Ok(id)
+    }
+
     pub(crate) fn resolve_variable_target(
         &self,
         source_name: &str,
@@ -1364,7 +1509,6 @@ pub(crate) fn syntax_source_word(
         source,
     })?;
 
-    let view = context.view();
     let kind = read_syntax_body_item(context, SyntaxDefinitionErrorKind::MissingKind)?;
     let SourceBlockItem::Marker(marker) = kind else {
         return Err(SourceWordError::SyntaxDefinition {
@@ -1372,14 +1516,30 @@ pub(crate) fn syntax_source_word(
             kind: SyntaxDefinitionErrorKind::MissingKind,
         });
     };
-    if marker.name().as_str() != "STATEMENT" {
-        return Err(SourceWordError::SyntaxDefinition {
+    let view = context.view();
+    match marker.name().as_str() {
+        "STATEMENT" => {
+            publish_statement_syntax_definition(context, view, name, name_token.span(), marker)
+        }
+        "BLOCK" => publish_block_syntax_definition(context, view, name, name_token.span(), marker),
+        _ => Err(SourceWordError::SyntaxDefinition {
             span: marker.span(),
             kind: SyntaxDefinitionErrorKind::UnsupportedKind,
-        });
+        }),
     }
-    require_empty_syntax_marker_remainder(&marker, SyntaxDefinitionErrorKind::UnsupportedKind)?;
+}
 
+fn publish_statement_syntax_definition(
+    context: &mut NativeSourceWordContext<'_, '_>,
+    view: SourceView<'_>,
+    name: NormalizedName,
+    name_span: SourceSpan,
+    kind_marker: SourceBlockMarker<'_>,
+) -> Result<(), SourceWordError> {
+    require_empty_syntax_marker_remainder(
+        &kind_marker,
+        SyntaxDefinitionErrorKind::UnsupportedKind,
+    )?;
     let mut builder = SourceWordImplementationBuilder::new();
     loop {
         match read_syntax_body_item(context, SyntaxDefinitionErrorKind::MissingEnds)? {
@@ -1413,8 +1573,289 @@ pub(crate) fn syntax_source_word(
     let implementation = builder
         .complete()
         .map_err(|source| SourceWordError::SyntaxBuild { source })?;
-    context.publish_statement_source_word(name, name_token.span(), implementation)?;
+    context.publish_statement_source_word(name, name_span, implementation)?;
     Ok(())
+}
+
+fn publish_block_syntax_definition(
+    context: &mut NativeSourceWordContext<'_, '_>,
+    view: SourceView<'_>,
+    name: NormalizedName,
+    name_span: SourceSpan,
+    kind_marker: SourceBlockMarker<'_>,
+) -> Result<(), SourceWordError> {
+    require_empty_syntax_marker_remainder(
+        &kind_marker,
+        SyntaxDefinitionErrorKind::UnsupportedKind,
+    )?;
+    let sections = read_block_syntax_sections(context, view)?;
+    let artifacts = complete_block_syntax_sections(sections, kind_marker.span())?;
+    context.publish_structured_source_word(
+        name,
+        name_span,
+        artifacts.grammar,
+        artifacts.syntax_markers,
+        artifacts.implementation,
+    )?;
+    Ok(())
+}
+
+#[derive(Debug)]
+struct BlockSyntaxArtifacts {
+    grammar: StructuredGrammar,
+    syntax_markers: Vec<SourceWordSyntaxMarker>,
+    implementation: UserDefinedStructuredSourceWordImplementation,
+}
+
+#[derive(Debug)]
+struct BlockSyntaxSection {
+    kind: BlockSyntaxSectionKind,
+    header_span: SourceSpan,
+    instructions: Vec<SourceProcessingInstruction>,
+}
+
+#[derive(Debug)]
+enum BlockSyntaxSectionKind {
+    Start,
+    Marker {
+        name: NormalizedName,
+        cardinality: MarkerCardinality,
+    },
+    Last {
+        name: NormalizedName,
+    },
+}
+
+fn read_block_syntax_sections(
+    context: &mut NativeSourceWordContext<'_, '_>,
+    view: SourceView<'_>,
+) -> Result<Vec<BlockSyntaxSection>, SourceWordError> {
+    let mut sections: Vec<BlockSyntaxSection> = Vec::new();
+
+    loop {
+        match read_syntax_body_item(context, SyntaxDefinitionErrorKind::MissingEnds)? {
+            SourceBlockItem::Statement(statement) => {
+                let Some(section) = sections.last_mut() else {
+                    return Err(SourceWordError::SyntaxDefinition {
+                        span: statement.span(),
+                        kind: SyntaxDefinitionErrorKind::MissingKind,
+                    });
+                };
+                section
+                    .instructions
+                    .push(parse_source_processing_statement(view, statement)?);
+            }
+            SourceBlockItem::Marker(marker) if marker.name().as_str() == "ENDS" => {
+                require_empty_syntax_marker_remainder_with(&marker, |token| {
+                    SyntaxDefinitionErrorKind::TrailingOperationToken { kind: token.kind() }
+                })?;
+                break;
+            }
+            SourceBlockItem::Marker(marker) => {
+                sections.push(parse_block_syntax_section_header(view, marker)?);
+            }
+            SourceBlockItem::Terminal(SourceBlockTerminal::Eof { span }) => {
+                return Err(SourceWordError::SyntaxDefinition {
+                    span,
+                    kind: SyntaxDefinitionErrorKind::MissingEnds,
+                });
+            }
+            SourceBlockItem::Terminal(SourceBlockTerminal::LexError { error }) => {
+                return Err(SourceWordError::DefLex { source: error });
+            }
+        }
+    }
+
+    Ok(sections)
+}
+
+fn parse_block_syntax_section_header(
+    view: SourceView<'_>,
+    marker: SourceBlockMarker<'_>,
+) -> Result<BlockSyntaxSection, SourceWordError> {
+    let kind = match marker.name().as_str() {
+        "START" => {
+            require_empty_syntax_marker_remainder(
+                &marker,
+                SyntaxDefinitionErrorKind::UnsupportedKind,
+            )?;
+            BlockSyntaxSectionKind::Start
+        }
+        "MARK" => BlockSyntaxSectionKind::Marker {
+            name: read_syntax_marker_name(view, &marker)?,
+            cardinality: MarkerCardinality::One,
+        },
+        "MARK_OPTIONAL" => BlockSyntaxSectionKind::Marker {
+            name: read_syntax_marker_name(view, &marker)?,
+            cardinality: MarkerCardinality::Optional,
+        },
+        "MARK_ANY" => BlockSyntaxSectionKind::Marker {
+            name: read_syntax_marker_name(view, &marker)?,
+            cardinality: MarkerCardinality::ZeroOrMore,
+        },
+        "MARK_SOME" => BlockSyntaxSectionKind::Marker {
+            name: read_syntax_marker_name(view, &marker)?,
+            cardinality: MarkerCardinality::OneOrMore,
+        },
+        "LAST" => BlockSyntaxSectionKind::Last {
+            name: read_syntax_marker_name(view, &marker)?,
+        },
+        _ => {
+            return Err(SourceWordError::SyntaxDefinition {
+                span: marker.span(),
+                kind: SyntaxDefinitionErrorKind::UnsupportedKind,
+            });
+        }
+    };
+    Ok(BlockSyntaxSection {
+        kind,
+        header_span: marker.span(),
+        instructions: Vec::new(),
+    })
+}
+
+fn read_syntax_marker_name(
+    view: SourceView<'_>,
+    marker: &SourceBlockMarker<'_>,
+) -> Result<NormalizedName, SourceWordError> {
+    let mut reader = SourceStatementReader::new(marker.remaining_tokens(), marker.token().span());
+    let token = reader.read_name().map_err(syntax_operation_reader_error)?;
+    let name = normalized_token(view, token)?;
+    reader.finish().map_err(syntax_operation_reader_error)?;
+    Ok(name)
+}
+
+fn complete_block_syntax_sections(
+    sections: Vec<BlockSyntaxSection>,
+    fallback_span: SourceSpan,
+) -> Result<BlockSyntaxArtifacts, SourceWordError> {
+    let Some(BlockSyntaxSection {
+        kind: BlockSyntaxSectionKind::Start,
+        header_span,
+        ..
+    }) = sections.first()
+    else {
+        let span = sections
+            .first()
+            .map(|section| section.header_span)
+            .unwrap_or(fallback_span);
+        return Err(SourceWordError::SyntaxDefinition {
+            span,
+            kind: SyntaxDefinitionErrorKind::MissingKind,
+        });
+    };
+    let start_header_span = *header_span;
+
+    let mut validation = SourceWordImplementationBuilder::new();
+    for instruction in sections
+        .iter()
+        .flat_map(|section| section.instructions.iter().cloned())
+    {
+        validation.push(instruction);
+    }
+    validation
+        .complete()
+        .map_err(|source| SourceWordError::SyntaxBuild { source })?;
+
+    let mut sections = sections.into_iter();
+    let start = sections.next().expect("start section was validated above");
+    let start = SourceWordImplementation::from_prevalidated_instructions(start.instructions);
+    let mut groups = Vec::new();
+    let mut syntax_markers = Vec::new();
+    let mut markers = Vec::new();
+    let mut terminator = None;
+    let mut terminator_implementation = None;
+
+    for section in sections {
+        let section_span = section_origin_span(&section);
+        match section.kind {
+            BlockSyntaxSectionKind::Start => {
+                return Err(SourceWordError::SyntaxDefinition {
+                    span: section_span,
+                    kind: SyntaxDefinitionErrorKind::UnsupportedKind,
+                });
+            }
+            BlockSyntaxSectionKind::Marker { name, cardinality } => {
+                if terminator.is_some() {
+                    return Err(SourceWordError::SyntaxDefinition {
+                        span: section_span,
+                        kind: SyntaxDefinitionErrorKind::UnsupportedKind,
+                    });
+                }
+                let marker = MarkerIdentity::new(name.clone());
+                groups.push(MarkerGroup::new(marker, cardinality));
+                syntax_markers.push(SourceWordSyntaxMarker::new(
+                    name.clone(),
+                    SourceWordSyntaxMarkerRole::BlockContinuation,
+                ));
+                markers.push(UserDefinedStructuredMarkerImplementation::new(
+                    name,
+                    SourceWordImplementation::from_prevalidated_instructions(section.instructions),
+                ));
+            }
+            BlockSyntaxSectionKind::Last { name } => {
+                if terminator.is_some() {
+                    return Err(SourceWordError::SyntaxDefinition {
+                        span: section_span,
+                        kind: SyntaxDefinitionErrorKind::UnsupportedKind,
+                    });
+                }
+                terminator = Some(MarkerIdentity::new(name.clone()));
+                syntax_markers.push(SourceWordSyntaxMarker::new(
+                    name.clone(),
+                    SourceWordSyntaxMarkerRole::BlockTerminator,
+                ));
+                terminator_implementation =
+                    Some(UserDefinedStructuredTerminatorImplementation::new(
+                        name,
+                        SourceWordImplementation::from_prevalidated_instructions(
+                            section.instructions,
+                        ),
+                    ));
+            }
+        }
+    }
+
+    let Some(terminator_identity) = terminator else {
+        return Err(SourceWordError::SyntaxDefinition {
+            span: start_header_span,
+            kind: SyntaxDefinitionErrorKind::MissingKind,
+        });
+    };
+    let Some(terminator_implementation) = terminator_implementation else {
+        return Err(SourceWordError::SyntaxDefinition {
+            span: start_header_span,
+            kind: SyntaxDefinitionErrorKind::MissingKind,
+        });
+    };
+    let grammar = StructuredGrammar::new(groups, Some(terminator_identity)).map_err(|_| {
+        SourceWordError::SyntaxDefinition {
+            span: terminator_implementation
+                .implementation
+                .instructions()
+                .first()
+                .map_or(start_header_span, |instruction| instruction.origin().span()),
+            kind: SyntaxDefinitionErrorKind::UnsupportedKind,
+        }
+    })?;
+
+    Ok(BlockSyntaxArtifacts {
+        grammar,
+        syntax_markers,
+        implementation: UserDefinedStructuredSourceWordImplementation::new(
+            start,
+            markers,
+            terminator_implementation,
+        ),
+    })
+}
+
+fn section_origin_span(section: &BlockSyntaxSection) -> SourceSpan {
+    section
+        .instructions
+        .first()
+        .map(|instruction| instruction.origin().span())
+        .unwrap_or(section.header_span)
 }
 
 fn read_syntax_body_item<'source>(
@@ -1683,6 +2124,65 @@ fn normalized_token(view: SourceView<'_>, token: Token) -> Result<NormalizedName
 }
 
 #[derive(Debug)]
+pub(crate) struct UserDefinedStructuredSourceWordOwner {
+    implementation: UserDefinedStructuredSourceWordImplementation,
+    state: SourceWordEvaluationState,
+}
+
+impl UserDefinedStructuredSourceWordOwner {
+    pub(crate) fn new(
+        implementation: UserDefinedStructuredSourceWordImplementation,
+        state: SourceWordEvaluationState,
+    ) -> Self {
+        Self {
+            implementation,
+            state,
+        }
+    }
+}
+
+impl NativeStructuredSourceWordOwner for UserDefinedStructuredSourceWordOwner {
+    fn current_body_context(&self) -> StructuredBodyContext {
+        StructuredBodyContext::inherited()
+    }
+
+    fn accept_marker<'source>(
+        &mut self,
+        context: &mut NativeStructuredSourceWordContext<'source, '_>,
+        marker: SourceBlockMarker<'source>,
+        accept: crate::structured_grammar::GrammarAccept,
+    ) -> Result<(), SourceWordError> {
+        let crate::structured_grammar::GrammarAccept::Intermediate { group_index } = accept else {
+            return Err(SourceWordError::UnsupportedSourceWord {
+                span: marker.span(),
+            });
+        };
+        let Some(implementation) = self.implementation.marker(group_index) else {
+            return Err(SourceWordError::UnsupportedSourceWord {
+                span: marker.span(),
+            });
+        };
+        context.evaluate_user_defined_source_word(
+            implementation,
+            &mut self.state,
+            marker.statement().tokens(),
+        )
+    }
+
+    fn complete<'source>(
+        &mut self,
+        context: &mut NativeStructuredSourceWordContext<'source, '_>,
+        marker: SourceBlockMarker<'source>,
+    ) -> Result<(), SourceWordError> {
+        context.evaluate_user_defined_source_word(
+            self.implementation.terminator(),
+            &mut self.state,
+            marker.statement().tokens(),
+        )
+    }
+}
+
+#[derive(Debug)]
 struct IfSourceWordOwner {
     branches: Vec<IfBranch>,
     current_body_index: usize,
@@ -1719,10 +2219,10 @@ impl NativeStructuredSourceWordOwner for IfSourceWordOwner {
         )
     }
 
-    fn accept_marker(
+    fn accept_marker<'source>(
         &mut self,
-        context: &mut NativeStructuredSourceWordContext<'_, '_>,
-        marker: SourceBlockMarker<'_>,
+        context: &mut NativeStructuredSourceWordContext<'source, '_>,
+        marker: SourceBlockMarker<'source>,
         _accept: crate::structured_grammar::GrammarAccept,
     ) -> Result<(), SourceWordError> {
         let condition = if marker.name().as_str() == "ELSIF" {
@@ -1744,10 +2244,10 @@ impl NativeStructuredSourceWordOwner for IfSourceWordOwner {
         Ok(())
     }
 
-    fn complete(
+    fn complete<'source>(
         &mut self,
-        context: &mut NativeStructuredSourceWordContext<'_, '_>,
-        marker: SourceBlockMarker<'_>,
+        context: &mut NativeStructuredSourceWordContext<'source, '_>,
+        marker: SourceBlockMarker<'source>,
     ) -> Result<(), SourceWordError> {
         require_empty_if_marker_remainder(&marker)?;
 
@@ -2043,8 +2543,8 @@ struct SourceWordEntry {
 enum SourceWordKind {
     OneShot(OneShotSourceWordImplementation),
     Structured {
-        start: NativeStructuredSourceWordStartHandler,
-        grammar: crate::structured_grammar::StructuredGrammar,
+        implementation: StructuredSourceWordImplementation,
+        grammar: StructuredGrammar,
     },
 }
 
@@ -2052,6 +2552,12 @@ enum SourceWordKind {
 enum OneShotSourceWordImplementation {
     Native(NativeSourceWordHandler),
     UserDefined(SourceWordImplementation),
+}
+
+#[derive(Debug, Clone)]
+enum StructuredSourceWordImplementation {
+    Native(NativeStructuredSourceWordStartHandler),
+    UserDefined(UserDefinedStructuredSourceWordImplementation),
 }
 
 impl SourceWordRegistry {
@@ -2093,12 +2599,32 @@ impl SourceWordRegistry {
     pub(crate) fn register_structured(
         &mut self,
         start: NativeStructuredSourceWordStartHandler,
-        grammar: crate::structured_grammar::StructuredGrammar,
+        grammar: StructuredGrammar,
         syntax_markers: Vec<SourceWordSyntaxMarker>,
     ) -> SourceWordId {
         let id = SourceWordId::from_slot(self.entries.len());
         self.entries.push(SourceWordEntry {
-            kind: SourceWordKind::Structured { start, grammar },
+            kind: SourceWordKind::Structured {
+                implementation: StructuredSourceWordImplementation::Native(start),
+                grammar,
+            },
+            syntax_markers,
+        });
+        id
+    }
+
+    pub(crate) fn register_user_defined_structured(
+        &mut self,
+        grammar: StructuredGrammar,
+        syntax_markers: Vec<SourceWordSyntaxMarker>,
+        implementation: UserDefinedStructuredSourceWordImplementation,
+    ) -> SourceWordId {
+        let id = SourceWordId::from_slot(self.entries.len());
+        self.entries.push(SourceWordEntry {
+            kind: SourceWordKind::Structured {
+                implementation: StructuredSourceWordImplementation::UserDefined(implementation),
+                grammar,
+            },
             syntax_markers,
         });
         id
@@ -2126,8 +2652,8 @@ pub(crate) struct SourceWordLookup<'a> {
 pub(crate) enum SourceWordDispatch<'a> {
     OneShot(OneShotSourceWordDispatch<'a>),
     Structured {
-        start: NativeStructuredSourceWordStartHandler,
-        grammar: &'a crate::structured_grammar::StructuredGrammar,
+        implementation: StructuredSourceWordDispatch<'a>,
+        grammar: &'a StructuredGrammar,
     },
 }
 
@@ -2135,6 +2661,12 @@ pub(crate) enum SourceWordDispatch<'a> {
 pub(crate) enum OneShotSourceWordDispatch<'a> {
     Native(NativeSourceWordHandler),
     UserDefined(&'a SourceWordImplementation),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum StructuredSourceWordDispatch<'a> {
+    Native(NativeStructuredSourceWordStartHandler),
+    UserDefined(&'a UserDefinedStructuredSourceWordImplementation),
 }
 
 impl<'a> SourceWordLookup<'a> {
@@ -2158,8 +2690,18 @@ impl<'a> SourceWordLookup<'a> {
                     }
                 })
             }
-            SourceWordKind::Structured { start, grammar } => SourceWordDispatch::Structured {
-                start: *start,
+            SourceWordKind::Structured {
+                implementation,
+                grammar,
+            } => SourceWordDispatch::Structured {
+                implementation: match implementation {
+                    StructuredSourceWordImplementation::Native(start) => {
+                        StructuredSourceWordDispatch::Native(*start)
+                    }
+                    StructuredSourceWordImplementation::UserDefined(implementation) => {
+                        StructuredSourceWordDispatch::UserDefined(implementation)
+                    }
+                },
                 grammar,
             },
         })

--- a/crates/tbx-next/src/source_word_evaluator.rs
+++ b/crates/tbx-next/src/source_word_evaluator.rs
@@ -42,6 +42,11 @@ pub(crate) struct UserDefinedSourceWordContextParts<'source, 'state> {
     pub(crate) capabilities: SourceProcessingCapabilities,
 }
 
+#[derive(Debug, Default)]
+pub(crate) struct SourceWordEvaluationState {
+    locals: RuntimeLocals,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum SourceWordEvaluationError {
     CapabilityUnavailable {
@@ -180,6 +185,15 @@ pub(crate) fn evaluate_source_word(
     implementation: &SourceWordImplementation,
     context: &mut UserDefinedSourceWordContext<'_, '_>,
 ) -> Result<(), SourceWordEvaluationError> {
+    let mut state = SourceWordEvaluationState::new();
+    evaluate_source_word_with_state(implementation, context, &mut state)
+}
+
+pub(crate) fn evaluate_source_word_with_state(
+    implementation: &SourceWordImplementation,
+    context: &mut UserDefinedSourceWordContext<'_, '_>,
+    state: &mut SourceWordEvaluationState,
+) -> Result<(), SourceWordEvaluationError> {
     if !context.capabilities.allows(implementation.capabilities()) {
         return Err(SourceWordEvaluationError::CapabilityUnavailable {
             required: implementation.capabilities(),
@@ -192,16 +206,21 @@ pub(crate) fn evaluate_source_word(
         });
     }
 
-    let mut locals = RuntimeLocals::default();
     for instruction in implementation.instructions() {
         evaluate_instruction(
             instruction.operation(),
             instruction.origin(),
             context,
-            &mut locals,
+            &mut state.locals,
         )?;
     }
     Ok(())
+}
+
+impl SourceWordEvaluationState {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
 }
 
 fn evaluate_instruction(

--- a/crates/tbx-next/src/source_word_ir.rs
+++ b/crates/tbx-next/src/source_word_ir.rs
@@ -111,6 +111,17 @@ pub(crate) enum SourceProcessingOperation {
 }
 
 impl SourceProcessingOperation {
+    pub(crate) fn produced_binding_for_validation(&self) -> Option<&LocalBinding> {
+        self.produced_binding()
+    }
+
+    pub(crate) fn consumed_local_references(&self) -> impl Iterator<Item = &LocalReference> {
+        self.consumed_locals()
+            .map(|(reference, _consumer)| reference)
+            .collect::<Vec<_>>()
+            .into_iter()
+    }
+
     fn produced_local_type(&self) -> Option<SourceLocalType> {
         match self {
             Self::ReadName { .. } => Some(SourceLocalType::NameInput),

--- a/crates/tbx-next/src/source_word_ir.rs
+++ b/crates/tbx-next/src/source_word_ir.rs
@@ -11,6 +11,22 @@ pub(crate) struct SourceWordImplementation {
 }
 
 impl SourceWordImplementation {
+    pub(crate) fn from_prevalidated_instructions(
+        instructions: Vec<SourceProcessingInstruction>,
+    ) -> Self {
+        let capabilities = instructions.iter().fold(
+            SourceProcessingCapabilities::empty(),
+            |mut capabilities, instruction| {
+                capabilities.include(instruction.operation.required_capabilities());
+                capabilities
+            },
+        );
+        Self {
+            instructions,
+            capabilities,
+        }
+    }
+
     pub(crate) fn instructions(&self) -> &[SourceProcessingInstruction] {
         &self.instructions
     }
@@ -477,6 +493,13 @@ impl SourceProcessingCapabilities {
             resolve_variable: true,
             emit_runtime_code: true,
             emit_structural_branch: false,
+        }
+    }
+
+    pub(crate) const fn structured_runtime() -> Self {
+        Self {
+            emit_structural_branch: true,
+            ..Self::statement_runtime()
         }
     }
 


### PR DESCRIPTION
## Summary
- `SYNTAX ... BLOCK` で `START` / `MARK_*` / `LAST` sectionsを authoringし、同じ宣言から `StructuredGrammar` と marker reservationを作るようにしました。
- `Structured` dispatch内に native/user-defined 実装方式を分け、user-defined structured ownerから共通 evaluatorを呼び出すようにしました。
- `SYNTAX` 所有 marker に `START` / `MARK*` / `LAST` を追加し、BLOCKの公開原子性、marker順序違反、nested native/user-definedのテストを追加しました。

## Notes
- `_FOLLOWING` / `_COMPLETE` の structural branch 解決は #1565 の範囲なので、このPRでは既存どおり未対応です。

## Verification
- `cargo test -p tbx-next`
- `cargo ci-clippy`
- `cargo ci-test`
- `cargo ci-fmt`

Closes #1564
