### PR TITLE
TBX Next: 式中の実行時ワード呼び出しを実装する

### DIFF
--- a/crates/tbx-next/src/expression.rs
+++ b/crates/tbx-next/src/expression.rs
@@ -5,6 +5,7 @@ use crate::lexer::{Token, TokenKind};
 use crate::operator::{OperatorLookup, OperatorSemantic};
 use crate::source::{SourceError, SourceSpan, SourceView};
 use crate::value::Value;
+use crate::word::WordId;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ExpressionStaging {
@@ -22,6 +23,7 @@ pub(crate) enum ExpressionError {
     Source(SourceError),
     Syntax(ExpressionSyntaxError),
     Variable(ExpressionVariableError),
+    Call(ExpressionCallError),
     InstructionBuild(InstructionBuildError),
 }
 
@@ -54,11 +56,28 @@ pub(crate) enum ExpressionVariableErrorKind {
     TargetIsNotVariable,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ExpressionCallError {
+    span: SourceSpan,
+    kind: ExpressionCallErrorKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ExpressionCallErrorKind {
+    InvalidName,
+    UndefinedName,
+    TargetIsNotRuntimeWord,
+}
+
 pub(crate) trait ExpressionVariableResolver {
     fn resolve_variable(
         &self,
         source_name: &str,
     ) -> Result<GlobalVarId, ExpressionVariableErrorKind>;
+}
+
+pub(crate) trait ExpressionRuntimeWordResolver {
+    fn resolve_runtime_word(&self, source_name: &str) -> Result<WordId, ExpressionCallErrorKind>;
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -68,7 +87,7 @@ struct ParsedExpression {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct BinaryOperator {
-    semantic: OperatorSemantic,
+    semantic: Option<OperatorSemantic>,
     precedence: u8,
     comparison: bool,
 }
@@ -79,9 +98,11 @@ struct ExpressionParser<'a, 'r> {
     tokens: &'a [Token],
     operators: OperatorLookup,
     variables: &'r dyn ExpressionVariableResolver,
+    runtime_words: &'r dyn ExpressionRuntimeWordResolver,
     position: usize,
 }
 
+const PRECEDENCE_COMMA: u8 = 0;
 const PRECEDENCE_COMPARISON: u8 = 1;
 const PRECEDENCE_ADDITIVE: u8 = 2;
 const PRECEDENCE_MULTIPLICATIVE: u8 = 3;
@@ -92,8 +113,9 @@ pub(crate) fn parse_expression(
     tokens: &[Token],
     operators: OperatorLookup,
     variables: &dyn ExpressionVariableResolver,
+    runtime_words: &dyn ExpressionRuntimeWordResolver,
 ) -> Result<ExpressionStaging, ExpressionError> {
-    let mut parser = ExpressionParser::new(view, tokens, operators, variables);
+    let mut parser = ExpressionParser::new(view, tokens, operators, variables, runtime_words);
     parser.parse_complete()
 }
 
@@ -105,6 +127,15 @@ where
         &self,
         source_name: &str,
     ) -> Result<GlobalVarId, ExpressionVariableErrorKind> {
+        self(source_name)
+    }
+}
+
+impl<F> ExpressionRuntimeWordResolver for F
+where
+    F: Fn(&str) -> Result<WordId, ExpressionCallErrorKind>,
+{
+    fn resolve_runtime_word(&self, source_name: &str) -> Result<WordId, ExpressionCallErrorKind> {
         self(source_name)
     }
 }
@@ -172,6 +203,16 @@ impl ExpressionVariableError {
     }
 }
 
+impl ExpressionCallError {
+    pub(crate) const fn span(self) -> SourceSpan {
+        self.span
+    }
+
+    pub(crate) const fn kind(self) -> ExpressionCallErrorKind {
+        self.kind
+    }
+}
+
 impl From<SourceError> for ExpressionError {
     fn from(error: SourceError) -> Self {
         Self::Source(error)
@@ -184,19 +225,21 @@ impl<'a, 'r> ExpressionParser<'a, 'r> {
         tokens: &'a [Token],
         operators: OperatorLookup,
         variables: &'r dyn ExpressionVariableResolver,
+        runtime_words: &'r dyn ExpressionRuntimeWordResolver,
     ) -> Self {
         Self {
             view,
             tokens,
             operators,
             variables,
+            runtime_words,
             position: 0,
         }
     }
 
     fn parse_complete(&mut self) -> Result<ExpressionStaging, ExpressionError> {
         let mut staging = ExpressionStaging::new();
-        self.parse_infix_expression(&mut staging, PRECEDENCE_COMPARISON)?;
+        self.parse_infix_expression(&mut staging, PRECEDENCE_COMMA)?;
 
         match self.peek() {
             Some(token) if is_expression_terminator(token.kind()) => Ok(staging),
@@ -226,10 +269,12 @@ impl<'a, 'r> ExpressionParser<'a, 'r> {
             let operator_token = self.advance();
             let rhs = self.parse_infix_expression(staging, operator.precedence + 1)?;
             parsed.contains_comparison |= operator.comparison || rhs.contains_comparison;
-            staging.append_mapped_instruction(
-                Instruction::Call(self.operators.resolve(operator.semantic)),
-                operator_token.span(),
-            );
+            if let Some(semantic) = operator.semantic {
+                staging.append_mapped_instruction(
+                    Instruction::Call(self.operators.resolve(semantic)),
+                    operator_token.span(),
+                );
+            }
         }
 
         Ok(parsed)
@@ -264,10 +309,79 @@ impl<'a, 'r> ExpressionParser<'a, 'r> {
         &mut self,
         staging: &mut ExpressionStaging,
     ) -> Result<ParsedExpression, ExpressionError> {
-        let parsed = self.parse_primary(staging)?;
+        let parsed = if self
+            .peek()
+            .is_some_and(|token| token.kind() == TokenKind::Name)
+        {
+            self.parse_name_primary_or_call(staging)?
+        } else {
+            self.parse_primary(staging)?
+        };
 
-        // Future call syntax belongs here, after a name/callable primary and
-        // before infix binding. Grouping `(` is handled only by `parse_primary`.
+        Ok(parsed)
+    }
+
+    fn parse_name_primary_or_call(
+        &mut self,
+        staging: &mut ExpressionStaging,
+    ) -> Result<ParsedExpression, ExpressionError> {
+        let name = self.advance();
+        let source_name = self.view.slice(name.span())?;
+
+        if self
+            .peek()
+            .is_some_and(|token| token.kind() == TokenKind::LParen)
+        {
+            let word = self
+                .runtime_words
+                .resolve_runtime_word(source_name)
+                .map_err(|kind| {
+                    ExpressionError::Call(ExpressionCallError {
+                        span: name.span(),
+                        kind,
+                    })
+                })?;
+            let parsed = self.parse_call_arguments(staging)?;
+            staging.append_mapped_instruction(Instruction::Call(word), name.span());
+            return Ok(parsed);
+        }
+
+        let id = self
+            .variables
+            .resolve_variable(source_name)
+            .map_err(|kind| {
+                ExpressionError::Variable(ExpressionVariableError {
+                    span: name.span(),
+                    kind,
+                })
+            })?;
+        staging.append_mapped_instruction(Instruction::LoadVar(id), name.span());
+        Ok(ParsedExpression {
+            contains_comparison: false,
+        })
+    }
+
+    fn parse_call_arguments(
+        &mut self,
+        staging: &mut ExpressionStaging,
+    ) -> Result<ParsedExpression, ExpressionError> {
+        let lparen = self.advance();
+        debug_assert_eq!(lparen.kind(), TokenKind::LParen);
+
+        if self
+            .peek()
+            .is_some_and(|token| token.kind() == TokenKind::RParen)
+        {
+            self.advance();
+            return Ok(ParsedExpression {
+                contains_comparison: false,
+            });
+        }
+
+        // ADR #1575 defines this as zero or one ordinary expression. Commas are
+        // not argument separators, and value counts are deliberately not tracked.
+        let parsed = self.parse_infix_expression(staging, PRECEDENCE_COMMA)?;
+        self.consume_rparen(lparen)?;
         Ok(parsed)
     }
 
@@ -289,44 +403,30 @@ impl<'a, 'r> ExpressionParser<'a, 'r> {
                     contains_comparison: false,
                 })
             }
-            TokenKind::Name => {
-                let token = self.advance();
-                let source_name = self.view.slice(token.span())?;
-                let id = self
-                    .variables
-                    .resolve_variable(source_name)
-                    .map_err(|kind| {
-                        ExpressionError::Variable(ExpressionVariableError {
-                            span: token.span(),
-                            kind,
-                        })
-                    })?;
-                staging.append_mapped_instruction(Instruction::LoadVar(id), token.span());
-                Ok(ParsedExpression {
-                    contains_comparison: false,
-                })
-            }
             TokenKind::LParen => {
                 let lparen = self.advance();
-                let parsed = self.parse_infix_expression(staging, PRECEDENCE_COMPARISON)?;
-                match self.peek() {
-                    Some(token) if token.kind() == TokenKind::RParen => {
-                        self.advance();
-                        Ok(parsed)
-                    }
-                    Some(token) if is_expression_terminator(token.kind()) => {
-                        Err(self.syntax(lparen, ExpressionSyntaxErrorKind::UnmatchedParenthesis))
-                    }
-                    Some(token) => Err(self.syntax(token, unexpected_token(token))),
-                    None => {
-                        Err(self.syntax(lparen, ExpressionSyntaxErrorKind::UnmatchedParenthesis))
-                    }
-                }
+                let parsed = self.parse_infix_expression(staging, PRECEDENCE_COMMA)?;
+                self.consume_rparen(lparen)?;
+                Ok(parsed)
             }
             TokenKind::Eof | TokenKind::LineBoundary | TokenKind::RParen => {
                 Err(self.syntax(token, ExpressionSyntaxErrorKind::MissingOperand))
             }
             _ => Err(self.syntax(token, unexpected_token(token))),
+        }
+    }
+
+    fn consume_rparen(&mut self, lparen: Token) -> Result<(), ExpressionError> {
+        match self.peek() {
+            Some(token) if token.kind() == TokenKind::RParen => {
+                self.advance();
+                Ok(())
+            }
+            Some(token) if is_expression_terminator(token.kind()) => {
+                Err(self.syntax(lparen, ExpressionSyntaxErrorKind::UnmatchedParenthesis))
+            }
+            Some(token) => Err(self.syntax(token, unexpected_token(token))),
+            None => Err(self.syntax(lparen, ExpressionSyntaxErrorKind::UnmatchedParenthesis)),
         }
     }
 
@@ -426,6 +526,7 @@ fn parse_unsigned_i32(source: &str, span: SourceSpan) -> Result<i32, ExpressionE
 
 fn binary_operator(kind: TokenKind) -> Option<BinaryOperator> {
     match kind {
+        TokenKind::Comma => Some(binary_without_instruction(PRECEDENCE_COMMA, false)),
         TokenKind::Star => Some(binary(
             OperatorSemantic::Multiply,
             PRECEDENCE_MULTIPLICATIVE,
@@ -475,7 +576,15 @@ fn binary_operator(kind: TokenKind) -> Option<BinaryOperator> {
 
 const fn binary(semantic: OperatorSemantic, precedence: u8, comparison: bool) -> BinaryOperator {
     BinaryOperator {
-        semantic,
+        semantic: Some(semantic),
+        precedence,
+        comparison,
+    }
+}
+
+const fn binary_without_instruction(precedence: u8, comparison: bool) -> BinaryOperator {
+    BinaryOperator {
+        semantic: None,
         precedence,
         comparison,
     }
@@ -499,7 +608,8 @@ mod tests {
     use crate::primitive::PrimitiveRegistry;
     use crate::source::{SourceId, SourceTexts};
     use crate::source_mapping::SourceMappedCode;
-    use crate::word::PublishedWords;
+    use crate::word::{PublishedWords, WordId};
+    use std::cell::Cell;
     use std::collections::HashMap;
 
     fn source(text: &str) -> (SourceTexts, SourceId) {
@@ -537,10 +647,24 @@ mod tests {
         text: &str,
         variables: impl ExpressionVariableResolver,
     ) -> (SourceTexts, SourceId, ExpressionStaging) {
+        parse_with_resolvers(text, variables, empty_runtime_words())
+    }
+
+    fn parse_with_resolvers(
+        text: &str,
+        variables: impl ExpressionVariableResolver,
+        runtime_words: impl ExpressionRuntimeWordResolver,
+    ) -> (SourceTexts, SourceId, ExpressionStaging) {
         let (sources, id) = source(text);
         let tokens = lex(sources.view(), id);
-        let staging = parse_expression(sources.view(), &tokens, operators(), &variables)
-            .expect("expression should parse");
+        let staging = parse_expression(
+            sources.view(),
+            &tokens,
+            operators(),
+            &variables,
+            &runtime_words,
+        )
+        .expect("expression should parse");
         (sources, id, staging)
     }
 
@@ -552,15 +676,33 @@ mod tests {
         text: &str,
         variables: impl ExpressionVariableResolver,
     ) -> (SourceTexts, SourceId, ExpressionError) {
+        parse_error_with_resolvers(text, variables, empty_runtime_words())
+    }
+
+    fn parse_error_with_resolvers(
+        text: &str,
+        variables: impl ExpressionVariableResolver,
+        runtime_words: impl ExpressionRuntimeWordResolver,
+    ) -> (SourceTexts, SourceId, ExpressionError) {
         let (sources, id) = source(text);
         let tokens = lex(sources.view(), id);
-        let error = parse_expression(sources.view(), &tokens, operators(), &variables)
-            .expect_err("expression should fail");
+        let error = parse_expression(
+            sources.view(),
+            &tokens,
+            operators(),
+            &variables,
+            &runtime_words,
+        )
+        .expect_err("expression should fail");
         (sources, id, error)
     }
 
     fn empty_variables() -> impl ExpressionVariableResolver {
         |_source_name: &str| Err(ExpressionVariableErrorKind::UndefinedName)
+    }
+
+    fn empty_runtime_words() -> impl ExpressionRuntimeWordResolver {
+        |_source_name: &str| Err(ExpressionCallErrorKind::UndefinedName)
     }
 
     fn variables(cases: &[(&str, GlobalVarId)]) -> impl ExpressionVariableResolver {
@@ -574,6 +716,20 @@ mod tests {
                 .get(&source_name.to_ascii_uppercase())
                 .copied()
                 .ok_or(ExpressionVariableErrorKind::UndefinedName)
+        }
+    }
+
+    fn runtime_words(cases: &[(&str, WordId)]) -> impl ExpressionRuntimeWordResolver {
+        let words = cases
+            .iter()
+            .map(|(name, id)| (name.to_ascii_uppercase(), *id))
+            .collect::<HashMap<_, _>>();
+
+        move |source_name: &str| {
+            words
+                .get(&source_name.to_ascii_uppercase())
+                .copied()
+                .ok_or(ExpressionCallErrorKind::UndefinedName)
         }
     }
 
@@ -622,6 +778,19 @@ mod tests {
     ) {
         let ExpressionError::Variable(error) = error else {
             panic!("expected variable resolution error");
+        };
+
+        assert_eq!(error.span(), expected_span);
+        assert_eq!(error.kind(), expected_kind);
+    }
+
+    fn assert_call_error(
+        error: ExpressionError,
+        expected_span: SourceSpan,
+        expected_kind: ExpressionCallErrorKind,
+    ) {
+        let ExpressionError::Call(error) = error else {
+            panic!("expected call resolution error");
         };
 
         assert_eq!(error.span(), expected_span);
@@ -881,6 +1050,112 @@ mod tests {
     }
 
     #[test]
+    fn comma_expression_evaluates_both_sides_without_emitting_separator_instruction() {
+        let lookup = operators();
+        let (sources, id, staging) = parse("1 + 2, 3 * 4");
+        let view = sources.view();
+
+        assert_eq!(
+            instructions(&staging),
+            [
+                Instruction::Push(value(1)),
+                Instruction::Push(value(2)),
+                call(lookup, OperatorSemantic::Add),
+                Instruction::Push(value(3)),
+                Instruction::Push(value(4)),
+                call(lookup, OperatorSemantic::Multiply),
+            ]
+        );
+        assert_eq!(
+            spans(&staging),
+            [
+                span(view, id, 0, 1),
+                span(view, id, 4, 5),
+                span(view, id, 2, 3),
+                span(view, id, 7, 8),
+                span(view, id, 11, 12),
+                span(view, id, 9, 10),
+            ]
+        );
+    }
+
+    #[test]
+    fn runtime_word_call_lowers_after_ordinary_pre_call_expression() {
+        let lookup = operators();
+        let a = GlobalVarId::test_invalid(0);
+        let b = GlobalVarId::test_invalid(1);
+        let foo = WordId::test_invalid(20);
+        let g = WordId::test_invalid(21);
+        let (sources, id, staging) = parse_with_resolvers(
+            "FOO(G(A), B + 1) * 2",
+            variables(&[("A", a), ("B", b)]),
+            runtime_words(&[("FOO", foo), ("G", g)]),
+        );
+        let view = sources.view();
+
+        assert_eq!(
+            instructions(&staging),
+            [
+                Instruction::LoadVar(a),
+                Instruction::Call(g),
+                Instruction::LoadVar(b),
+                Instruction::Push(value(1)),
+                call(lookup, OperatorSemantic::Add),
+                Instruction::Call(foo),
+                Instruction::Push(value(2)),
+                call(lookup, OperatorSemantic::Multiply),
+            ]
+        );
+        assert_eq!(
+            spans(&staging),
+            [
+                span(view, id, 6, 7),
+                span(view, id, 4, 5),
+                span(view, id, 10, 11),
+                span(view, id, 14, 15),
+                span(view, id, 12, 13),
+                span(view, id, 0, 3),
+                span(view, id, 19, 20),
+                span(view, id, 17, 18),
+            ]
+        );
+    }
+
+    #[test]
+    fn zero_argument_runtime_word_call_emits_only_call_at_name_span() {
+        let foo = WordId::test_invalid(30);
+        let (sources, id, staging) =
+            parse_with_resolvers("FOO()", empty_variables(), runtime_words(&[("FOO", foo)]));
+
+        assert_eq!(instructions(&staging), [Instruction::Call(foo)]);
+        assert_eq!(spans(&staging), [span(sources.view(), id, 0, 3)]);
+    }
+
+    #[test]
+    fn call_target_is_resolved_once_before_instruction_staging() {
+        let old = WordId::test_invalid(40);
+        let new = WordId::test_invalid(41);
+        let current = Cell::new(old);
+        let resolver = |source_name: &str| {
+            assert_eq!(source_name, "FOO");
+            let resolved = current.get();
+            current.set(new);
+            Ok(resolved)
+        };
+        let (_sources, _id, staging) =
+            parse_with_resolvers("FOO() + FOO()", empty_variables(), resolver);
+
+        assert_eq!(
+            instructions(&staging),
+            [
+                Instruction::Call(old),
+                Instruction::Call(new),
+                call(operators(), OperatorSemantic::Add),
+            ]
+        );
+    }
+
+    #[test]
     fn unresolved_name_primary_is_structured_variable_error_at_name_span() {
         let (sources, id, error) = parse_error("FOO");
 
@@ -892,17 +1167,45 @@ mod tests {
     }
 
     #[test]
-    fn call_like_name_sequence_still_does_not_fallback_to_call_syntax() {
+    fn runtime_word_call_rejects_undefined_and_non_runtime_targets_at_name_span() {
         let variable = GlobalVarId::test_invalid(4);
         let (sources, id, error) =
-            parse_error_with_variables("FOO(1)", variables(&[("FOO", variable)]));
+            parse_error_with_resolvers("FOO(1)", empty_variables(), |_source_name: &str| {
+                Err(ExpressionCallErrorKind::UndefinedName)
+            });
 
-        assert_syntax_error(
+        assert_call_error(
             error,
-            span(sources.view(), id, 3, 4),
-            ExpressionSyntaxErrorKind::UnexpectedToken {
-                kind: TokenKind::LParen,
-            },
+            span(sources.view(), id, 0, 3),
+            ExpressionCallErrorKind::UndefinedName,
+        );
+
+        let (sources, id, error) = parse_error_with_resolvers(
+            "FOO(1)",
+            variables(&[("FOO", variable)]),
+            |_source_name: &str| Err(ExpressionCallErrorKind::TargetIsNotRuntimeWord),
+        );
+
+        assert_call_error(
+            error,
+            span(sources.view(), id, 0, 3),
+            ExpressionCallErrorKind::TargetIsNotRuntimeWord,
+        );
+    }
+
+    #[test]
+    fn call_like_variable_name_sequence_resolves_as_runtime_call_target() {
+        let variable = GlobalVarId::test_invalid(4);
+        let word = WordId::test_invalid(50);
+        let (_sources, _id, staging) = parse_with_resolvers(
+            "FOO(1)",
+            variables(&[("FOO", variable)]),
+            runtime_words(&[("FOO", word)]),
+        );
+
+        assert_eq!(
+            instructions(&staging),
+            [Instruction::Push(value(1)), Instruction::Call(word)]
         );
     }
 

--- a/crates/tbx-next/src/source_processor.rs
+++ b/crates/tbx-next/src/source_processor.rs
@@ -4,7 +4,8 @@ use std::rc::Rc;
 use crate::binding::Bindings;
 use crate::block_code::{BlockCodeBuildError, BlockCodeBuilder};
 use crate::expression::{
-    parse_expression, ExpressionError, ExpressionSyntaxErrorKind, ExpressionVariableErrorKind,
+    parse_expression, ExpressionCallErrorKind, ExpressionError, ExpressionSyntaxErrorKind,
+    ExpressionVariableErrorKind,
 };
 use crate::global_variable::{GlobalVariableView, GlobalVariables};
 use crate::instruction::{
@@ -166,6 +167,7 @@ pub(crate) enum CompileErrorKind {
     WordResolution { source: WordResolutionError },
     Expression { source: ExpressionSyntaxErrorKind },
     ExpressionVariable { source: ExpressionVariableErrorKind },
+    ExpressionCall { source: ExpressionCallErrorKind },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1352,10 +1354,18 @@ fn compile_expression_tokens(
     expression_tokens.push(Token::new(TokenKind::Eof, view.span(source_id, end, end)?));
 
     let resolver = |source_name: &str| resolve_variable_name(bindings, source_name);
-    parse_expression(view, &expression_tokens, operators, &resolver)
-        .map_err(SourceProcessorError::from_expression_error)?
-        .commit_to(code)
-        .map_err(SourceProcessorError::from_expression_error)
+    let runtime_word_resolver =
+        |source_name: &str| resolve_runtime_word_name(bindings, source_name);
+    parse_expression(
+        view,
+        &expression_tokens,
+        operators,
+        &resolver,
+        &runtime_word_resolver,
+    )
+    .map_err(SourceProcessorError::from_expression_error)?
+    .commit_to(code)
+    .map_err(SourceProcessorError::from_expression_error)
 }
 
 pub(crate) fn run_source(
@@ -1427,6 +1437,23 @@ fn resolve_variable_name(
         }
         Err(WordResolutionError::InvalidWordName) => Err(ExpressionVariableErrorKind::InvalidName),
         Err(WordResolutionError::UndefinedName) => Err(ExpressionVariableErrorKind::UndefinedName),
+        Err(WordResolutionError::TargetIsNotWord) => {
+            unreachable!("binding lookup does not require a runtime word target")
+        }
+    }
+}
+
+fn resolve_runtime_word_name(
+    bindings: &Bindings,
+    source_name: &str,
+) -> Result<crate::word::WordId, ExpressionCallErrorKind> {
+    match resolve_binding_name(bindings, source_name) {
+        Ok(ResolvedBinding::RuntimeWord(id)) => Ok(id),
+        Ok(ResolvedBinding::Variable(_) | ResolvedBinding::SourceWord(_)) => {
+            Err(ExpressionCallErrorKind::TargetIsNotRuntimeWord)
+        }
+        Err(WordResolutionError::InvalidWordName) => Err(ExpressionCallErrorKind::InvalidName),
+        Err(WordResolutionError::UndefinedName) => Err(ExpressionCallErrorKind::UndefinedName),
         Err(WordResolutionError::TargetIsNotWord) => {
             unreachable!("binding lookup does not require a runtime word target")
         }
@@ -2329,6 +2356,12 @@ impl SourceProcessorError {
             ExpressionError::Variable(error) => Self::Compile(CompileError {
                 span: error.span(),
                 kind: CompileErrorKind::ExpressionVariable {
+                    source: error.kind(),
+                },
+            }),
+            ExpressionError::Call(error) => Self::Compile(CompileError {
+                span: error.span(),
+                kind: CompileErrorKind::ExpressionCall {
                     source: error.kind(),
                 },
             }),
@@ -6749,6 +6782,152 @@ mod tests {
         );
 
         assert_eq!(result.data_stack(), [value(7)]);
+    }
+
+    #[test]
+    fn top_level_eval_can_call_primitive_runtime_word_inside_expression() {
+        let mut session = RuntimeDefinitionSession::new();
+        let add = session.register_primitive("ADD", add_top_two);
+        let (sources, id) = source("EVAL ADD(2, 5)");
+
+        let unit = compile_source(
+            sources.view(),
+            id,
+            SourceCompileContext::with_source_words_and_operators(
+                &session.bindings,
+                session.source_words.lookup(),
+                session.operators.lookup(),
+            ),
+        )
+        .expect("expression runtime primitive call should compile");
+        let result = session
+            .run_unit_with_published_code(&unit)
+            .expect("expression runtime primitive call should run");
+
+        assert_eq!(
+            unit.instructions().get(address(0)),
+            Ok(&Instruction::Push(value(2)))
+        );
+        assert_eq!(
+            unit.instructions().get(address(1)),
+            Ok(&Instruction::Push(value(5)))
+        );
+        assert_eq!(
+            unit.instructions().get(address(2)),
+            Ok(&Instruction::Call(add))
+        );
+        assert_eq!(
+            unit.source_span(location(&unit, 2)),
+            Ok(Some(span(sources.view(), id, 5, 8)))
+        );
+        assert_eq!(result.data_stack(), [value(7)]);
+    }
+
+    #[test]
+    fn top_level_eval_can_call_compiled_runtime_word_inside_expression() {
+        let mut session = RuntimeDefinitionSession::new();
+        let inc_add = session.register_primitive("ADD", add_top_two);
+        session.publish_def("DEF INC\nEVAL 1\nADD\nEND");
+        let Some(Binding::Word(inc)) = session.bindings.get(&name("INC")).copied() else {
+            panic!("INC should be published");
+        };
+        let (sources, id) = source("EVAL INC(6)");
+
+        let unit = compile_source(
+            sources.view(),
+            id,
+            SourceCompileContext::with_source_words_and_operators(
+                &session.bindings,
+                session.source_words.lookup(),
+                session.operators.lookup(),
+            ),
+        )
+        .expect("expression compiled runtime call should compile");
+        let result = session
+            .run_unit_with_published_code(&unit)
+            .expect("expression compiled runtime call should run");
+
+        assert_eq!(
+            unit.instructions().get(address(0)),
+            Ok(&Instruction::Push(value(6)))
+        );
+        assert_eq!(
+            unit.instructions().get(address(1)),
+            Ok(&Instruction::Call(inc))
+        );
+        assert_eq!(
+            session.code.instruction_view().get(address(1)),
+            Ok(&Instruction::Call(inc_add))
+        );
+        assert_eq!(result.data_stack(), [value(7)]);
+    }
+
+    #[test]
+    fn expression_runtime_call_keeps_early_bound_word_id_after_redefinition() {
+        let mut session = RuntimeDefinitionSession::new();
+        session.register_primitive("PUSH41", push_41);
+        session.publish_def("DEF TARGET\nPUSH41\nEND");
+        let Some(Binding::Word(old)) = session.bindings.get(&name("TARGET")).copied() else {
+            panic!("TARGET should be published");
+        };
+        let (old_sources, old_id) = source("EVAL TARGET()");
+        let old_unit = compile_source(
+            old_sources.view(),
+            old_id,
+            SourceCompileContext::with_source_words_and_operators(
+                &session.bindings,
+                session.source_words.lookup(),
+                session.operators.lookup(),
+            ),
+        )
+        .expect("old expression runtime call should compile");
+
+        let (new_sources, new_id) = source("99\nEND");
+        let new_value_span = span(new_sources.view(), new_id, 0, 2);
+        let new_end_span = span(new_sources.view(), new_id, 3, 6);
+        let redefinition = session
+            .code
+            .redefine_word(
+                &mut session.words,
+                &mut session.bindings,
+                &name("TARGET"),
+                |builder| {
+                    builder.append_mapped(Instruction::Push(value(99)), new_value_span)?;
+                    builder.append_mapped(Instruction::Return, new_end_span)?;
+                    Ok(())
+                },
+            )
+            .expect("TARGET should redefine in published code");
+
+        let (new_eval_sources, new_eval_id) = source("EVAL TARGET()");
+        let new_unit = compile_source(
+            new_eval_sources.view(),
+            new_eval_id,
+            SourceCompileContext::with_source_words_and_operators(
+                &session.bindings,
+                session.source_words.lookup(),
+                session.operators.lookup(),
+            ),
+        )
+        .expect("new expression runtime call should compile");
+        let old_result = session
+            .run_unit_with_published_code(&old_unit)
+            .expect("old expression runtime call should run old body");
+        let new_result = session
+            .run_unit_with_published_code(&new_unit)
+            .expect("new expression runtime call should run new body");
+
+        assert_eq!(redefinition.previous(), old);
+        assert_eq!(
+            old_unit.instructions().get(address(0)),
+            Ok(&Instruction::Call(redefinition.previous()))
+        );
+        assert_eq!(
+            new_unit.instructions().get(address(0)),
+            Ok(&Instruction::Call(redefinition.current()))
+        );
+        assert_eq!(old_result.data_stack(), [value(41)]);
+        assert_eq!(new_result.data_stack(), [value(99)]);
     }
 
     #[test]

--- a/crates/tbx-next/src/source_word.rs
+++ b/crates/tbx-next/src/source_word.rs
@@ -2,7 +2,8 @@ use std::collections::HashMap;
 
 use crate::binding::{Binding, BindingInsertError, Bindings};
 use crate::expression::{
-    parse_expression, ExpressionError, ExpressionStaging, ExpressionVariableErrorKind,
+    parse_expression, ExpressionCallErrorKind, ExpressionError, ExpressionStaging,
+    ExpressionVariableErrorKind,
 };
 use crate::global_variable::GlobalVariables;
 use crate::instruction::Instruction;
@@ -726,8 +727,16 @@ impl<'source, 'state> NativeStructuredSourceWordContext<'source, 'state> {
         ));
 
         let resolver = |source_name: &str| resolve_variable_name(self.bindings, source_name);
-        parse_expression(self.view, &expression_tokens, operators, &resolver)
-            .map_err(|source| SourceWordError::Expression { source })
+        let runtime_word_resolver =
+            |source_name: &str| resolve_runtime_word_name(self.bindings, source_name);
+        parse_expression(
+            self.view,
+            &expression_tokens,
+            operators,
+            &resolver,
+            &runtime_word_resolver,
+        )
+        .map_err(|source| SourceWordError::Expression { source })
     }
 
     fn evaluate_user_defined_source_word(
@@ -1368,8 +1377,16 @@ impl<'source, 'state> NativeSourceWordContext<'source, 'state> {
         ));
 
         let resolver = |source_name: &str| resolve_variable_name(self.bindings(), source_name);
-        parse_expression(self.view, &expression_tokens, operators, &resolver)
-            .map_err(|source| SourceWordError::Expression { source })
+        let runtime_word_resolver =
+            |source_name: &str| resolve_runtime_word_name(self.bindings(), source_name);
+        parse_expression(
+            self.view,
+            &expression_tokens,
+            operators,
+            &resolver,
+            &runtime_word_resolver,
+        )
+        .map_err(|source| SourceWordError::Expression { source })
     }
 
     pub(crate) fn commit_staging(
@@ -2621,6 +2638,23 @@ fn resolve_variable_name(
         }
         Err(WordResolutionError::InvalidWordName) => Err(ExpressionVariableErrorKind::InvalidName),
         Err(WordResolutionError::UndefinedName) => Err(ExpressionVariableErrorKind::UndefinedName),
+        Err(WordResolutionError::TargetIsNotWord) => {
+            unreachable!("binding lookup does not require a runtime word target")
+        }
+    }
+}
+
+fn resolve_runtime_word_name(
+    bindings: &Bindings,
+    source_name: &str,
+) -> Result<WordId, ExpressionCallErrorKind> {
+    match resolve_binding_name(bindings, source_name) {
+        Ok(ResolvedBinding::RuntimeWord(id)) => Ok(id),
+        Ok(ResolvedBinding::Variable(_) | ResolvedBinding::SourceWord(_)) => {
+            Err(ExpressionCallErrorKind::TargetIsNotRuntimeWord)
+        }
+        Err(WordResolutionError::InvalidWordName) => Err(ExpressionCallErrorKind::InvalidName),
+        Err(WordResolutionError::UndefinedName) => Err(ExpressionCallErrorKind::UndefinedName),
         Err(WordResolutionError::TargetIsNotWord) => {
             unreachable!("binding lookup does not require a runtime word target")
         }

--- a/crates/tbx-next/src/source_word_evaluator.rs
+++ b/crates/tbx-next/src/source_word_evaluator.rs
@@ -134,6 +134,7 @@ impl SourceWordEvaluationError {
                 }
                 ExpressionError::Syntax(error) => Some(error.span()),
                 ExpressionError::Variable(error) => Some(error.span()),
+                ExpressionError::Call(error) => Some(error.span()),
             },
             Self::UndefinedLocal { reference, .. } | Self::LocalTypeMismatch { reference, .. } => {
                 Some(reference.span())
@@ -583,8 +584,16 @@ fn stage_expression(
     ));
 
     let resolver = |source_name: &str| resolve_variable_name(context.bindings, source_name);
-    parse_expression(context.view, &expression_tokens, operators, &resolver)
-        .map_err(|source| SourceWordEvaluationError::Expression { source, origin })
+    let runtime_word_resolver =
+        |source_name: &str| resolve_runtime_word_name(context.bindings, source_name);
+    parse_expression(
+        context.view,
+        &expression_tokens,
+        operators,
+        &resolver,
+        &runtime_word_resolver,
+    )
+    .map_err(|source| SourceWordEvaluationError::Expression { source, origin })
 }
 
 fn parse_line_number(
@@ -624,6 +633,27 @@ fn resolve_variable_name(
         }
         Err(WordResolutionError::UndefinedName) => {
             Err(crate::expression::ExpressionVariableErrorKind::UndefinedName)
+        }
+        Err(WordResolutionError::TargetIsNotWord) => {
+            unreachable!("binding lookup does not require a runtime word target")
+        }
+    }
+}
+
+fn resolve_runtime_word_name(
+    bindings: &Bindings,
+    source_name: &str,
+) -> Result<crate::word::WordId, crate::expression::ExpressionCallErrorKind> {
+    match resolve_binding_name(bindings, source_name) {
+        Ok(ResolvedBinding::RuntimeWord(id)) => Ok(id),
+        Ok(ResolvedBinding::Variable(_) | ResolvedBinding::SourceWord(_)) => {
+            Err(crate::expression::ExpressionCallErrorKind::TargetIsNotRuntimeWord)
+        }
+        Err(WordResolutionError::InvalidWordName) => {
+            Err(crate::expression::ExpressionCallErrorKind::InvalidName)
+        }
+        Err(WordResolutionError::UndefinedName) => {
+            Err(crate::expression::ExpressionCallErrorKind::UndefinedName)
         }
         Err(WordResolutionError::TargetIsNotWord) => {
             unreachable!("binding lookup does not require a runtime word target")


### PR DESCRIPTION
## Summary
- `NAME()` / `NAME(expr)` を式中 runtime word call として解析し、事前評価後に `Instruction::Call(WordId)` を生成
- call 用の runtime word 解決を variable 解決と分離し、未定義名・variable・source word target を構造化エラー化
- カンマを通常式の低優先演算子として扱い、区切り命令や arity 追跡なしで source 順に staging
- `EVAL` と source word 経由の expression staging からも同じ call lowering を使うよう接続

## Verification
- `cargo ci-clippy`
- `cargo ci-test`
- `cargo ci-fmt`

Closes #1588
