### PR TITLE
TBX NextにDUP組み込みワードを追加

### DIFF
--- a/crates/tbx-next/src/lib.rs
+++ b/crates/tbx-next/src/lib.rs
@@ -122,6 +122,11 @@ mod structured_grammar;
 #[allow(dead_code)]
 mod operator;
 
+// #1580/#1583 add the minimal named data-stack primitive words without exposing
+// return-stack or VM-control access to primitive handlers.
+#[allow(dead_code)]
+mod stack_primitive;
+
 // ADR #1442/#1451 parse minimal expressions into expression-local staging
 // before committing resolved instructions into a temporary execution unit.
 #[allow(dead_code)]

--- a/crates/tbx-next/src/source_processor.rs
+++ b/crates/tbx-next/src/source_processor.rs
@@ -2435,6 +2435,7 @@ mod tests {
         StructuredBodyContext, StructuredBuildTargetScope, StructuredLineNumberScope,
         StructuredSourceWordInstance, VarSyntaxErrorKind,
     };
+    use crate::stack_primitive::register_stack_primitives;
     use crate::structured_grammar::{
         MarkerCardinality, MarkerGroup, MarkerIdentity, StructuredGrammar,
     };
@@ -3379,6 +3380,17 @@ mod tests {
                 globals: GlobalVariables::new(),
                 code: PublishedCode::new(),
             }
+        }
+
+        fn new_with_named_operators_and_stack_primitives() -> Self {
+            let mut session = Self::new_with_named_operators();
+            register_stack_primitives(
+                &mut session.primitives,
+                &mut session.words,
+                &mut session.bindings,
+            )
+            .expect("stack primitives should bootstrap");
+            session
         }
 
         fn publish_def(&mut self, text: &str) -> (SourceTexts, SourceId, TemporaryExecutionUnit) {
@@ -9384,6 +9396,51 @@ mod tests {
             Ok(&Instruction::Call(sum))
         );
         assert_eq!(result.data_stack(), [value(42)]);
+    }
+
+    #[test]
+    fn published_def_body_can_call_builtin_dup_runtime_word() {
+        let mut session = RuntimeDefinitionSession::new_with_named_operators_and_stack_primitives();
+        let dup = resolve_word_name(&session.bindings, "DUP").expect("DUP should bootstrap");
+        let multiply = resolve_word_name(&session.bindings, "MULTIPLY")
+            .expect("MULTIPLY should be a named operator");
+        session.publish_def("DEF SQUARE\nDUP\nMULTIPLY\nEND");
+        let Some(Binding::Word(square)) = session.bindings.get(&name("SQUARE")).copied() else {
+            panic!("SQUARE should be published");
+        };
+        let (caller_sources, caller_id) = source("EVAL SQUARE(7)");
+
+        let caller = compile_source(
+            caller_sources.view(),
+            caller_id,
+            SourceCompileContext::with_source_words_and_operators(
+                &session.bindings,
+                session.source_words.lookup(),
+                session.operators.lookup(),
+            ),
+        )
+        .expect("caller should compile with DUP-backed runtime word");
+        let result = session
+            .run_unit_with_published_code(&caller)
+            .expect("caller should run DUP-backed runtime word");
+
+        assert_eq!(
+            session.code.instruction_view().get(address(0)),
+            Ok(&Instruction::Call(dup))
+        );
+        assert_eq!(
+            session.code.instruction_view().get(address(1)),
+            Ok(&Instruction::Call(multiply))
+        );
+        assert_eq!(
+            session.code.instruction_view().get(address(2)),
+            Ok(&Instruction::Return)
+        );
+        assert_eq!(
+            caller.instructions().get(address(1)),
+            Ok(&Instruction::Call(square))
+        );
+        assert_eq!(result.data_stack(), [value(49)]);
     }
 
     #[test]

--- a/crates/tbx-next/src/stack_primitive.rs
+++ b/crates/tbx-next/src/stack_primitive.rs
@@ -1,0 +1,183 @@
+use crate::binding::{BindingInsertError, Bindings};
+use crate::bootstrap::{register_primitive, PrimitiveBootstrapError};
+use crate::name::NormalizedName;
+use crate::primitive::{PrimitiveContext, PrimitiveError, PrimitiveRegistry};
+use crate::word::{PublishedWords, WordId};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct StackPrimitiveWords {
+    dup: WordId,
+}
+
+pub(crate) fn register_stack_primitives(
+    primitives: &mut PrimitiveRegistry,
+    words: &mut PublishedWords,
+    bindings: &mut Bindings,
+) -> Result<StackPrimitiveWords, PrimitiveBootstrapError> {
+    let dup_name = builtin_name("DUP");
+    bindings
+        .validate_new_name(&dup_name)
+        .map_err(primitive_bootstrap_precheck_error)?;
+
+    let dup_primitive = primitives.register(dup);
+    let dup = register_primitive(words, bindings, dup_name, dup_primitive)?;
+
+    Ok(StackPrimitiveWords { dup })
+}
+
+impl StackPrimitiveWords {
+    pub(crate) const fn dup(self) -> WordId {
+        self.dup
+    }
+}
+
+fn builtin_name(input: &str) -> NormalizedName {
+    NormalizedName::new(input).expect("built-in stack primitive name should be valid")
+}
+
+fn primitive_bootstrap_precheck_error(error: BindingInsertError) -> PrimitiveBootstrapError {
+    match error {
+        BindingInsertError::NameConflict => PrimitiveBootstrapError::NameConflict,
+        BindingInsertError::ReservedName => PrimitiveBootstrapError::ReservedName,
+    }
+}
+
+fn dup(context: &mut PrimitiveContext<'_>) -> Result<(), PrimitiveError> {
+    let value = context.peek()?;
+    context.push(value);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::binding::{Binding, Bindings};
+    use crate::instruction::{Instruction, InstructionSequence};
+    use crate::primitive::PrimitiveRegistry;
+    use crate::value::Value;
+    use crate::vm::{ExecutionView, RunOutcome, Vm, VmErrorKind};
+    use crate::word::{PublishedWords, WordDefinition};
+    use crate::word_lookup::PublishedWordLookup;
+    use crate::word_resolution::resolve_word_name;
+
+    fn value(value: i16) -> Value {
+        Value::integer(value)
+    }
+
+    fn name(input: &str) -> NormalizedName {
+        NormalizedName::new(input).expect("test input should be a valid name")
+    }
+
+    fn execution<'a>(
+        code: &'a InstructionSequence,
+        words: &'a PublishedWords,
+        primitives: &'a PrimitiveRegistry,
+    ) -> ExecutionView<'a> {
+        ExecutionView::new(
+            code.view(),
+            PublishedWordLookup::new(words),
+            primitives.lookup(),
+        )
+    }
+
+    fn run_dup(inputs: &[Value]) -> (Vm, Result<RunOutcome, crate::vm::VmError>) {
+        let mut primitives = PrimitiveRegistry::new();
+        let mut words = PublishedWords::new();
+        let mut bindings = Bindings::new();
+        let stack_words = register_stack_primitives(&mut primitives, &mut words, &mut bindings)
+            .expect("stack primitives should bootstrap");
+        let mut code = InstructionSequence::new();
+        let entry = if let Some((first, rest)) = inputs.split_first() {
+            let entry = code.append(Instruction::Push(*first));
+            for value in rest {
+                code.append(Instruction::Push(*value));
+            }
+            code.append(Instruction::Call(stack_words.dup()));
+            entry
+        } else {
+            code.append(Instruction::Call(stack_words.dup()))
+        };
+        code.append(Instruction::Halt);
+
+        let mut vm = Vm::new(code.view(), entry).expect("test entry should be valid");
+        let result = vm.run(execution(&code, &words, &primitives));
+        (vm, result)
+    }
+
+    #[test]
+    fn dup_copies_the_only_stack_value() {
+        let (mut vm, result) = run_dup(&[value(7)]);
+
+        assert_eq!(result, Ok(RunOutcome::Halted));
+        assert_eq!(vm.data_stack_depth(), 2);
+        assert_eq!(vm.pop_data(), Ok(value(7)));
+        assert_eq!(vm.pop_data(), Ok(value(7)));
+    }
+
+    #[test]
+    fn dup_copies_only_top_value_without_reordering_lower_values() {
+        let (mut vm, result) = run_dup(&[value(3), value(5), value(8)]);
+
+        assert_eq!(result, Ok(RunOutcome::Halted));
+        assert_eq!(vm.data_stack_depth(), 4);
+        assert_eq!(vm.pop_data(), Ok(value(8)));
+        assert_eq!(vm.pop_data(), Ok(value(8)));
+        assert_eq!(vm.pop_data(), Ok(value(5)));
+        assert_eq!(vm.pop_data(), Ok(value(3)));
+    }
+
+    #[test]
+    fn dup_underflow_fails_without_changing_the_stack() {
+        let (vm, result) = run_dup(&[]);
+        let error = result.expect_err("empty stack should make DUP fail");
+
+        assert!(matches!(
+            error.kind(),
+            VmErrorKind::PrimitiveFailed {
+                source: PrimitiveError::DataStackUnderflow { .. },
+                ..
+            }
+        ));
+        assert_eq!(vm.data_stack_depth(), 0);
+    }
+
+    #[test]
+    fn stack_primitive_bootstrap_publishes_dup_as_runtime_word() {
+        let mut primitives = PrimitiveRegistry::new();
+        let mut words = PublishedWords::new();
+        let mut bindings = Bindings::new();
+
+        let stack_words = register_stack_primitives(&mut primitives, &mut words, &mut bindings)
+            .expect("stack primitives should bootstrap");
+
+        assert_eq!(primitives.len(), 1);
+        assert_eq!(words.len(), 1);
+        assert_eq!(resolve_word_name(&bindings, "dup"), Ok(stack_words.dup()));
+        assert_eq!(
+            bindings.get(&name("DUP")),
+            Some(&Binding::Word(stack_words.dup()))
+        );
+        assert!(matches!(
+            words.get(stack_words.dup()),
+            Ok(WordDefinition::Primitive { .. })
+        ));
+    }
+
+    #[test]
+    fn stack_primitive_bootstrap_prechecks_dup_name_conflict() {
+        let mut primitives = PrimitiveRegistry::new();
+        let mut words = PublishedWords::new();
+        let mut bindings = Bindings::new();
+        let existing = WordId::test_invalid(0);
+        bindings
+            .insert_new(name("DUP"), Binding::Word(existing))
+            .expect("test setup should bind DUP");
+
+        let result = register_stack_primitives(&mut primitives, &mut words, &mut bindings);
+
+        assert_eq!(result, Err(PrimitiveBootstrapError::NameConflict));
+        assert_eq!(primitives.len(), 0);
+        assert_eq!(words.len(), 0);
+        assert_eq!(bindings.get(&name("DUP")), Some(&Binding::Word(existing)));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a `DUP` built-in runtime word for TBX Next stack manipulation.
- Registers `DUP` as an ordinary named primitive word through bootstrap.
- Covers single-value, multi-value, underflow atomicity, bootstrap/name resolution, and a `DEF SQUARE` runtime path.

Closes #1583

## Verification

- `cargo test -p tbx-next stack_primitive`
- `cargo test -p tbx-next published_def_body_can_call_builtin_dup_runtime_word`
- `cargo test -p tbx-next`
- `cargo ci-clippy`
- `cargo ci-test`
- `cargo ci-fmt`
