### PR TITLE
TBX Next: ユーザー定義BLOCKの構造分岐先を解決する

### DIFF
--- a/crates/tbx-next/src/source_processor.rs
+++ b/crates/tbx-next/src/source_processor.rs
@@ -5152,6 +5152,120 @@ mod tests {
     }
 
     #[test]
+    fn user_defined_while_uses_complete_branch_for_exit_and_explicit_back_branch() {
+        let (words, primitives, operators, mut source_words, mut bindings, mut globals, variables) =
+            global_source_fixture();
+        publish_user_source_word(
+            "SYNTAX UWHILE\nBLOCK\nSTART\nPOSITION AS loop_start\nREAD_EXPR AS condition\nEMIT_EXPR condition\nEMIT_BRANCH_IF_FALSE_COMPLETE\nLAST ENDUWHILE\nEXPECT_END\nEMIT_BRANCH loop_start\nENDS",
+            &mut bindings,
+            &mut globals,
+            &mut source_words,
+            operators.lookup(),
+        );
+
+        run_with_source_words_operators_and_mut_globals(
+            "LET A = 0\nUWHILE A < 3\nLET A = A + 1\nENDUWHILE",
+            &bindings,
+            &mut globals,
+            &source_words,
+            &words,
+            &primitives,
+            operators.lookup(),
+        );
+        assert_eq!(globals.view().read(variables[0]), Ok(value(3)));
+
+        run_with_source_words_operators_and_mut_globals(
+            "LET A = 9\nUWHILE A < 3\nLET A = 0\nENDUWHILE",
+            &bindings,
+            &mut globals,
+            &source_words,
+            &words,
+            &primitives,
+            operators.lookup(),
+        );
+        assert_eq!(globals.view().read(variables[0]), Ok(value(9)));
+    }
+
+    #[test]
+    fn user_defined_if_resolves_following_through_complete_branch_sections() {
+        let (words, primitives, operators, mut source_words, mut bindings, mut globals, variables) =
+            global_source_fixture();
+        publish_user_source_word(
+            "SYNTAX UIF\nBLOCK\nSTART\nREAD_EXPR AS start_condition\nEMIT_EXPR start_condition\nEMIT_BRANCH_IF_FALSE_FOLLOWING\nMARK_ANY UELSIF\nEMIT_BRANCH_COMPLETE\nREAD_EXPR AS elsif_condition\nEMIT_EXPR elsif_condition\nEMIT_BRANCH_IF_FALSE_FOLLOWING\nMARK_OPTIONAL UELSE\nEMIT_BRANCH_COMPLETE\nEXPECT_END\nLAST ENDUIF\nEXPECT_END\nENDS",
+            &mut bindings,
+            &mut globals,
+            &mut source_words,
+            operators.lookup(),
+        );
+
+        run_with_source_words_operators_and_mut_globals(
+            "UIF 0\nLET A = 1\nUELSIF 0\nLET A = 2\nUELSIF 1\nLET A = 3\nUELSE\nLET A = 4\nENDUIF",
+            &bindings,
+            &mut globals,
+            &source_words,
+            &words,
+            &primitives,
+            operators.lookup(),
+        );
+        assert_eq!(globals.view().read(variables[0]), Ok(value(3)));
+
+        run_with_source_words_operators_and_mut_globals(
+            "UIF 0\nLET A = 1\nUELSIF 0\nLET A = 2\nUELSE\nLET A = 4\nENDUIF",
+            &bindings,
+            &mut globals,
+            &source_words,
+            &words,
+            &primitives,
+            operators.lookup(),
+        );
+        assert_eq!(globals.view().read(variables[0]), Ok(value(4)));
+
+        run_with_source_words_operators_and_mut_globals(
+            "UIF 0\nLET A = 1\nENDUIF",
+            &bindings,
+            &mut globals,
+            &source_words,
+            &words,
+            &primitives,
+            operators.lookup(),
+        );
+        assert_eq!(globals.view().read(variables[0]), Ok(value(4)));
+    }
+
+    #[test]
+    fn nested_user_defined_structural_branches_remain_owner_local() {
+        let (words, primitives, operators, mut source_words, mut bindings, mut globals, variables) =
+            global_source_fixture();
+        publish_user_source_word(
+            "SYNTAX UWHILE\nBLOCK\nSTART\nPOSITION AS loop_start\nREAD_EXPR AS condition\nEMIT_EXPR condition\nEMIT_BRANCH_IF_FALSE_COMPLETE\nLAST ENDUWHILE\nEXPECT_END\nEMIT_BRANCH loop_start\nENDS",
+            &mut bindings,
+            &mut globals,
+            &mut source_words,
+            operators.lookup(),
+        );
+        publish_user_source_word(
+            "SYNTAX UIF\nBLOCK\nSTART\nREAD_EXPR AS condition\nEMIT_EXPR condition\nEMIT_BRANCH_IF_FALSE_FOLLOWING\nMARK_OPTIONAL UELSE\nEMIT_BRANCH_COMPLETE\nEXPECT_END\nLAST ENDUIF\nEXPECT_END\nENDS",
+            &mut bindings,
+            &mut globals,
+            &mut source_words,
+            operators.lookup(),
+        );
+
+        run_with_source_words_operators_and_mut_globals(
+            "LET A = 0\nLET B = 0\nUWHILE A < 3\nUIF A = 1\nLET B = B + 10\nUELSE\nLET B = B + 1\nENDUIF\nLET A = A + 1\nENDUWHILE",
+            &bindings,
+            &mut globals,
+            &source_words,
+            &words,
+            &primitives,
+            operators.lookup(),
+        );
+
+        assert_eq!(globals.view().read(variables[0]), Ok(value(3)));
+        assert_eq!(globals.view().read(variables[1]), Ok(value(12)));
+    }
+
+    #[test]
     fn user_defined_return_equivalent_runs_through_runtime_definition_body() {
         let mut session = RuntimeDefinitionSession::new();
         register_builtin_global_variables(&mut session.globals, &mut session.bindings)

--- a/crates/tbx-next/src/source_processor.rs
+++ b/crates/tbx-next/src/source_processor.rs
@@ -5175,6 +5175,17 @@ mod tests {
         assert_eq!(globals.view().read(variables[0]), Ok(value(3)));
 
         run_with_source_words_operators_and_mut_globals(
+            "LET A = 2\nUWHILE A < 3\nLET A = A + 1\nENDUWHILE",
+            &bindings,
+            &mut globals,
+            &source_words,
+            &words,
+            &primitives,
+            operators.lookup(),
+        );
+        assert_eq!(globals.view().read(variables[0]), Ok(value(3)));
+
+        run_with_source_words_operators_and_mut_globals(
             "LET A = 9\nUWHILE A < 3\nLET A = 0\nENDUWHILE",
             &bindings,
             &mut globals,
@@ -5208,6 +5219,17 @@ mod tests {
             operators.lookup(),
         );
         assert_eq!(globals.view().read(variables[0]), Ok(value(3)));
+
+        run_with_source_words_operators_and_mut_globals(
+            "UIF 1\nLET A = 1\nUELSIF 1\nLET A = 2\nUELSE\nLET A = 4\nENDUIF",
+            &bindings,
+            &mut globals,
+            &source_words,
+            &words,
+            &primitives,
+            operators.lookup(),
+        );
+        assert_eq!(globals.view().read(variables[0]), Ok(value(1)));
 
         run_with_source_words_operators_and_mut_globals(
             "UIF 0\nLET A = 1\nUELSIF 0\nLET A = 2\nUELSE\nLET A = 4\nENDUIF",

--- a/crates/tbx-next/src/source_word.rs
+++ b/crates/tbx-next/src/source_word.rs
@@ -2236,7 +2236,10 @@ impl NativeStructuredSourceWordOwner for UserDefinedStructuredSourceWordOwner {
             self.implementation.terminator(),
             &mut self.state,
             marker.statement().tokens(),
-        )
+        )?;
+        self.state
+            .complete_structural_branches(context.code)
+            .map_err(|source| SourceWordError::UserDefinedEvaluation { source })
     }
 }
 

--- a/crates/tbx-next/src/source_word_evaluator.rs
+++ b/crates/tbx-next/src/source_word_evaluator.rs
@@ -225,8 +225,7 @@ impl StructuralBranchState {
         code: &mut dyn InstructionBuildTarget,
         target: InstructionAddress,
     ) -> Result<(), SourceWordEvaluationError> {
-        let patches = std::mem::take(&mut self.following);
-        patch_structural_branches(code, patches, target)
+        patch_structural_branches(code, &mut self.following, target)
     }
 
     fn patch_complete_to(
@@ -234,23 +233,27 @@ impl StructuralBranchState {
         code: &mut dyn InstructionBuildTarget,
         target: InstructionAddress,
     ) -> Result<(), SourceWordEvaluationError> {
-        let patches = std::mem::take(&mut self.complete);
-        patch_structural_branches(code, patches, target)
+        patch_structural_branches(code, &mut self.complete, target)
     }
 }
 
 fn patch_structural_branches(
     code: &mut dyn InstructionBuildTarget,
-    patches: Vec<StructuralBranchPatch>,
+    patches: &mut Vec<StructuralBranchPatch>,
     target: InstructionAddress,
 ) -> Result<(), SourceWordEvaluationError> {
-    for patch in patches {
-        code.patch_branch_target(patch.branch, target)
-            .map_err(|source| SourceWordEvaluationError::InstructionBuild {
+    let mut patched = 0;
+    while let Some(patch) = patches.get(patched).copied() {
+        if let Err(source) = code.patch_branch_target(patch.branch, target) {
+            patches.drain(0..patched);
+            return Err(SourceWordEvaluationError::InstructionBuild {
                 source,
                 origin: patch.origin,
-            })?;
+            });
+        }
+        patched += 1;
     }
+    patches.clear();
     Ok(())
 }
 
@@ -738,7 +741,7 @@ impl RuntimeLocal {
 mod tests {
     use super::*;
     use crate::binding::{Binding, Bindings};
-    use crate::block_code::BlockCodeBuilder;
+    use crate::block_code::{BlockCodeBuildError, BlockCodeBuilder};
     use crate::global_variable::GlobalVariables;
     use crate::instruction::Instruction;
     use crate::lexer::Lexer;
@@ -812,6 +815,84 @@ mod tests {
         let mut primitives = PrimitiveRegistry::new();
         let mut words = PublishedWords::new();
         register_operator_primitives(&mut primitives, &mut words).lookup()
+    }
+
+    #[derive(Debug)]
+    struct FailingPatchTarget {
+        len: usize,
+    }
+
+    impl FailingPatchTarget {
+        fn new(len: usize) -> Self {
+            Self { len }
+        }
+    }
+
+    impl InstructionBuildTarget for FailingPatchTarget {
+        fn current_len(&self) -> usize {
+            self.len
+        }
+
+        fn append_mapped(
+            &mut self,
+            _instruction: Instruction,
+            _span: SourceSpan,
+        ) -> Result<InstructionAddress, InstructionBuildError> {
+            unreachable!("patch failure test does not append instructions")
+        }
+
+        fn append_unmapped(
+            &mut self,
+            _instruction: Instruction,
+        ) -> Result<InstructionAddress, InstructionBuildError> {
+            unreachable!("patch failure test does not append instructions")
+        }
+
+        fn append_resolved_mapped(
+            &mut self,
+            _instruction: Instruction,
+            _span: SourceSpan,
+        ) -> Result<InstructionAddress, InstructionBuildError> {
+            unreachable!("patch failure test does not append instructions")
+        }
+
+        fn append_resolved_unmapped(
+            &mut self,
+            _instruction: Instruction,
+        ) -> Result<InstructionAddress, InstructionBuildError> {
+            unreachable!("patch failure test does not append instructions")
+        }
+
+        fn append_mapped_jump_placeholder(
+            &mut self,
+            _span: SourceSpan,
+        ) -> Result<InstructionAddress, InstructionBuildError> {
+            unreachable!("patch failure test does not append instructions")
+        }
+
+        fn append_mapped_jump_if_zero_placeholder(
+            &mut self,
+            _span: SourceSpan,
+        ) -> Result<InstructionAddress, InstructionBuildError> {
+            unreachable!("patch failure test does not append instructions")
+        }
+
+        fn patch_branch_target(
+            &mut self,
+            branch: InstructionAddress,
+            _target: InstructionAddress,
+        ) -> Result<(), InstructionBuildError> {
+            Err(InstructionBuildError::BlockCodeBuild {
+                source: BlockCodeBuildError::UnknownBranchPatch { branch },
+            })
+        }
+
+        fn validate_local_target(
+            &self,
+            _address: InstructionAddress,
+        ) -> Result<(), InstructionBuildError> {
+            Ok(())
+        }
     }
 
     #[test]
@@ -1132,5 +1213,33 @@ mod tests {
             SourceWordEvaluationError::VariableResolution { .. }
         ));
         assert_eq!(code.len(), 0);
+    }
+
+    #[test]
+    fn failed_structural_branch_patch_keeps_unfinished_patch_state() {
+        let (sources, source_id, _tokens) = lex("IF 0");
+        let view = sources.view();
+        let origin = origin(span(view, source_id, 0, 2));
+        let mut state = SourceWordEvaluationState::new();
+        let branch = InstructionAddress::from_index(0);
+        state.structural_branches.record_following(branch, origin);
+        let mut target = FailingPatchTarget::new(1);
+
+        let error = state
+            .complete_structural_branches(&mut target)
+            .expect_err("failed patch should reject structural completion");
+
+        assert!(matches!(
+            error,
+            SourceWordEvaluationError::InstructionBuild {
+                source: InstructionBuildError::BlockCodeBuild {
+                    source: BlockCodeBuildError::UnknownBranchPatch { branch: actual }
+                },
+                ..
+            } if actual == branch
+        ));
+        assert_eq!(state.structural_branches.following.len(), 1);
+        assert_eq!(state.structural_branches.following[0].branch, branch);
+        assert!(state.structural_branches.complete.is_empty());
     }
 }

--- a/crates/tbx-next/src/source_word_evaluator.rs
+++ b/crates/tbx-next/src/source_word_evaluator.rs
@@ -45,6 +45,7 @@ pub(crate) struct UserDefinedSourceWordContextParts<'source, 'state> {
 #[derive(Debug, Default)]
 pub(crate) struct SourceWordEvaluationState {
     locals: RuntimeLocals,
+    structural_branches: StructuralBranchState,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -161,6 +162,98 @@ struct RuntimeLocals {
     values: HashMap<NormalizedName, RuntimeLocal>,
 }
 
+#[derive(Debug, Default)]
+struct StructuralBranchState {
+    // #1561 keeps FOLLOWING/COMPLETE branch placeholders owner-local and
+    // private so user-authored source words do not gain a generic TARGET API.
+    following: Vec<StructuralBranchPatch>,
+    complete: Vec<StructuralBranchPatch>,
+    pending_section_start: Option<InstructionAddress>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct StructuralBranchPatch {
+    branch: InstructionAddress,
+    origin: SourceInstructionOrigin,
+}
+
+impl StructuralBranchState {
+    fn begin_section(&mut self, start: InstructionAddress) {
+        self.pending_section_start = Some(start);
+    }
+
+    fn record_following(&mut self, branch: InstructionAddress, origin: SourceInstructionOrigin) {
+        self.following
+            .push(StructuralBranchPatch { branch, origin });
+    }
+
+    fn record_complete(&mut self, branch: InstructionAddress, origin: SourceInstructionOrigin) {
+        self.complete.push(StructuralBranchPatch { branch, origin });
+    }
+
+    fn patch_following_section_start(
+        &mut self,
+        code: &mut dyn InstructionBuildTarget,
+    ) -> Result<(), SourceWordEvaluationError> {
+        let Some(target) = self.pending_section_start.take() else {
+            return Ok(());
+        };
+        self.patch_following_to(code, target)
+    }
+
+    fn patch_following_after_complete_branch(
+        &mut self,
+        code: &mut dyn InstructionBuildTarget,
+    ) -> Result<(), SourceWordEvaluationError> {
+        let target = code.current_address();
+        self.pending_section_start = None;
+        self.patch_following_to(code, target)
+    }
+
+    fn patch_all_to_current_address(
+        &mut self,
+        code: &mut dyn InstructionBuildTarget,
+    ) -> Result<(), SourceWordEvaluationError> {
+        let target = code.current_address();
+        self.pending_section_start = None;
+        self.patch_following_to(code, target)?;
+        self.patch_complete_to(code, target)
+    }
+
+    fn patch_following_to(
+        &mut self,
+        code: &mut dyn InstructionBuildTarget,
+        target: InstructionAddress,
+    ) -> Result<(), SourceWordEvaluationError> {
+        let patches = std::mem::take(&mut self.following);
+        patch_structural_branches(code, patches, target)
+    }
+
+    fn patch_complete_to(
+        &mut self,
+        code: &mut dyn InstructionBuildTarget,
+        target: InstructionAddress,
+    ) -> Result<(), SourceWordEvaluationError> {
+        let patches = std::mem::take(&mut self.complete);
+        patch_structural_branches(code, patches, target)
+    }
+}
+
+fn patch_structural_branches(
+    code: &mut dyn InstructionBuildTarget,
+    patches: Vec<StructuralBranchPatch>,
+    target: InstructionAddress,
+) -> Result<(), SourceWordEvaluationError> {
+    for patch in patches {
+        code.patch_branch_target(patch.branch, target)
+            .map_err(|source| SourceWordEvaluationError::InstructionBuild {
+                source,
+                origin: patch.origin,
+            })?;
+    }
+    Ok(())
+}
+
 impl<'source, 'state> UserDefinedSourceWordContext<'source, 'state> {
     pub(crate) fn new(parts: UserDefinedSourceWordContextParts<'source, 'state>) -> Self {
         let source_word_token = parts
@@ -206,12 +299,17 @@ pub(crate) fn evaluate_source_word_with_state(
         });
     }
 
+    state
+        .structural_branches
+        .begin_section(context.code.current_address());
+
     for instruction in implementation.instructions() {
         evaluate_instruction(
             instruction.operation(),
             instruction.origin(),
             context,
             &mut state.locals,
+            &mut state.structural_branches,
         )?;
     }
     Ok(())
@@ -221,6 +319,13 @@ impl SourceWordEvaluationState {
     pub(crate) fn new() -> Self {
         Self::default()
     }
+
+    pub(crate) fn complete_structural_branches(
+        &mut self,
+        code: &mut dyn InstructionBuildTarget,
+    ) -> Result<(), SourceWordEvaluationError> {
+        self.structural_branches.patch_all_to_current_address(code)
+    }
 }
 
 fn evaluate_instruction(
@@ -228,10 +333,17 @@ fn evaluate_instruction(
     origin: SourceInstructionOrigin,
     context: &mut UserDefinedSourceWordContext<'_, '_>,
     locals: &mut RuntimeLocals,
+    structural_branches: &mut StructuralBranchState,
 ) -> Result<(), SourceWordEvaluationError> {
     // #1556/#1559 keep this as a small source-processing evaluator: operations
     // are connected only to the current context capabilities, not to runtime VM
     // values or a generic source-processing stack.
+    match operation {
+        SourceProcessingOperation::EmitBranchComplete
+        | SourceProcessingOperation::EmitBranchIfFalseComplete => {}
+        _ => structural_branches.patch_following_section_start(context.code)?,
+    }
+
     match operation {
         SourceProcessingOperation::ReadName { bind } => {
             let token = context
@@ -398,11 +510,35 @@ fn evaluate_instruction(
                 }
             }
         }
-        SourceProcessingOperation::EmitBranchFollowing
-        | SourceProcessingOperation::EmitBranchIfFalseFollowing
-        | SourceProcessingOperation::EmitBranchComplete
-        | SourceProcessingOperation::EmitBranchIfFalseComplete => {
-            return Err(SourceWordEvaluationError::UnsupportedStructuralBranch { origin });
+        SourceProcessingOperation::EmitBranchFollowing => {
+            let branch = context
+                .code
+                .append_mapped_jump_placeholder(origin.span())
+                .map_err(|source| SourceWordEvaluationError::InstructionBuild { source, origin })?;
+            structural_branches.record_following(branch, origin);
+        }
+        SourceProcessingOperation::EmitBranchIfFalseFollowing => {
+            let branch = context
+                .code
+                .append_mapped_jump_if_zero_placeholder(origin.span())
+                .map_err(|source| SourceWordEvaluationError::InstructionBuild { source, origin })?;
+            structural_branches.record_following(branch, origin);
+        }
+        SourceProcessingOperation::EmitBranchComplete => {
+            let branch = context
+                .code
+                .append_mapped_jump_placeholder(origin.span())
+                .map_err(|source| SourceWordEvaluationError::InstructionBuild { source, origin })?;
+            structural_branches.record_complete(branch, origin);
+            structural_branches.patch_following_after_complete_branch(context.code)?;
+        }
+        SourceProcessingOperation::EmitBranchIfFalseComplete => {
+            let branch = context
+                .code
+                .append_mapped_jump_if_zero_placeholder(origin.span())
+                .map_err(|source| SourceWordEvaluationError::InstructionBuild { source, origin })?;
+            structural_branches.record_complete(branch, origin);
+            structural_branches.patch_following_after_complete_branch(context.code)?;
         }
     }
     Ok(())


### PR DESCRIPTION
## Summary

- Implement owner-local patch state for user-defined `BLOCK` structural branch operations.
- Resolve `FOLLOWING` branches at section start, after leading `EMIT_BRANCH_COMPLETE`, or at structured completion as required.
- Resolve `COMPLETE` branches to the normal completion point and keep nested owner state isolated.
- Add runtime control-flow tests for user-defined `UWHILE`, `UIF`/`UELSIF`/`UELSE`, and nested user-defined structured owners.

Closes #1565

## Verification

- `cargo test -p tbx-next`
- `cargo ci-clippy`
- `cargo ci-test`
- `cargo ci-fmt`
