### PR TITLE
TBX Next に最小実行時出力能力を追加する

### DIFF
--- a/crates/tbx-next/src/lib.rs
+++ b/crates/tbx-next/src/lib.rs
@@ -142,6 +142,11 @@ mod line_number;
 #[allow(dead_code)]
 mod global_variable;
 
+// ADR #1528 keeps runtime external output as a narrow host-supplied capability
+// that receives only completed output text.
+#[allow(dead_code)]
+mod runtime_output;
+
 pub const STATUS_MESSAGE: &str =
     "TBX Next is under development; language features are not implemented yet.";
 

--- a/crates/tbx-next/src/primitive.rs
+++ b/crates/tbx-next/src/primitive.rs
@@ -1,3 +1,4 @@
+use crate::runtime_output::{RuntimeOutput, RuntimeOutputError};
 use crate::stack::{DataStack, StackError};
 use crate::value::Value;
 use crate::word::PrimitiveId;
@@ -7,6 +8,7 @@ pub(crate) type PrimitiveHandler = fn(&mut PrimitiveContext<'_>) -> Result<(), P
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum PrimitiveError {
     DataStackUnderflow { source: StackError },
+    OutputFailed { source: RuntimeOutputError },
     Failed,
 }
 
@@ -17,16 +19,28 @@ pub(crate) enum PrimitiveLookupError {
 
 /// Limited primitive execution context.
 ///
-/// Handlers receive only data-stack operations. They cannot observe or mutate
-/// the instruction pointer, return stack, halted flag, word tables, bindings,
-/// instruction sequence, or primitive registry.
+/// Handlers receive only data-stack operations and the narrow runtime output
+/// capability. They cannot observe or mutate the instruction pointer, return
+/// stack, halted flag, word tables, bindings, instruction sequence, primitive
+/// registry, compiler, or source-processing state.
 pub(crate) struct PrimitiveContext<'a> {
     data_stack: &'a mut DataStack,
+    output: Option<&'a mut dyn RuntimeOutput>,
 }
 
 impl<'a> PrimitiveContext<'a> {
     pub(crate) fn new(data_stack: &'a mut DataStack) -> Self {
-        Self { data_stack }
+        Self {
+            data_stack,
+            output: None,
+        }
+    }
+
+    pub(crate) fn with_output(
+        data_stack: &'a mut DataStack,
+        output: Option<&'a mut dyn RuntimeOutput>,
+    ) -> Self {
+        Self { data_stack, output }
     }
 
     pub(crate) fn push(&mut self, value: Value) {
@@ -49,6 +63,16 @@ impl<'a> PrimitiveContext<'a> {
         self.data_stack
             .peek()
             .map_err(|source| PrimitiveError::DataStackUnderflow { source })
+    }
+
+    pub(crate) fn write_output(&mut self, text: &str) -> Result<(), PrimitiveError> {
+        self.output
+            .as_deref_mut()
+            .ok_or(PrimitiveError::OutputFailed {
+                source: RuntimeOutputError::Unavailable,
+            })?
+            .write(text)
+            .map_err(|source| PrimitiveError::OutputFailed { source })
     }
 }
 

--- a/crates/tbx-next/src/runtime_output.rs
+++ b/crates/tbx-next/src/runtime_output.rs
@@ -1,0 +1,47 @@
+/// Limited runtime output capability supplied by the host.
+///
+/// ADR #1528 keeps concrete I/O ownership outside the VM. Runtime words pass
+/// only output text whose language-level formatting has already been decided.
+pub(crate) trait RuntimeOutput {
+    fn write(&mut self, text: &str) -> Result<(), RuntimeOutputError>;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RuntimeOutputError {
+    Unavailable,
+    Failed,
+}
+
+#[cfg(test)]
+#[derive(Debug, Default)]
+pub(crate) struct TestOutput {
+    chunks: Vec<String>,
+    fail_next: Option<RuntimeOutputError>,
+}
+
+#[cfg(test)]
+impl TestOutput {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn fail_next_write(&mut self, error: RuntimeOutputError) {
+        self.fail_next = Some(error);
+    }
+
+    pub(crate) fn chunks(&self) -> &[String] {
+        &self.chunks
+    }
+}
+
+#[cfg(test)]
+impl RuntimeOutput for TestOutput {
+    fn write(&mut self, text: &str) -> Result<(), RuntimeOutputError> {
+        if let Some(error) = self.fail_next.take() {
+            return Err(error);
+        }
+
+        self.chunks.push(text.to_owned());
+        Ok(())
+    }
+}

--- a/crates/tbx-next/src/vm.rs
+++ b/crates/tbx-next/src/vm.rs
@@ -6,10 +6,12 @@ use crate::instruction::{
     InstructionLookupError, InstructionView,
 };
 use crate::primitive::{PrimitiveContext, PrimitiveError, PrimitiveLookup, PrimitiveLookupError};
+use crate::runtime_output::RuntimeOutput;
 use crate::stack::{DataStack, ReturnFrame, ReturnStack, StackError};
 use crate::value::Value;
 use crate::word::{WordDefinition, WordId, WordLookupError};
 use crate::word_lookup::PublishedWordLookup;
+use std::fmt;
 
 /// Mutable execution state for the initial TBX Next VM core.
 ///
@@ -80,12 +82,12 @@ pub(crate) enum VmErrorKind {
     },
 }
 
-#[derive(Debug)]
 pub(crate) struct ExecutionView<'a> {
     instructions: InstructionLookup<'a>,
     words: PublishedWordLookup<'a>,
     primitives: PrimitiveLookup<'a>,
     globals: Option<GlobalExecutionAccess<'a>>,
+    output: Option<&'a mut dyn RuntimeOutput>,
 }
 
 #[derive(Debug)]
@@ -113,6 +115,7 @@ impl<'a> ExecutionView<'a> {
             words,
             primitives,
             globals: None,
+            output: None,
         }
     }
 
@@ -134,6 +137,11 @@ impl<'a> ExecutionView<'a> {
         self
     }
 
+    pub(crate) fn with_output(mut self, output: &'a mut dyn RuntimeOutput) -> Self {
+        self.output = Some(output);
+        self
+    }
+
     pub(crate) const fn instructions(self) -> InstructionLookup<'a> {
         self.instructions
     }
@@ -144,6 +152,19 @@ impl<'a> ExecutionView<'a> {
 
     pub(crate) const fn primitives(self) -> PrimitiveLookup<'a> {
         self.primitives
+    }
+}
+
+impl fmt::Debug for ExecutionView<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ExecutionView")
+            .field("instructions", &self.instructions)
+            .field("words", &self.words)
+            .field("primitives", &self.primitives)
+            .field("globals", &self.globals)
+            .field("output", &self.output.is_some())
+            .finish()
     }
 }
 
@@ -160,6 +181,10 @@ pub(crate) trait VmExecutionView<'a> {
     fn read_global(&self, id: GlobalVarId) -> Result<Value, GlobalVariableError>;
 
     fn write_global(&mut self, id: GlobalVarId, value: Value) -> Result<(), GlobalVariableError>;
+
+    fn runtime_output(&mut self) -> Option<&mut (dyn RuntimeOutput + '_)> {
+        None
+    }
 }
 
 impl<'a> VmExecutionView<'a> for ExecutionView<'a> {
@@ -192,6 +217,13 @@ impl<'a> VmExecutionView<'a> for ExecutionView<'a> {
             Some(GlobalExecutionAccess::Read(_)) | None => {
                 Err(GlobalVariableError::InvalidGlobalVarId { id })
             }
+        }
+    }
+
+    fn runtime_output(&mut self) -> Option<&mut (dyn RuntimeOutput + '_)> {
+        match self.output.as_mut() {
+            Some(output) => Some(&mut **output),
+            None => None,
         }
     }
 }
@@ -243,6 +275,10 @@ impl<'a, T: VmExecutionView<'a> + ?Sized> VmExecutionView<'a> for &mut T {
 
     fn write_global(&mut self, id: GlobalVarId, value: Value) -> Result<(), GlobalVariableError> {
         (**self).write_global(id, value)
+    }
+
+    fn runtime_output(&mut self) -> Option<&mut (dyn RuntimeOutput + '_)> {
+        (**self).runtime_output()
     }
 }
 
@@ -449,7 +485,7 @@ impl Vm {
 
     fn step_call<'a, E: VmExecutionView<'a>>(
         &mut self,
-        execution: E,
+        mut execution: E,
         location: CodeLocation,
         id: WordId,
     ) -> Result<StepOutcome, VmError> {
@@ -470,7 +506,8 @@ impl Vm {
                     })?;
 
                 let checkpoint = self.data_stack.clone();
-                let mut context = PrimitiveContext::new(&mut self.data_stack);
+                let mut context =
+                    PrimitiveContext::with_output(&mut self.data_stack, execution.runtime_output());
                 match handler(&mut context) {
                     Ok(()) => {
                         self.instruction_pointer = next;
@@ -629,6 +666,7 @@ mod tests {
     use crate::instruction::InstructionAddressError;
     use crate::instruction::InstructionSequence;
     use crate::primitive::{PrimitiveLookupError, PrimitiveRegistry};
+    use crate::runtime_output::{RuntimeOutputError, TestOutput};
     use crate::word::{CompletedWordDefinition, PrimitiveId, PublishedWords, WordLookupError};
     use crate::word_lookup::PublishedWordLookup;
 
@@ -747,6 +785,23 @@ mod tests {
         context.pop()?;
         context.push(value(99));
         Err(PrimitiveError::Failed)
+    }
+
+    fn write_alpha(context: &mut PrimitiveContext<'_>) -> Result<(), PrimitiveError> {
+        context.write_output("alpha")
+    }
+
+    fn write_beta(context: &mut PrimitiveContext<'_>) -> Result<(), PrimitiveError> {
+        context.write_output("beta")
+    }
+
+    fn write_empty(context: &mut PrimitiveContext<'_>) -> Result<(), PrimitiveError> {
+        context.write_output("")
+    }
+
+    fn pop_then_write_output(context: &mut PrimitiveContext<'_>) -> Result<(), PrimitiveError> {
+        context.pop()?;
+        context.write_output("after-pop")
     }
 
     #[test]
@@ -1607,6 +1662,96 @@ mod tests {
         assert_eq!(vm.return_stack_depth(), 0);
         assert_eq!(vm.data_stack_depth(), 1);
         assert_eq!(vm.peek_data(), Ok(value(7)));
+    }
+
+    #[test]
+    fn primitive_output_writes_completed_chunks_in_order() {
+        let mut primitives = PrimitiveRegistry::new();
+        let alpha = primitives.register(write_alpha);
+        let beta = primitives.register(write_beta);
+        let empty = primitives.register(write_empty);
+        let mut words = PublishedWords::new();
+        let alpha_word = words.add(CompletedWordDefinition::primitive(alpha));
+        let beta_word = words.add(CompletedWordDefinition::primitive(beta));
+        let empty_word = words.add(CompletedWordDefinition::primitive(empty));
+        let mut code = InstructionSequence::new();
+        let entry = code.append(Instruction::Call(alpha_word));
+        code.append(Instruction::Call(beta_word));
+        code.append(Instruction::Call(empty_word));
+        code.append(Instruction::Halt);
+        let mut output = TestOutput::new();
+        let mut vm = new_vm(&code, entry);
+
+        let result = vm.run(execution(&code, &words, &primitives).with_output(&mut output));
+
+        assert_eq!(result, Ok(RunOutcome::Halted));
+        assert_eq!(output.chunks(), ["alpha", "beta", ""]);
+        assert_eq!(vm.data_stack_depth(), 0);
+    }
+
+    #[test]
+    fn primitive_output_failure_propagates_and_restores_vm_state() {
+        let mut primitives = PrimitiveRegistry::new();
+        let primitive = primitives.register(pop_then_write_output);
+        let mut words = PublishedWords::new();
+        let word = words.add(CompletedWordDefinition::primitive(primitive));
+        let mut code = InstructionSequence::new();
+        let entry = code.append(Instruction::Push(value(7)));
+        let call = code.append(Instruction::Call(word));
+        code.append(Instruction::Halt);
+        let mut output = TestOutput::new();
+        output.fail_next_write(RuntimeOutputError::Failed);
+        let mut vm = new_vm(&code, entry);
+
+        assert_eq!(vm.step(code.view()), Ok(StepOutcome::Continued));
+        let before = snapshot(&vm);
+        let result = vm.step(execution(&code, &words, &primitives).with_output(&mut output));
+
+        assert_eq!(
+            result,
+            Err(VmError {
+                location: location(&code, call),
+                kind: VmErrorKind::PrimitiveFailed {
+                    primitive,
+                    source: PrimitiveError::OutputFailed {
+                        source: RuntimeOutputError::Failed,
+                    }
+                }
+            })
+        );
+        assert_vm_state(&vm, before);
+        assert!(output.chunks().is_empty());
+    }
+
+    #[test]
+    fn missing_output_capability_is_a_primitive_failure_without_vm_mutation() {
+        let mut primitives = PrimitiveRegistry::new();
+        let primitive = primitives.register(pop_then_write_output);
+        let mut words = PublishedWords::new();
+        let word = words.add(CompletedWordDefinition::primitive(primitive));
+        let mut code = InstructionSequence::new();
+        let entry = code.append(Instruction::Push(value(11)));
+        let call = code.append(Instruction::Call(word));
+        code.append(Instruction::Halt);
+        let mut vm = new_vm(&code, entry);
+
+        assert_eq!(vm.step(code.view()), Ok(StepOutcome::Continued));
+        let before = snapshot(&vm);
+        let result = vm.step(execution(&code, &words, &primitives));
+
+        assert_eq!(
+            result,
+            Err(VmError {
+                location: location(&code, call),
+                kind: VmErrorKind::PrimitiveFailed {
+                    primitive,
+                    source: PrimitiveError::OutputFailed {
+                        source: RuntimeOutputError::Unavailable,
+                    }
+                }
+            })
+        );
+        assert_vm_state(&vm, before);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add a narrow `RuntimeOutput` capability for completed runtime output text.
- Thread that capability through `ExecutionView` into `PrimitiveContext` without exposing compiler, source processing, or concrete OS I/O.
- Add a test-only output sink and VM tests for ordered writes, empty output, unavailable output, output failure propagation, and data-stack restoration after failure.

Closes #1585

## Verification

- `cargo test -p tbx-next`
- `cargo ci-clippy`
- `cargo ci-test`
- `cargo ci-fmt`
