### PR TITLE
TBX Nextのソース登録に表示名を含める

### DIFF
--- a/crates/tbx-next/src/block_code.rs
+++ b/crates/tbx-next/src/block_code.rs
@@ -247,7 +247,7 @@ mod tests {
 
     fn source(text: &str) -> (SourceTexts, SourceId) {
         let mut sources = SourceTexts::new();
-        let id = sources.register(text);
+        let id = sources.register(text, "test.tbx");
         (sources, id)
     }
 

--- a/crates/tbx-next/src/expression.rs
+++ b/crates/tbx-next/src/expression.rs
@@ -614,7 +614,7 @@ mod tests {
 
     fn source(text: &str) -> (SourceTexts, SourceId) {
         let mut sources = SourceTexts::new();
-        let id = sources.register(text);
+        let id = sources.register(text, "test.tbx");
         (sources, id)
     }
 

--- a/crates/tbx-next/src/instruction_builder.rs
+++ b/crates/tbx-next/src/instruction_builder.rs
@@ -231,7 +231,7 @@ mod tests {
 
     fn source(text: &str) -> (SourceTexts, SourceId) {
         let mut sources = SourceTexts::new();
-        let id = sources.register(text);
+        let id = sources.register(text, "test.tbx");
         (sources, id)
     }
 

--- a/crates/tbx-next/src/lexer.rs
+++ b/crates/tbx-next/src/lexer.rs
@@ -377,7 +377,7 @@ mod tests {
 
     fn lexer_for(text: &str) -> (SourceTexts, SourceId) {
         let mut sources = SourceTexts::new();
-        let id = sources.register(text);
+        let id = sources.register(text, "test.tbx");
         (sources, id)
     }
 
@@ -885,8 +885,8 @@ mod tests {
     #[test]
     fn same_offsets_in_different_sources_keep_distinct_source_ids() {
         let mut sources = SourceTexts::new();
-        let first = sources.register("A");
-        let second = sources.register("B");
+        let first = sources.register("A", "test.tbx");
+        let second = sources.register("B", "test.tbx");
         let view = sources.view();
         let mut first_lexer = Lexer::new(view, first).expect("first source should lex");
         let mut second_lexer = Lexer::new(view, second).expect("second source should lex");

--- a/crates/tbx-next/src/line_number.rs
+++ b/crates/tbx-next/src/line_number.rs
@@ -159,7 +159,7 @@ mod tests {
 
     fn source(text: &str) -> (SourceTexts, SourceId) {
         let mut sources = SourceTexts::new();
-        let id = sources.register(text);
+        let id = sources.register(text, "test.tbx");
         (sources, id)
     }
 

--- a/crates/tbx-next/src/published_code.rs
+++ b/crates/tbx-next/src/published_code.rs
@@ -371,7 +371,7 @@ mod tests {
 
     fn source(text: &str) -> (SourceTexts, SourceId) {
         let mut sources = SourceTexts::new();
-        let id = sources.register(text);
+        let id = sources.register(text, "test.tbx");
         (sources, id)
     }
 

--- a/crates/tbx-next/src/source.rs
+++ b/crates/tbx-next/src/source.rs
@@ -101,7 +101,18 @@ pub(crate) enum SourceError {
 #[derive(Debug)]
 pub(crate) struct SourceTexts {
     owner: SourceOwnerId,
-    sources: Vec<Box<str>>,
+    sources: Vec<SourceRecord>,
+}
+
+/// Complete source payload registered under one `SourceId`.
+///
+/// ADR #1529 requires source text and user-facing display information to share
+/// the same registration and lifetime so later diagnostics cannot lose their
+/// association while source mappings may still refer to this `SourceId`.
+#[derive(Debug)]
+struct SourceRecord {
+    text: Box<str>,
+    display_name: Box<str>,
 }
 
 impl SourceTexts {
@@ -112,12 +123,19 @@ impl SourceTexts {
         }
     }
 
-    pub(crate) fn register(&mut self, text: impl Into<Box<str>>) -> SourceId {
+    pub(crate) fn register(
+        &mut self,
+        text: impl Into<Box<str>>,
+        display_name: impl Into<Box<str>>,
+    ) -> SourceId {
         let id = SourceId {
             owner: self.owner,
             slot: self.sources.len(),
         };
-        self.sources.push(text.into());
+        self.sources.push(SourceRecord {
+            text: text.into(),
+            display_name: display_name.into(),
+        });
         id
     }
 
@@ -141,18 +159,25 @@ impl SourceTexts {
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct SourceView<'a> {
     owner: SourceOwnerId,
-    sources: &'a [Box<str>],
+    sources: &'a [SourceRecord],
 }
 
 impl<'a> SourceView<'a> {
     pub(crate) fn source(self, id: SourceId) -> Result<&'a str, SourceError> {
+        self.record(id).map(|source| source.text.as_ref())
+    }
+
+    pub(crate) fn display_name(self, id: SourceId) -> Result<&'a str, SourceError> {
+        self.record(id).map(|source| source.display_name.as_ref())
+    }
+
+    fn record(self, id: SourceId) -> Result<&'a SourceRecord, SourceError> {
         if id.owner != self.owner {
             return Err(SourceError::InvalidSourceId { id });
         }
 
         self.sources
             .get(id.slot)
-            .map(|source| source.as_ref())
             .ok_or(SourceError::InvalidSourceId { id })
     }
 
@@ -231,7 +256,7 @@ mod tests {
 
     fn register(text: &str) -> (SourceTexts, SourceId) {
         let mut sources = SourceTexts::new();
-        let id = sources.register(text);
+        let id = sources.register(text, "test.tbx");
         (sources, id)
     }
 
@@ -255,23 +280,26 @@ mod tests {
     fn registers_empty_ascii_and_utf8_sources() {
         let mut sources = SourceTexts::new();
 
-        let empty = sources.register("");
-        let ascii = sources.register("PRINT 10");
-        let utf8 = sources.register("PRINT \"あ\"");
+        let empty = sources.register("", "empty.tbx");
+        let ascii = sources.register("PRINT 10", "ascii.tbx");
+        let utf8 = sources.register("PRINT \"あ\"", "utf8.tbx");
         let view = sources.view();
 
         assert_eq!(view.source(empty), Ok(""));
         assert_eq!(view.source(ascii), Ok("PRINT 10"));
         assert_eq!(view.source(utf8), Ok("PRINT \"あ\""));
+        assert_eq!(view.display_name(empty), Ok("empty.tbx"));
+        assert_eq!(view.display_name(ascii), Ok("ascii.tbx"));
+        assert_eq!(view.display_name(utf8), Ok("utf8.tbx"));
     }
 
     #[test]
     fn each_registration_receives_distinct_source_id() {
         let mut sources = SourceTexts::new();
 
-        let first = sources.register("A");
-        let second = sources.register("A");
-        let third = sources.register("B");
+        let first = sources.register("A", "same-name.tbx");
+        let second = sources.register("A", "same-name.tbx");
+        let third = sources.register("B", "different-name.tbx");
 
         assert_ne!(first, second);
         assert_ne!(first, third);
@@ -279,6 +307,35 @@ mod tests {
         assert_eq!(sources.view().source(first), Ok("A"));
         assert_eq!(sources.view().source(second), Ok("A"));
         assert_eq!(sources.view().source(third), Ok("B"));
+        assert_eq!(sources.view().display_name(first), Ok("same-name.tbx"));
+        assert_eq!(sources.view().display_name(second), Ok("same-name.tbx"));
+        assert_eq!(sources.view().display_name(third), Ok("different-name.tbx"));
+    }
+
+    #[test]
+    fn each_registration_keeps_text_and_display_name_together() {
+        let mut sources = SourceTexts::new();
+
+        let empty = sources.register("", "<stdin>");
+        let ascii = sources.register("PRINT 10", "program.tbx");
+        let utf8 = sources.register("PRINT \"あ\"", "unicode.tbx");
+        let same_display_name = sources.register("PRINT 20", "program.tbx");
+        let same_text = sources.register("PRINT 10", "copy.tbx");
+        let view = sources.view();
+
+        assert_eq!(view.source(empty), Ok(""));
+        assert_eq!(view.display_name(empty), Ok("<stdin>"));
+        assert_eq!(view.source(ascii), Ok("PRINT 10"));
+        assert_eq!(view.display_name(ascii), Ok("program.tbx"));
+        assert_eq!(view.source(utf8), Ok("PRINT \"あ\""));
+        assert_eq!(view.display_name(utf8), Ok("unicode.tbx"));
+        assert_eq!(view.source(same_display_name), Ok("PRINT 20"));
+        assert_eq!(view.display_name(same_display_name), Ok("program.tbx"));
+        assert_eq!(view.source(same_text), Ok("PRINT 10"));
+        assert_eq!(view.display_name(same_text), Ok("copy.tbx"));
+
+        assert_ne!(ascii, same_display_name);
+        assert_ne!(ascii, same_text);
     }
 
     #[test]
@@ -380,6 +437,10 @@ mod tests {
             Err(SourceError::InvalidSourceId { id: invalid })
         );
         assert_eq!(
+            sources.view().display_name(invalid),
+            Err(SourceError::InvalidSourceId { id: invalid })
+        );
+        assert_eq!(
             sources.view().span(invalid, 0, 0),
             Err(SourceError::InvalidSourceId { id: invalid })
         );
@@ -388,17 +449,21 @@ mod tests {
     #[test]
     fn source_ids_from_different_owners_do_not_collide_at_the_same_slot() {
         let mut first_owner = SourceTexts::new();
-        let first_id = first_owner.register("ABC");
+        let first_id = first_owner.register("ABC", "first.tbx");
         let first_span = span(first_owner.view(), first_id, 0, 1);
 
         let mut second_owner = SourceTexts::new();
-        let second_id = second_owner.register("XYZ");
+        let second_id = second_owner.register("XYZ", "second.tbx");
 
         assert_eq!(first_id.slot, second_id.slot);
         assert_ne!(first_id, second_id);
         assert_eq!(first_owner.view().slice(first_span), Ok("A"));
         assert_eq!(
             second_owner.view().source(first_id),
+            Err(SourceError::InvalidSourceId { id: first_id })
+        );
+        assert_eq!(
+            second_owner.view().display_name(first_id),
             Err(SourceError::InvalidSourceId { id: first_id })
         );
         assert_eq!(
@@ -410,8 +475,8 @@ mod tests {
     #[test]
     fn same_offsets_in_different_sources_are_different_spans() {
         let mut sources = SourceTexts::new();
-        let first = sources.register("ABC");
-        let second = sources.register("XYZ");
+        let first = sources.register("ABC", "first.tbx");
+        let second = sources.register("XYZ", "second.tbx");
         let view = sources.view();
 
         let first_span = span(view, first, 0, 1);
@@ -425,8 +490,8 @@ mod tests {
     #[test]
     fn slice_in_source_rejects_mismatched_source_id() {
         let mut sources = SourceTexts::new();
-        let first = sources.register("ABC");
-        let second = sources.register("XYZ");
+        let first = sources.register("ABC", "first.tbx");
+        let second = sources.register("XYZ", "second.tbx");
         let view = sources.view();
         let first_span = span(view, first, 0, 1);
 

--- a/crates/tbx-next/src/source_mapping.rs
+++ b/crates/tbx-next/src/source_mapping.rs
@@ -286,7 +286,7 @@ mod tests {
 
     fn source(text: &str) -> (SourceTexts, SourceId) {
         let mut sources = SourceTexts::new();
-        let id = sources.register(text);
+        let id = sources.register(text, "test.tbx");
         (sources, id)
     }
 
@@ -380,7 +380,7 @@ mod tests {
     #[test]
     fn same_local_index_is_separate_per_code_space() {
         let (mut sources, first_source) = source("A");
-        let second_source = sources.register("B");
+        let second_source = sources.register("B", "test.tbx");
         let mut first_code = InstructionSequence::new();
         let mut second_code = InstructionSequence::new();
         let first_address = first_code.append(Instruction::Halt);
@@ -499,7 +499,7 @@ mod tests {
     #[test]
     fn published_code_mapping_uses_code_owner_not_source_owner() {
         let (mut sources, first_source) = source("A");
-        let second_source = sources.register("B");
+        let second_source = sources.register("B", "test.tbx");
         let mut published_code = InstructionSequence::new();
         let entry = published_code.append(Instruction::Halt);
         let first_span = span(sources.view(), first_source, 0, 1);

--- a/crates/tbx-next/src/source_processor.rs
+++ b/crates/tbx-next/src/source_processor.rs
@@ -2462,7 +2462,7 @@ mod tests {
 
     fn source(text: &str) -> (SourceTexts, SourceId) {
         let mut sources = SourceTexts::new();
-        let id = sources.register(text);
+        let id = sources.register(text, "test.tbx");
         (sources, id)
     }
 
@@ -6467,7 +6467,7 @@ mod tests {
     #[test]
     fn each_run_uses_fresh_vm_state() {
         let (mut sources, first) = source("PUSH1 PUSH2");
-        let second = sources.register("");
+        let second = sources.register("", "test.tbx");
         let mut words = PublishedWords::new();
         let mut bindings = Bindings::new();
         let mut primitives = PrimitiveRegistry::new();
@@ -10324,7 +10324,7 @@ mod tests {
         let original_word_count = words.len();
         let original_published_len = published_code.len();
         let (mut sources, first) = source("user_word user_word");
-        let second = sources.register("user_word");
+        let second = sources.register("user_word", "test.tbx");
         let published_views = [published_code.view()];
         let first_result = run_source(
             sources.view(),
@@ -10429,8 +10429,8 @@ mod tests {
     #[test]
     fn published_runtime_error_maps_to_published_source_span() {
         let mut sources = SourceTexts::new();
-        let published_source = sources.register("fail");
-        let temporary_source = sources.register("bad");
+        let published_source = sources.register("fail", "test.tbx");
+        let temporary_source = sources.register("bad", "test.tbx");
         let mut words = PublishedWords::new();
         let mut bindings = Bindings::new();
         let mut primitives = PrimitiveRegistry::new();
@@ -10484,10 +10484,10 @@ mod tests {
     #[test]
     fn nested_published_runtime_error_uses_deepest_callee_mapping() {
         let mut sources = SourceTexts::new();
-        let inner_source = sources.register("inner_fail");
-        let middle_source = sources.register("middle_call");
-        let outer_source = sources.register("outer_call");
-        let temporary_source = sources.register("outer");
+        let inner_source = sources.register("inner_fail", "test.tbx");
+        let middle_source = sources.register("middle_call", "test.tbx");
+        let outer_source = sources.register("outer_call", "test.tbx");
+        let temporary_source = sources.register("outer", "test.tbx");
         let mut words = PublishedWords::new();
         let mut bindings = Bindings::new();
         let mut primitives = PrimitiveRegistry::new();
@@ -10621,7 +10621,7 @@ mod tests {
     #[test]
     fn runtime_error_mapping_distinguishes_end_out_of_range_and_unmapped() {
         let mut sources = SourceTexts::new();
-        let temporary_source = sources.register("bad");
+        let temporary_source = sources.register("bad", "test.tbx");
         let mut words = PublishedWords::new();
         let mut bindings = Bindings::new();
         let mut primitives = PrimitiveRegistry::new();
@@ -10684,9 +10684,9 @@ mod tests {
             out_of_range_mapping.view(),
             unmapped_mapping.view(),
         ];
-        let end_source = sources.register("endfail");
-        let out_of_range_source = sources.register("rangefail");
-        let unmapped_source = sources.register("unmappedfail");
+        let end_source = sources.register("endfail", "test.tbx");
+        let out_of_range_source = sources.register("rangefail", "test.tbx");
+        let unmapped_source = sources.register("unmappedfail", "test.tbx");
 
         assert_runtime_error(
             run_source(

--- a/crates/tbx-next/src/source_word.rs
+++ b/crates/tbx-next/src/source_word.rs
@@ -2877,7 +2877,7 @@ mod tests {
 
     fn statement_tokens(text: &str) -> (SourceTexts, SourceId, Vec<Token>) {
         let mut sources = SourceTexts::new();
-        let source_id = sources.register(text);
+        let source_id = sources.register(text, "test.tbx");
         let mut lexer = crate::lexer::Lexer::new(sources.view(), source_id)
             .expect("test source should create lexer");
         let mut tokens = Vec::new();
@@ -3284,7 +3284,7 @@ mod tests {
     #[test]
     fn native_context_emits_mapped_temporary_instruction() {
         let mut sources = SourceTexts::new();
-        let source_id = sources.register("TEST");
+        let source_id = sources.register("TEST", "test.tbx");
         let mut lexer = crate::lexer::Lexer::new(sources.view(), source_id)
             .expect("test source should create lexer");
         let mut tokens = Vec::new();

--- a/crates/tbx-next/src/source_word_evaluator.rs
+++ b/crates/tbx-next/src/source_word_evaluator.rs
@@ -816,7 +816,7 @@ mod tests {
 
     fn lex(text: &str) -> (SourceTexts, SourceId, Vec<Token>) {
         let mut sources = SourceTexts::new();
-        let source_id = sources.register(text);
+        let source_id = sources.register(text, "test.tbx");
         let mut lexer = Lexer::new(sources.view(), source_id).expect("lexer should construct");
         let mut tokens = Vec::new();
         loop {

--- a/crates/tbx-next/src/source_word_ir.rs
+++ b/crates/tbx-next/src/source_word_ir.rs
@@ -648,7 +648,7 @@ mod tests {
 
     fn setup_source() -> (SourceTexts, SourceId) {
         let mut sources = SourceTexts::new();
-        let source_id = sources.register("READ_NAME AS name reference span padding\n");
+        let source_id = sources.register("READ_NAME AS name reference span padding\n", "test.tbx");
         (sources, source_id)
     }
 

--- a/crates/tbx-next/src/static_quotation.rs
+++ b/crates/tbx-next/src/static_quotation.rs
@@ -172,7 +172,7 @@ mod tests {
 
     fn source(text: &str) -> (SourceTexts, SourceId) {
         let mut sources = SourceTexts::new();
-        let id = sources.register(text);
+        let id = sources.register(text, "test.tbx");
         (sources, id)
     }
 


### PR DESCRIPTION
## Summary

- `SourceTexts` の登録スロットをソース本文と表示名の組に変更
- `SourceView` から `SourceId` 基準で本文と表示名を read-only に取得できる経路を追加
- 既存 fixture を同時登録 API へ移行し、複数登録・同一表示名・owner 不一致の契約をテストで確認

## Verification

- `cargo ci-clippy`
- `cargo ci-test`
- `cargo ci-fmt`

Closes #1590
